### PR TITLE
feat(lsp): `noExcessiveCognitiveComplexity` diagnostic shows levels

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
@@ -118,8 +118,10 @@ impl Rule for NoExcessiveCognitiveComplexity {
                 rule_category!(),
                 range,
                 markup!({ 
-                    format!("Excessive complexity of {calculated_score} detected \
-                    (max: {max_allowed_complexity}).") 
+                    format!(
+                        "Excessive complexity of {calculated_score} detected \
+                    (max: {max_allowed_complexity})."
+                    ) 
                 }),
             )
             .note(if calculated_score == &MAX_SCORE {

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
@@ -117,7 +117,7 @@ impl Rule for NoExcessiveCognitiveComplexity {
             RuleDiagnostic::new(
                 rule_category!(),
                 range,
-                markup!({ 
+                markup!({
                     format!(
                         "Excessive complexity of {calculated_score} detected \
                     (max: {max_allowed_complexity})."

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
@@ -121,7 +121,7 @@ impl Rule for NoExcessiveCognitiveComplexity {
                     format!(
                         "Excessive complexity of {calculated_score} detected \
                     (max: {max_allowed_complexity})."
-                    ) 
+                    )
                 }),
             )
             .note(if calculated_score == &MAX_SCORE {

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_cognitive_complexity.rs
@@ -117,7 +117,10 @@ impl Rule for NoExcessiveCognitiveComplexity {
             RuleDiagnostic::new(
                 rule_category!(),
                 range,
-                markup!("Excessive complexity detected."),
+                markup!({ 
+                    format!("Excessive complexity of {calculated_score} detected \
+                    (max: {max_allowed_complexity}).") 
+                }),
             )
             .note(if calculated_score == &MAX_SCORE {
                 "Please refactor this function to reduce its complexity. \

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/booleanOperators.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/booleanOperators.js.snap
@@ -19,7 +19,7 @@ function booleanOperators() {
 ```
 booleanOperators.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 4 detected (max: 3).
   
   > 1 │ function booleanOperators() {
       │          ^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/booleanOperators2.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/booleanOperators2.js.snap
@@ -18,7 +18,7 @@ function booleanOperators2() {
 ```
 booleanOperators2.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 3 detected (max: 2).
   
   > 1 │ function booleanOperators2() {
       │          ^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/complexEventHandler.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/complexEventHandler.ts.snap
@@ -106,7 +106,7 @@ function handleArrowDown(event: React.KeyboardEvent) {
 ```
 complexEventHandler.ts:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 26 detected (max: 15).
   
   > 1 │ function handleArrowDown(event: React.KeyboardEvent) {
       │          ^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/excessiveNesting.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/excessiveNesting.js.snap
@@ -38,7 +38,7 @@ function excessiveNesting() {
 ```
 excessiveNesting.js:10:46 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 255 detected (max: 15).
   
      8 │                             function nested7() {
      9 │                                 function nested8() {

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/functionalChain.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/functionalChain.js.snap
@@ -25,7 +25,7 @@ function functionalChain(array) {
 ```
 functionalChain.js:4:24 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 3 detected (max: 2).
   
     2 │     return array
     3 │         .filter(Boolean)

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/lambdas.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/lambdas.js.snap
@@ -40,7 +40,7 @@ function lambdas(array) {
 ```
 lambdas.js:4:26 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 4 detected (max: 3).
   
     2 │     for (item of array) {              // +1, nesting = 1
     3 │         if (item) {                    // +2, nesting = 2
@@ -57,7 +57,7 @@ lambdas.js:4:26 lint/complexity/noExcessiveCognitiveComplexity ━━━━━�
 ```
 lambdas.js:10:22 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 4 detected (max: 3).
   
      8 │             };
      9 │ 
@@ -74,7 +74,7 @@ lambdas.js:10:22 lint/complexity/noExcessiveCognitiveComplexity ━━━━━�
 ```
 lambdas.js:16:23 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 4 detected (max: 3).
   
     14 │             }
     15 │ 
@@ -91,7 +91,7 @@ lambdas.js:16:23 lint/complexity/noExcessiveCognitiveComplexity ━━━━━�
 ```
 lambdas.js:22:32 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 4 detected (max: 3).
   
     20 │             };
     21 │ 

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/nestedControlFlowStructures.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/nestedControlFlowStructures.js.snap
@@ -22,7 +22,7 @@ function nestedControlFlowStructures(num) {
 ```
 nestedControlFlowStructures.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 9 detected (max: 8).
   
   > 1 │ function nestedControlFlowStructures(num) {
       │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/simpleBranches.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/simpleBranches.js.snap
@@ -20,7 +20,7 @@ function simpleBranches() {
 ```
 simpleBranches.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 3 detected (max: 2).
   
   > 1 │ function simpleBranches() {
       │          ^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/simpleBranches2.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/simpleBranches2.js.snap
@@ -18,7 +18,7 @@ function simpleBranches2() {
 ```
 simpleBranches2.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 2 detected (max: 1).
   
   > 1 │ function simpleBranches2() {
       │          ^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/sumOfPrimes.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noExcessiveCognitiveComplexity/sumOfPrimes.js.snap
@@ -23,7 +23,7 @@ function sumOfPrimes(max) {
 ```
 sumOfPrimes.js:1:10 lint/complexity/noExcessiveCognitiveComplexity ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Excessive complexity detected.
+  ! Excessive complexity of 7 detected (max: 6).
   
   > 1 │ function sumOfPrimes(max) {
       │          ^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- When running the biome cli, it reports: `Please refactor this function to reduce its complexity score from 17 to the max allowed complexity 15`.
- In the editor, biome reports: `Excessive complexity detected. (biome: lint/complexity/noExcessiveCognitiveComplexity)`

see: https://github.com/biomejs/biome/discussions/4012

This PR simply inserts the levels in the diagnostic message to fix that.

I haven't touched any rust code before, but the change seems straightforward enough, though.