### PR TITLE
refactor(aria_metadata): generate ARIA metadata from specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,8 +144,12 @@ name = "biome_aria_metadata"
 version = "0.5.7"
 dependencies = [
  "biome_string_case",
+ "prettyplease",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1300,7 +1304,7 @@ checksum = "cf95d9c7e6aba67f8fc07761091e93254677f4db9e27197adecebc7039a58722"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1798,7 +1802,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1968,7 +1972,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2467,7 +2471,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2794,6 +2798,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -3258,7 +3272,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3295,7 +3309,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3306,7 +3320,7 @@ checksum = "330f01ce65a3a5fe59a60c82f3c9a024b573b8a6e875bd233fe5f934e71d54e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3532,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3566,7 +3580,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3586,7 +3600,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3700,7 +3714,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3804,7 +3818,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3845,7 +3859,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4133,7 +4147,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -4155,7 +4169,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/biome.json
+++ b/biome.json
@@ -31,6 +31,7 @@
       "benchmark/target/**"
     ],
     "include": [
+      "packages/aria-data/*.js",
       "packages/@biomejs/**",
       "packages/tailwindcss-config-analyzer/**",
       "benchmark/**"

--- a/crates/biome_aria/src/lib.rs
+++ b/crates/biome_aria/src/lib.rs
@@ -24,20 +24,6 @@ pub fn is_aria_property_valid(property: &str) -> bool {
     AriaPropertiesEnum::from_str(property).is_ok()
 }
 
-/// It checks if an ARIA property type is valid
-///
-/// ## Examples
-///
-/// ```
-/// use biome_aria::is_aria_property_type_valid;
-///
-/// assert!(is_aria_property_type_valid("string"));
-/// assert!(!is_aria_property_type_valid("bogus"));
-/// ```
-pub fn is_aria_property_type_valid(property_type: &str) -> bool {
-    AriaPropertyTypeEnum::from_str(property_type).is_ok()
-}
-
 #[cfg(test)]
 mod test {
     use crate::roles::AriaRoles;

--- a/crates/biome_aria_metadata/CONTRIBUTING.md
+++ b/crates/biome_aria_metadata/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Biome ARIA metadata
+
+The `build.rs` script uses `aria-data.json` to generate ARIA metadata.
+`aria-data.json` is a symlink to `packages/aria-data/aria-data-<version>.json`.
+See the documentation of `packages/aria-data` to generate this file.

--- a/crates/biome_aria_metadata/Cargo.toml
+++ b/crates/biome_aria_metadata/Cargo.toml
@@ -17,8 +17,12 @@ version              = "0.5.7"
 
 [build-dependencies]
 biome_string_case = { workspace = true }
+prettyplease      = "0.2.22"
 proc-macro2       = { workspace = true, features = ["span-locations"] }
 quote             = { workspace = true }
+serde             = { workspace = true }
+serde_json        = { workspace = true }
+syn               = "2.0.76"
 
 [lints]
 workspace = true

--- a/crates/biome_aria_metadata/aria-data.json
+++ b/crates/biome_aria_metadata/aria-data.json
@@ -1,0 +1,1 @@
+../../packages/aria-data/aria-data-1-2.json

--- a/crates/biome_aria_metadata/build.rs
+++ b/crates/biome_aria_metadata/build.rs
@@ -1,151 +1,13 @@
-//! Metadata of:
-//! - ARIA properties
-//! - ARIA property types
-//! - ARIA roles
+//! Generate ARAI metadata from `./aria-data.json`
 
 use biome_string_case::Case;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::{env, fs, io};
 
-pub const ARIA_PROPERTIES: [&str; 48] = [
-    "aria-activedescendant",
-    "aria-atomic",
-    "aria-autocomplete",
-    "aria-busy",
-    "aria-checked",
-    "aria-colcount",
-    "aria-colindex",
-    "aria-colspan",
-    "aria-controls",
-    "aria-current",
-    "aria-describedby",
-    "aria-details",
-    "aria-disabled",
-    "aria-dropeffect",
-    "aria-errormessage",
-    "aria-expanded",
-    "aria-flowto",
-    "aria-grabbed",
-    "aria-haspopup",
-    "aria-hidden",
-    "aria-invalid",
-    "aria-keyshortcuts",
-    "aria-label",
-    "aria-labelledby",
-    "aria-level",
-    "aria-live",
-    "aria-modal",
-    "aria-multiline",
-    "aria-multiselectable",
-    "aria-orientation",
-    "aria-owns",
-    "aria-placeholder",
-    "aria-posinset",
-    "aria-pressed",
-    "aria-readonly",
-    "aria-relevant",
-    "aria-required",
-    "aria-roledescription",
-    "aria-rowcount",
-    "aria-rowindex",
-    "aria-rowspan",
-    "aria-selected",
-    "aria-setsize",
-    "aria-sort",
-    "aria-valuemax",
-    "aria-valuemin",
-    "aria-valuenow",
-    "aria-valuetext",
-];
-
-pub const ARIA_PROPERTY_TYPE: [&str; 9] = [
-    "boolean",
-    "id",
-    "idlist",
-    "integer",
-    "number",
-    "string",
-    "token",
-    "tokenlist",
-    "tristate",
-];
-
-pub const ARIA_WIDGET_ROLES: [&str; 27] = [
-    "alert",
-    "alertdialog",
-    "button",
-    "checkbox",
-    "dialog",
-    "gridcell",
-    "link",
-    "log",
-    "marquee",
-    "menuitem",
-    "menuitemcheckbox",
-    "menuitemradio",
-    "option",
-    "progressbar",
-    "radio",
-    "scrollbar",
-    "searchbox",
-    "slider",
-    "spinbutton",
-    "status",
-    "switch",
-    "tab",
-    "tabpanel",
-    "textbox",
-    "timer",
-    "tooltip",
-    "treeitem",
-];
-
-pub const ARIA_ABSTRACT_ROLES: [&str; 12] = [
-    "command",
-    "composite",
-    "input",
-    "landmark",
-    "range",
-    "roletype",
-    "section",
-    "sectionhead",
-    "select",
-    "structure",
-    "widget",
-    "window",
-];
-
-pub const ARIA_DOCUMENT_STRUCTURE_ROLES: [&str; 25] = [
-    "article",
-    "cell",
-    "columnheader",
-    "definition",
-    "directory",
-    "document",
-    "feed",
-    "figure",
-    "group",
-    "heading",
-    "img",
-    "list",
-    "listitem",
-    "math",
-    "none",
-    "note",
-    "presentation",
-    "region",
-    "row",
-    "rowgroup",
-    "rowheader",
-    "separator",
-    "table",
-    "term",
-    "toolbar",
-];
-
-const ISO_COUNTRIES: [&str; 233] = [
+const ISO_COUNTRIES: &[&str] = &[
     "AF", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ", "BS",
     "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BA", "BW", "BR", "IO", "VG", "BN",
     "BG", "BF", "MM", "BI", "KH", "CM", "CA", "CV", "KY", "CF", "TD", "CL", "CN", "CX", "CC", "CO",
@@ -163,7 +25,7 @@ const ISO_COUNTRIES: [&str; 233] = [
     "UZ", "VU", "VE", "VN", "WF", "EH", "YE", "ZM", "ZW",
 ];
 
-const ISO_LANGUAGES: [&str; 150] = [
+const ISO_LANGUAGES: &[&str] = &[
     "ab", "aa", "af", "sq", "am", "ar", "an", "hy", "as", "ay", "az", "ba", "eu", "bn", "dz", "bh",
     "bi", "br", "bg", "my", "be", "km", "ca", "zh", "zh-Hans", "zh-Hant", "co", "hr", "cs", "da",
     "nl", "en", "eo", "et", "fo", "fa", "fj", "fi", "fr", "fy", "gl", "gd", "gv", "ka", "de", "el",
@@ -176,17 +38,247 @@ const ISO_LANGUAGES: [&str; 150] = [
     "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
 ];
 
+#[derive(Debug, Default, serde::Deserialize)]
+struct Aria {
+    roles: BTreeMap<String, AriaRole>,
+    attributes: BTreeMap<String, AriaAttribute>,
+}
+
+impl Aria {
+    fn inherits_role(&self, role_name: &str, candidate_role_name: &str) -> Result<bool, String> {
+        if !self.roles.contains_key(candidate_role_name) {
+            return Err(format!("The role '{candidate_role_name}' doesn't exist"));
+        }
+        let mut stack = vec![role_name];
+        while let Some(role_name) = stack.pop() {
+            let Some(role) = self.roles.get(role_name) else {
+                return Err(format!("The role '{role_name}' doesn't exist"));
+            };
+            if role.superclass_roles.contains(candidate_role_name) {
+                return Ok(true);
+            }
+            stack.extend(role.superclass_roles.iter().map(String::as_str));
+        }
+        Ok(false)
+    }
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct AriaRole {
+    description: String,
+    deprecated_in_version: Option<String>,
+    is_abstract: bool,
+    superclass_roles: BTreeSet<String>,
+    subclass_roles: BTreeSet<String>,
+    base_concepts: BTreeSet<Concept>,
+    related_concepts: BTreeSet<Concept>,
+    allowed_child_roles: BTreeSet<String>,
+    required_parent_roles: BTreeSet<String>,
+    required_attributes: BTreeSet<AriaAttributeReference>,
+    supported_attributes: BTreeSet<AriaAttributeReference>,
+    inherited_attributes: BTreeSet<AriaAttributeReference>,
+    prohibited_attributes: BTreeSet<AriaAttributeReference>,
+    name_from: BTreeSet<AriaNameFrom>,
+    is_accessible_name_required: bool,
+    has_presentational_children: bool,
+    implicit_values_for_role: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum AriaNameFrom {
+    Author,
+    Contents,
+    Prohibited,
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+enum Concept {
+    /// An attribute or an element
+    Any {
+        name: String,
+        module: ConceptModule,
+    },
+    Attribute {
+        name: String,
+        module: ConceptModule,
+    },
+    Element {
+        name: String,
+        #[serde(default)]
+        attributes: BTreeMap<String, String>,
+        module: ConceptModule,
+    },
+    Role {
+        name: String,
+        module: ConceptModule,
+    },
+    Text {
+        name: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum ConceptModule {
+    Aria,
+    Daisy,
+    Dom,
+    #[serde(rename = "dublin core")]
+    DublinCore,
+    Html,
+    Japi,
+    Smil,
+    Svg,
+    Xforms,
+    Xhtml,
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(from = "AriaAttributeReferenceShortcut")]
+struct AriaAttributeReference {
+    name: String,
+    deprecated_in_version: Option<String>,
+}
+
+impl From<AriaAttributeReferenceShortcut> for AriaAttributeReference {
+    fn from(value: AriaAttributeReferenceShortcut) -> Self {
+        match value {
+            AriaAttributeReferenceShortcut::Active(name) => Self {
+                name,
+                deprecated_in_version: None,
+            },
+            AriaAttributeReferenceShortcut::Deprecated {
+                name,
+                deprecated_in_version,
+            } => Self {
+                name,
+                deprecated_in_version,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+#[serde(untagged, rename_all_fields = "camelCase")]
+enum AriaAttributeReferenceShortcut {
+    Active(String),
+    Deprecated {
+        name: String,
+        deprecated_in_version: Option<String>,
+    },
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct AriaAttribute {
+    r#type: AriaAttributeType,
+    description: String,
+    deprecated_in_version: Option<String>,
+    related_concepts: BTreeSet<Concept>,
+    used_in_roles: BTreeSet<String>,
+    inherits_into_roles: BTreeSet<String>,
+    value_type: AriaValueType,
+    values: BTreeMap<String, ValueDefinition>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde::Deserialize)]
+enum AriaValueType {
+    #[default]
+    #[serde(rename = "true/false")]
+    Boolean,
+    #[serde(rename = "ID reference")]
+    IdReference,
+    #[serde(rename = "ID reference list")]
+    IdReferenceList,
+    #[serde(rename = "integer")]
+    Integer,
+    #[serde(rename = "number")]
+    Number,
+    #[serde(rename = "true/false/undefined")]
+    OptionalBoolean,
+    #[serde(rename = "string")]
+    String,
+    #[serde(rename = "token")]
+    Token,
+    #[serde(rename = "token list")]
+    TokenList,
+    #[serde(rename = "tristate")]
+    Tristate,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum AriaAttributeType {
+    #[default]
+    Property,
+    State,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct ValueDefinition {
+    description: String,
+    is_default: bool,
+}
+
 fn main() -> io::Result<()> {
-    let aria_properties = generate_properties();
-    let aria_roles = generate_roles();
+    // CARGO instructions: rern if one of these files change
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=aria-data.json");
+
+    let text = std::fs::read_to_string("aria-data.json")?;
+    let data: Aria = serde_json::from_str(&text)?;
+
+    let aria_attribute_names: Vec<_> = data.attributes.keys().map(|name| name.as_str()).collect();
+    let abstract_aria_roles: BTreeMap<_, _> = data
+        .roles
+        .iter()
+        .filter(|(_, role)| role.is_abstract)
+        .collect();
+    let abstract_aria_role_names: Vec<_> = abstract_aria_roles
+        .keys()
+        .map(|name| name.as_str())
+        .collect();
+    let structure_aria_roles: Vec<_> = data
+        .roles
+        .keys()
+        .filter(|name| data.inherits_role(name, "structure").is_ok_and(|b| b))
+        .map(|name| name.as_str())
+        .collect();
+    let widget_aria_roles: Vec<_> = data
+        .roles
+        .keys()
+        .filter(|name| data.inherits_role(name, "widget").is_ok_and(|b| b))
+        .map(|name| name.as_str())
+        .collect();
+
+    let aria_properties = generate_enums(&aria_attribute_names[..], "AriaPropertiesEnum");
+
+    let abstract_roles = generate_enums(&abstract_aria_role_names[..], "AriaAbstractRolesEnum");
+    let structure_roles =
+        generate_enums(&structure_aria_roles[..], "AriaDocumentStructureRolesEnum");
+    let widget_roles = generate_enums(&widget_aria_roles[..], "AriaWidgetRolesEnum");
+
+    let iso_countries = generate_enums(ISO_COUNTRIES, "IsoCountries");
+    let iso_languages = generate_enums(ISO_LANGUAGES, "IsoLanguages");
+
     let tokens = quote! {
-        use std::str::FromStr;
-
-
         #aria_properties
-        #aria_roles
+        #abstract_roles
+        #structure_roles
+        #widget_roles
+        #iso_countries
+        #iso_languages
     };
     let ast = tokens.to_string();
+
+    // Format code
+    let ast = syn::parse_file(&ast).unwrap();
+    let ast = prettyplease::unparse(&ast);
 
     let out_dir = env::var("OUT_DIR").unwrap();
     fs::write(PathBuf::from(out_dir).join("roles_and_properties.rs"), ast)?;
@@ -194,61 +286,11 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
-fn generate_properties() -> TokenStream {
-    let properties = generate_enums(
-        ARIA_PROPERTIES.len(),
-        ARIA_PROPERTIES.iter(),
-        "AriaPropertiesEnum",
-    );
-
-    let property_types = generate_enums(
-        ARIA_PROPERTY_TYPE.len(),
-        ARIA_PROPERTY_TYPE.iter(),
-        "AriaPropertyTypeEnum",
-    );
-
-    quote! {
-        #properties
-        #property_types
-    }
-}
-
-fn generate_roles() -> TokenStream {
-    let widget_roles = generate_enums(
-        ARIA_WIDGET_ROLES.len(),
-        ARIA_WIDGET_ROLES.iter(),
-        "AriaWidgetRolesEnum",
-    );
-    let abstract_roles = generate_enums(
-        ARIA_ABSTRACT_ROLES.len(),
-        ARIA_ABSTRACT_ROLES.iter(),
-        "AriaAbstractRolesEnum",
-    );
-
-    let document_structure_roles = generate_enums(
-        ARIA_DOCUMENT_STRUCTURE_ROLES.len(),
-        ARIA_DOCUMENT_STRUCTURE_ROLES.iter(),
-        "AriaDocumentStructureRolesEnum",
-    );
-
-    let iso_countries = generate_enums(ISO_COUNTRIES.len(), ISO_COUNTRIES.iter(), "IsoCountries");
-
-    let iso_languages = generate_enums(ISO_LANGUAGES.len(), ISO_LANGUAGES.iter(), "IsoLanguages");
-
-    quote! {
-        #widget_roles
-        #abstract_roles
-        #document_structure_roles
-        #iso_countries
-        #iso_languages
-    }
-}
-
-fn generate_enums(len: usize, array: std::slice::Iter<&str>, enum_name: &str) -> TokenStream {
+fn generate_enums(array: &[&str], enum_name: &str) -> TokenStream {
     let enum_name = Ident::new(enum_name, Span::call_site());
-    let mut enum_metadata = Vec::with_capacity(len);
-    let mut from_enum_metadata = Vec::with_capacity(len);
-    let mut from_string_metadata = Vec::with_capacity(len);
+    let mut enum_metadata = Vec::with_capacity(array.len());
+    let mut from_enum_metadata = Vec::with_capacity(array.len());
+    let mut from_string_metadata = Vec::with_capacity(array.len());
     for property in array {
         let name = Ident::new(&Case::Pascal.convert(property), Span::call_site());
         let property = Literal::string(property);
@@ -266,21 +308,12 @@ fn generate_enums(len: usize, array: std::slice::Iter<&str>, enum_name: &str) ->
     });
 
     quote! {
-
-        #[derive(Debug, Eq, PartialEq)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub enum #enum_name {
             #( #enum_metadata ),*
         }
 
-        impl From<#enum_name> for &str {
-            fn from(property: #enum_name) -> Self {
-                match property {
-                    #( #from_enum_metadata ),*
-                }
-            }
-        }
-
-        impl FromStr for #enum_name {
+        impl std::str::FromStr for #enum_name {
             type Err = String;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {

--- a/crates/biome_aria_metadata/src/lib.rs
+++ b/crates/biome_aria_metadata/src/lib.rs
@@ -30,3 +30,42 @@ pub const ISO_LANGUAGES: [&str; 150] = [
     "tt", "te", "th", "bo", "ti", "to", "ts", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "vi", "vo",
     "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
 ];
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum AriaPropertyTypeEnum {
+    /// true/false
+    Boolean,
+    /// Id reference
+    Id,
+    /// List of Id references
+    Idlist,
+    Integer,
+    Number,
+    String,
+    /// Value among a set of allowed terms
+    Token,
+    /// List of values among a set of allowed terms
+    Tokenlist,
+    /// true/false/mixed
+    /// FIXME: Also true/false/undefined?
+    Tristate,
+}
+
+// TODO: to remove once the code that depends on that is refactored.
+impl std::str::FromStr for AriaPropertyTypeEnum {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "boolean" => Ok(AriaPropertyTypeEnum::Boolean),
+            "id" => Ok(AriaPropertyTypeEnum::Id),
+            "idlist" => Ok(AriaPropertyTypeEnum::Idlist),
+            "integer" => Ok(AriaPropertyTypeEnum::Integer),
+            "number" => Ok(AriaPropertyTypeEnum::Number),
+            "string" => Ok(AriaPropertyTypeEnum::String),
+            "token" => Ok(AriaPropertyTypeEnum::Token),
+            "tokenlist" => Ok(AriaPropertyTypeEnum::Tokenlist),
+            "tristate" => Ok(AriaPropertyTypeEnum::Tristate),
+            _ => Err("aria property type not implemented"),
+        }
+    }
+}

--- a/packages/aria-data/README.md
+++ b/packages/aria-data/README.md
@@ -1,0 +1,10 @@
+# ARIA data
+
+This package provides a script that extracts data from the ARIA specification.
+This is a best effort approach because the ARIA specification is in a semi-structured representation.
+
+Just call the script with the version of the ARIA specification and write t oa given file:
+
+```shell
+node generate-aria-data.js 1.2 >| aria-data-1-2.json
+```

--- a/packages/aria-data/aria-data-1-1.json
+++ b/packages/aria-data/aria-data-1-1.json
@@ -1,0 +1,5044 @@
+{
+  "permalink": "https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/",
+  "url": "https://www.w3.org/TR/wai-aria-1.1/",
+  "version": "1.1",
+  "roles": {
+    "alert": {
+      "description": "A type of live region with important, and usually time-sensitive, information. See related alertdialog and status.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "alert",
+          "module": "xforms"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "assertive",
+        "aria-atomic": "true"
+      }
+    },
+    "alertdialog": {
+      "description": "A type of dialog that contains an alert message, where initial focus goes to an element within the dialog. See related alert and dialog.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "alert",
+        "dialog"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "alert",
+          "module": "xforms"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "application": {
+      "description": "A structure containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a widget role.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Device Independence Delivery Unit"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "article": {
+      "description": "A section of a page that consists of a composition that forms an independent part of a document, page, or site.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "document"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "article",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "banner": {
+      "description": "A region that contains mostly site-oriented content, rather than page-specific content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "button": {
+      "description": "An input that allows for user-triggered actions when clicked or pressed. See related link.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "button",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "link",
+          "module": "aria"
+        },
+        {
+          "type": "any",
+          "name": "trigger",
+          "module": "xforms"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-pressed"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "cell": {
+      "description": "A cell in a tabular container. See related gridcell.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-colspan",
+        "aria-rowindex",
+        "aria-rowspan"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "checkbox": {
+      "description": "A checkable input that has three possible values: true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "menuitemcheckbox",
+        "switch"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "input",
+          "module": "html"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-readonly"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-checked": "false"
+      }
+    },
+    "columnheader": {
+      "description": "A cell containing header information for a column.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "th",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "combobox": {
+      "description": "A composite widget containing a single-line textbox and another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of the textbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "select",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "select",
+          "module": "xforms"
+        }
+      ],
+      "allowedChildRoles": [
+        "textbox",
+        "listbox",
+        "tree",
+        "grid",
+        "dialog"
+      ],
+      "requiredAttributes": [
+        "aria-controls",
+        "aria-expanded"
+      ],
+      "supportedAttributes": [
+        "aria-autocomplete",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-expanded": "false",
+        "aria-haspopup": "listbox"
+      }
+    },
+    "command": {
+      "description": "A form of widget that performs an action but does not receive input data.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "button",
+        "link",
+        "menuitem"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "menuitem",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "complementary": {
+      "description": "A supporting section of the document, designed to be complementary to the main content at a similar level in the DOM hierarchy, but remains meaningful when separated from the main content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "composite": {
+      "description": "A widget that may contain navigable descendants or owned children.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "grid",
+        "select",
+        "spinbutton",
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "contentinfo": {
+      "description": "A large perceivable region that contains information about the parent document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "definition": {
+      "description": "A definition of a term or concept. See related term.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "dd",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "dfn",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "dialog": {
+      "description": "A dialog is a descendant window of the primary window of a web application. For HTML pages, the primary application window is the entire web document, i.e., the body element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "window"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "directory": {
+      "description": "A list of references to members of a group, such as a static table of contents.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "guide",
+          "module": "daisy"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "document": {
+      "description": "An element containing content that assistive technology users may want to browse in a reading mode.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "article"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Device Independence Delivery Unit"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-expanded"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "feed": {
+      "description": "A scrollable list of articles where scrolling may cause articles to be added to or removed from either end of the list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "allowedChildRoles": [
+        "article"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "figure": {
+      "description": "A perceivable section of content that typically contains a graphical document, images, code snippets, or example text. The parts of a figure MAY be user-navigable.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "figure",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "form": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a form. See related search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "form",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "grid": {
+      "description": "A composite widget containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "table"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-level",
+        "aria-multiselectable",
+        "aria-readonly"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "gridcell": {
+      "description": "A cell in a grid or treegrid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "widget"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-readonly",
+        "aria-required",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "group": {
+      "description": "A set of user interface objects which are not intended to be included in a page summary or table of contents by assistive technologies.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "row",
+        "select",
+        "toolbar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "fieldset",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "heading": {
+      "description": "A heading for a section of the page.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "h1",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-level"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-level": "2"
+      }
+    },
+    "img": {
+      "description": "A container for a collection of elements that form an image.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "img",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "input": {
+      "description": "A generic type of widget that allows user input.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "checkbox",
+        "option",
+        "radio",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "input",
+          "module": "xforms"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "landmark": {
+      "description": "A perceivable section containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "banner",
+        "complementary",
+        "contentinfo",
+        "form",
+        "main",
+        "navigation",
+        "region",
+        "search"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "link": {
+      "description": "An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related button.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "a",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "link",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-expanded"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "list": {
+      "description": "A section containing listitem elements. See related listbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "directory",
+        "feed"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "ol",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "ul",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "listitem",
+        "listitem"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "listbox": {
+      "description": "A widget that allows the user to select one or more items from a list of choices. See related combobox and list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        },
+        {
+          "type": "any",
+          "name": "select",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "select",
+          "module": "xforms"
+        }
+      ],
+      "allowedChildRoles": [
+        "option"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "listitem": {
+      "description": "A single item in a list or directory.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "li",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "item",
+          "module": "xforms"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "list"
+      ],
+      "supportedAttributes": [
+        "aria-level",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "log": {
+      "description": "A type of live region where new information is added in meaningful order and old information may disappear. See related marquee.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite"
+      }
+    },
+    "main": {
+      "description": "The main content of a document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "marquee": {
+      "description": "A type of live region where non-essential information changes frequently. See related log.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "math": {
+      "description": "Content that represents a mathematical expression.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true
+    },
+    "menu": {
+      "description": "A type of widget that offers a list of choices to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "menubar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        },
+        {
+          "type": "any",
+          "name": "select",
+          "module": "xforms"
+        },
+        {
+          "type": "any",
+          "name": "menu",
+          "module": "japi"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitemradio",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "menubar": {
+      "description": "A presentation of menu that usually remains visible and is usually presented horizontally.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menu"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "toolbar",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitemradio",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "menuitem": {
+      "description": "An option in a set of choices contained by a menu or menubar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "subclassRoles": [
+        "menuitemcheckbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "menu_item",
+          "module": "japi"
+        },
+        {
+          "type": "any",
+          "name": "menuitem",
+          "module": "html"
+        },
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "menu",
+        "menubar"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "menuitemcheckbox": {
+      "description": "A menuitem with a checkable state whose possible values are true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "checkbox",
+        "menuitem"
+      ],
+      "subclassRoles": [
+        "menuitemradio"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "menu",
+        "menubar"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-checked": "false"
+      }
+    },
+    "menuitemradio": {
+      "description": "A checkable menuitem in a set of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menuitemcheckbox",
+        "radio"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "menu",
+        "menubar"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-checked": "false"
+      }
+    },
+    "navigation": {
+      "description": "A collection of navigational elements (usually links) for navigating the document or related documents.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "nav",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "none": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym presentation.",
+      "isAbstract": false,
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "note": {
+      "description": "A section whose content is parenthetic or ancillary to the main content of the resource.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "option": {
+      "description": "A selectable item in a select list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "option",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        },
+        {
+          "type": "any",
+          "name": "item",
+          "module": "xforms"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-selected"
+      ],
+      "supportedAttributes": [
+        "aria-checked",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-selected": "false"
+      }
+    },
+    "presentation": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym none.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "progressbar": {
+      "description": "An element that displays the progress status for tasks that take a long time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range",
+        "status"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "status",
+          "module": "aria"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "radio": {
+      "description": "A checkable input in a group of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "menuitemradio"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "input",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-checked": "false"
+      }
+    },
+    "radiogroup": {
+      "description": "A group of radio buttons.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "radio"
+      ],
+      "supportedAttributes": [
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "range": {
+      "description": "An input representing a range of values that can be set by the user.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "supportedAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "region": {
+      "description": "A perceivable section containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "frame",
+          "module": "html"
+        },
+        {
+          "type": "text",
+          "name": "Device Independence Glossary perceivable unit"
+        },
+        {
+          "type": "role",
+          "name": "section",
+          "module": "aria"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "roletype": {
+      "description": "The base role from which all other roles in this taxonomy inherit.",
+      "isAbstract": true,
+      "subclassRoles": [
+        "structure",
+        "widget",
+        "window"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "role",
+          "module": "xhtml"
+        },
+        {
+          "type": "any",
+          "name": "rel",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "type",
+          "module": "dublin core"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "row": {
+      "description": "A row of cells in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group",
+        "widget"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "tr",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "cell",
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "rowgroup",
+        "table",
+        "treegrid"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-level",
+        "aria-rowindex",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowgroup": {
+      "description": "A structure containing one or more row elements in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "tbody",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "tfoot",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "thead",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "table",
+        "treegrid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowheader": {
+      "description": "A cell containing header information for a row in a grid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "th",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "scrollbar": {
+      "description": "A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range"
+      ],
+      "requiredAttributes": [
+        "aria-controls",
+        "aria-orientation",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical",
+        "aria-valuemax": "100",
+        "aria-valuenow": "aria-valuemax"
+      }
+    },
+    "search": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related form and searchbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "searchbox": {
+      "description": "A type of textbox intended for specifying search criteria. See related textbox and search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "textbox"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "input",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-autocomplete",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-multiline",
+        "aria-owns",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "section": {
+      "description": "A renderable structural containment unit in a document or application.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "alert",
+        "cell",
+        "definition",
+        "figure",
+        "group",
+        "img",
+        "landmark",
+        "list",
+        "listitem",
+        "log",
+        "marquee",
+        "math",
+        "note",
+        "status",
+        "table",
+        "tabpanel",
+        "term",
+        "tooltip"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "par",
+          "module": "smil"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-expanded"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "sectionhead": {
+      "description": "A structure that labels or summarizes the topic of its related section.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "heading",
+        "rowheader",
+        "tab"
+      ],
+      "supportedAttributes": [
+        "aria-expanded"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "select": {
+      "description": "A form widget that allows the user to make selections from a set of choices.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "composite",
+        "group"
+      ],
+      "subclassRoles": [
+        "combobox",
+        "listbox",
+        "menu",
+        "radiogroup",
+        "tree"
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "separator": {
+      "description": "A divider that separates and distinguishes sections of content or groups of menuitems.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure",
+        "widget"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "hr",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-orientation",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100",
+        "aria-valuenow": "50"
+      }
+    },
+    "slider": {
+      "description": "A user input where the user selects a value from within a given range.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input",
+        "range"
+      ],
+      "requiredAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-orientation",
+        "aria-readonly"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemax": "100",
+        "aria-valuenow": "aria-valuemax"
+      }
+    },
+    "spinbutton": {
+      "description": "A form of range that expects the user to select from among discrete choices.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "input",
+        "range"
+      ],
+      "requiredAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-valuemin": "aria-valuemax",
+        "aria-valuenow": "0"
+      }
+    },
+    "status": {
+      "description": "A type of live region whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "progressbar",
+        "timer"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite",
+        "aria-atomic": "true"
+      }
+    },
+    "structure": {
+      "description": "A document structural element.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "application",
+        "document",
+        "presentation",
+        "rowgroup",
+        "section",
+        "sectionhead",
+        "separator"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "switch": {
+      "description": "A type of checkbox that represents on/off values, as opposed to checked/unchecked values. See related checkbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "checkbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "button",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-checked": "false"
+      }
+    },
+    "tab": {
+      "description": "A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead",
+        "widget"
+      ],
+      "requiredParentRoles": [
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-selected": "false"
+      }
+    },
+    "table": {
+      "description": "A section containing data arranged in rows and columns. See related grid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "grid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "any",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colcount",
+        "aria-rowcount"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "tablist": {
+      "description": "A list of tab elements, which are references to tabpanel elements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "guide",
+          "module": "daisy"
+        }
+      ],
+      "allowedChildRoles": [
+        "tab"
+      ],
+      "supportedAttributes": [
+        "aria-level",
+        "aria-multiselectable",
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tabpanel": {
+      "description": "A container for the resources associated with a tab, where each tab is contained in a tablist.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "term": {
+      "description": "A word or phrase with a corresponding definition. See related definition.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "dt",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "textbox": {
+      "description": "A type of input that allows free-form text as its value.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "searchbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "input",
+          "module": "xforms"
+        },
+        {
+          "type": "any",
+          "name": "textarea",
+          "module": "html"
+        },
+        {
+          "type": "any",
+          "name": "input",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-autocomplete",
+        "aria-multiline",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "timer": {
+      "description": "A type of live region containing a numerical counter which indicates an amount of elapsed time from a start point, or the time remaining until an end point.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "status"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "toolbar": {
+      "description": "A collection of commonly used function buttons or controls represented in compact visual form.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menubar",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tooltip": {
+      "description": "A contextual popup that displays a description for an element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "tree": {
+      "description": "A type of list that may contain sub-level nested groups that can be collapsed and expanded.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "allowedChildRoles": [
+        "group",
+        "treeitem",
+        "treeitem"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "treegrid": {
+      "description": "A grid whose rows can be expanded and collapsed in the same manner as for a tree.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "grid",
+        "tree"
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-level",
+        "aria-live",
+        "aria-multiselectable",
+        "aria-orientation",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "treeitem": {
+      "description": "An option item of a tree. This is an element within a tree that may be expanded or collapsed if it contains a sub-level group of tree item elements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "listitem",
+        "option"
+      ],
+      "requiredParentRoles": [
+        "group",
+        "tree"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-level",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "widget": {
+      "description": "An interactive component of a graphical user interface (GUI).",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "command",
+        "composite",
+        "gridcell",
+        "input",
+        "range",
+        "row",
+        "separator",
+        "tab"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "window": {
+      "description": "A browser or application window.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "dialog"
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-modal"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    }
+  },
+  "attributes": {
+    "aria-activedescendant": {
+      "type": "property",
+      "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "active",
+          "module": "dom"
+        }
+      ],
+      "usedInRoles": [
+        "application",
+        "composite",
+        "group",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "combobox",
+        "grid",
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "row",
+        "searchbox",
+        "select",
+        "spinbutton",
+        "tablist",
+        "toolbar",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "ID reference"
+    },
+    "aria-atomic": {
+      "type": "property",
+      "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Assistive technologies will present only the changed node or nodes.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Assistive technologies will present the entire changed region as a whole, including the author-defined label if one exists.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-autocomplete": {
+      "type": "property",
+      "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be presented if they are made.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "selection",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "combobox",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "token",
+      "values": {
+        "inline": {
+          "description": "When a user is providing input, text suggesting one way to complete the provided input may be dynamically inserted after the caret.",
+          "isDefault": false
+        },
+        "list": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed.",
+          "isDefault": false
+        },
+        "both": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-colcount": {
+      "type": "property",
+      "description": "Defines the total number of columns in a table, grid, or treegrid. See related aria-colindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colindex": {
+      "type": "property",
+      "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid. See related aria-colcount and aria-colspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colspan": {
+      "type": "property",
+      "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-colindex and aria-rowspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-controls": {
+      "type": "property",
+      "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element. See related aria-owns.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "XML Events [[XML-EVENTS]] object hyperlink target in HTML [[xhtml11]]"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-describedby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that describes the object. See related aria-labelledby.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Hint or Help in XForms [XFORMS10]"
+        },
+        {
+          "type": "any",
+          "name": "label",
+          "module": "xforms"
+        },
+        {
+          "type": "any",
+          "name": "label",
+          "module": "html"
+        },
+        {
+          "type": "text",
+          "name": "online help"
+        },
+        {
+          "type": "any",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-details": {
+      "type": "property",
+      "description": "Identifies the element that provides a detailed, extended description for the object. See related aria-describedby.",
+      "valueType": "ID reference"
+    },
+    "aria-dropeffect": {
+      "type": "property",
+      "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "token list",
+      "values": {
+        "copy": {
+          "description": "A duplicate of the source object will be dropped into the target.",
+          "isDefault": false
+        },
+        "execute": {
+          "description": "A function supported by the drop target is executed, using the drag source as an input.",
+          "isDefault": false
+        },
+        "link": {
+          "description": "A reference or shortcut to the dragged object will be created in the target object.",
+          "isDefault": false
+        },
+        "move": {
+          "description": "The source object will be removed from its current location and dropped into the target.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "No operation can be performed; effectively cancels the drag operation if an attempt is made to drop on this object. Ignored if combined with any other token value. e.g., 'none copy' is equivalent to a 'copy' value.",
+          "isDefault": true
+        },
+        "popup": {
+          "description": "There is a popup menu or dialog that allows the user to choose one of the drag operations (copy, move, link, execute) and any other drag functionality, such as cancel.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-errormessage": {
+      "type": "property",
+      "description": "Identifies the element that provides an error message for the object.  See related aria-invalid and aria-describedby. ",
+      "valueType": "ID reference"
+    },
+    "aria-flowto": {
+      "type": "property",
+      "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "XHTML 2 [[XHTML2]] :nextfocus :prevfocus"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-haspopup": {
+      "type": "property",
+      "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "aria-controls",
+          "module": "aria"
+        },
+        {
+          "type": "text",
+          "name": "User Agent Accessibility Guidelines [UAAG10] conditional content"
+        }
+      ],
+      "valueType": "token",
+      "values": {
+        "false": {
+          "description": "Indicates the element does not have a popup.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "menu": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "listbox": {
+          "description": "Indicates the popup is a listbox.",
+          "isDefault": false
+        },
+        "tree": {
+          "description": "Indicates the popup is a tree.",
+          "isDefault": false
+        },
+        "grid": {
+          "description": "Indicates the popup is a grid.",
+          "isDefault": false
+        },
+        "dialog": {
+          "description": "Indicates the popup is a dialog.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-keyshortcuts": {
+      "type": "property",
+      "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Keyboard shortcut"
+        }
+      ],
+      "valueType": "string"
+    },
+    "aria-label": {
+      "type": "property",
+      "description": "Defines a string value that labels the current element. See related aria-labelledby.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "title",
+          "module": "html"
+        }
+      ],
+      "valueType": "string"
+    },
+    "aria-labelledby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that labels the current element. See related aria-describedby.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "label",
+          "module": "html"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-level": {
+      "type": "property",
+      "description": "Defines the hierarchical level of an element within a structure.",
+      "usedInRoles": [
+        "grid",
+        "heading",
+        "listitem",
+        "row",
+        "tablist"
+      ],
+      "inheritsIntoRoles": [
+        "treegrid",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-live": {
+      "type": "property",
+      "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+      "valueType": "token",
+      "values": {
+        "assertive": {
+          "description": "Indicates that updates to the region have the highest priority and should be presented the user immediately.",
+          "isDefault": false
+        },
+        "off": {
+          "description": "Indicates that updates to the region should not be presented to the user unless the used is currently focused on that region.",
+          "isDefault": true
+        },
+        "polite": {
+          "description": "Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-modal": {
+      "type": "property",
+      "description": "Indicates whether an element is modal when displayed.",
+      "usedInRoles": [
+        "window"
+      ],
+      "inheritsIntoRoles": [
+        "alertdialog",
+        "dialog"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Element is not modal.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Element is modal.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiline": {
+      "type": "property",
+      "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "This is a single-line text box.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "This is a multi-line text box.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiselectable": {
+      "type": "property",
+      "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+      "usedInRoles": [
+        "grid",
+        "listbox",
+        "tablist",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Only one item can be selected.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "More than one item in the widget may be selected at a time.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-orientation": {
+      "type": "property",
+      "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+      "usedInRoles": [
+        "scrollbar",
+        "select",
+        "separator",
+        "slider",
+        "tablist",
+        "toolbar"
+      ],
+      "inheritsIntoRoles": [
+        "combobox",
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "token",
+      "values": {
+        "horizontal": {
+          "description": "The element is oriented horizontally.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's orientation is unknown/ambiguous.",
+          "isDefault": true
+        },
+        "vertical": {
+          "description": "The element is oriented vertically.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-owns": {
+      "type": "property",
+      "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship. See related aria-controls.",
+      "valueType": "ID reference list"
+    },
+    "aria-placeholder": {
+      "type": "property",
+      "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "placeholder",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "string"
+    },
+    "aria-posinset": {
+      "type": "property",
+      "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-setsize.",
+      "usedInRoles": [
+        "article",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-readonly": {
+      "type": "property",
+      "description": "Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "readonly",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "checkbox",
+        "combobox",
+        "grid",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The user can set the value of the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The user cannot change the value of the element.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-relevant": {
+      "type": "property",
+      "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related aria-atomic.",
+      "valueType": "token list",
+      "values": {
+        "additions": {
+          "description": "Element nodes are added to the accessibility tree within the live region.",
+          "isDefault": false
+        },
+        "additions text": {
+          "description": "Equivalent to the combination of values, \"additions text\".",
+          "isDefault": false
+        },
+        "all": {
+          "description": "Equivalent to the combination of all values, \"additions removals text\".",
+          "isDefault": false
+        },
+        "removals": {
+          "description": "Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.",
+          "isDefault": false
+        },
+        "text": {
+          "description": "Text content or a text alternative is added to any descendant in the accessibility tree of the live region.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-required": {
+      "type": "property",
+      "description": "Indicates that user input is required on the element before a form may be submitted.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "required",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "User input is not necessary to submit the form.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Users need to provide input on an element before a form is submitted.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-roledescription": {
+      "type": "property",
+      "description": "Defines a human-readable, author-localized description for the role of an element.",
+      "valueType": "string"
+    },
+    "aria-rowcount": {
+      "type": "property",
+      "description": "Defines the total number of rows in a table, grid, or treegrid. See related aria-rowindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowindex": {
+      "type": "property",
+      "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid. See related aria-rowcount and aria-rowspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowspan": {
+      "type": "property",
+      "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-rowindex and aria-colspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-setsize": {
+      "type": "property",
+      "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-posinset.",
+      "usedInRoles": [
+        "article",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-sort": {
+      "type": "property",
+      "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+      "usedInRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "token",
+      "values": {
+        "ascending": {
+          "description": "Items are sorted in ascending order by this column.",
+          "isDefault": false
+        },
+        "descending": {
+          "description": "Items are sorted in descending order by this column.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "There is no defined sort applied to the column.",
+          "isDefault": true
+        },
+        "other": {
+          "description": "A sort algorithm other than ascending or descending has been applied.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-valuemax": {
+      "type": "property",
+      "description": "Defines the maximum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "range",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "progressbar"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuemin": {
+      "type": "property",
+      "description": "Defines the minimum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "range",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "progressbar"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuenow": {
+      "type": "property",
+      "description": "Defines the current value for a range widget. See related aria-valuetext.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "range",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "progressbar"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuetext": {
+      "type": "property",
+      "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "range",
+          "module": "xforms"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "separator"
+      ],
+      "inheritsIntoRoles": [
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "string"
+    },
+    "aria-busy": {
+      "type": "state",
+      "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "There are no expected updates for the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element is being updated.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-checked": {
+      "type": "state",
+      "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets. See related aria-pressed and aria-selected.",
+      "usedInRoles": [
+        "checkbox",
+        "option",
+        "radio",
+        "switch"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being checked but is not currently checked.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state checkbox or menuitemcheckbox.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is checked.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being checked.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-current": {
+      "type": "state",
+      "description": "Indicates the element that represents the current item within a container or set of related elements.",
+      "valueType": "token",
+      "values": {
+        "page": {
+          "description": "Represents the current page within a set of pages.",
+          "isDefault": false
+        },
+        "step": {
+          "description": "Represents the current step within a process.",
+          "isDefault": false
+        },
+        "location": {
+          "description": "Represents the current location within an environment or context.",
+          "isDefault": false
+        },
+        "date": {
+          "description": "Represents the current date within a collection of dates.",
+          "isDefault": false
+        },
+        "time": {
+          "description": "Represents the current time within a set of times.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Represents the current item within a set.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "Does not represent the current item within a set.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-disabled": {
+      "type": "state",
+      "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. See related aria-hidden and aria-readonly.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The element is enabled.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element and all focusable descendants are disabled and its value cannot be changed by the user.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-expanded": {
+      "type": "state",
+      "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Tapered prompts in voice browsing. Switch in SMIL [SMIL3]."
+        }
+      ],
+      "usedInRoles": [
+        "button",
+        "combobox",
+        "document",
+        "link",
+        "section",
+        "sectionhead",
+        "window"
+      ],
+      "inheritsIntoRoles": [
+        "alert",
+        "alertdialog",
+        "article",
+        "banner",
+        "cell",
+        "columnheader",
+        "complementary",
+        "contentinfo",
+        "definition",
+        "dialog",
+        "directory",
+        "feed",
+        "figure",
+        "form",
+        "grid",
+        "gridcell",
+        "group",
+        "heading",
+        "img",
+        "landmark",
+        "list",
+        "listbox",
+        "listitem",
+        "log",
+        "main",
+        "marquee",
+        "math",
+        "menu",
+        "menubar",
+        "navigation",
+        "note",
+        "progressbar",
+        "radiogroup",
+        "region",
+        "row",
+        "rowheader",
+        "search",
+        "select",
+        "status",
+        "tab",
+        "table",
+        "tabpanel",
+        "term",
+        "timer",
+        "toolbar",
+        "tooltip",
+        "tree",
+        "treegrid",
+        "treeitem"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The element, or another grouping element it controls, is collapsed.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element, or another grouping element it controls, is expanded.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element, or another grouping element it controls, is neither expandable nor collapsible; all its child elements are shown or there are no child elements.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-grabbed": {
+      "type": "state",
+      "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "Indicates that the element supports being dragged.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Indicates that the element has been \"grabbed\" for dragging.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "Indicates that the element does not support being dragged.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-hidden": {
+      "type": "state",
+      "description": "Indicates whether the element is exposed to an accessibility API. See related aria-disabled.",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The element is exposed to the accessibility API as if it was rendered.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is hidden from the accessibility API.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's hidden state is determined by the user agent based on whether it is rendered.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-invalid": {
+      "type": "state",
+      "description": "Indicates the entered value does not conform to the format expected by the application. See related aria-errormessage.",
+      "relatedConcepts": [
+        {
+          "type": "any",
+          "name": "valid",
+          "module": "xforms"
+        }
+      ],
+      "valueType": "token",
+      "values": {
+        "grammar": {
+          "description": "A grammatical error was detected.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "There are no detected errors in the value.",
+          "isDefault": true
+        },
+        "spelling": {
+          "description": "A spelling error was detected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The value entered by the user has failed validation.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-pressed": {
+      "type": "state",
+      "description": "Indicates the current \"pressed\" state of toggle buttons. See related aria-checked and aria-selected.",
+      "usedInRoles": [
+        "button"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being pressed but is not currently pressed.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state toggle button.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is pressed.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being pressed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-selected": {
+      "type": "state",
+      "description": "Indicates the current \"selected\" state of various widgets. See related aria-checked and aria-pressed.",
+      "usedInRoles": [
+        "gridcell",
+        "option",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "treeitem"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The selectable element is not selected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The selectable element is selected.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element is not selectable.",
+          "isDefault": true
+        }
+      }
+    }
+  }
+}

--- a/packages/aria-data/aria-data-1-2.json
+++ b/packages/aria-data/aria-data-1-2.json
@@ -1,0 +1,6432 @@
+{
+  "permalink": "https://www.w3.org/TR/2023/REC-wai-aria-1.2-20230606/",
+  "url": "https://www.w3.org/TR/wai-aria-1.2/",
+  "version": "1.2",
+  "roles": {
+    "alert": {
+      "description": "A type of live region with important, and usually time-sensitive, information. See related alertdialog and status.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "assertive",
+        "aria-atomic": "true"
+      }
+    },
+    "alertdialog": {
+      "description": "A type of dialog that contains an alert message, where initial focus goes to an element within the dialog. See related alert and dialog.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "alert",
+        "dialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "application": {
+      "description": "A structure containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a widget role.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-invalid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "article": {
+      "description": "A section of a page that consists of a composition that forms an independent part of a document, page, or site.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "document"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "article",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "banner": {
+      "description": "A landmark that contains mostly site-oriented content, rather than page-specific content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "blockquote": {
+      "description": "A section of content that is quoted from another source.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "blockquote",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "button": {
+      "description": "An input that allows for user-triggered actions when clicked or pressed. See related link.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "button",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "link",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-haspopup",
+        "aria-expanded",
+        "aria-pressed"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "caption": {
+      "description": "Visible content that names, and may also describe, a figure, table, grid, or treegrid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "caption",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "figcaption",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "figure",
+        "grid",
+        "table",
+        "treegrid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "cell": {
+      "description": "A cell in a tabular container. See related gridcell.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-colspan",
+        "aria-rowindex",
+        "aria-rowspan"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "checkbox": {
+      "description": "A checkable input that has three possible values: true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "switch"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "checkbox"
+          },
+          "module": "html"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "code": {
+      "description": "A section whose content represents a fragment of computer code.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "code",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "columnheader": {
+      "description": "A cell containing header information for a column.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "th",
+          "attributes": {
+            "scope": "col"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "combobox": {
+      "description": "An input that controls another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of the input.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "select",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-controls",
+        "aria-expanded"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-autocomplete",
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-haspopup": "listbox"
+      }
+    },
+    "command": {
+      "description": "A form of widget that performs an action but does not receive input data.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "button",
+        "link",
+        "menuitem"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "complementary": {
+      "description": "A landmark that is designed to be complementary to the main content at a similar level in the DOM hierarchy, but remaining meaningful when separated from the main content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "composite": {
+      "description": "A widget that may contain navigable descendants or owned children.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "grid",
+        "select",
+        "spinbutton",
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "contentinfo": {
+      "description": "A landmark that contains information about the parent document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "definition": {
+      "description": "A definition of a term or concept. See related term.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "deletion": {
+      "description": "A deletion contains content that is marked as removed or content that is being suggested for removal. See related insertion.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "del",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "dialog": {
+      "description": "A dialog is a descendant window of the primary window of a web application. For HTML pages, the primary application window is the entire web document, i.e., the body element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "window"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "directory": {
+      "description": "A list of references to members of a group, such as a static table of contents.",
+      "deprecatedInVersion": "1.2",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "document": {
+      "description": "An element containing content that assistive technology users may want to browse in a reading mode.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "article"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "emphasis": {
+      "description": "One or more emphasized characters. See related strong.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "em",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "feed": {
+      "description": "A scrollable list of articles where scrolling may cause articles to be added to or removed from either end of the list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "allowedChildRoles": [
+        "article"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "figure": {
+      "description": "A perceivable section of content that typically contains a graphical document, images, code snippets, or example text. The parts of a figure MAY be user-navigable.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "figure",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "form": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a form. See related search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "form",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "generic": {
+      "description": "A nameless container element that has no semantic meaning on its own.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "div",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "span",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "grid": {
+      "description": "A composite widget containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "table"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-readonly"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "gridcell": {
+      "description": "A cell in a grid or treegrid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "widget"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "group": {
+      "description": "A set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "row",
+        "select",
+        "toolbar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "fieldset",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "heading": {
+      "description": "A heading for a section of the page.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "h1",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h2",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h3",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h4",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h5",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h6",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-level"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "img": {
+      "description": "A container for a collection of elements that form an image.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "img",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "input": {
+      "description": "A generic type of widget that allows user input.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "checkbox",
+        "combobox",
+        "option",
+        "radio",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "supportedAttributes": [
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "insertion": {
+      "description": "An insertion contains content that is marked as added or content that is being suggested for addition. See related deletion.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "ins",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "landmark": {
+      "description": "A perceivable section containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "banner",
+        "complementary",
+        "contentinfo",
+        "form",
+        "main",
+        "navigation",
+        "region",
+        "search"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "link": {
+      "description": "An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related button.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "a",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "link",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "list": {
+      "description": "A section containing listitem elements. See related listbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "directory",
+        "feed"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "ol",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "ul",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "listitem"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "listbox": {
+      "description": "A widget that allows the user to select one or more items from a list of choices. See related combobox and list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        },
+        {
+          "type": "element",
+          "name": "select",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "option",
+        "option"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-invalid",
+        "aria-multiselectable",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "listitem": {
+      "description": "A single item in a list or directory.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "li",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "directory",
+        "list"
+      ],
+      "supportedAttributes": [
+        "aria-level",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "log": {
+      "description": "A type of live region where new information is added in meaningful order and old information may disappear. See related marquee.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite"
+      }
+    },
+    "main": {
+      "description": "A landmark containing the main content of a document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "marquee": {
+      "description": "A type of live region where non-essential information changes frequently. See related log.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "math": {
+      "description": "Content that represents a mathematical expression.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "meter": {
+      "description": "An element that represents a scalar measurement within a known range, or a fractional value. See related progressbar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "meter",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "menu": {
+      "description": "A type of widget that offers a list of choices to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "menubar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitem",
+        "group",
+        "menuitemradio",
+        "group",
+        "menuitemcheckbox",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "menubar": {
+      "description": "A presentation of menu that usually remains visible and is usually presented horizontally.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menu"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "toolbar",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitem",
+        "group",
+        "menuitemradio",
+        "group",
+        "menuitemcheckbox",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "menuitem": {
+      "description": "An option in a set of choices contained by a menu or menubar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "subclassRoles": [
+        "menuitemcheckbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "menu",
+        "menubar"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "menuitemcheckbox": {
+      "description": "A menuitem with a checkable state whose possible values are true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menuitem"
+      ],
+      "subclassRoles": [
+        "menuitemradio"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "menu",
+        "menubar"
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "menuitemradio": {
+      "description": "A checkable menuitem in a set of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menuitemcheckbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "menu",
+        "menubar"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "navigation": {
+      "description": "A landmark containing a collection of navigational elements (usually links) for navigating the document or related documents.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "nav",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "none": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym presentation.",
+      "isAbstract": false,
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "note": {
+      "description": "A section whose content is parenthetic or ancillary to the main content of the resource.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "option": {
+      "description": "A selectable item in a listbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "option",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "group",
+        "listbox"
+      ],
+      "requiredAttributes": [
+        "aria-selected"
+      ],
+      "supportedAttributes": [
+        "aria-checked",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-selected": "false"
+      }
+    },
+    "paragraph": {
+      "description": "A paragraph of content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "p",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "presentation": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym none.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "progressbar": {
+      "description": "An element that displays the progress status for tasks that take a long time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range",
+        "widget"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "status",
+          "module": "aria"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "radio": {
+      "description": "A checkable input in a group of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "radio"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "radiogroup": {
+      "description": "A group of radio buttons.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "radio"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "range": {
+      "description": "An element representing a range of values.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "supportedAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "region": {
+      "description": "A landmark containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "section",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "roletype": {
+      "description": "The base role from which all other roles inherit.",
+      "isAbstract": true,
+      "subclassRoles": [
+        "structure",
+        "widget",
+        "window"
+      ],
+      "supportedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "row": {
+      "description": "A row of cells in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group",
+        "widget"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "tr",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "cell",
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "rowgroup",
+        "table",
+        "treegrid"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-expanded",
+        "aria-level",
+        "aria-posinset",
+        "aria-rowindex",
+        "aria-setsize",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowgroup": {
+      "description": "A structure containing one or more row elements in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "tbody",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "tfoot",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "thead",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "table",
+        "treegrid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowheader": {
+      "description": "A cell containing header information for a row.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "th",
+          "attributes": {
+            "scope": "row"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "scrollbar": {
+      "description": "A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range",
+        "widget"
+      ],
+      "requiredAttributes": [
+        "aria-controls",
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-orientation",
+        "aria-valuemax",
+        "aria-valuemin"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "search": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related form and searchbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "searchbox": {
+      "description": "A type of textbox intended for specifying search criteria. See related textbox and search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "textbox"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "search"
+          },
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-autocomplete",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-multiline",
+        "aria-owns",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "section": {
+      "description": "A renderable structural containment unit in a document or application.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "alert",
+        "blockquote",
+        "caption",
+        "cell",
+        "code",
+        "definition",
+        "deletion",
+        "emphasis",
+        "figure",
+        "group",
+        "img",
+        "insertion",
+        "landmark",
+        "list",
+        "listitem",
+        "log",
+        "marquee",
+        "math",
+        "note",
+        "paragraph",
+        "status",
+        "strong",
+        "subscript",
+        "superscript",
+        "table",
+        "tabpanel",
+        "term",
+        "time",
+        "tooltip"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "sectionhead": {
+      "description": "A structure that labels or summarizes the topic of its related section.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "heading",
+        "rowheader",
+        "tab"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "select": {
+      "description": "A form widget that allows the user to make selections from a set of choices.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "composite",
+        "group"
+      ],
+      "subclassRoles": [
+        "listbox",
+        "menu",
+        "radiogroup",
+        "tree"
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "separator": {
+      "description": "A divider that separates and distinguishes sections of content or groups of menuitems.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure",
+        "widget"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "hr",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-orientation",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "slider": {
+      "description": "An input where the user selects a value from within a given range.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input",
+        "range"
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-orientation",
+        "aria-readonly",
+        "aria-valuemax",
+        "aria-valuemin"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "spinbutton": {
+      "description": "A form of range that expects the user to select from among discrete choices.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "input",
+        "range"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-valuemin": "aria-valuemax",
+        "aria-valuenow": "0"
+      }
+    },
+    "status": {
+      "description": "A type of live region whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "timer"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite",
+        "aria-atomic": "true"
+      }
+    },
+    "strong": {
+      "description": "Content that is important, serious, or urgent. See related emphasis.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "strong",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "structure": {
+      "description": "A document structural element.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "application",
+        "document",
+        "generic",
+        "presentation",
+        "range",
+        "rowgroup",
+        "section",
+        "sectionhead",
+        "separator"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "subscript": {
+      "description": "One or more subscripted characters. See related superscript.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "sub",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "sup",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "superscript": {
+      "description": "One or more superscripted characters.  See related superscript.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "sub",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "sup",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "switch": {
+      "description": "A type of checkbox that represents on/off values, as opposed to checked/unchecked values. See related checkbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "checkbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "button",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "tab": {
+      "description": "A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead",
+        "widget"
+      ],
+      "requiredParentRoles": [
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-posinset",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-selected": "false"
+      }
+    },
+    "table": {
+      "description": "A section containing data arranged in rows and columns. See related grid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "grid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colcount",
+        "aria-rowcount"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "tablist": {
+      "description": "A list of tab elements, which are references to tabpanel elements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite"
+      ],
+      "allowedChildRoles": [
+        "tab"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tabpanel": {
+      "description": "A container for the resources associated with a tab, where each tab is contained in a tablist.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "term": {
+      "description": "A word or phrase with a corresponding definition. See related definition.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "dfn",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "textbox": {
+      "description": "A type of input that allows free-form text as its value.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "searchbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "textarea",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "text"
+          },
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-autocomplete",
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-multiline",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "time": {
+      "description": "An element that represents a specific point in time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "time",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "timer": {
+      "description": "A type of live region containing a numerical counter which indicates an amount of elapsed time from a start point, or the time remaining until an end point.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "status"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "toolbar": {
+      "description": "A collection of commonly used function buttons or controls represented in compact visual form.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menubar",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tooltip": {
+      "description": "A contextual popup that displays a description for an element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "tree": {
+      "description": "A widget that allows the user to select one or more items from a hierarchically organized collection.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "allowedChildRoles": [
+        "group",
+        "treeitem",
+        "treeitem"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-multiselectable",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "treegrid": {
+      "description": "A grid whose rows can be expanded and collapsed in the same manner as for a tree.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "grid",
+        "tree"
+      ],
+      "allowedChildRoles": [
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-multiselectable",
+        "aria-orientation",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "treeitem": {
+      "description": "An option item of a tree. This is an element within a tree that may be expanded or collapsed if it contains a sub-level group of tree item elements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "listitem",
+        "option"
+      ],
+      "requiredParentRoles": [
+        "group",
+        "tree"
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-haspopup"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-level",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "widget": {
+      "description": "An interactive component of a graphical user interface (GUI).",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "command",
+        "composite",
+        "gridcell",
+        "input",
+        "progressbar",
+        "row",
+        "scrollbar",
+        "separator",
+        "tab"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "window": {
+      "description": "A browser or application window.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "dialog"
+      ],
+      "supportedAttributes": [
+        "aria-modal"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    }
+  },
+  "attributes": {
+    "aria-activedescendant": {
+      "type": "property",
+      "description": "Identifies the currently active element when DOM focus is on a composite widget, combobox, textbox, group, or application.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "active",
+          "module": "dom"
+        }
+      ],
+      "usedInRoles": [
+        "application",
+        "combobox",
+        "composite",
+        "group",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "row",
+        "searchbox",
+        "select",
+        "spinbutton",
+        "tablist",
+        "toolbar",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "ID reference"
+    },
+    "aria-atomic": {
+      "type": "property",
+      "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Assistive technologies will present only the changed node or nodes.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Assistive technologies will present the entire changed region as a whole, including the author-defined label if one exists.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-autocomplete": {
+      "type": "property",
+      "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.",
+      "usedInRoles": [
+        "combobox",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "token",
+      "values": {
+        "inline": {
+          "description": "When a user is providing input, text suggesting one way to complete the provided input may be dynamically inserted after the caret.",
+          "isDefault": false
+        },
+        "list": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed.",
+          "isDefault": false
+        },
+        "both": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input may be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-colcount": {
+      "type": "property",
+      "description": "Defines the total number of columns in a table, grid, or treegrid. See related aria-colindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colindex": {
+      "type": "property",
+      "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid. See related aria-colcount and aria-colspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colspan": {
+      "type": "property",
+      "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-colindex and aria-rowspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-controls": {
+      "type": "property",
+      "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element. See related aria-owns.",
+      "valueType": "ID reference list"
+    },
+    "aria-describedby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that describes the object. See related aria-labelledby.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "label",
+          "module": "html"
+        },
+        {
+          "type": "text",
+          "name": "online help"
+        },
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-details": {
+      "type": "property",
+      "description": "Identifies the element that provides a detailed, extended description for the object. See related aria-describedby.",
+      "valueType": "ID reference"
+    },
+    "aria-dropeffect": {
+      "type": "property",
+      "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "token list",
+      "values": {
+        "copy": {
+          "description": "A duplicate of the source object will be dropped into the target.",
+          "isDefault": false
+        },
+        "execute": {
+          "description": "A function supported by the drop target is executed, using the drag source as an input.",
+          "isDefault": false
+        },
+        "link": {
+          "description": "A reference or shortcut to the dragged object will be created in the target object.",
+          "isDefault": false
+        },
+        "move": {
+          "description": "The source object will be removed from its current location and dropped into the target.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "No operation can be performed; effectively cancels the drag operation if an attempt is made to drop on this object. Ignored if combined with any other token value. e.g., 'none copy' is equivalent to a 'copy' value.",
+          "isDefault": true
+        },
+        "popup": {
+          "description": "There is a popup menu or dialog that allows the user to choose one of the drag operations (copy, move, link, execute) and any other drag functionality, such as cancel.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-errormessage": {
+      "type": "property",
+      "description": "Identifies the element that provides an error message for an object. See related aria-invalid and aria-describedby.",
+      "usedInRoles": [
+        "application",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "ID reference"
+    },
+    "aria-flowto": {
+      "type": "property",
+      "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.",
+      "valueType": "ID reference list"
+    },
+    "aria-haspopup": {
+      "type": "property",
+      "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "aria-controls",
+          "module": "aria"
+        }
+      ],
+      "usedInRoles": [
+        "application",
+        "button",
+        "combobox",
+        "gridcell",
+        "link",
+        "menuitem",
+        "slider",
+        "tab",
+        "textbox",
+        "treeitem"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "rowheader",
+        "searchbox"
+      ],
+      "valueType": "token",
+      "values": {
+        "false": {
+          "description": "Indicates the element does not have a popup.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "menu": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "listbox": {
+          "description": "Indicates the popup is a listbox.",
+          "isDefault": false
+        },
+        "tree": {
+          "description": "Indicates the popup is a tree.",
+          "isDefault": false
+        },
+        "grid": {
+          "description": "Indicates the popup is a grid.",
+          "isDefault": false
+        },
+        "dialog": {
+          "description": "Indicates the popup is a dialog.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-keyshortcuts": {
+      "type": "property",
+      "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Keyboard shortcut"
+        }
+      ],
+      "valueType": "string"
+    },
+    "aria-label": {
+      "type": "property",
+      "description": "Defines a string value that labels the current element. See related aria-labelledby.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "title",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "caption",
+        "code",
+        "deletion",
+        "emphasis",
+        "generic",
+        "insertion",
+        "paragraph",
+        "presentation",
+        "strong",
+        "subscript",
+        "superscript"
+      ],
+      "valueType": "string"
+    },
+    "aria-labelledby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that labels the current element. See related aria-describedby.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "label",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "caption",
+        "code",
+        "deletion",
+        "emphasis",
+        "generic",
+        "insertion",
+        "paragraph",
+        "presentation",
+        "strong",
+        "subscript",
+        "superscript"
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-level": {
+      "type": "property",
+      "description": "Defines the hierarchical level of an element within a structure.",
+      "usedInRoles": [
+        "heading",
+        "listitem",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-live": {
+      "type": "property",
+      "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+      "valueType": "token",
+      "values": {
+        "assertive": {
+          "description": "Indicates that updates to the region have the highest priority and should be presented the user immediately.",
+          "isDefault": false
+        },
+        "off": {
+          "description": "Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.",
+          "isDefault": true
+        },
+        "polite": {
+          "description": "Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-modal": {
+      "type": "property",
+      "description": "Indicates whether an element is modal when displayed.",
+      "usedInRoles": [
+        "window"
+      ],
+      "inheritsIntoRoles": [
+        "alertdialog",
+        "dialog"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Element is not modal.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Element is modal.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiline": {
+      "type": "property",
+      "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "This is a single-line text box.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "This is a multi-line text box.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiselectable": {
+      "type": "property",
+      "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+      "usedInRoles": [
+        "grid",
+        "listbox",
+        "tablist",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Only one item can be selected.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "More than one item in the widget may be selected at a time.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-orientation": {
+      "type": "property",
+      "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+      "usedInRoles": [
+        "scrollbar",
+        "select",
+        "separator",
+        "slider",
+        "tablist",
+        "toolbar"
+      ],
+      "inheritsIntoRoles": [
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "token",
+      "values": {
+        "horizontal": {
+          "description": "The element is oriented horizontally.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's orientation is unknown/ambiguous.",
+          "isDefault": true
+        },
+        "vertical": {
+          "description": "The element is oriented vertically.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-owns": {
+      "type": "property",
+      "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship. See related aria-controls.",
+      "valueType": "ID reference list"
+    },
+    "aria-placeholder": {
+      "type": "property",
+      "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "placeholder",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "string"
+    },
+    "aria-posinset": {
+      "type": "property",
+      "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-setsize.",
+      "usedInRoles": [
+        "article",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-readonly": {
+      "type": "property",
+      "description": "Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "readonly",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "checkbox",
+        "combobox",
+        "grid",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The user can set the value of the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The user cannot change the value of the element.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-relevant": {
+      "type": "property",
+      "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related aria-atomic.",
+      "valueType": "token list",
+      "values": {
+        "additions": {
+          "description": "Element nodes are added to the accessibility tree within the live region.",
+          "isDefault": false
+        },
+        "additions text": {
+          "description": "Equivalent to the combination of values, \"additions text\".",
+          "isDefault": true
+        },
+        "all": {
+          "description": "Equivalent to the combination of all values, \"additions removals text\".",
+          "isDefault": false
+        },
+        "removals": {
+          "description": "Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.",
+          "isDefault": false
+        },
+        "text": {
+          "description": "Text content or a text alternative is added to any descendant in the accessibility tree of the live region.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-required": {
+      "type": "property",
+      "description": "Indicates that user input is required on the element before a form may be submitted.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "required",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "User input is not necessary to submit the form.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Users need to provide input on an element before a form is submitted.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-roledescription": {
+      "type": "property",
+      "description": "Defines a human-readable, author-localized description for the role of an element.",
+      "valueType": "string"
+    },
+    "aria-rowcount": {
+      "type": "property",
+      "description": "Defines the total number of rows in a table, grid, or treegrid. See related aria-rowindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowindex": {
+      "type": "property",
+      "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid. See related aria-rowcount and aria-rowspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowspan": {
+      "type": "property",
+      "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-rowindex and aria-colspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-setsize": {
+      "type": "property",
+      "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-posinset.",
+      "usedInRoles": [
+        "article",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-sort": {
+      "type": "property",
+      "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+      "usedInRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "token",
+      "values": {
+        "ascending": {
+          "description": "Items are sorted in ascending order by this column.",
+          "isDefault": false
+        },
+        "descending": {
+          "description": "Items are sorted in descending order by this column.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "There is no defined sort applied to the column.",
+          "isDefault": true
+        },
+        "other": {
+          "description": "A sort algorithm other than ascending or descending has been applied.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-valuemax": {
+      "type": "property",
+      "description": "Defines the maximum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "range",
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "max",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuemin": {
+      "type": "property",
+      "description": "Defines the minimum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "range",
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "min",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuenow": {
+      "type": "property",
+      "description": "Defines the current value for a range widget. See related aria-valuetext.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "range",
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "value",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "meter",
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuetext": {
+      "type": "property",
+      "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+      "usedInRoles": [
+        "range",
+        "separator",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "string"
+    },
+    "aria-busy": {
+      "type": "state",
+      "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "There are no expected updates for the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element is being updated.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-checked": {
+      "type": "state",
+      "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets. See related aria-pressed and aria-selected.",
+      "usedInRoles": [
+        "checkbox",
+        "menuitemcheckbox",
+        "option",
+        "radio",
+        "switch"
+      ],
+      "inheritsIntoRoles": [
+        "menuitemradio",
+        "switch",
+        "treeitem"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being checked but is not currently checked.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state checkbox or menuitemcheckbox.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is checked.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being checked.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-current": {
+      "type": "state",
+      "description": "Indicates the element that represents the current item within a container or set of related elements.",
+      "valueType": "token",
+      "values": {
+        "page": {
+          "description": "Represents the current page within a set of pages.",
+          "isDefault": false
+        },
+        "step": {
+          "description": "Represents the current step within a process.",
+          "isDefault": false
+        },
+        "location": {
+          "description": "Represents the current location within an environment or context.",
+          "isDefault": false
+        },
+        "date": {
+          "description": "Represents the current date within a collection of dates.",
+          "isDefault": false
+        },
+        "time": {
+          "description": "Represents the current time within a set of times.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Represents the current item within a set.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "Does not represent the current item within a set.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-disabled": {
+      "type": "state",
+      "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. See related aria-hidden and aria-readonly.",
+      "usedInRoles": [
+        "application",
+        "button",
+        "composite",
+        "gridcell",
+        "group",
+        "input",
+        "link",
+        "menuitem",
+        "scrollbar",
+        "separator",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "checkbox",
+        "columnheader",
+        "combobox",
+        "grid",
+        "listbox",
+        "menu",
+        "menubar",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "option",
+        "radio",
+        "radiogroup",
+        "row",
+        "rowheader",
+        "searchbox",
+        "select",
+        "slider",
+        "spinbutton",
+        "switch",
+        "tablist",
+        "textbox",
+        "toolbar",
+        "tree",
+        "treegrid",
+        "treeitem"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The element is enabled.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element and all focusable descendants are disabled and its value cannot be changed by the user.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-expanded": {
+      "type": "state",
+      "description": "Indicates whether a grouping element owned or controlled by this element is expanded or collapsed.",
+      "usedInRoles": [
+        "application",
+        "button",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "link",
+        "listbox",
+        "menuitem",
+        "row",
+        "rowheader",
+        "tab",
+        "treeitem"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "rowheader",
+        "switch"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The grouping element this element owns or controls is collapsed.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The grouping element this element owns or controls is expanded.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not own or control a grouping element that is expandable.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-grabbed": {
+      "type": "state",
+      "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "Indicates that the element supports being dragged.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Indicates that the element has been \"grabbed\" for dragging.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "Indicates that the element does not support being dragged.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-hidden": {
+      "type": "state",
+      "description": "Indicates whether the element is exposed to an accessibility API. See related aria-disabled.",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The element is exposed to the accessibility API as if it was rendered.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is hidden from the accessibility API.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's hidden state is determined by the user agent based on whether it is rendered.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-invalid": {
+      "type": "state",
+      "description": "Indicates the entered value does not conform to the format expected by the application. See related aria-errormessage.",
+      "usedInRoles": [
+        "application",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "token",
+      "values": {
+        "grammar": {
+          "description": "A grammatical error was detected.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "There are no detected errors in the value.",
+          "isDefault": true
+        },
+        "spelling": {
+          "description": "A spelling error was detected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The value entered by the user has failed validation.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-pressed": {
+      "type": "state",
+      "description": "Indicates the current \"pressed\" state of toggle buttons. See related aria-checked and aria-selected.",
+      "usedInRoles": [
+        "button"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being pressed but is not currently pressed.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state toggle button.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is pressed.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being pressed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-selected": {
+      "type": "state",
+      "description": "Indicates the current \"selected\" state of various widgets. See related aria-checked and aria-pressed.",
+      "usedInRoles": [
+        "gridcell",
+        "option",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "treeitem"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The selectable element is not selected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The selectable element is selected.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element is not selectable.",
+          "isDefault": true
+        }
+      }
+    }
+  }
+}

--- a/packages/aria-data/aria-data-1-3-draft.json
+++ b/packages/aria-data/aria-data-1-3-draft.json
@@ -1,0 +1,7041 @@
+{
+  "permalink": "https://www.w3.org/TR/2024/WD-wai-aria-1.3-20240123/",
+  "url": "https://www.w3.org/TR/wai-aria-1.3/",
+  "version": "1.3",
+  "roles": {
+    "alert": {
+      "description": "A type of live region with important, and usually time-sensitive, information. See related alertdialog and status.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "assertive",
+        "aria-atomic": "true"
+      }
+    },
+    "alertdialog": {
+      "description": "A type of dialog that contains an alert message, where initial focus goes to an element within the dialog. See related alert and dialog.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "alert",
+        "dialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "application": {
+      "description": "A structure containing one or more focusable elements requiring user input, such as keyboard or gesture events, that do not follow a standard interaction pattern supported by a widget role.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-invalid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "article": {
+      "description": "A section of a page that consists of a composition that forms an independent part of a document, page, or site.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "document"
+      ],
+      "subclassRoles": [
+        "comment"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "article",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "banner": {
+      "description": "A landmark that contains mostly site-oriented content, rather than page-specific content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "header",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "blockquote": {
+      "description": "A section of content that is quoted from another source.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "blockquote",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "button": {
+      "description": "An input that allows for user-triggered actions when clicked or pressed. See related link.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "button",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "link",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-haspopup",
+        "aria-expanded",
+        "aria-pressed"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "caption": {
+      "description": "Visible content that names, or describes a figure, grid, group, radiogroup, table or treegrid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "caption",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "figcaption",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "legend",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "figure",
+        "grid",
+        "group",
+        "radiogroup",
+        "table",
+        "treegrid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "cell": {
+      "description": "A cell in a tabular container. See related gridcell.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-colindextext",
+        "aria-colspan",
+        "aria-rowindex",
+        "aria-rowindextext",
+        "aria-rowspan"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "checkbox": {
+      "description": "A checkable input that has three possible values: true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "switch"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "checkbox"
+          },
+          "module": "html"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "code": {
+      "description": "A section whose content represents a fragment of computer code.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "code",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "columnheader": {
+      "description": "A cell containing header information for a column.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "th",
+          "attributes": {
+            "scope": "col"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colindextext",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowindextext",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "combobox": {
+      "description": "An input that controls another element, such as a listbox or grid, that can dynamically pop up to help the user set the value of the input.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "select",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-expanded"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-autocomplete",
+        "aria-controls",
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-haspopup": "listbox"
+      }
+    },
+    "command": {
+      "description": "A form of widget that performs an action but does not receive input data.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "button",
+        "link",
+        "menuitem"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "comment": {
+      "description": "A comment contains content expressing reaction to other content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "article"
+      ],
+      "supportedAttributes": [
+        "aria-level",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "complementary": {
+      "description": "A landmark that is designed to be complementary to the main content that it is a sibling to, or a direct descendant of. The contents of a complementary landmark would be expected to remain meaningful if it were to be separated from the main content it is relevant to.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "aside",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "composite": {
+      "description": "A widget that can contain navigable accessibility descendants.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "grid",
+        "select",
+        "spinbutton",
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "contentinfo": {
+      "description": "A landmark that contains information about the parent document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "footer",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "definition": {
+      "description": "A definition of a term or concept. See related term.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "deletion": {
+      "description": "A deletion represents content that is marked as removed, content that is being suggested for removal, or content that is no longer relevant in the context of its accompanying content. See related insertion.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "del",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "s",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "dialog": {
+      "description": "A dialog is a descendant window of the primary window of a web application. For HTML pages, the primary application window is the entire web document, i.e., the body element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "window"
+      ],
+      "subclassRoles": [
+        "alertdialog"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-modal",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "directory": {
+      "description": "A list of references to members of a group, such as a static table of contents.",
+      "deprecatedInVersion": "1.2",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "document": {
+      "description": "An element containing content that assistive technology users might want to browse in a reading mode.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "article"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "emphasis": {
+      "description": "One or more emphasized characters. See related strong.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "em",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "feed": {
+      "description": "A scrollable list of articles where scrolling might cause articles to be added to or removed from either end of the list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "list"
+      ],
+      "allowedChildRoles": [
+        "article"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "figure": {
+      "description": "A perceivable section of content that typically contains a graphical document, images, media player, code snippets, or example text. The parts of a figure MAY be user-navigable.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "figure",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "form": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a form. See related search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "form",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "generic": {
+      "description": "A nameless container element that has no semantic meaning on its own.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "div",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "span",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-label",
+        "aria-labelledby",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "grid": {
+      "description": "A composite widget containing a collection of one or more rows with one or more cells where some or all cells in the grid are focusable by using methods of two-dimensional navigation, such as directional arrow keys.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "table"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "caption",
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-readonly"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "gridcell": {
+      "description": "A cell in a grid or treegrid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "widget"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "td",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colindextext",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowindextext",
+        "aria-rowspan"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "group": {
+      "description": "A set of user interface objects that is not intended to be included in a page summary or table of contents by assistive technologies.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "row",
+        "select",
+        "toolbar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "fieldset",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "heading": {
+      "description": "A heading for a section of the page.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "h1",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h2",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h3",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h4",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h5",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "h6",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-level"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "image": {
+      "description": "A container for a collection of elements that form an image. See synonym img.",
+      "isAbstract": false,
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "img": {
+      "description": "A container for a collection of elements that form an image. See synonym image.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "img",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "input": {
+      "description": "A generic type of widget that allows user input.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "widget"
+      ],
+      "subclassRoles": [
+        "checkbox",
+        "combobox",
+        "option",
+        "radio",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "supportedAttributes": [
+        "aria-disabled"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "insertion": {
+      "description": "An insertion contains content that is marked as added or content that is being suggested for addition. See related deletion.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "ins",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "landmark": {
+      "description": "A perceivable section containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "banner",
+        "complementary",
+        "contentinfo",
+        "form",
+        "main",
+        "navigation",
+        "region",
+        "search"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "link": {
+      "description": "An interactive reference to an internal or external resource that, when activated, causes the user agent to navigate to that resource. See related button.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "a",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "link",
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "list": {
+      "description": "A section containing listitem elements. See related listbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "directory",
+        "feed"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "ol",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "ul",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "listitem"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "listbox": {
+      "description": "A widget that allows the user to select one or more items from a list of choices. See related combobox and list.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        },
+        {
+          "type": "element",
+          "name": "select",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "option",
+        "option"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-invalid",
+        "aria-multiselectable",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "listitem": {
+      "description": "A single item in a list or directory.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "li",
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "directory",
+        "list"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "log": {
+      "description": "A type of live region where new information is added in meaningful order and old information can disappear. See related marquee.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite"
+      }
+    },
+    "main": {
+      "description": "A landmark containing the main content of a document.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "main",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "mark": {
+      "description": "Content which is marked or highlighted for reference or notation purposes, due to the content's relevance in the enclosing context.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "mark",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "marquee": {
+      "description": "A type of live region where non-essential information changes frequently. See related log.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "math": {
+      "description": "Content that represents a mathematical expression.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "menu": {
+      "description": "A type of widget that offers a list of choices to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "menubar"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitem",
+        "group",
+        "menuitemradio",
+        "group",
+        "menuitemcheckbox",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "separator"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "menubar": {
+      "description": "A presentation of menu that usually remains visible and is usually presented horizontally.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menu"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "toolbar",
+          "module": "aria"
+        }
+      ],
+      "allowedChildRoles": [
+        "group",
+        "menuitem",
+        "group",
+        "menuitemradio",
+        "group",
+        "menuitemcheckbox",
+        "menuitem",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "separator"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "menuitem": {
+      "description": "An option in a set of choices contained by a menu or menubar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "command"
+      ],
+      "subclassRoles": [
+        "menuitemcheckbox",
+        "menuitemradio"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        },
+        {
+          "type": "role",
+          "name": "option",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "menu",
+        "menubar",
+        "group",
+        "menu",
+        "group",
+        "menubar"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "menuitemcheckbox": {
+      "description": "A menuitem with a checkable state whose possible values are true, false, or mixed.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menuitem"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitemradio",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "menu",
+        "menubar",
+        "group",
+        "menu",
+        "group",
+        "menubar"
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "menuitemradio": {
+      "description": "A checkable menuitem in a set of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "menuitem"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menuitemcheckbox",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "menu",
+        "menubar",
+        "group",
+        "menu",
+        "group",
+        "menubar"
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "meter": {
+      "description": "An element that represents a scalar measurement within a known range, or a fractional value. See related progressbar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "meter",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "navigation": {
+      "description": "A landmark containing a collection of navigational elements (usually links) for navigating the document or related documents.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "nav",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "none": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym presentation.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "note": {
+      "description": "A section whose content represents additional information or parenthetical context to the primary content it supplements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "option": {
+      "description": "An item in a listbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "treeitem"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "option",
+          "module": "html"
+        }
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "listitem",
+          "module": "aria"
+        }
+      ],
+      "requiredParentRoles": [
+        "listbox",
+        "group",
+        "listbox"
+      ],
+      "supportedAttributes": [
+        "aria-checked",
+        "aria-posinset",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "paragraph": {
+      "description": "A paragraph of content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "p",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "presentation": {
+      "description": "An element whose implicit native role semantics will not be mapped to the accessibility API. See synonym none.",
+      "isAbstract": false,
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "progressbar": {
+      "description": "An element that displays the progress status for tasks that take a long time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range",
+        "widget"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "status",
+          "module": "aria"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "radio": {
+      "description": "A checkable input in a group of elements with the same role, only one of which can be checked at a time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "radio"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "supportedAttributes": [
+        "aria-posinset",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "radiogroup": {
+      "description": "A group of radio buttons.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "list",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "range": {
+      "description": "An element representing a range of values.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "supportedAttributes": [
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "region": {
+      "description": "A landmark containing content that is relevant to a specific, author-specified  purpose and sufficiently important that users will likely want to be able to navigate to the section easily and to have it listed in a summary of the page. Such a page summary could be generated dynamically by a user agent or assistive technology.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "section",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "roletype": {
+      "description": "The base role from which all other roles inherit.",
+      "isAbstract": true,
+      "subclassRoles": [
+        "structure",
+        "widget",
+        "window"
+      ],
+      "supportedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "row": {
+      "description": "A row of cells in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group",
+        "widget"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "tr",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "cell",
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "table",
+        "treegrid",
+        "rowgroup"
+      ],
+      "supportedAttributes": [
+        "aria-colindex",
+        "aria-expanded",
+        "aria-level",
+        "aria-posinset",
+        "aria-rowindex",
+        "aria-rowindextext",
+        "aria-setsize",
+        "aria-selected"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowgroup": {
+      "description": "A structure containing one or more row elements in a tabular container.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "tbody",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "tfoot",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "thead",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "row"
+      ],
+      "requiredParentRoles": [
+        "grid",
+        "table",
+        "treegrid"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "rowheader": {
+      "description": "A cell containing header information for a row.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "cell",
+        "gridcell",
+        "sectionhead"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "th",
+          "attributes": {
+            "scope": "row"
+          },
+          "module": "html"
+        }
+      ],
+      "requiredParentRoles": [
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-sort"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-colindex",
+        "aria-colindextext",
+        "aria-colspan",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowindex",
+        "aria-rowindextext",
+        "aria-rowspan",
+        "aria-selected"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "scrollbar": {
+      "description": "A graphical object that controls the scrolling of content within a viewing area, regardless of whether the content is fully displayed within the viewing area.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "range",
+        "widget"
+      ],
+      "requiredAttributes": [
+        "aria-controls",
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-orientation",
+        "aria-valuemax",
+        "aria-valuemin"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "search": {
+      "description": "A landmark region that contains a collection of items and objects that, as a whole, combine to create a search facility. See related form and searchbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "landmark"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "search",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "searchbox": {
+      "description": "A type of textbox intended for specifying search criteria. See related textbox and search.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "textbox"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "search"
+          },
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-autocomplete",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-haspopup",
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-multiline",
+        "aria-owns",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "section": {
+      "description": "A renderable structural containment unit on a page.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "alert",
+        "blockquote",
+        "caption",
+        "cell",
+        "code",
+        "definition",
+        "deletion",
+        "emphasis",
+        "figure",
+        "group",
+        "img",
+        "insertion",
+        "landmark",
+        "list",
+        "listitem",
+        "log",
+        "mark",
+        "marquee",
+        "math",
+        "note",
+        "paragraph",
+        "status",
+        "strong",
+        "subscript",
+        "suggestion",
+        "superscript",
+        "table",
+        "tabpanel",
+        "term",
+        "time",
+        "tooltip"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "sectionhead": {
+      "description": "A structure that labels or summarizes the topic of its related section.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "structure"
+      ],
+      "subclassRoles": [
+        "columnheader",
+        "heading",
+        "rowheader",
+        "tab"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "select": {
+      "description": "A form widget that allows the user to make selections from a set of choices.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "composite",
+        "group"
+      ],
+      "subclassRoles": [
+        "listbox",
+        "menu",
+        "radiogroup",
+        "tree"
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "separator": {
+      "description": "A divider that separates and distinguishes sections of content or groups of menuitems.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "structure",
+        "widget"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "hr",
+          "module": "html"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-orientation",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "slider": {
+      "description": "An input where the user selects a value from within a given range.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input",
+        "range"
+      ],
+      "requiredAttributes": [
+        "aria-valuenow"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-orientation",
+        "aria-readonly",
+        "aria-valuemax",
+        "aria-valuemin"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-valuetext"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal",
+        "aria-valuemin": "0",
+        "aria-valuemax": "100"
+      }
+    },
+    "spinbutton": {
+      "description": "A form of range that expects the user to select from among discrete choices.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite",
+        "input",
+        "range"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-readonly",
+        "aria-required",
+        "aria-valuemax",
+        "aria-valuemin",
+        "aria-valuenow",
+        "aria-valuetext"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-valuemin": "aria-valuemax"
+      }
+    },
+    "status": {
+      "description": "A type of live region whose content is advisory information for the user but is not important enough to justify an alert, often but not necessarily presented as a status bar.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "timer"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "output",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "polite",
+        "aria-atomic": "true"
+      }
+    },
+    "strong": {
+      "description": "Content that is important, serious, or urgent. See related emphasis.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "strong",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "structure": {
+      "description": "A document structural element.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "application",
+        "document",
+        "generic",
+        "none",
+        "range",
+        "rowgroup",
+        "section",
+        "sectionhead",
+        "separator"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "subscript": {
+      "description": "One or more subscripted characters. See related superscript.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "sub",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "sup",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "suggestion": {
+      "description": "A single proposed change to content.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "allowedChildRoles": [
+        "insertion",
+        "deletion"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "superscript": {
+      "description": "One or more superscripted characters.  See related superscript.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "sub",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "sup",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "switch": {
+      "description": "A type of checkbox that represents on/off values, as opposed to checked/unchecked values. See related checkbox.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "checkbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "button",
+          "module": "aria"
+        }
+      ],
+      "requiredAttributes": [
+        "aria-checked"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-expanded",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true
+    },
+    "tab": {
+      "description": "A grouping label providing a mechanism for selecting the tab content that is to be rendered to the user.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "sectionhead",
+        "widget"
+      ],
+      "requiredParentRoles": [
+        "tablist"
+      ],
+      "supportedAttributes": [
+        "aria-disabled",
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-posinset",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": true,
+      "implicitValuesForRole": {
+        "aria-selected": "false"
+      }
+    },
+    "table": {
+      "description": "A section containing data arranged in rows and columns. See related grid.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "subclassRoles": [
+        "grid"
+      ],
+      "baseConcepts": [
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "allowedChildRoles": [
+        "caption",
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "supportedAttributes": [
+        "aria-colcount",
+        "aria-rowcount"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "tablist": {
+      "description": "A list of tab elements, which are references to tabpanel elements.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "composite"
+      ],
+      "allowedChildRoles": [
+        "tab"
+      ],
+      "supportedAttributes": [
+        "aria-multiselectable",
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tabpanel": {
+      "description": "A container for the resources associated with a tab, where each tab is contained in a tablist.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "term": {
+      "description": "A word or phrase with an optional corresponding definition. See related definition.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "dfn",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "textbox": {
+      "description": "A type of input that allows free-form text as its value.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "input"
+      ],
+      "subclassRoles": [
+        "searchbox"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "textarea",
+          "module": "html"
+        },
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "text"
+          },
+          "module": "html"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-activedescendant",
+        "aria-autocomplete",
+        "aria-errormessage",
+        "aria-haspopup",
+        "aria-invalid",
+        "aria-multiline",
+        "aria-placeholder",
+        "aria-readonly",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "time": {
+      "description": "An element that represents a specific point in time.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "time",
+          "module": "html"
+        }
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "prohibitedAttributes": [
+        "aria-braillelabel",
+        "aria-label",
+        "aria-labelledby"
+      ],
+      "nameFrom": [
+        "prohibited"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "timer": {
+      "description": "A type of live region containing a numerical counter which indicates an amount of elapsed time from a start point, or the time remaining until an end point.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "status"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-live": "off"
+      }
+    },
+    "toolbar": {
+      "description": "A collection of commonly used function buttons or controls represented in compact visual form.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "group"
+      ],
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "menubar",
+          "module": "aria"
+        }
+      ],
+      "supportedAttributes": [
+        "aria-orientation"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "horizontal"
+      }
+    },
+    "tooltip": {
+      "description": "A contextual popup that displays a description for an element.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "section"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "tree": {
+      "description": "A widget that allows the user to select one or more items from a hierarchically organized collection.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "select"
+      ],
+      "subclassRoles": [
+        "treegrid"
+      ],
+      "allowedChildRoles": [
+        "group",
+        "treeitem",
+        "treeitem"
+      ],
+      "supportedAttributes": [
+        "aria-errormessage",
+        "aria-invalid",
+        "aria-multiselectable",
+        "aria-required"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-orientation",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false,
+      "implicitValuesForRole": {
+        "aria-orientation": "vertical"
+      }
+    },
+    "treegrid": {
+      "description": "A grid whose rows can be expanded and collapsed in the same manner as for a tree.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "grid",
+        "tree"
+      ],
+      "allowedChildRoles": [
+        "caption",
+        "row",
+        "rowgroup",
+        "row"
+      ],
+      "inheritedAttributes": [
+        "aria-activedescendant",
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-colcount",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        "aria-errormessage",
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        "aria-invalid",
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-multiselectable",
+        "aria-orientation",
+        "aria-owns",
+        "aria-readonly",
+        "aria-relevant",
+        "aria-required",
+        "aria-roledescription",
+        "aria-rowcount"
+      ],
+      "nameFrom": [
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "treeitem": {
+      "description": "An item in a tree.",
+      "isAbstract": false,
+      "superclassRoles": [
+        "listitem",
+        "option"
+      ],
+      "requiredParentRoles": [
+        "tree",
+        "group",
+        "treeitem"
+      ],
+      "supportedAttributes": [
+        "aria-expanded",
+        "aria-haspopup",
+        "aria-level"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-checked",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        "aria-disabled",
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-posinset",
+        "aria-relevant",
+        "aria-roledescription",
+        "aria-selected",
+        "aria-setsize"
+      ],
+      "nameFrom": [
+        "contents",
+        "author"
+      ],
+      "isAccessibleNameRequired": true,
+      "hasPresentationalChildren": false
+    },
+    "widget": {
+      "description": "An interactive component of a graphical user interface (GUI).",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "command",
+        "composite",
+        "gridcell",
+        "input",
+        "progressbar",
+        "row",
+        "scrollbar",
+        "separator",
+        "tab"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    },
+    "window": {
+      "description": "A browser or application window.",
+      "isAbstract": true,
+      "superclassRoles": [
+        "roletype"
+      ],
+      "subclassRoles": [
+        "dialog"
+      ],
+      "supportedAttributes": [
+        "aria-modal"
+      ],
+      "inheritedAttributes": [
+        "aria-atomic",
+        "aria-braillelabel",
+        "aria-brailleroledescription",
+        "aria-busy",
+        "aria-controls",
+        "aria-current",
+        "aria-describedby",
+        "aria-description",
+        "aria-details",
+        {
+          "name": "aria-disabled",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-dropeffect",
+        {
+          "name": "aria-errormessage",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-flowto",
+        "aria-grabbed",
+        {
+          "name": "aria-haspopup",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-hidden",
+        {
+          "name": "aria-invalid",
+          "deprecatedInVersion": "1.2"
+        },
+        "aria-keyshortcuts",
+        "aria-label",
+        "aria-labelledby",
+        "aria-live",
+        "aria-owns",
+        "aria-relevant",
+        "aria-roledescription"
+      ],
+      "nameFrom": [],
+      "isAccessibleNameRequired": false,
+      "hasPresentationalChildren": false
+    }
+  },
+  "attributes": {
+    "aria-activedescendant": {
+      "type": "property",
+      "description": "Identifies the currently active element when DOM focus is on a composite widget, combobox, textbox, group, or application.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "active",
+          "module": "dom"
+        }
+      ],
+      "usedInRoles": [
+        "application",
+        "combobox",
+        "composite",
+        "group",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "row",
+        "searchbox",
+        "select",
+        "spinbutton",
+        "tablist",
+        "toolbar",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "ID reference"
+    },
+    "aria-atomic": {
+      "type": "property",
+      "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Assistive technologies will present only the changed node or nodes.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Assistive technologies will present the entire changed region as a whole, including the author-defined label if one exists.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-autocomplete": {
+      "type": "property",
+      "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.",
+      "usedInRoles": [
+        "combobox",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "token",
+      "values": {
+        "inline": {
+          "description": "When a user is providing input, text suggesting one way to complete the provided input might be dynamically inserted after the caret.",
+          "isDefault": false
+        },
+        "list": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed.",
+          "isDefault": false
+        },
+        "both": {
+          "description": "When a user is providing input, an element containing a collection of values that could complete the provided input might be displayed. If displayed, one value in the collection is automatically selected, and the text needed to complete the automatically selected value appears after the caret in the input.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "When a user is providing input, an automatic suggestion that attempts to predict how the user intends to complete the input is not displayed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-braillelabel": {
+      "type": "property",
+      "description": "Defines a string value that labels the current element, which is intended to be converted into Braille. See related aria-label.",
+      "usedInRoles": [
+        "caption",
+        "code",
+        "definition",
+        "deletion",
+        "emphasis",
+        "generic",
+        "insertion",
+        "mark",
+        "none",
+        "paragraph",
+        "strong",
+        "subscript",
+        "suggestion",
+        "superscript",
+        "term",
+        "time"
+      ],
+      "valueType": "string"
+    },
+    "aria-brailleroledescription": {
+      "type": "property",
+      "description": "Defines a human-readable, author-localized abbreviated description for the role of an element, which is intended to be converted into Braille. See related aria-roledescription.",
+      "usedInRoles": [
+        "generic"
+      ],
+      "valueType": "string"
+    },
+    "aria-colcount": {
+      "type": "property",
+      "description": "Defines the total number of columns in a table, grid, or treegrid. See related aria-colindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colindex": {
+      "type": "property",
+      "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid. See related aria-colindextext, aria-colcount, and aria-colspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-colindextext": {
+      "type": "property",
+      "description": "Defines a human readable text alternative of aria-colindex. See related aria-rowindextext.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "string"
+    },
+    "aria-colspan": {
+      "type": "property",
+      "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-colindex and aria-rowspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-controls": {
+      "type": "property",
+      "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element. See related aria-owns.",
+      "valueType": "ID reference list"
+    },
+    "aria-describedby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that describes the object. See related aria-labelledby and aria-description.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "label",
+          "module": "html"
+        },
+        {
+          "type": "text",
+          "name": "online help"
+        },
+        {
+          "type": "element",
+          "name": "table",
+          "module": "html"
+        }
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-description": {
+      "type": "property",
+      "description": "Defines a string value that describes or annotates the current element. See related aria-describedby.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "title",
+          "module": "html"
+        }
+      ],
+      "valueType": "string"
+    },
+    "aria-details": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that provide additional information related to the object. See related aria-describedby.",
+      "valueType": "ID reference list"
+    },
+    "aria-dropeffect": {
+      "type": "property",
+      "description": "Indicates what functions can be performed when a dragged object is released on the drop target.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "token list",
+      "values": {
+        "copy": {
+          "description": "A duplicate of the source object will be dropped into the target.",
+          "isDefault": false
+        },
+        "execute": {
+          "description": "A function supported by the drop target is executed, using the drag source as an input.",
+          "isDefault": false
+        },
+        "link": {
+          "description": "A reference or shortcut to the dragged object will be created in the target object.",
+          "isDefault": false
+        },
+        "move": {
+          "description": "The source object will be removed from its current location and dropped into the target.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "No operation can be performed; effectively cancels the drag operation if an attempt is made to drop on this object. Ignored if combined with any other token value. e.g., 'none copy' is equivalent to a 'copy' value.",
+          "isDefault": true
+        },
+        "popup": {
+          "description": "There is a popup menu or dialog that allows the user to choose one of the drag operations (copy, move, link, execute) and any other drag functionality, such as cancel.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-errormessage": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that provides an error message for an object. See related aria-invalid and aria-describedby.",
+      "usedInRoles": [
+        "application",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-flowto": {
+      "type": "property",
+      "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion, allows assistive technology to override the general default of reading in document source order.",
+      "valueType": "ID reference list"
+    },
+    "aria-haspopup": {
+      "type": "property",
+      "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+      "relatedConcepts": [
+        {
+          "type": "role",
+          "name": "aria-controls",
+          "module": "aria"
+        }
+      ],
+      "usedInRoles": [
+        "application",
+        "button",
+        "combobox",
+        "gridcell",
+        "link",
+        "menuitem",
+        "slider",
+        "tab",
+        "textbox",
+        "treeitem"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "rowheader",
+        "searchbox"
+      ],
+      "valueType": "token",
+      "values": {
+        "false": {
+          "description": "Indicates the element does not have a popup.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "menu": {
+          "description": "Indicates the popup is a menu.",
+          "isDefault": false
+        },
+        "listbox": {
+          "description": "Indicates the popup is a listbox.",
+          "isDefault": false
+        },
+        "tree": {
+          "description": "Indicates the popup is a tree.",
+          "isDefault": false
+        },
+        "grid": {
+          "description": "Indicates the popup is a grid.",
+          "isDefault": false
+        },
+        "dialog": {
+          "description": "Indicates the popup is a dialog.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-keyshortcuts": {
+      "type": "property",
+      "description": "Defines keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+      "relatedConcepts": [
+        {
+          "type": "text",
+          "name": "Keyboard shortcut"
+        }
+      ],
+      "valueType": "string"
+    },
+    "aria-label": {
+      "type": "property",
+      "description": "Defines a string value that labels the current element. See related aria-labelledby.",
+      "usedInRoles": [
+        "caption",
+        "code",
+        "definition",
+        "deletion",
+        "emphasis",
+        "generic",
+        "insertion",
+        "mark",
+        "none",
+        "paragraph",
+        "strong",
+        "subscript",
+        "suggestion",
+        "superscript",
+        "term",
+        "time"
+      ],
+      "valueType": "string"
+    },
+    "aria-labelledby": {
+      "type": "property",
+      "description": "Identifies the element (or elements) that labels the current element. See related aria-label and aria-describedby.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "label",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "caption",
+        "code",
+        "definition",
+        "deletion",
+        "emphasis",
+        "generic",
+        "insertion",
+        "mark",
+        "none",
+        "paragraph",
+        "strong",
+        "subscript",
+        "suggestion",
+        "superscript",
+        "term",
+        "time"
+      ],
+      "valueType": "ID reference list"
+    },
+    "aria-level": {
+      "type": "property",
+      "description": "Defines the hierarchical level of an element within a structure.",
+      "usedInRoles": [
+        "comment",
+        "heading",
+        "row",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-live": {
+      "type": "property",
+      "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+      "valueType": "token",
+      "values": {
+        "assertive": {
+          "description": "Indicates that updates to the region have the highest priority and should be presented the user immediately.",
+          "isDefault": false
+        },
+        "off": {
+          "description": "Indicates that updates to the region should not be presented to the user unless the user is currently focused on that region.",
+          "isDefault": true
+        },
+        "polite": {
+          "description": "Indicates that updates to the region should be presented at the next graceful opportunity, such as at the end of speaking the current sentence or when the user pauses typing.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-modal": {
+      "type": "property",
+      "description": "Indicates whether an element is modal when displayed.",
+      "usedInRoles": [
+        "window"
+      ],
+      "inheritsIntoRoles": [
+        "alertdialog",
+        "dialog"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Element is not modal.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Element is modal.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiline": {
+      "type": "property",
+      "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "This is a single-line text box.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "This is a multi-line text box.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-multiselectable": {
+      "type": "property",
+      "description": "Indicates that the user can select more than one item from the current selectable descendants.",
+      "usedInRoles": [
+        "grid",
+        "listbox",
+        "tablist",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "Only one item can be selected.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "More than one item in the widget can be selected at a time.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-orientation": {
+      "type": "property",
+      "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+      "usedInRoles": [
+        "scrollbar",
+        "select",
+        "separator",
+        "slider",
+        "tablist",
+        "toolbar"
+      ],
+      "inheritsIntoRoles": [
+        "listbox",
+        "menu",
+        "menubar",
+        "radiogroup",
+        "tree",
+        "treegrid"
+      ],
+      "valueType": "token",
+      "values": {
+        "horizontal": {
+          "description": "The element is oriented horizontally.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's orientation is unknown/ambiguous.",
+          "isDefault": true
+        },
+        "vertical": {
+          "description": "The element is oriented vertically.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-owns": {
+      "type": "property",
+      "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship between DOM elements where the DOM hierarchy cannot be used to represent the relationship. See related aria-controls.",
+      "valueType": "ID reference list"
+    },
+    "aria-placeholder": {
+      "type": "property",
+      "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value. A hint could be a sample value or a brief description of the expected format.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "placeholder",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "searchbox"
+      ],
+      "valueType": "string"
+    },
+    "aria-posinset": {
+      "type": "property",
+      "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-setsize.",
+      "usedInRoles": [
+        "article",
+        "comment",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "comment",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-readonly": {
+      "type": "property",
+      "description": "Indicates that the element is not editable, but is otherwise operable. See related aria-disabled.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "readonly",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "checkbox",
+        "combobox",
+        "grid",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The user can set the value of the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The user cannot change the value of the element.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-relevant": {
+      "type": "property",
+      "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. See related aria-atomic.",
+      "valueType": "token list",
+      "values": {
+        "additions": {
+          "description": "Element nodes are added to the accessibility tree within the live region.",
+          "isDefault": false
+        },
+        "additions text": {
+          "description": "Equivalent to the combination of values, \"additions text\".",
+          "isDefault": true
+        },
+        "all": {
+          "description": "Equivalent to the combination of all values, \"additions removals text\".",
+          "isDefault": false
+        },
+        "removals": {
+          "description": "Text content, a text alternative, or an element node within the live region is removed from the accessibility tree.",
+          "isDefault": false
+        },
+        "text": {
+          "description": "Text content or a text alternative is added to any descendant in the accessibility tree of the live region.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-required": {
+      "type": "property",
+      "description": "Indicates that user input is required on the element before a form can be submitted.",
+      "relatedConcepts": [
+        {
+          "type": "attribute",
+          "name": "required",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "User input is not necessary to submit the form.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "Users need to provide input on an element before a form is submitted.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-roledescription": {
+      "type": "property",
+      "description": "Defines a human-readable, author-localized description for the role of an element.",
+      "usedInRoles": [
+        "generic"
+      ],
+      "valueType": "string"
+    },
+    "aria-rowcount": {
+      "type": "property",
+      "description": "Defines the total number of rows in a table, grid, or treegrid. See related aria-rowindex.",
+      "usedInRoles": [
+        "table"
+      ],
+      "inheritsIntoRoles": [
+        "grid",
+        "treegrid"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowindex": {
+      "type": "property",
+      "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid. See related aria-rowindextext, aria-rowcount, and aria-rowspan.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-rowindextext": {
+      "type": "property",
+      "description": "Defines a human readable text alternative of aria-rowindex. See related aria-colindextext.",
+      "usedInRoles": [
+        "cell",
+        "row"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "gridcell",
+        "rowheader"
+      ],
+      "valueType": "string"
+    },
+    "aria-rowspan": {
+      "type": "property",
+      "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid. See related aria-rowindex and aria-colspan.",
+      "usedInRoles": [
+        "cell"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "integer"
+    },
+    "aria-setsize": {
+      "type": "property",
+      "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM. See related aria-posinset.",
+      "usedInRoles": [
+        "article",
+        "comment",
+        "listitem",
+        "menuitem",
+        "option",
+        "radio",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "comment",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "treeitem"
+      ],
+      "valueType": "integer"
+    },
+    "aria-sort": {
+      "type": "property",
+      "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+      "usedInRoles": [
+        "columnheader",
+        "rowheader"
+      ],
+      "valueType": "token",
+      "values": {
+        "ascending": {
+          "description": "Items are sorted in ascending order.",
+          "isDefault": false
+        },
+        "descending": {
+          "description": "Items are sorted in descending order.",
+          "isDefault": false
+        },
+        "none": {
+          "description": "There is no defined sort applied.",
+          "isDefault": true
+        },
+        "other": {
+          "description": "A sort algorithm other than ascending or descending has been applied.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-valuemax": {
+      "type": "property",
+      "description": "Defines the maximum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "range"
+          },
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "max",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuemin": {
+      "type": "property",
+      "description": "Defines the minimum allowed value for a range widget.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "range"
+          },
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "min",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuenow": {
+      "type": "property",
+      "description": "Defines the current value for a range widget. See related aria-valuetext.",
+      "relatedConcepts": [
+        {
+          "type": "element",
+          "name": "input",
+          "attributes": {
+            "type": "range"
+          },
+          "module": "html"
+        },
+        {
+          "type": "attribute",
+          "name": "value",
+          "module": "html"
+        }
+      ],
+      "usedInRoles": [
+        "meter",
+        "range",
+        "scrollbar",
+        "separator",
+        "slider",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "number"
+    },
+    "aria-valuetext": {
+      "type": "property",
+      "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+      "usedInRoles": [
+        "range",
+        "separator",
+        "spinbutton"
+      ],
+      "inheritsIntoRoles": [
+        "meter",
+        "progressbar",
+        "scrollbar",
+        "slider",
+        "spinbutton"
+      ],
+      "valueType": "string"
+    },
+    "aria-busy": {
+      "type": "state",
+      "description": "Indicates an element is being modified and that assistive technologies could wait until the modifications are complete before exposing them to the user.",
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "There are no expected updates for the element.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element is being updated.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-checked": {
+      "type": "state",
+      "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets. See related aria-pressed and aria-selected.",
+      "usedInRoles": [
+        "checkbox",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "option",
+        "radio",
+        "switch"
+      ],
+      "inheritsIntoRoles": [
+        "switch",
+        "treeitem"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being checked but is not currently checked.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state checkbox or menuitemcheckbox.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is checked.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being checked.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-current": {
+      "type": "state",
+      "description": "Indicates the element that represents the current item within a container or set of related elements.",
+      "valueType": "token",
+      "values": {
+        "page": {
+          "description": "Represents the current page within a set of pages.",
+          "isDefault": false
+        },
+        "step": {
+          "description": "Represents the current step within a process.",
+          "isDefault": false
+        },
+        "location": {
+          "description": "Represents the current location within an environment or context.",
+          "isDefault": false
+        },
+        "date": {
+          "description": "Represents the current date within a collection of dates.",
+          "isDefault": false
+        },
+        "time": {
+          "description": "Represents the current time within a set of times.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Represents the current item within a set.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "Does not represent the current item within a set.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-disabled": {
+      "type": "state",
+      "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. See related aria-hidden and aria-readonly.",
+      "usedInRoles": [
+        "application",
+        "button",
+        "composite",
+        "gridcell",
+        "group",
+        "input",
+        "link",
+        "menuitem",
+        "scrollbar",
+        "separator",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "checkbox",
+        "columnheader",
+        "combobox",
+        "grid",
+        "listbox",
+        "menu",
+        "menubar",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "option",
+        "radio",
+        "radiogroup",
+        "row",
+        "rowheader",
+        "searchbox",
+        "select",
+        "slider",
+        "spinbutton",
+        "switch",
+        "tablist",
+        "textbox",
+        "toolbar",
+        "tree",
+        "treegrid",
+        "treeitem"
+      ],
+      "valueType": "true/false",
+      "values": {
+        "false": {
+          "description": "The element is enabled.",
+          "isDefault": true
+        },
+        "true": {
+          "description": "The element and all focusable descendants are disabled and its value cannot be changed by the user.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-expanded": {
+      "type": "state",
+      "description": "Indicates whether a grouping element that is the accessibility child of or is controlled by this element is expanded or collapsed.",
+      "usedInRoles": [
+        "application",
+        "button",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "link",
+        "listbox",
+        "menuitem",
+        "row",
+        "rowheader",
+        "tab",
+        "treeitem"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "menuitemcheckbox",
+        "menuitemradio",
+        "rowheader",
+        "switch"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The grouping element this element controls or is the accessibility parent of is collapsed.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The grouping element this element controls or is the accessibility parent of is expanded.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not own or control a grouping element that is expandable.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-grabbed": {
+      "type": "state",
+      "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.",
+      "deprecatedInVersion": "1.1",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "Indicates that the element supports being dragged.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "Indicates that the element has been \"grabbed\" for dragging.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "Indicates that the element does not support being dragged.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-hidden": {
+      "type": "state",
+      "description": "Indicates whether the element is exposed to an accessibility API. See related aria-disabled.",
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The element is exposed to the accessibility API as if it was rendered.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is hidden from the accessibility API.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element's hidden state is determined by the user agent based on whether it is rendered.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-invalid": {
+      "type": "state",
+      "description": "Indicates the entered value does not conform to the format expected by the application. See related aria-errormessage.",
+      "usedInRoles": [
+        "application",
+        "checkbox",
+        "combobox",
+        "gridcell",
+        "listbox",
+        "radiogroup",
+        "slider",
+        "spinbutton",
+        "textbox",
+        "tree"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "searchbox",
+        "switch",
+        "treegrid"
+      ],
+      "valueType": "token",
+      "values": {
+        "grammar": {
+          "description": "A grammatical error was detected.",
+          "isDefault": false
+        },
+        "false": {
+          "description": "There are no detected errors in the value.",
+          "isDefault": true
+        },
+        "spelling": {
+          "description": "A spelling error was detected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The value entered by the user has failed validation.",
+          "isDefault": false
+        }
+      }
+    },
+    "aria-pressed": {
+      "type": "state",
+      "description": "Indicates the current \"pressed\" state of toggle buttons. See related aria-checked and aria-selected.",
+      "usedInRoles": [
+        "button"
+      ],
+      "valueType": "tristate",
+      "values": {
+        "false": {
+          "description": "The element supports being pressed but is not currently pressed.",
+          "isDefault": false
+        },
+        "mixed": {
+          "description": "Indicates a mixed mode value for a tri-state toggle button.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The element is pressed.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element does not support being pressed.",
+          "isDefault": true
+        }
+      }
+    },
+    "aria-selected": {
+      "type": "state",
+      "description": "Indicates the current \"selected\" state of various widgets. See related aria-checked and aria-pressed.",
+      "usedInRoles": [
+        "gridcell",
+        "option",
+        "row",
+        "tab"
+      ],
+      "inheritsIntoRoles": [
+        "columnheader",
+        "rowheader",
+        "treeitem"
+      ],
+      "valueType": "true/false/undefined",
+      "values": {
+        "false": {
+          "description": "The selectable element is not selected.",
+          "isDefault": false
+        },
+        "true": {
+          "description": "The selectable element is selected.",
+          "isDefault": false
+        },
+        "undefined": {
+          "description": "The element is not selectable.",
+          "isDefault": true
+        }
+      }
+    }
+  }
+}

--- a/packages/aria-data/generate-aria-data.js
+++ b/packages/aria-data/generate-aria-data.js
@@ -1,0 +1,355 @@
+#!/usr/bin/node
+import * as util from "node:util";
+import * as process from "node:process";
+import { Browser, BrowserErrorCaptureEnum } from "happy-dom";
+
+function parseAriaSpec(doc, { url, version }) {
+	const permalink = doc.querySelector("a.u-url")?.href;
+	const roleDefs = doc.querySelectorAll(".role");
+	const roles = {};
+	for (const def of roleDefs) {
+		const name = def.id;
+		const { deprecatedInVersion, description } = parseDescription(
+			def.querySelector("p"),
+		);
+		// We use the terminology of the ARIA 1.3 specification
+		// See <https://www.w3.org/TR/wai-aria-1.3/#Properties>
+		roles[name] = {
+			description,
+			deprecatedInVersion,
+			isAbstract: parseBoolean(def.querySelector(".role-abstract")),
+			superclassRoles: textContents(
+				def.querySelectorAll(".role-parent code") ??
+					def.querySelector(".role-parent-head + td code"),
+			),
+			subclassRoles: textContents(
+				def.querySelectorAll(".role-children code") ??
+					def.querySelector(".role-children-head + td code"),
+			),
+			// We added fallback (`??`) because some roles miss the `.role-base` classes.
+			baseConcepts: parseConceptList(
+				def.querySelector(".role-base") ??
+					def.querySelector(".role-base-head + td"),
+				version,
+			),
+			// We added fallback (`??`) because some roles miss the `.role-related` classes.
+			relatedConcepts: parseConceptList(
+				def.querySelector(".role-related") ??
+					def.querySelector(".role-related-head + td"),
+				version,
+			),
+			allowedChildRoles: textContents(
+				def.querySelectorAll(".role-mustcontain code") ??
+					def.querySelector(".role-mustcontain-head + td code"),
+			),
+			requiredParentRoles: textContents(
+				def.querySelectorAll(".role-scope code") ??
+					def.querySelector(".role-scope-head + td code"),
+			),
+			requiredAttributes: parseAttributeList(
+				def.querySelector(".role-required-properties") ??
+					def.querySelector(".role-required-properties-head + td"),
+			),
+			supportedAttributes: parseAttributeList(
+				def.querySelector(".role-properties") ??
+					def.querySelector(".role-properties-head + td"),
+			),
+			inheritedAttributes: parseAttributeList(
+				def.querySelector(".role-inherited") ??
+					def.querySelector(".role-inherited-head + td"),
+			),
+			prohibitedAttributes: parseAttributeList(
+				def.querySelector(".role-disallowed") ??
+					def.querySelector(".role-disallowed-head + td"),
+			),
+			nameFrom: parseNamesFrom(def.querySelector(".role-namefrom")),
+			isAccessibleNameRequired: parseBoolean(
+				def.querySelector(".role-namerequired") ??
+					def.querySelector(".role-namerequired-head + td"),
+			),
+			hasPresentationalChildren: parseBoolean(
+				def.querySelector(".role-childpresentational") ??
+					def.querySelector(".role-childpresentational-head + td"),
+			),
+			implicitValuesForRole: parseImplicitValForRole(
+				def.querySelectorAll(".implicit-values code") ??
+					def.querySelector(".implicit-values-head + td code"),
+			),
+		};
+	}
+	const propertyDefs = doc.querySelectorAll(".property");
+	const attributes = {};
+	for (const def of propertyDefs) {
+		const name = def.id;
+		const { deprecatedInVersion, description } = parseDescription(
+			def.querySelector("p"),
+		);
+		attributes[name] = {
+			type: "property",
+			description,
+			deprecatedInVersion,
+			relatedConcepts: parseConceptList(
+				def.querySelector(".property-related, .state-related"),
+				version,
+			),
+			usedInRoles: textContents(
+				def.querySelectorAll(
+					".property-applicability code, .state-applicability code",
+				),
+			),
+			inheritsIntoRoles: textContents(
+				def.querySelectorAll(
+					".property-descendants code, .state-descendants code",
+				),
+			),
+			valueType:
+				def.querySelector(".property-value a, .state-value a")?.textContent ??
+				null,
+			values: parseAttributeValues(
+				def.querySelectorAll(".value-name, .value-description"),
+			),
+		};
+	}
+	const stateDefs = doc.querySelectorAll(".state");
+	for (const def of stateDefs) {
+		const name = def.id;
+		const { deprecatedInVersion, description } = parseDescription(
+			def.querySelector("p"),
+		);
+		attributes[name] = {
+			type: "state",
+			description,
+			deprecatedInVersion,
+			relatedConcepts: parseConceptList(
+				def.querySelector(".property-related, .state-related"),
+				version,
+			),
+			usedInRoles: textContents(
+				def.querySelectorAll(
+					".property-applicability code, .state-applicability code",
+				),
+			),
+			inheritsIntoRoles: textContents(
+				def.querySelectorAll(
+					".property-descendants code, .state-descendants code",
+				),
+			),
+			valueType:
+				def.querySelector(".property-value a, .state-value a")?.textContent ??
+				null,
+			values: parseAttributeValues(
+				def.querySelectorAll(".value-name, .value-description"),
+			),
+		};
+	}
+	return {
+		permalink,
+		url,
+		version,
+		roles,
+		attributes,
+	};
+}
+
+const DESCRIPTION_REGEX = /(?:\[Deprecated in ARIA ([\d.]+)\])?[ ]?(.+)/;
+
+function parseDescription(node) {
+	const text = node?.textContent;
+	if (text != null) {
+		const [_, deprecatedInVersion, description] = text.match(DESCRIPTION_REGEX);
+		return { deprecatedInVersion, description };
+	}
+	return {};
+}
+
+function parseBoolean(node) {
+	return node?.textContent === "True";
+}
+
+function parseNamesFrom(node) {
+	return (
+		node?.textContent
+			.trim()
+			.split("\n")
+			.map((name) => name.trim())
+			.filter(
+				(name) =>
+					name == "author" || name == "contents" || name == "prohibited",
+			) ?? []
+	);
+}
+
+function parseImplicitValForRole(nodeList) {
+	const arrayed = textContents(nodeList);
+	if (arrayed != null) {
+		const result = {};
+		for (let i = 0; i < arrayed.length; i += 2) {
+			const name = arrayed[i];
+			const value = arrayed[i + 1];
+			result[name] = value;
+		}
+		return result;
+	}
+}
+
+function parseConceptList(node, version) {
+	if (node != null) {
+		const list = textContents(node.querySelectorAll("li"));
+		if (list != null) {
+			return list.flatMap((attribute) => parseConcept(attribute, version));
+		}
+		// There is a single attribute (no list)
+		return parseConcept(node.textContent, version);
+	}
+}
+
+/**
+ * <input>
+ * <input type="checkbox">
+ * <input[type="checkbox"]>
+ */
+const HTML_CONCEPT_REGEX = /<(\w+)(?: ?\[?(\w+)="?(\w+)"?\]?)?>/g;
+
+const MODULE_CONCEPT_REGEX =
+	/(DAISY|DOM|Dublin Core|X?HTML|html|JAPI|SMIL|SVG|XForms)\d*(?: \[\1\d*\])? ([a-z]\w*)/gi;
+const CONCEPT_IN_MODULE_REGEX =
+	/^([a-z]\w*) in \[?(DAISY|DOM|Dublin Core|X?HTML|html|JAPI|SMIL|SVG|XForms)\d*\]?/gi;
+
+const CONCEPT_ATTRIBUTE_IN_MODULE_REGEX =
+	/([a-z]\w*) attribute in \[?(DAISY|DOM|Dublin Core|X?HTML|JAPI|SMIL|SVG|XForms)\d*\]?/gi;
+
+function parseConcept(spacedText, version) {
+	const text = spacedText.trim();
+	const result = [];
+	for (const [_, name, attributeName, attributeValue] of text.matchAll(
+		HTML_CONCEPT_REGEX,
+	)) {
+		let attributes;
+		if (attributeName != null && attributeValue != null) {
+			attributes = { [attributeName]: attributeValue };
+		}
+		result.push({
+			type: "element",
+			name: name.toLowerCase(),
+			attributes,
+			module: "html",
+		});
+	}
+	for (const [_, module, name] of text.matchAll(MODULE_CONCEPT_REGEX)) {
+		if (name === "and") {
+			// Avoid false positives
+			continue;
+		}
+		result.push({
+			type: version === "1.1" ? "any" : "element",
+			name: name.toLowerCase(),
+			module: module.toLowerCase(),
+		});
+	}
+	for (const [_, name, module] of text.matchAll(CONCEPT_IN_MODULE_REGEX)) {
+		result.push({
+			type: version === "1.1" ? "any" : "element",
+			name: name.toLowerCase(),
+			module: module.toLowerCase(),
+		});
+	}
+	for (const [_, name, module] of text.matchAll(
+		CONCEPT_ATTRIBUTE_IN_MODULE_REGEX,
+	)) {
+		result.push({
+			type: "attribute",
+			name: name.toLowerCase(),
+			module: module.toLowerCase(),
+		});
+	}
+	if (result.length == 0) {
+		if (text.includes(" ")) {
+			result.push({
+				type: "text",
+				name: text,
+			});
+		} else {
+			result.push({
+				type: "role",
+				name: text,
+				module: "aria",
+			});
+		}
+	}
+	return result;
+}
+
+function parseAttributeList(node) {
+	if (node != null) {
+		const list = textContents(node.querySelectorAll("li"));
+		if (list != null) {
+			return list.map((attribute) => parseAttribute(attribute));
+		}
+		// There is a single attribute (no list)
+		return [parseAttribute(node.textContent)];
+	}
+}
+
+const ATTRIBUTE_REGEX =
+	/([\w\d-]+)(?: \(state\))?(?: \(.*deprecated.*in ARIA ([\d.]+)\))?/;
+
+function parseAttribute(text) {
+	const [_, name, deprecatedInVersion] = text.match(ATTRIBUTE_REGEX);
+	if (deprecatedInVersion != null) {
+		return { name, deprecatedInVersion };
+	}
+	return name;
+}
+
+function parseAttributeValues(nodeList) {
+	const arrayed = textContents(nodeList);
+	if (arrayed != null) {
+		const result = {};
+		for (let i = 0; i < arrayed.length; i += 2) {
+			const defaultIndex = arrayed[i].indexOf(" (default)");
+			const isDefault = defaultIndex !== -1;
+			const value = isDefault ? arrayed[i].slice(0, defaultIndex) : arrayed[i];
+			result[value] = {
+				description: arrayed[i + 1],
+				isDefault,
+			};
+		}
+		return result;
+	}
+}
+
+function textContents(nodeList) {
+	if (nodeList != null && nodeList.length > 0) {
+		return Array.from(new Set(nodeList)).map((x) => x.textContent);
+	}
+}
+
+const DEFAULT_ARIA_SSPEC_VERSION = "1.2";
+
+const VERSION_REGEX = /^\d+(?:\.\d+)*$/;
+
+async function run({ positionals: [version = DEFAULT_ARIA_SSPEC_VERSION] }) {
+	if (!VERSION_REGEX.test(version)) {
+		console.error(
+			`"${version}" is not a valid version. default: "${DEFAULT_ARIA_SSPEC_VERSION}"`,
+		);
+		process.exit(1);
+	}
+	const url = `https://www.w3.org/TR/wai-aria-${version}/`;
+
+	const browser = new Browser({
+		settings: { errorCapture: BrowserErrorCaptureEnum.processLevel },
+	});
+	const page = browser.newPage();
+	await page.goto(url);
+
+	const parsed = parseAriaSpec(page.mainFrame.document, { url, version });
+	const json = JSON.stringify(parsed, null, "  ");
+	console.log(json);
+}
+
+await run(
+	util.parseArgs({
+		allowPositionals: true,
+	}),
+);

--- a/packages/aria-data/package.json
+++ b/packages/aria-data/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@biomejs/aria-data",
+  "version": "0.0.0",
+  "description": "Structured representation of the ARIA roles, properties, and states",
+  "private": true,
+  "license": "MIT OR Apache-2.0",
+  "author": "Victorien Elvinger",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "type": "module",
+  "dependencies": {
+    "happy-dom": "^15.7.4"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
 
+  packages/aria-data:
+    dependencies:
+      happy-dom:
+        specifier: ^15.7.4
+        version: 15.7.4
+
   packages/tailwindcss-config-analyzer:
     dependencies:
       tailwindcss:
@@ -418,6 +424,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -538,6 +548,10 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  happy-dom@15.7.4:
+    resolution: {integrity: sha512-r1vadDYGMtsHAAsqhDuk4IpPvr6N8MGKy5ntBo7tSdim+pWDxus2PNqOcOt8LuDZ4t3KJHE+gCuzupcx/GKnyQ==}
+    engines: {node: '>=18.0.0'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -971,6 +985,14 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1387,6 +1409,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  entities@4.5.0: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
@@ -1528,6 +1552,12 @@ snapshots:
   globals@14.0.0: {}
 
   graphemer@1.4.0: {}
+
+  happy-dom@15.7.4:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   has-flag@3.0.0: {}
 
@@ -1929,6 +1959,10 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - "packages/aria-data"
   - "packages/tailwindcss-config-analyzer"
   - "crates/biome_formatter_test/src/prettier"
   - "benchmark"


### PR DESCRIPTION
## Summary

Our ARIA metadata are currently handwritten and mostly based on ARIA 1.1 (some of them are in ARIA 1.2).
Some of these metadata are erroneous or incomplete.
I first started to update them manually. However, this took too much time and it is error-prone.

The aria-query NPM package provides [a JSON file](https://github.com/A11yance/aria-query/blob/main/scripts/roles.json) with the ARIA metadata.
This seems to be manually updated.
I also noticed several issues and some lack of fidelity with the specification (they mix related and base concepts for example).
 
Thus, I decided to write a script that extracts ARIA metadata directly from the specification.
The script is written in JavaScript and relies on `happy-dom` NPM package that parse the HTML page of the ARIA specification.
I chose `happy-dom` because it has less dependencies than `jsdom` and `linkedom`. It is also more used than `linkedom`.
This is a best effort approach, however the generated data seems pretty good (I tried for the three available versions of ARIA).
I placed the script in `packages/aria-data`.

I updated the `biome_aria_metadata` `build.rs` script to generate its code from `aria-data.json`.
For now, `aria-data.json` is symlinked to `packages/aria-data/aria-data-1-2.json`.
I used the `prettyplease` crate (widely used in the community) to format the output of `build.rs`.
I think it is a better alternative to starting a process to run `rustfmt`.

Now that we have a pretty reliable ARIA metadata source, we will be able to transfer more stuff from `biome_aria` to `biome_aria_metadata`.

## Test Plan

CI must pass.
