### PR TITLE
feat(grit): support for Grit pattern, predicate and function definitions

### DIFF
--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -18,8 +18,17 @@ pub enum CompileError {
     /// A metavariables was discovered in an unexpected context.
     UnexpectedMetavariable,
 
+    /// If a function with the same name is defined multiple times.
+    DuplicateFunctionDefinition(String),
+
     /// If a function or bubble pattern has multiple parameters with the same name.
     DuplicateParameters,
+
+    /// If a function with the same name is defined multiple times.
+    DuplicatePatternDefinition(String),
+
+    /// If a function with the same name is defined multiple times.
+    DuplicatePredicateDefinition(String),
 
     /// A metavariable was expected at the given range.
     InvalidMetavariableRange(ByteRange),
@@ -89,8 +98,17 @@ impl Diagnostic for CompileError {
             CompileError::UnexpectedMetavariable => {
                 fmt.write_markup(markup! { "Unexpected metavariable" })
             }
+            CompileError::DuplicateFunctionDefinition(name) => {
+                fmt.write_markup(markup! { "Duplicate function definition: "{{name}} })
+            }
             CompileError::DuplicateParameters => {
                 fmt.write_markup(markup! { "Duplicate parameters" })
+            }
+            CompileError::DuplicatePatternDefinition(name) => {
+                fmt.write_markup(markup! { "Duplicate pattern definition: "{{name}} })
+            }
+            CompileError::DuplicatePredicateDefinition(name) => {
+                fmt.write_markup(markup! { "Duplicate predicate definition: "{{name}} })
             }
             CompileError::InvalidMetavariableRange(_) => {
                 fmt.write_markup(markup! { "Invalid range for metavariable" })

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -45,9 +45,9 @@ pub struct GritExecContext<'a> {
 
     loadable_files: &'a [GritTargetFile],
     files: &'a FileOwners<GritTargetTree>,
-    functions: Vec<GritFunctionDefinition<GritQueryContext>>,
-    patterns: Vec<PatternDefinition<GritQueryContext>>,
-    predicates: Vec<PredicateDefinition<GritQueryContext>>,
+    functions: &'a [GritFunctionDefinition<GritQueryContext>],
+    patterns: &'a [PatternDefinition<GritQueryContext>],
+    predicates: &'a [PredicateDefinition<GritQueryContext>],
 }
 
 impl<'a> GritExecContext<'a> {
@@ -56,30 +56,33 @@ impl<'a> GritExecContext<'a> {
         name: Option<&'a str>,
         loadable_files: &'a [GritTargetFile],
         files: &'a FileOwners<GritTargetTree>,
+        functions: &'a [GritFunctionDefinition<GritQueryContext>],
+        patterns: &'a [PatternDefinition<GritQueryContext>],
+        predicates: &'a [PredicateDefinition<GritQueryContext>],
     ) -> Self {
         Self {
             lang,
             name,
             loadable_files,
             files,
-            functions: Vec::new(),
-            patterns: Vec::new(),
-            predicates: Vec::new(),
+            functions,
+            patterns,
+            predicates,
         }
     }
 }
 
 impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext<'a> {
     fn pattern_definitions(&self) -> &[PatternDefinition<GritQueryContext>] {
-        &self.patterns
+        self.patterns
     }
 
     fn predicate_definitions(&self) -> &[PredicateDefinition<GritQueryContext>] {
-        &self.predicates
+        self.predicates
     }
 
     fn function_definitions(&self) -> &[GritFunctionDefinition<GritQueryContext>] {
-        &self.functions
+        self.functions
     }
 
     fn ignore_limit_pattern(&self) -> bool {

--- a/crates/biome_grit_patterns/src/grit_definitions.rs
+++ b/crates/biome_grit_patterns/src/grit_definitions.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+
+use crate::{
+    grit_context::GritQueryContext,
+    pattern_compiler::{
+        compilation_context::{DefinitionInfo, NodeCompilationContext},
+        FunctionDefinitionCompiler, PatternDefinitionCompiler, PredicateDefinitionCompiler,
+    },
+    util::TextRangeGritExt,
+    CompileError,
+};
+use biome_grit_syntax::{AnyGritDefinition, GritDefinitionList, GritVariableList};
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::{
+    GritFunctionDefinition, PatternDefinition, PredicateDefinition,
+};
+use grit_util::ByteRange;
+
+#[derive(Clone, Debug)]
+pub struct Definitions {
+    pub patterns: Vec<PatternDefinition<GritQueryContext>>,
+    pub predicates: Vec<PredicateDefinition<GritQueryContext>>,
+    pub functions: Vec<GritFunctionDefinition<GritQueryContext>>,
+}
+
+/// Compiles all definitions.
+///
+/// Must be called after [scan_definitions()].
+pub fn compile_definitions(
+    definitions: GritDefinitionList,
+    context: &mut NodeCompilationContext,
+) -> Result<Definitions, CompileError> {
+    let mut patterns = Vec::new();
+    let mut predicates = Vec::new();
+    let mut functions = Vec::new();
+    for definition in definitions {
+        match definition? {
+            AnyGritDefinition::AnyGritPattern(_) => continue, // Handled separately.
+            AnyGritDefinition::GritPatternDefinition(node) => {
+                patterns.push(PatternDefinitionCompiler::from_node(node, context)?);
+            }
+            AnyGritDefinition::GritPredicateDefinition(node) => {
+                predicates.push(PredicateDefinitionCompiler::from_node(node, context)?);
+            }
+            AnyGritDefinition::GritFunctionDefinition(node) => {
+                functions.push(FunctionDefinitionCompiler::from_node(node, context)?);
+            }
+            AnyGritDefinition::GritBogusDefinition(_) => {
+                unreachable!(); // Should be handled in `scan_definitions()`.
+            }
+        }
+    }
+
+    Ok(Definitions {
+        patterns,
+        predicates,
+        functions,
+    })
+}
+
+pub struct ScannedDefinitionInfo {
+    pub pattern_definition_info: BTreeMap<String, DefinitionInfo>,
+    pub predicate_definition_info: BTreeMap<String, DefinitionInfo>,
+    pub function_definition_info: BTreeMap<String, DefinitionInfo>,
+}
+
+/// Finds all definitions so that we can allocate their scopes in preparation
+/// for the compilation phase.
+pub fn scan_definitions(
+    definitions: GritDefinitionList,
+) -> Result<ScannedDefinitionInfo, CompileError> {
+    let mut pattern_definition_info = BTreeMap::new();
+    let mut pattern_index = 0;
+
+    let mut predicate_definition_info = BTreeMap::new();
+    let mut predicate_index = 0;
+
+    let mut function_definition_info = BTreeMap::new();
+    let mut function_index = 0;
+
+    for definition in definitions {
+        match definition? {
+            AnyGritDefinition::AnyGritPattern(_) => continue, // Handled separately.
+            AnyGritDefinition::GritPatternDefinition(node) => {
+                let name = node.name()?.text();
+                let name = name.trim();
+                if pattern_definition_info.contains_key(name) {
+                    return Err(CompileError::DuplicatePatternDefinition(name.to_owned()));
+                }
+
+                pattern_definition_info.insert(
+                    name.to_owned(),
+                    DefinitionInfo {
+                        index: pattern_index,
+                        parameters: collect_variables(node.args()?.grit_variable_list())?,
+                    },
+                );
+
+                pattern_index += 1;
+            }
+            AnyGritDefinition::GritPredicateDefinition(node) => {
+                let name = node.name()?.text();
+                let name = name.trim();
+                if predicate_definition_info.contains_key(name) {
+                    return Err(CompileError::DuplicatePredicateDefinition(name.to_owned()));
+                }
+
+                predicate_definition_info.insert(
+                    name.to_owned(),
+                    DefinitionInfo {
+                        index: predicate_index,
+                        parameters: collect_variables(node.args()?.grit_variable_list())?,
+                    },
+                );
+
+                predicate_index += 1;
+            }
+            AnyGritDefinition::GritFunctionDefinition(node) => {
+                let name = node.name()?.text();
+                let name = name.trim();
+                if function_definition_info.contains_key(name) {
+                    return Err(CompileError::DuplicateFunctionDefinition(name.to_owned()));
+                }
+
+                function_definition_info.insert(
+                    name.to_owned(),
+                    DefinitionInfo {
+                        index: function_index,
+                        parameters: collect_variables(node.args())?,
+                    },
+                );
+
+                function_index += 1;
+            }
+            AnyGritDefinition::GritBogusDefinition(bogus) => {
+                return Err(CompileError::UnexpectedKind(
+                    bogus
+                        .items()
+                        .next()
+                        .map(|item| item.kind().into())
+                        .unwrap_or_default(),
+                ));
+            }
+        }
+    }
+
+    Ok(ScannedDefinitionInfo {
+        pattern_definition_info,
+        predicate_definition_info,
+        function_definition_info,
+    })
+}
+
+fn collect_variables(
+    variables: GritVariableList,
+) -> Result<Vec<(String, ByteRange)>, CompileError> {
+    variables
+        .into_iter()
+        .map(|var| {
+            let token = var?.value_token()?;
+            Ok((
+                token.text_trimmed().to_string(),
+                token.text_trimmed_range().to_byte_range(),
+            ))
+        })
+        .collect()
+}

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -1,5 +1,8 @@
 use crate::diagnostics::CompilerDiagnostic;
 use crate::grit_context::{GritExecContext, GritQueryContext, GritTargetFile};
+use crate::grit_definitions::{
+    compile_definitions, scan_definitions, Definitions, ScannedDefinitionInfo,
+};
 use crate::grit_resolved_pattern::GritResolvedPattern;
 use crate::grit_target_language::GritTargetLanguage;
 use crate::grit_tree::GritTargetTree;
@@ -39,6 +42,9 @@ const GLOBAL_VARS: [(&str, usize); 4] = [
 #[derive(Clone, Debug)]
 pub struct GritQuery {
     pub pattern: Pattern<GritQueryContext>,
+
+    /// Definitions for named patterns, predicates and functions.
+    pub definitions: Definitions,
 
     /// Diagnostics discovered during compilation of the query.
     pub diagnostics: Vec<CompilerDiagnostic>,
@@ -91,16 +97,28 @@ impl GritQuery {
 
     pub fn from_node(
         root: GritRoot,
-        path: Option<&Path>,
+        source_path: Option<&Path>,
         lang: GritTargetLanguage,
     ) -> Result<Self, CompileError> {
-        let context = CompilationContext::new(path, lang);
+        let ScannedDefinitionInfo {
+            pattern_definition_info,
+            predicate_definition_info,
+            function_definition_info,
+        } = scan_definitions(root.definitions())?;
+
+        let context = CompilationContext {
+            source_path,
+            lang,
+            pattern_definition_info,
+            predicate_definition_info,
+            function_definition_info,
+        };
 
         let mut vars_array = vec![GLOBAL_VARS
             .iter()
             .map(|global_var| VariableSourceLocations {
                 name: global_var.0.to_string(),
-                file: path
+                file: source_path
                     .map(Path::to_string_lossy)
                     .map_or_else(|| "unnamed".to_owned(), |p| p.to_string()),
                 locations: BTreeSet::new(),
@@ -124,22 +142,23 @@ impl GritQuery {
             &mut diagnostics,
         );
 
+        let mut definitions = compile_definitions(root.definitions(), &mut node_context)?;
+
         let pattern = PatternCompiler::from_node(
             &root.pattern().ok_or(CompileError::MissingPattern)?,
             &mut node_context,
         )?;
 
-        let mut pattern_definitions = Vec::new();
         let pattern = auto_wrap_pattern(
             pattern,
-            &mut pattern_definitions,
+            &mut definitions.patterns,
             true,
             None,
             &mut node_context,
             None,
         )?;
 
-        let name = path
+        let name = source_path
             .and_then(Path::file_stem)
             .map(OsStr::to_string_lossy)
             .map(|stem| stem.into_owned());
@@ -148,6 +167,7 @@ impl GritQuery {
 
         Ok(Self {
             pattern,
+            definitions,
             name,
             language,
             diagnostics,

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -69,6 +69,9 @@ impl GritQuery {
             self.name.as_deref(),
             &files,
             &file_owners,
+            &self.definitions.functions,
+            &self.definitions.patterns,
+            &self.definitions.predicates,
         );
 
         let var_registry = VarRegistry::from_locations(&self.variable_locations);

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -4,6 +4,7 @@ mod grit_analysis_ext;
 mod grit_binding;
 mod grit_code_snippet;
 mod grit_context;
+mod grit_definitions;
 mod grit_file;
 mod grit_js_parser;
 mod grit_node;

--- a/crates/biome_grit_patterns/src/pattern_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler.rs
@@ -37,6 +37,7 @@ mod contains_compiler;
 mod divide_compiler;
 mod equal_compiler;
 mod every_compiler;
+mod function_definition_compiler;
 mod if_compiler;
 mod includes_compiler;
 mod like_compiler;
@@ -53,8 +54,10 @@ mod multiply_compiler;
 mod node_like_compiler;
 mod not_compiler;
 mod or_compiler;
+mod pattern_definition_compiler;
 mod predicate_call_compiler;
 mod predicate_compiler;
+mod predicate_definition_compiler;
 mod predicate_return_compiler;
 mod regex_compiler;
 mod rewrite_compiler;
@@ -66,6 +69,10 @@ mod subtract_compiler;
 mod variable_compiler;
 mod where_compiler;
 mod within_compiler;
+
+pub use function_definition_compiler::FunctionDefinitionCompiler;
+pub use pattern_definition_compiler::PatternDefinitionCompiler;
+pub use predicate_definition_compiler::PredicateDefinitionCompiler;
 
 use self::{
     accumulate_compiler::AccumulateCompiler, add_compiler::AddCompiler,

--- a/crates/biome_grit_patterns/src/pattern_compiler/and_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/and_compiler.rs
@@ -3,7 +3,7 @@ use super::{
     PatternCompiler,
 };
 use crate::{grit_context::GritQueryContext, CompileError};
-use biome_grit_syntax::{GritPatternAnd, GritPredicateAnd};
+use biome_grit_syntax::{GritPatternAnd, GritPatternList, GritPredicateAnd, GritPredicateList};
 use grit_pattern_matcher::pattern::{And, PrAnd};
 
 pub(crate) struct AndCompiler;
@@ -13,8 +13,14 @@ impl AndCompiler {
         node: &GritPatternAnd,
         context: &mut NodeCompilationContext,
     ) -> Result<And<GritQueryContext>, CompileError> {
-        let patterns = node
-            .patterns()
+        Self::from_patterns(node.patterns(), context)
+    }
+
+    pub(crate) fn from_patterns(
+        patterns: GritPatternList,
+        context: &mut NodeCompilationContext,
+    ) -> Result<And<GritQueryContext>, CompileError> {
+        let patterns = patterns
             .into_iter()
             .map(|pattern| match pattern {
                 Ok(pattern) => Ok(PatternCompiler::from_node(&pattern, context)?),
@@ -33,8 +39,14 @@ impl PrAndCompiler {
         node: &GritPredicateAnd,
         context: &mut NodeCompilationContext,
     ) -> Result<PrAnd<GritQueryContext>, CompileError> {
-        let predicates = node
-            .predicates()
+        Self::from_predicates(node.predicates(), context)
+    }
+
+    pub(crate) fn from_predicates(
+        predicates: GritPredicateList,
+        context: &mut NodeCompilationContext,
+    ) -> Result<PrAnd<GritQueryContext>, CompileError> {
+        let predicates = predicates
             .into_iter()
             .map(|predicate| match predicate {
                 Ok(predicate) => Ok(PredicateCompiler::from_node(&predicate, context)?),

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -3,9 +3,9 @@ use crate::{grit_context::GritQueryContext, CompileError, NodeLikeArgumentError}
 use biome_grit_syntax::{
     AnyGritMaybeNamedArg, AnyGritPattern, GritNamedArgList, GritNodeLike, GritSyntaxKind,
 };
-use biome_rowan::{AstNode, TextRange};
+use biome_rowan::AstNode;
 use grit_pattern_matcher::pattern::{Call, CallFunction, FilePattern, Pattern};
-use grit_util::Language;
+use grit_util::{ByteRange, Language};
 use std::collections::BTreeMap;
 
 const VALID_FILE_ARGS: &[&str] = &["$name", "$body"];
@@ -58,7 +58,7 @@ pub(super) fn call_pattern_from_node_with_name(
     }
 }
 
-pub(super) fn collect_params(parameters: &[(String, TextRange)]) -> Vec<String> {
+pub(super) fn collect_params(parameters: &[(String, ByteRange)]) -> Vec<String> {
     parameters.iter().map(|p| p.0.clone()).collect()
 }
 

--- a/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
@@ -1,5 +1,5 @@
-use biome_rowan::TextRange;
 use grit_pattern_matcher::pattern::VariableSourceLocations;
+use grit_util::ByteRange;
 
 use crate::{diagnostics::CompilerDiagnostic, grit_target_language::GritTargetLanguage};
 use std::{collections::BTreeMap, path::Path};
@@ -17,6 +17,7 @@ pub(crate) struct CompilationContext<'a> {
 }
 
 impl<'a> CompilationContext<'a> {
+    #[cfg(test)]
     pub(crate) fn new(source_path: Option<&'a Path>, lang: GritTargetLanguage) -> Self {
         Self {
             source_path,
@@ -80,5 +81,5 @@ impl<'a> NodeCompilationContext<'a> {
 
 pub(crate) struct DefinitionInfo {
     pub(crate) index: usize,
-    pub(crate) parameters: Vec<(String, TextRange)>,
+    pub(crate) parameters: Vec<(String, ByteRange)>,
 }

--- a/crates/biome_grit_patterns/src/pattern_compiler/function_definition_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/function_definition_compiler.rs
@@ -1,0 +1,43 @@
+use super::{and_compiler::PrAndCompiler, compilation_context::NodeCompilationContext};
+use crate::{grit_context::GritQueryContext, CompileError};
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::{GritFunctionDefinition, Predicate};
+use std::collections::BTreeMap;
+
+pub struct FunctionDefinitionCompiler;
+
+impl FunctionDefinitionCompiler {
+    pub fn from_node(
+        node: biome_grit_syntax::GritFunctionDefinition,
+        context: &mut NodeCompilationContext,
+    ) -> Result<GritFunctionDefinition<GritQueryContext>, CompileError> {
+        let name = node.name()?.text();
+        let name = name.trim();
+        let mut local_vars = BTreeMap::new();
+        let (scope_index, mut context) = create_scope!(context, local_vars);
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+        let params = context.get_variables(
+            &context
+                .compilation
+                .function_definition_info
+                .get(name)
+                .ok_or_else(|| CompileError::UnknownFunctionOrPredicate(name.to_owned()))?
+                .parameters,
+        );
+
+        let body = Predicate::And(Box::new(PrAndCompiler::from_predicates(
+            node.body()?.predicates(),
+            &mut context,
+        )?));
+
+        let pattern_def = GritFunctionDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().copied().collect(),
+            body,
+        );
+        Ok(pattern_def)
+    }
+}

--- a/crates/biome_grit_patterns/src/pattern_compiler/pattern_definition_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/pattern_definition_compiler.rs
@@ -1,0 +1,44 @@
+use super::{and_compiler::AndCompiler, compilation_context::NodeCompilationContext};
+use crate::{grit_context::GritQueryContext, CompileError};
+use biome_grit_syntax::GritPatternDefinition;
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::{Pattern, PatternDefinition};
+use std::collections::BTreeMap;
+
+pub struct PatternDefinitionCompiler;
+
+impl PatternDefinitionCompiler {
+    pub fn from_node(
+        node: GritPatternDefinition,
+        context: &mut NodeCompilationContext,
+    ) -> Result<PatternDefinition<GritQueryContext>, CompileError> {
+        let name = node.name()?.text();
+        let name = name.trim();
+        let mut local_vars = BTreeMap::new();
+        let (scope_index, mut context) = create_scope!(context, local_vars);
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+        let params = context.get_variables(
+            &context
+                .compilation
+                .pattern_definition_info
+                .get(name)
+                .ok_or_else(|| CompileError::UnknownFunctionOrPattern(name.to_owned()))?
+                .parameters,
+        );
+
+        let body = Pattern::And(Box::new(AndCompiler::from_patterns(
+            node.body()?.patterns(),
+            &mut context,
+        )?));
+
+        let pattern_def = PatternDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().copied().collect(),
+            body,
+        );
+        Ok(pattern_def)
+    }
+}

--- a/crates/biome_grit_patterns/src/pattern_compiler/predicate_definition_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/predicate_definition_compiler.rs
@@ -1,0 +1,44 @@
+use super::{and_compiler::PrAndCompiler, compilation_context::NodeCompilationContext};
+use crate::{grit_context::GritQueryContext, CompileError};
+use biome_grit_syntax::GritPredicateDefinition;
+use biome_rowan::AstNode;
+use grit_pattern_matcher::pattern::{Predicate, PredicateDefinition};
+use std::collections::BTreeMap;
+
+pub struct PredicateDefinitionCompiler;
+
+impl PredicateDefinitionCompiler {
+    pub fn from_node(
+        node: GritPredicateDefinition,
+        context: &mut NodeCompilationContext,
+    ) -> Result<PredicateDefinition<GritQueryContext>, CompileError> {
+        let name = node.name()?.text();
+        let name = name.trim();
+        let mut local_vars = BTreeMap::new();
+        let (scope_index, mut context) = create_scope!(context, local_vars);
+        // important that this occurs first, as calls assume
+        // that parameters are registered first
+        let params = context.get_variables(
+            &context
+                .compilation
+                .predicate_definition_info
+                .get(name)
+                .ok_or_else(|| CompileError::UnknownFunctionOrPredicate(name.to_owned()))?
+                .parameters,
+        );
+
+        let body = Predicate::And(Box::new(PrAndCompiler::from_predicates(
+            node.body()?.predicates(),
+            &mut context,
+        )?));
+
+        let pattern_def = PredicateDefinition::new(
+            name.to_owned(),
+            scope_index,
+            params,
+            local_vars.values().copied().collect(),
+            body,
+        );
+        Ok(pattern_def)
+    }
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.grit
@@ -1,0 +1,4 @@
+pattern console_method_to_info($method) {
+  `console.$method($message)` => `console.info($message)`
+}
+console_method_to_info(method = `log`)

--- a/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: patternDefinition
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "1:1-1:29",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/patternDefinition.ts
@@ -1,0 +1,2 @@
+console.log('Hello, world!');
+console.warn('Can you hear me?');


### PR DESCRIPTION
## Summary

Adds support for Grit definitions:
- Pattern and predicates: https://docs.grit.io/guides/patterns
- Functions: https://docs.grit.io/language/functions#function-definitions

## Test Plan

Added a test. I admit test coverage is a bit light still, but I'll expand later as I improve the support for functions, since we currently don't have any built-in functions yet.
