### PR TITLE
fix(format/html): keep single quotes if string contains a double quote

### DIFF
--- a/crates/biome_html_formatter/src/html/auxiliary/string.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/string.rs
@@ -12,22 +12,32 @@ impl FormatNodeRule<HtmlString> for FormatHtmlString {
             let value_text = value.text().trim();
 
             if !(value_text.starts_with('"') && value_text.ends_with('"')) {
-                let range = if value_text.starts_with('\'') && value_text.ends_with('\'') {
+                let contains_double_quote = value_text.contains('"');
+
+                let range = if value_text.starts_with('\'')
+                    && value_text.ends_with('\'')
+                    && !contains_double_quote
+                {
                     value.text_range().add_start(1.into()).sub_end(1.into())
                 } else {
                     value.text_range()
                 };
-                write!(
-                    f,
-                    [format_replaced(
-                        value,
-                        &group(&format_args![
-                            text("\""),
-                            located_token_text(value, range),
-                            text("\""),
-                        ])
-                    )]
-                )?;
+
+                if !contains_double_quote {
+                    write!(
+                        f,
+                        [format_replaced(
+                            value,
+                            &group(&format_args![
+                                text("\""),
+                                located_token_text(value, range),
+                                text("\""),
+                            ])
+                        )]
+                    )?;
+                } else {
+                    value.format().fmt(f)?;
+                }
                 return Ok(());
             }
         }

--- a/crates/biome_html_formatter/tests/spec_tests.rs
+++ b/crates/biome_html_formatter/tests/spec_tests.rs
@@ -4,6 +4,6 @@ mod spec_test;
 mod formatter {
 
     mod html {
-        tests_macros::gen_tests! {"tests/specs/**/*.html", crate::spec_test::run, "unknown"}
+        tests_macros::gen_tests! {"tests/specs/**/*.html", crate::spec_test::run, ""}
     }
 }

--- a/crates/biome_html_formatter/tests/specs/attributes-single-quotes.html
+++ b/crates/biome_html_formatter/tests/specs/attributes-single-quotes.html
@@ -1,0 +1,1 @@
+<img src='foo.png' alt='should keep "these" quotes' />

--- a/crates/biome_html_formatter/tests/specs/attributes-single-quotes.html.snap
+++ b/crates/biome_html_formatter/tests/specs/attributes-single-quotes.html.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: attributes-single-quotes.html
+---
+# Input
+
+```html
+<img src='foo.png' alt='should keep "these" quotes' />
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+-----
+
+```html
+<img src="foo.png" alt='should keep "these" quotes' />```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR makes it so that we keep single quotes but only when the string contains a `"`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a test.
