### PR TITLE
fix(grit): fix node walking

### DIFF
--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -506,6 +506,9 @@ impl<'a> AstCursor for GritTargetNodeCursor<'a> {
     }
 
     fn goto_next_sibling(&mut self) -> bool {
+        if self.node == self.root {
+            return false;
+        }
         match self.node.next_sibling() {
             Some(sibling) => {
                 self.node = sibling;

--- a/crates/biome_grit_patterns/tests/quick_test.rs
+++ b/crates/biome_grit_patterns/tests/quick_test.rs
@@ -7,7 +7,12 @@ use biome_js_syntax::JsFileSource;
 #[ignore]
 #[test]
 fn test_query() {
-    let parse_grit_result = parse_grit("`foo.$x && foo.$x()`");
+    let parse_grit_result = parse_grit(
+        "`console.log($args)` where {
+    $args <: contains `world`
+}
+",
+    );
     if !parse_grit_result.diagnostics().is_empty() {
         panic!("Cannot parse query:\n{:?}", parse_grit_result.diagnostics());
     }
@@ -23,7 +28,9 @@ fn test_query() {
         println!("Diagnostics from compiling query:\n{:?}", query.diagnostics);
     }
 
-    let body = r#"foo.bar && foo.bar();
+    let body = r#"console.log("hello, world");
+console.log("hello", world);
+console.log(`hello ${world}`);
 "#;
 
     let file = GritTargetFile {
@@ -32,5 +39,5 @@ fn test_query() {
     };
     let results = query.execute(file).expect("could not execute query");
 
-    println!("Results: {results:?}");
+    println!("Results: {results:#?}");
 }

--- a/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.grit
@@ -1,0 +1,3 @@
+`console.log($args)` where {
+    $args <: contains `world`
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: containsSnippet
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "2:1-2:28",
+        "3:1-3:30",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/containsSnippet.ts
@@ -1,0 +1,3 @@
+console.log("hello, world");
+console.log("hello", world);
+console.log(`hello ${world}`);


### PR DESCRIPTION
## Summary

Due to a bug in our Grit node cursor, `contains` queries would report false positives when the matched node was contained in a sibling instead of inside the node itself. This is the issue we witnessed when drafting the 1.9 release notes, @Conaclos.

## Test Plan

Test added.
