### PR TITLE
feat(linter): support allow expressions

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -253,6 +253,8 @@ fn is_function_used_in_argument_or_expression_list(func: &AnyJsFunction) -> bool
         Some(
             JsSyntaxKind::JS_CALL_ARGUMENT_LIST
                 | JsSyntaxKind::JS_ARRAY_ELEMENT_LIST
+                // We include JS_PARENTHESIZED_EXPRESSION for IIFE (Immediately Invoked Function Expressions).
+                // We also assume that the parent of the parent is a call expression.
                 | JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION
         )
     )

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -229,7 +229,7 @@ fn is_direct_const_assertion_in_arrow_functions(func: &AnyJsFunction) -> bool {
 }
 
 /**
- * Checks if a function are not part of a declaration
+ * Checks if a function is not part of a declaration
  * JS_CALL_ARGUMENT_LIST
  * - window.addEventListener('click', () => {});
  * - const foo = arr.map(i => i * i);

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
@@ -41,3 +41,6 @@ const obj = {
 
 const func = (value: number) => ({ type: 'X', value }) as any;
 const func = (value: number) => ({ type: 'X', value }) as Action;
+
+export default () => {};
+export default function () {}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
@@ -47,6 +47,9 @@ const obj = {
 
 const func = (value: number) => ({ type: 'X', value }) as any;
 const func = (value: number) => ({ type: 'X', value }) as Action;
+
+export default () => {};
+export default function () {}
 ```
 
 # Diagnostics
@@ -267,6 +270,7 @@ invalid.ts:42:14 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
   > 42 │ const func = (value: number) => ({ type: 'X', value }) as any;
        │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     43 │ const func = (value: number) => ({ type: 'X', value }) as Action;
+    44 │ 
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -283,6 +287,42 @@ invalid.ts:43:14 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
     42 │ const func = (value: number) => ({ type: 'X', value }) as any;
   > 43 │ const func = (value: number) => ({ type: 'X', value }) as Action;
        │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    44 │ 
+    45 │ export default () => {};
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:45:16 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    43 │ const func = (value: number) => ({ type: 'X', value }) as Action;
+    44 │ 
+  > 45 │ export default () => {};
+       │                ^^^^^^^^
+    46 │ export default function () {}
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:46:16 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    45 │ export default () => {};
+  > 46 │ export default function () {}
+       │                ^^^^^^^^^^^^^^
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -33,5 +33,25 @@ const obj = {
   },
 };
 
+export default (): void => {};
+export default function (): void {}
+
+// check direct const assertions
 const func = (value: number) => ({ foo: 'bar', value }) as const;
 const func = () => x as const;
+
+
+// check allow expressions
+node.addEventListener('click', () => {});
+node.addEventListener('click', function () {});
+const foo = arr.map(i => i * i);
+fn(() => {});
+fn(function () {});
+[function () {}, () => {}];
+(function () {
+  console.log("This is an IIFE");
+})();
+(() => {
+  console.log("This is an IIFE");
+})();
+setTimeout(function() { console.log("Hello!"); }, 1000);

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -39,6 +39,26 @@ const obj = {
   },
 };
 
+export default (): void => {};
+export default function (): void {}
+
+// check direct const assertions
 const func = (value: number) => ({ foo: 'bar', value }) as const;
 const func = () => x as const;
+
+
+// check allow expressions
+node.addEventListener('click', () => {});
+node.addEventListener('click', function () {});
+const foo = arr.map(i => i * i);
+fn(() => {});
+fn(function () {});
+[function () {}, () => {}];
+(function () {
+  console.log("This is an IIFE");
+})();
+(() => {
+  console.log("This is an IIFE");
+})();
+setTimeout(function() { console.log("Hello!"); }, 1000);
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Related issue: https://github.com/biomejs/biome/issues/2017

Implemented support for allow expressions in useExplicitFunctionReturnType rule. (`allowExpressions` in typescript-eslint/explicit-function-return-type)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
