### PR TITLE
chore: enforce usage of to_ascii_lowercase_cow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ name = "biome_css_syntax"
 version = "0.5.7"
 dependencies = [
  "biome_rowan",
+ "biome_string_case",
  "schemars",
  "serde",
 ]
@@ -575,6 +576,7 @@ name = "biome_graphql_syntax"
 version = "0.1.0"
 dependencies = [
  "biome_rowan",
+ "biome_string_case",
  "schemars",
  "serde",
 ]
@@ -705,6 +707,7 @@ name = "biome_html_syntax"
 version = "0.5.7"
 dependencies = [
  "biome_rowan",
+ "biome_string_case",
  "schemars",
  "serde",
 ]
@@ -827,6 +830,7 @@ dependencies = [
  "biome_js_factory",
  "biome_js_parser",
  "biome_rowan",
+ "biome_string_case",
  "enumflags2",
  "schemars",
  "serde",
@@ -921,6 +925,7 @@ name = "biome_json_syntax"
 version = "0.5.7"
 dependencies = [
  "biome_rowan",
+ "biome_string_case",
  "schemars",
  "serde",
 ]
@@ -1227,6 +1232,7 @@ name = "biome_yaml_syntax"
 version = "0.0.1"
 dependencies = [
  "biome_rowan",
+ "biome_string_case",
  "schemars",
  "serde",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,6 @@
 allow-dbg-in-tests = true
+
+disallowed-methods = [
+  { path = "str::to_ascii_lowercase", reason = "Avoid memory allocation. Use `biome_string_case::StrExtension::to_ascii_lowercase_cow` instead." },
+  { path = "std::ffi::OsStr::to_ascii_lowercase", reason = "Avoid memory allocation. Use `biome_string_case::StrExtension::to_ascii_lowercase_cow` instead." }
+]

--- a/crates/biome_css_syntax/Cargo.toml
+++ b/crates/biome_css_syntax/Cargo.toml
@@ -13,9 +13,10 @@ version              = "0.5.7"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [features]
 schema = ["schemars", "biome_rowan/serde"]

--- a/crates/biome_css_syntax/src/file_source.rs
+++ b/crates/biome_css_syntax/src/file_source.rs
@@ -1,4 +1,5 @@
 use biome_rowan::FileSourceError;
+use biome_string_case::StrExtension;
 use std::{ffi::OsStr, path::Path};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -73,6 +74,6 @@ impl TryFrom<&Path> for CssFileSource {
         };
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
-        Self::try_from_extension(&extension.to_ascii_lowercase())
+        Self::try_from_extension(&extension.to_ascii_lowercase_cow())
     }
 }

--- a/crates/biome_graphql_syntax/Cargo.toml
+++ b/crates/biome_graphql_syntax/Cargo.toml
@@ -13,9 +13,10 @@ version              = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [features]
 schema = ["schemars", "biome_rowan/serde"]

--- a/crates/biome_graphql_syntax/src/file_source.rs
+++ b/crates/biome_graphql_syntax/src/file_source.rs
@@ -1,4 +1,5 @@
 use biome_rowan::FileSourceError;
+use biome_string_case::StrExtension;
 use std::ffi::OsStr;
 use std::path::Path;
 
@@ -70,6 +71,6 @@ impl TryFrom<&Path> for GraphqlFileSource {
         };
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
-        Self::try_from_extension(&extension.to_ascii_lowercase())
+        Self::try_from_extension(&extension.to_ascii_lowercase_cow())
     }
 }

--- a/crates/biome_html_syntax/Cargo.toml
+++ b/crates/biome_html_syntax/Cargo.toml
@@ -13,9 +13,10 @@ version              = "0.5.7"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [features]
 schema = ["schemars", "biome_rowan/serde"]

--- a/crates/biome_html_syntax/src/file_source.rs
+++ b/crates/biome_html_syntax/src/file_source.rs
@@ -1,4 +1,5 @@
 use biome_rowan::FileSourceError;
+use biome_string_case::StrExtension;
 use std::{ffi::OsStr, path::Path};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -79,6 +80,6 @@ impl TryFrom<&Path> for HtmlFileSource {
         };
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
-        Self::try_from_extension(&extension.to_ascii_lowercase())
+        Self::try_from_extension(&extension.to_ascii_lowercase_cow())
     }
 }

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -11,10 +11,11 @@ repository.workspace = true
 version              = "0.5.7"
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-enumflags2  = { workspace = true }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+enumflags2        = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 biome_js_factory = { path = "../biome_js_factory" }

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -1,4 +1,5 @@
 use biome_rowan::FileSourceError;
