### PR TITLE
refactor(parser/html): refactor comments to be nodes in the tree

### DIFF
--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -61,6 +61,20 @@ pub fn html_closing_element(
         ],
     ))
 }
+pub fn html_comment(
+    comment_start_token: SyntaxToken,
+    content_token: SyntaxToken,
+    comment_end_token: SyntaxToken,
+) -> HtmlComment {
+    HtmlComment::unwrap_cast(SyntaxNode::new_detached(
+        HtmlSyntaxKind::HTML_COMMENT,
+        [
+            Some(SyntaxElement::Token(comment_start_token)),
+            Some(SyntaxElement::Token(content_token)),
+            Some(SyntaxElement::Token(comment_end_token)),
+        ],
+    ))
+}
 pub fn html_content(value_token: SyntaxToken) -> HtmlContent {
     HtmlContent::unwrap_cast(SyntaxNode::new_detached(
         HtmlSyntaxKind::HTML_CONTENT,

--- a/crates/biome_html_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_html_factory/src/generated/syntax_factory.rs
@@ -109,6 +109,39 @@ impl SyntaxFactory for HtmlSyntaxFactory {
                 }
                 slots.into_node(HTML_CLOSING_ELEMENT, children)
             }
+            HTML_COMMENT => {
+                let mut elements = (&children).into_iter();
+                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
+                let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if element.kind() == T ! [<!--] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element {
+                    if element.kind() == HTML_LITERAL {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element {
+                    if element.kind() == T ! [-->] {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if current_element.is_some() {
+                    return RawSyntaxNode::new(
+                        HTML_COMMENT.to_bogus(),
+                        children.into_iter().map(Some),
+                    );
+                }
+                slots.into_node(HTML_COMMENT, children)
+            }
             HTML_CONTENT => {
                 let mut elements = (&children).into_iter();
                 let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();

--- a/crates/biome_html_formatter/src/generated.rs
+++ b/crates/biome_html_formatter/src/generated.rs
@@ -118,6 +118,46 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlClosingElement {
         )
     }
 }
+impl FormatRule<biome_html_syntax::HtmlComment>
+    for crate::html::auxiliary::comment::FormatHtmlComment
+{
+    type Context = HtmlFormatContext;
+    #[inline(always)]
+    fn fmt(
+        &self,
+        node: &biome_html_syntax::HtmlComment,
+        f: &mut HtmlFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<biome_html_syntax::HtmlComment>::fmt(self, node, f)
+    }
+}
+impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlComment {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_html_syntax::HtmlComment,
+        crate::html::auxiliary::comment::FormatHtmlComment,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatRefWithRule::new(
+            self,
+            crate::html::auxiliary::comment::FormatHtmlComment::default(),
+        )
+    }
+}
+impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlComment {
+    type Format = FormatOwnedWithRule<
+        biome_html_syntax::HtmlComment,
+        crate::html::auxiliary::comment::FormatHtmlComment,
+    >;
+    fn into_format(self) -> Self::Format {
+        #![allow(clippy::default_constructed_unit_structs)]
+        FormatOwnedWithRule::new(
+            self,
+            crate::html::auxiliary::comment::FormatHtmlComment::default(),
+        )
+    }
+}
 impl FormatRule<biome_html_syntax::HtmlContent>
     for crate::html::auxiliary::content::FormatHtmlContent
 {

--- a/crates/biome_html_formatter/src/html/any/element.rs
+++ b/crates/biome_html_formatter/src/html/any/element.rs
@@ -9,6 +9,7 @@ impl FormatRule<AnyHtmlElement> for FormatAnyHtmlElement {
     fn fmt(&self, node: &AnyHtmlElement, f: &mut HtmlFormatter) -> FormatResult<()> {
         match node {
             AnyHtmlElement::HtmlBogusElement(node) => node.format().fmt(f),
+            AnyHtmlElement::HtmlComment(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlContent(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlElement(node) => node.format().fmt(f),
             AnyHtmlElement::HtmlSelfClosingElement(node) => node.format().fmt(f),

--- a/crates/biome_html_formatter/src/html/auxiliary/comment.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/comment.rs
@@ -1,0 +1,10 @@
+use crate::prelude::*;
+use biome_html_syntax::HtmlComment;
+use biome_rowan::AstNode;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatHtmlComment;
+impl FormatNodeRule<HtmlComment> for FormatHtmlComment {
+    fn fmt_fields(&self, node: &HtmlComment, f: &mut HtmlFormatter) -> FormatResult<()> {
+        format_verbatim_node(node.syntax()).fmt(f)
+    }
+}

--- a/crates/biome_html_formatter/src/html/auxiliary/mod.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod attribute;
 pub(crate) mod attribute_initializer_clause;
 pub(crate) mod closing_element;
+pub(crate) mod comment;
 pub(crate) mod content;
 pub(crate) mod directive;
 pub(crate) mod element;

--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -289,3 +289,31 @@ fn unquoted_attribute_value_invalid_chars() {
         ERROR_TOKEN: 3,
     }
 }
+
+#[test]
+fn comment_start() {
+    assert_lex! {
+        "<!--",
+        COMMENT_START: 4,
+    }
+}
+
+#[test]
+fn comment_end() {
+    assert_lex! {
+        HtmlLexContext::Comment,
+        "-->",
+        COMMENT_END: 3,
+    }
+}
+
+#[test]
+fn comment_full() {
+    assert_lex! {
+        HtmlLexContext::Comment,
+        "<!-- foo -->",
+        COMMENT_START: 4,
+        HTML_LITERAL: 5,
+        COMMENT_END: 3,
+    }
+}

--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -158,6 +158,7 @@ impl ParseNodeList for ElementList {
 
     fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
         match p.cur() {
+            T![<!--] => parse_comment(p),
             T![<] => parse_element(p),
             HTML_LITERAL => {
                 let m = p.start();
@@ -262,4 +263,15 @@ fn parse_attribute_initializer(p: &mut HtmlParser) -> ParsedSyntax {
     p.bump_with_context(T![=], HtmlLexContext::AttributeValue);
     parse_attribute_string_literal(p).or_add_diagnostic(p, expected_initializer);
     Present(m.complete(p, HTML_ATTRIBUTE_INITIALIZER_CLAUSE))
+}
+
+fn parse_comment(p: &mut HtmlParser) -> ParsedSyntax {
+    if !p.at(T![<!--]) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump_with_context(T![<!--], HtmlLexContext::Comment);
+    p.bump_with_context(HTML_LITERAL, HtmlLexContext::Comment);
+    p.expect(T![-->]);
+    Present(m.complete(p, HTML_COMMENT))
 }

--- a/crates/biome_html_parser/src/token_source.rs
+++ b/crates/biome_html_parser/src/token_source.rs
@@ -33,6 +33,8 @@ pub(crate) enum HtmlLexContext {
     Doctype,
     /// Treat everything as text until the closing tag is encountered.
     EmbeddedLanguage(HtmlEmbededLanguage),
+    /// Comments are treated as text until the closing comment tag is encountered.
+    Comment,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/crates/biome_html_parser/tests/html_specs/ok/comment.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/ok/comment.html.snap
@@ -16,8 +16,14 @@ expression: snapshot
 HtmlRoot {
     bom_token: missing (optional),
     directive: missing (optional),
-    html: HtmlElementList [],
-    eof_token: EOF@0..21 "" [Comments("<!-- Hello World -->"), Newline("\n")] [],
+    html: HtmlElementList [
+        HtmlComment {
+            comment_start_token: COMMENT_START@0..4 "<!--" [] [],
+            content_token: HTML_LITERAL@4..17 " Hello World " [] [],
+            comment_end_token: COMMENT_END@17..20 "-->" [] [],
+        },
+    ],
+    eof_token: EOF@20..21 "" [Newline("\n")] [],
 }
 ```
 
@@ -27,7 +33,11 @@ HtmlRoot {
 0: HTML_ROOT@0..21
   0: (empty)
   1: (empty)
-  2: HTML_ELEMENT_LIST@0..0
-  3: EOF@0..21 "" [Comments("<!-- Hello World -->"), Newline("\n")] []
+  2: HTML_ELEMENT_LIST@0..20
+    0: HTML_COMMENT@0..20
+      0: COMMENT_START@0..4 "<!--" [] []
+      1: HTML_LITERAL@4..17 " Hello World " [] []
+      2: COMMENT_END@17..20 "-->" [] []
+  3: EOF@20..21 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_html_syntax/src/generated/kind.rs
+++ b/crates/biome_html_syntax/src/generated/kind.rs
@@ -19,6 +19,8 @@ pub enum HtmlSyntaxKind {
     EQ,
     BANG,
     MINUS,
+    COMMENT_START,
+    COMMENT_END,
     NULL_KW,
     TRUE_KW,
     FALSE_KW,
@@ -30,7 +32,6 @@ pub enum HtmlSyntaxKind {
     NEWLINE,
     WHITESPACE,
     IDENT,
-    COMMENT,
     HTML_IDENT,
     HTML_ROOT,
     HTML_DIRECTIVE,
@@ -46,6 +47,7 @@ pub enum HtmlSyntaxKind {
     HTML_ELEMENT_LIST,
     HTML_ATTRIBUTE_LIST,
     HTML_CONTENT,
+    HTML_COMMENT,
     HTML_BOGUS,
     HTML_BOGUS_ELEMENT,
     HTML_BOGUS_ATTRIBUTE,
@@ -56,7 +58,7 @@ use self::HtmlSyntaxKind::*;
 impl HtmlSyntaxKind {
     pub const fn is_punct(self) -> bool {
         match self {
-            L_ANGLE | R_ANGLE | SLASH | EQ | BANG | MINUS => true,
+            L_ANGLE | R_ANGLE | SLASH | EQ | BANG | MINUS | COMMENT_START | COMMENT_END => true,
             _ => false,
         }
     }
@@ -91,6 +93,8 @@ impl HtmlSyntaxKind {
             EQ => "=",
             BANG => "!",
             MINUS => "-",
+            COMMENT_START => "<!--",
+            COMMENT_END => "-->",
             NULL_KW => "null",
             TRUE_KW => "true",
             FALSE_KW => "false",
@@ -104,4 +108,4 @@ impl HtmlSyntaxKind {
 }
 #[doc = r" Utility macro for creating a SyntaxKind through simple macro syntax"]
 #[macro_export]
-macro_rules ! T { [<] => { $ crate :: HtmlSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: HtmlSyntaxKind :: R_ANGLE } ; [/] => { $ crate :: HtmlSyntaxKind :: SLASH } ; [=] => { $ crate :: HtmlSyntaxKind :: EQ } ; [!] => { $ crate :: HtmlSyntaxKind :: BANG } ; [-] => { $ crate :: HtmlSyntaxKind :: MINUS } ; [null] => { $ crate :: HtmlSyntaxKind :: NULL_KW } ; [true] => { $ crate :: HtmlSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: HtmlSyntaxKind :: FALSE_KW } ; [doctype] => { $ crate :: HtmlSyntaxKind :: DOCTYPE_KW } ; [html] => { $ crate :: HtmlSyntaxKind :: HTML_KW } ; [ident] => { $ crate :: HtmlSyntaxKind :: IDENT } ; [EOF] => { $ crate :: HtmlSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: HtmlSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: HtmlSyntaxKind :: HASH } ; }
+macro_rules ! T { [<] => { $ crate :: HtmlSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: HtmlSyntaxKind :: R_ANGLE } ; [/] => { $ crate :: HtmlSyntaxKind :: SLASH } ; [=] => { $ crate :: HtmlSyntaxKind :: EQ } ; [!] => { $ crate :: HtmlSyntaxKind :: BANG } ; [-] => { $ crate :: HtmlSyntaxKind :: MINUS } ; [<!--] => { $ crate :: HtmlSyntaxKind :: COMMENT_START } ; [-->] => { $ crate :: HtmlSyntaxKind :: COMMENT_END } ; [null] => { $ crate :: HtmlSyntaxKind :: NULL_KW } ; [true] => { $ crate :: HtmlSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: HtmlSyntaxKind :: FALSE_KW } ; [doctype] => { $ crate :: HtmlSyntaxKind :: DOCTYPE_KW } ; [html] => { $ crate :: HtmlSyntaxKind :: HTML_KW } ; [ident] => { $ crate :: HtmlSyntaxKind :: IDENT } ; [EOF] => { $ crate :: HtmlSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: HtmlSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: HtmlSyntaxKind :: HASH } ; }

--- a/crates/biome_html_syntax/src/generated/macros.rs
+++ b/crates/biome_html_syntax/src/generated/macros.rs
@@ -29,6 +29,10 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::HtmlClosingElement::new_unchecked(node) };
                     $body
                 }
+                $crate::HtmlSyntaxKind::HTML_COMMENT => {
+                    let $pattern = unsafe { $crate::HtmlComment::new_unchecked(node) };
+                    $body
+                }
                 $crate::HtmlSyntaxKind::HTML_CONTENT => {
                     let $pattern = unsafe { $crate::HtmlContent::new_unchecked(node) };
                     $body

--- a/crates/biome_html_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_html_syntax/src/generated/nodes_mut.rs
@@ -57,6 +57,26 @@ impl HtmlClosingElement {
         )
     }
 }
+impl HtmlComment {
+    pub fn with_comment_start_token(self, element: SyntaxToken) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(Some(element.into()))),
+        )
+    }
+    pub fn with_content_token(self, element: SyntaxToken) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(1usize..=1usize, once(Some(element.into()))),
+        )
+    }
+    pub fn with_comment_end_token(self, element: SyntaxToken) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(2usize..=2usize, once(Some(element.into()))),
+        )
+    }
+}
 impl HtmlContent {
     pub fn with_value_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -28,7 +28,7 @@ impl From<HtmlSyntaxKind> for u16 {
 
 impl HtmlSyntaxKind {
     pub fn is_comments(self) -> bool {
-        matches!(self, HtmlSyntaxKind::COMMENT)
+        matches!(self, HtmlSyntaxKind::HTML_COMMENT)
     }
 
     #[inline]
@@ -99,7 +99,7 @@ impl TryFrom<HtmlSyntaxKind> for TriviaPieceKind {
             }
         } else if value.is_comments() {
             match value {
-                HtmlSyntaxKind::COMMENT => Ok(TriviaPieceKind::SingleLineComment),
+                HtmlSyntaxKind::HTML_COMMENT => Ok(TriviaPieceKind::SingleLineComment),
                 _ => unreachable!("Not Comment"),
             }
         } else {

--- a/crates/biome_parser/src/parsed_syntax.rs
+++ b/crates/biome_parser/src/parsed_syntax.rs
@@ -61,7 +61,7 @@ impl ParsedSyntax {
         }
     }
 
-    /// Calls `op` if the syntax is absent ond otherwise returns [ParsedSyntax::Present]
+    /// Calls `op` if the syntax is absent and otherwise returns [ParsedSyntax::Present]
     #[inline]
     pub fn or_else<F>(self, op: F) -> ParsedSyntax
     where

--- a/xtask/codegen/html.ungram
+++ b/xtask/codegen/html.ungram
@@ -68,6 +68,7 @@ AnyHtmlElement =
 	HtmlSelfClosingElement
 	| HtmlElement
 	| HtmlContent
+	| HtmlComment
 	| HtmlBogusElement
 
 
@@ -99,6 +100,12 @@ HtmlClosingElement =
 	'/'
 	name: HtmlName
 	'>'
+
+// <!-- comment -->
+HtmlComment =
+	'<!--'
+	content: 'html_literal'
+	'-->'
 
 // ==================================
 // Attributes

--- a/xtask/codegen/src/html_kinds_src.rs
+++ b/xtask/codegen/src/html_kinds_src.rs
@@ -8,6 +8,8 @@ pub const HTML_KINDS_SRC: KindsSrc = KindsSrc {
         ("=", "EQ"),
         ("!", "BANG"),
         ("-", "MINUS"),
+        ("<!--", "COMMENT_START"),
+        ("-->", "COMMENT_END"),
     ],
     keywords: &["null", "true", "false", "doctype", "html"],
     literals: &["HTML_STRING_LITERAL", "HTML_LITERAL"],
@@ -16,7 +18,6 @@ pub const HTML_KINDS_SRC: KindsSrc = KindsSrc {
         "NEWLINE",
         "WHITESPACE",
         "IDENT",
-        "COMMENT",
         "HTML_IDENT",
     ],
     nodes: &[
@@ -34,6 +35,7 @@ pub const HTML_KINDS_SRC: KindsSrc = KindsSrc {
         "HTML_ELEMENT_LIST",
         "HTML_ATTRIBUTE_LIST",
         "HTML_CONTENT",
+        "HTML_COMMENT",
         // Bogus nodes
         "HTML_BOGUS",
         "HTML_BOGUS_ELEMENT",

--- a/xtask/codegen/src/js_kinds_src.rs
+++ b/xtask/codegen/src/js_kinds_src.rs
@@ -688,6 +688,8 @@ impl Field {
                     ("~=", _) => "whitespace_like",
                     (",", _) => "comma",
                     ("---", LanguageKind::Yaml) => "dashdashdash",
+                    ("<!--", LanguageKind::Html) => "comment_start",
+                    ("-->", LanguageKind::Html) => "comment_end",
                     _ => name,
                 };
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This PR changes how comments are parsed such that they are included in the AST as actual nodes, and not just trivia attached to other nodes.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Fixes #4043 (but not the mismatched formatting)

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Snapshots updated, CI should pass.
