### PR TITLE
fix(graphql_formatter): panic in block comments with empty line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ New entries must be placed in a section entitled `Unreleased`.
 Read
 our [guidelines for writing a good changelog entry](https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#changelog).
 
+## Unreleased
+
+### Analyzer
+
+### CLI
+
+### Configuration
+
+### Editors
+
+### Formatter
+
+#### Bug fixes
+
+- Fix [#3924](https://github.com/biomejs/biome/issues/3924) where GraphQL formatter panics in block comments with empty line. Contributed by @vohoanglong0107
+
+### JavaScript API
+
+### Linter
+
+### Parser
+
 ## v1.9.2 (2024-09-19)
 
 ### CLI

--- a/crates/biome_graphql_formatter/src/graphql/value/string_value.rs
+++ b/crates/biome_graphql_formatter/src/graphql/value/string_value.rs
@@ -40,14 +40,18 @@ impl FormatNodeRule<GraphqlStringValue> for FormatGraphqlStringValue {
 
                 let mut start = token.text_trimmed_range().start();
                 for line in trimmed_content.lines() {
+                    if line.is_empty() || is_blank(line) {
+                        // if the line is empty,
+                        // write an empty line because two hardline breaks don't work
+                        join.entry(&empty_line());
+                        continue;
+                    }
                     // Write the line with the minimum indentation level removed
                     // SAFETY: min_indent is always less than or equal to the length of the line
                     join.entry(&dynamic_text(&line[min_indent..], start));
                     start += line.text_len();
 
                     if line.is_empty() {
-                        // if the line is empty,
-                        // write an empty line because two hardline breaks don't work
                         join.entry(&empty_line());
                     } else {
                         // Write a hard line break after each line
@@ -66,4 +70,8 @@ impl FormatNodeRule<GraphqlStringValue> for FormatGraphqlStringValue {
             write![f, [graphql_string_literal_token.format()]]
         }
     }
+}
+
+fn is_blank(line: &str) -> bool {
+    line.chars().all(|c| c.is_whitespace())
 }

--- a/crates/biome_graphql_formatter/tests/specs/prettier/graphql/comments/fields.graphql
+++ b/crates/biome_graphql_formatter/tests/specs/prettier/graphql/comments/fields.graphql
@@ -2,4 +2,13 @@ query {
   someField # Trailing comment
 }
 
+type Foo {
+  """
+  empty line
 
+  line with spaces and tabs
+               		
+  comment
+  """
+  bar: Int
+}

--- a/crates/biome_graphql_formatter/tests/specs/prettier/graphql/comments/fields.graphql.prettier-snap
+++ b/crates/biome_graphql_formatter/tests/specs/prettier/graphql/comments/fields.graphql.prettier-snap
@@ -1,3 +1,14 @@
 query {
   someField # Trailing comment
 }
+
+type Foo {
+  """
+  empty line
+
+  line with spaces and tabs
+
+  comment
+  """
+  bar: Int
+}


### PR DESCRIPTION
## Summary

Fixes #3924
Previously the formatter tried to format block comments by removing the indentation in those comments, but it forgot to take empty lines into account when calculating and subtracting the indent level.

Also allows the formatter to format line with only spaces and tabs

## Test Plan

Added a new test containing block comment with empty lines and lines with only white spaces