+use biome_string_case::StrExtension;
 use std::{borrow::Cow, ffi::OsStr, path::Path};
 
 /// Enum of the different ECMAScript standard versions.
@@ -362,7 +363,7 @@ impl TryFrom<&Path> for JsFileSource {
             .file_name()
             // We assume the file extensions are case-insensitive.
             // Thus, we normalize the filrname to lowercase.
-            .map(|filename| filename.as_encoded_bytes().to_ascii_lowercase());
+            .map(|filename| filename.as_encoded_bytes().to_ascii_lowercase_cow());
 
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
@@ -377,7 +378,7 @@ impl TryFrom<&Path> for JsFileSource {
                 .extension()
                 // We assume the file extensions are case-insensitive.
                 // Thus, we normalize the extension to lowercase.
-                .map(|ext| Cow::Owned(ext.to_ascii_lowercase()))
+                .map(|ext| ext.to_ascii_lowercase_cow())
                 .ok_or(FileSourceError::MissingFileExtension)?,
         };
 

--- a/crates/biome_json_syntax/Cargo.toml
+++ b/crates/biome_json_syntax/Cargo.toml
@@ -13,9 +13,10 @@ version              = "0.5.7"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [features]
 schema = ["biome_rowan/serde", "schemars"]

--- a/crates/biome_json_syntax/src/file_source.rs
+++ b/crates/biome_json_syntax/src/file_source.rs
@@ -1,4 +1,5 @@
 use biome_rowan::FileSourceError;
+use biome_string_case::StrExtension;
 use core::str;
 use std::{
     ffi::OsStr,
@@ -279,7 +280,7 @@ impl TryFrom<&Path> for JsonFileSource {
         };
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
-        Self::try_from_extension(&extension.to_ascii_lowercase())
+        Self::try_from_extension(&extension.to_ascii_lowercase_cow())
     }
 }
 

--- a/crates/biome_string_case/src/lib.rs
+++ b/crates/biome_string_case/src/lib.rs
@@ -426,6 +426,7 @@ impl StrExtension for str {
     fn to_ascii_lowercase_cow(&self) -> Cow<Self> {
         let has_ascii_uppercase = self.bytes().any(|b| b.is_ascii_uppercase());
         if has_ascii_uppercase {
+            #[allow(clippy::disallowed_methods)]
             Cow::Owned(self.to_ascii_lowercase())
         } else {
             Cow::Borrowed(self)
@@ -440,6 +441,7 @@ impl StrExtension for std::ffi::OsStr {
             .iter()
             .any(|b| b.is_ascii_uppercase());
         if has_ascii_uppercase {
+            #[allow(clippy::disallowed_methods)]
             Cow::Owned(self.to_ascii_lowercase())
         } else {
             Cow::Borrowed(self)

--- a/crates/biome_yaml_syntax/Cargo.toml
+++ b/crates/biome_yaml_syntax/Cargo.toml
@@ -14,9 +14,10 @@ version              = "0.0.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-biome_rowan = { workspace = true, features = ["serde"] }
-schemars    = { workspace = true, optional = true }
-serde       = { workspace = true, features = ["derive"] }
+biome_rowan       = { workspace = true, features = ["serde"] }
+biome_string_case = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, features = ["derive"] }
 
 [features]
 schema = ["biome_rowan/serde", "schemars"]

--- a/crates/biome_yaml_syntax/src/file_source.rs
+++ b/crates/biome_yaml_syntax/src/file_source.rs
@@ -1,5 +1,6 @@
 use biome_rowan::FileSourceError;
 use std::{ffi::OsStr, path::Path};
+use biome_string_case::StrExtension;
 
 #[cfg_attr(feature = "schema", derive(schemars::YamlSchema))]
 #[derive(
@@ -88,7 +89,7 @@ impl TryFrom<&Path> for YamlFileSource {
         };
         // We assume the file extensions are case-insensitive
         // and we use the lowercase form of them for pattern matching
-        Self::try_from_extension(&extension.to_ascii_lowercase())
+        Self::try_from_extension(&extension.to_ascii_lowercase_cow())
     }
 }
 


### PR DESCRIPTION
## Summary

Basically the same ideas as https://github.com/oxc-project/oxc/issues/5586.
Enforce usage of `biome_string_case::StrExtension::to_ascii_lowercase_cow` with Clippy to minimize memory allocation.

## Test Plan

All existing tests should pass.