### PR TITLE
feat(linter): support direct const assertions in useExplicitFunctionReturnType rule

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -192,10 +192,8 @@ impl Rule for UseExplicitFunctionReturnType {
 
 /**
  * Checks if an arrow function immediately returns a `as const` value.
- * ```
  * const func = (value: number) => ({ foo: 'bar', value }) as const;
  * const func = () => x as const;
- * ```
  */
 fn is_direct_const_assertion_in_arrow_functions(func: &AnyJsFunction) -> bool {
     let AnyJsFunction::JsArrowFunctionExpression(arrow_func) = func else {

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -61,6 +61,11 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
+    /// ```ts,expect_diagnostic
+    /// // Should use const assertions
+    /// const func = (value: number) => ({ type: 'X', value }) as any;
+    /// ```
+    ///
     /// ### Valid
     /// ```ts
     /// // No return value should be expected (void)
@@ -88,6 +93,10 @@ declare_lint_rule! {
     ///     return;
     ///   }
     /// }
+    /// ```
+    ///
+    /// ```ts
+    /// const func = (value: number) => ({ foo: 'bar', value }) as const;
     /// ```
     ///
     pub UseExplicitFunctionReturnType {

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
@@ -38,3 +38,6 @@ const obj = {
     return "test"
   },
 };
+
+const func = (value: number) => ({ type: 'X', value }) as any;
+const func = (value: number) => ({ type: 'X', value }) as Action;

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
@@ -45,6 +45,8 @@ const obj = {
   },
 };
 
+const func = (value: number) => ({ type: 'X', value }) as any;
+const func = (value: number) => ({ type: 'X', value }) as Action;
 ```
 
 # Diagnostics
@@ -247,6 +249,40 @@ invalid.ts:37:3 lint/nursery/useExplicitFunctionReturnType ━━━━━━━
        │   ^
     40 │ };
     41 │ 
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:42:14 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    40 │ };
+    41 │ 
+  > 42 │ const func = (value: number) => ({ type: 'X', value }) as any;
+       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    43 │ const func = (value: number) => ({ type: 'X', value }) as Action;
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:43:14 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    42 │ const func = (value: number) => ({ type: 'X', value }) as any;
+  > 43 │ const func = (value: number) => ({ type: 'X', value }) as Action;
+       │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -32,3 +32,6 @@ const obj = {
     return "test"
   },
 };
+
+const func = (value: number) => ({ foo: 'bar', value }) as const;
+const func = () => x as const;

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -39,4 +39,6 @@ const obj = {
   },
 };
 
+const func = (value: number) => ({ foo: 'bar', value }) as const;
+const func = () => x as const;
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Related issue: https://github.com/biomejs/biome/issues/2017

Implemented support for direct const assertions in arrow functions in this rule. (`allowDirectConstAssertionInArrowFunctions` in typescript-eslint/explicit-function-return-type)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
