### PR TITLE
feat(cli): automatically use github reporter when in github actions environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### CLI
 
+#### New features
+
+- When Biome detects that it's running in Github Actions, it will automatically default the reporter to `github` if no reporter is specified. Contributed by @dyc3.
+
 ### Configuration
 
 #### Bug fixes

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -51,10 +51,9 @@ pub struct CliOptions {
     /// Allows to change how diagnostics and summary are reported.
     #[bpaf(
         long("reporter"),
-        argument("json|json-pretty|github|junit|summary|gitlab"),
-        fallback(CliReporter::default())
+        argument("json|json-pretty|github|junit|summary|gitlab")
     )]
-    pub reporter: CliReporter,
+    pub reporter: Option<CliReporter>,
 
     #[bpaf(
         long("log-level"),
@@ -116,7 +115,7 @@ impl FromStr for ColorsArg {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum CliReporter {
     /// The default reporter
     #[default]
@@ -133,12 +132,6 @@ pub enum CliReporter {
     Summary,
     /// Reports linter diagnostics using the [GitLab Code Quality report](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool).
     GitLab,
-}
-
-impl CliReporter {
-    pub(crate) const fn is_default(&self) -> bool {
-        matches!(self, Self::Default)
-    }
 }
 
 impl FromStr for CliReporter {

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -564,7 +564,7 @@ impl BiomeCommand {
         match self.cli_options() {
             Some(cli_options) => {
                 // To properly display GitHub annotations we need to disable colors
-                if matches!(cli_options.reporter, CliReporter::GitHub) {
+                if matches!(cli_options.reporter, Some(CliReporter::GitHub)) {
                     return Some(&ColorsArg::Off);
                 }
                 // We want force colors in CI, to give e better UX experience


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes it so we automatically use the github reporter when none is specified, and we know we are running in a github actions environment.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested manually. The presence of this environment var indicates a github actions environment.

```
GITHUB_ACTIONS=true cargo run --bin biome -- ci
```
