### PR TITLE
perf(linter): performance improvement for css semantic model

### DIFF
--- a/crates/biome_css_analyze/src/services/semantic.rs
+++ b/crates/biome_css_analyze/src/services/semantic.rs
@@ -99,7 +99,6 @@ impl Visitor for SemanticModelBuilderVisitor {
     fn visit(&mut self, event: &WalkEvent<CssSyntaxNode>, _ctx: VisitorContext<CssLanguage>) {
         match event {
             WalkEvent::Enter(node) => {
-                self.builder.push_node(node);
                 self.extractor.enter(node);
             }
             WalkEvent::Leave(node) => {

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use biome_css_syntax::{CssRoot, CssSyntaxKind, CssSyntaxNode};
+use biome_css_syntax::CssRoot;
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 
@@ -12,7 +12,6 @@ use crate::events::SemanticEvent;
 
 pub struct SemanticModelBuilder {
     root: CssRoot,
-    node_by_range: FxHashMap<TextRange, CssSyntaxNode>,
     /// List of all top-level rules in the CSS file
     rules: Vec<Rule>,
     global_custom_variables: FxHashMap<String, CssGlobalCustomVariable>,
@@ -30,7 +29,6 @@ impl SemanticModelBuilder {
     pub fn new(root: CssRoot) -> Self {
         Self {
             root,
-            node_by_range: FxHashMap::default(),
             rules: Vec::new(),
             current_rule_stack: Vec::new(),
             global_custom_variables: FxHashMap::default(),
@@ -44,24 +42,12 @@ impl SemanticModelBuilder {
     pub fn build(self) -> SemanticModel {
         let data = SemanticModelData {
             root: self.root,
-            node_by_range: self.node_by_range,
             rules: self.rules,
             global_custom_variables: self.global_custom_variables,
             range_to_rule: self.range_to_rule,
             rules_by_id: self.rules_by_id,
         };
         SemanticModel::new(data)
-    }
-
-    #[inline]
-    pub fn push_node(&mut self, node: &CssSyntaxNode) {
-        use CssSyntaxKind::*;
-        if matches!(
-            node.kind(),
-            CSS_SELECTOR_LIST | CSS_DECLARATION | CSS_DECLARATION_OR_RULE_LIST | CSS_QUALIFIED_RULE
-        ) {
-            self.node_by_range.insert(node.text_range(), node.clone());
-        }
     }
 
     #[inline]

--- a/crates/biome_css_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_css_semantic/src/semantic_model/builder.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use biome_css_syntax::{CssRoot, CssSyntaxKind, CssSyntaxNode};
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
@@ -18,7 +20,7 @@ pub struct SemanticModelBuilder {
     current_rule_stack: Vec<RuleId>,
     next_rule_id: RuleId,
     /// Map to get the rule containing the given range of CST nodes
-    range_to_rule: FxHashMap<TextRange, Rule>,
+    range_to_rule: BTreeMap<TextRange, Rule>,
     rules_by_id: FxHashMap<RuleId, Rule>,
     /// Indicates if the current node is within a `:root` selector
     is_in_root_selector: bool,
@@ -32,7 +34,7 @@ impl SemanticModelBuilder {
             rules: Vec::new(),
             current_rule_stack: Vec::new(),
             global_custom_variables: FxHashMap::default(),
-            range_to_rule: FxHashMap::default(),
+            range_to_rule: BTreeMap::default(),
             is_in_root_selector: false,
             next_rule_id: RuleId::default(),
             rules_by_id: FxHashMap::default(),

--- a/crates/biome_css_semantic/src/semantic_model/mod.rs
+++ b/crates/biome_css_semantic/src/semantic_model/mod.rs
@@ -16,7 +16,6 @@ pub fn semantic_model(root: &CssRoot) -> SemanticModel {
     for node in root.preorder() {
         match node {
             biome_css_syntax::WalkEvent::Enter(node) => {
-                builder.push_node(&node);
                 extractor.enter(&node);
             }
             biome_css_syntax::WalkEvent::Leave(node) => extractor.leave(&node),

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, rc::Rc};
 
-use biome_css_syntax::{CssRoot, CssSyntaxNode};
+use biome_css_syntax::CssRoot;
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 
@@ -22,11 +22,6 @@ impl SemanticModel {
 
     pub fn root(&self) -> &CssRoot {
         &self.data.root
-    }
-
-    /// Retrieves a node by its text range.
-    pub fn node_by_range(&self, range: TextRange) -> Option<&CssSyntaxNode> {
-        self.data.node_by_range.get(&range)
     }
 
     /// Returns a slice of all rules in the CSS document.
@@ -61,8 +56,6 @@ impl SemanticModel {
 #[derive(Debug)]
 pub(crate) struct SemanticModelData {
     pub(crate) root: CssRoot,
-    /// Map to each by its range
-    pub(crate) node_by_range: FxHashMap<TextRange, CssSyntaxNode>,
     /// List of all top-level rules in the CSS document
     pub(crate) rules: Vec<Rule>,
     /// Map of CSS variables declared in the `:root` selector or using the @property rule.

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, rc::Rc};
 
 use biome_css_syntax::CssRoot;
-use biome_rowan::TextRange;
+use biome_rowan::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
 /// The façade for all semantic information of a CSS document.
@@ -39,13 +39,21 @@ impl SemanticModel {
 
     /// Returns the rule that contains the given range.
     pub fn get_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
-        let (_, rule) = self
-            .data
-            .range_to_rule
-            .range(..=target_range)
-            .rev()
-            .find(|(&range, _)| range.contains_range(target_range))?;
-        Some(rule)
+        if target_range.start() == TextSize::from(0) {
+            self.data
+                .range_to_rule
+                .iter()
+                .rev()
+                .find(|(&range, _)| range.contains_range(target_range))
+                .map(|(_, rule)| rule)
+        } else {
+            self.data
+                .range_to_rule
+                .range(..=target_range)
+                .rev()
+                .find(|(&range, _)| range.contains_range(target_range))
+                .map(|(_, rule)| rule)
+        }
     }
 }
 

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -39,6 +39,11 @@ impl SemanticModel {
 
     /// Returns the rule that contains the given range.
     pub fn get_rule_by_range(&self, target_range: TextRange) -> Option<&Rule> {
+        // Generally, this function narrows down the search before finding the most specific rule for better performance.
+        // But when the target range starts from 0, the BTreeMap's range method may not work as expected due to
+        // the comparison semantics of TextRange.
+
+        // Handle the edge case where the target range starts from 0.
         if target_range.start() == TextSize::from(0) {
             self.data
                 .range_to_rule

--- a/crates/biome_text_size/src/range.rs
+++ b/crates/biome_text_size/src/range.rs
@@ -13,7 +13,7 @@ use {
 /// A range in text, represented as a pair of [`TextSize`][struct@TextSize].
 ///
 /// It is a logic error for `start` to be greater than `end`.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct TextRange {
     // Invariant: start <= end
     start: TextSize,

--- a/crates/biome_text_size/src/range.rs
+++ b/crates/biome_text_size/src/range.rs
@@ -34,9 +34,9 @@ impl PartialOrd for TextRange {
 
 impl Ord for TextRange {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.end <= other.start {
+        if self.end < other.start {
             Ordering::Less
-        } else if self.start >= other.end {
+        } else if self.start > other.end {
             Ordering::Greater
         } else {
             Ordering::Equal

--- a/crates/biome_text_size/src/range.rs
+++ b/crates/biome_text_size/src/range.rs
@@ -34,12 +34,10 @@ impl PartialOrd for TextRange {
 
 impl Ord for TextRange {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.end < other.start {
-            Ordering::Less
-        } else if self.start > other.end {
-            Ordering::Greater
-        } else {
-            Ordering::Equal
+        match self.start.cmp(&other.start) {
+            Ordering::Less => Ordering::Less,
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Equal => self.end.cmp(&other.end),
         }
     }
 }

--- a/crates/biome_text_size/src/range.rs
+++ b/crates/biome_text_size/src/range.rs
@@ -13,7 +13,7 @@ use {
 /// A range in text, represented as a pair of [`TextSize`][struct@TextSize].
 ///
 /// It is a logic error for `start` to be greater than `end`.
-#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct TextRange {
     // Invariant: start <= end
     start: TextSize,
@@ -23,6 +23,24 @@ pub struct TextRange {
 impl fmt::Debug for TextRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}..{}", self.start().raw, self.end().raw)
+    }
+}
+
+impl PartialOrd for TextRange {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TextRange {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self.end <= other.start {
+            Ordering::Less
+        } else if self.start >= other.end {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
According to the [profile](https://codspeed.io/biomejs/biome/branches/togami2864:2784), get_rule_by_range and process_selector significantly affect performance.

I implemented the following improvements to address these issues:

- Replaced `FxHashMap` with `BTreeMap`  to search `range_to_rule` more efficiently.
- Used `Cow` to minimize unnecessary memory allocation in `process_selector`
- Removed unused functions.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
CI should pass
<!-- What demonstrates that your implementation is correct? -->
