### PR TITLE
fix(useFilenamingConvention): don't suggest names with disallowed case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) no longer suggests names with a disallowed case. Contributed by @Conaclos
+
 - [useSemanticElements](https://biomejs.dev/linter/rules/use-semantic-elements/) now ignores `alert` and `alertdialog` roles ([3858](https://github.com/biomejs/biome/issues/3858)). Contributed by @Conaclos
 
 - [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) now ignores `@/` imports and recognizes type imports from Definitely Typed and `bun` imports. Contributed by @Conaclos

--- a/crates/biome_aria_metadata/build.rs
+++ b/crates/biome_aria_metadata/build.rs
@@ -250,10 +250,7 @@ fn generate_enums(len: usize, array: std::slice::Iter<&str>, enum_name: &str) ->
     let mut from_enum_metadata = Vec::with_capacity(len);
     let mut from_string_metadata = Vec::with_capacity(len);
     for property in array {
-        let name = Ident::new(
-            &Case::Pascal.convert(&property.replace('-', "_")),
-            Span::call_site(),
-        );
+        let name = Ident::new(&Case::Pascal.convert(property), Span::call_site());
         let property = Literal::string(property);
         from_enum_metadata.push(quote! {
             #enum_name::#name => #property

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/0_start_with_digit.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/0_start_with_digit.ts.snap
@@ -1,0 +1,17 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 0_start_with_digit.ts
+---
+# Input
+```ts
+
+```
+
+# Diagnostics
+```
+0_start_with_digit.ts lint/style/useFilenamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The filename should be in camelCase or kebab-case or snake_case or equal to the name of an export.
+  
+
+```


### PR DESCRIPTION
## Summary

Fix partially #3952.
`useFilenamingConvention` no longer suggests names with a disallowed case.

## Test Plan

I added a test.