### PR TITLE
fix(useButtonType): don't report dynamically created button with valid type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useButtonType](https://biomejs.dev/linter/rules/use-button-type/) no longer reports dynamically created button with a valid type ([#4072](https://github.com/biomejs/biome/issues/4072)).
+
+  The following code is no longer reported:
+
+  ```js
+  React.createElement("button", { type: "button" }, "foo")
+  ```
+
+  Contributed by @Conaclos
+
 ### Parser
 
 ## v1.9.2 (2024-09-19)

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -105,14 +105,7 @@ impl ReactApiCall for ReactCreateElementCall {
                 let AnyJsObjectMember::JsPropertyObjectMember(property) = member.ok()? else {
                     return None;
                 };
-                let property_name = property.name().ok()?;
-
-                let property_name = property_name.as_js_literal_member_name()?;
-                if property_name.name().ok()? == prop_name {
-                    Some(property)
-                } else {
-                    None
-                }
+                (property.name().ok()?.name()? == prop_name).then_some(property)
             })
         })
     }

--- a/crates/biome_js_analyze/tests/specs/a11y/useButtonType/inObject.js
+++ b/crates/biome_js_analyze/tests/specs/a11y/useButtonType/inObject.js
@@ -12,6 +12,5 @@ React.createElement('button', {
 React.createElement('button', {});
 
 // valid
-React.createElement('button', {
-    "type": foo
-});
+React.createElement('button', { "type": foo });
+React.createElement("button", { type: "button" }, "foo")

--- a/crates/biome_js_analyze/tests/specs/a11y/useButtonType/inObject.js.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useButtonType/inObject.js.snap
@@ -18,10 +18,8 @@ React.createElement('button', {
 React.createElement('button', {});
 
 // valid
-React.createElement('button', {
-    "type": foo
-});
-
+React.createElement('button', { "type": foo });
+React.createElement("button", { type: "button" }, "foo")
 ```
 
 # Diagnostics
@@ -121,5 +119,3 @@ inObject.js:12:31 lint/a11y/useButtonType ━━━━━━━━━━━━�
   
 
 ```
-
-


### PR DESCRIPTION
## Summary

Fix #4072 

This solves two bugs:
1. The `find_prop_by_name` utility only returned quoted property.
    For instance `{ "type": foo }` was reported, while `{ type: foo }` was not reported.
2. The rule was always reporting `"type"` property set with any string value, including valid ones.

I have to admit that I was a bit surprised that our JSX rules handle dynamic code such as `React.createElement`. I wonder if we should restrict our rules to JSX and ignore dynamic creation completely.

I took the opportunity of refactoring a bit the flow to make it more readable.

## Test Plan

I added a test
