### PR TITLE
fix(linter): apply `useExplicitFunctionReturnType` only to TypeScript…

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/top_level_all_down_level_not_all.snap
@@ -41,25 +41,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-fix.js:1:1 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Missing return type on function.
-  
-  > 1 │ 
-      │ 
-  > 2 │     function f() {arguments;}
-      │     ^^^^^^^^^^
-    3 │     const FOO = "FOO";
-    4 │     var x, y;
-  
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
-  
-  i Add a return type annotation.
-  
-
-```
-
-```block
 fix.js:2:14 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function is unused.
@@ -170,5 +151,5 @@ fix.js format ━━━━━━━━━━━━━━━━━━━━━━
 ```block
 Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
-Found 5 warnings.
+Found 4 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/top_level_all_true_group_level_all_false.snap
@@ -30,25 +30,6 @@ expression: content
 # Emitted Messages
 
 ```block
-fix.js:1:1 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Missing return type on function.
-  
-  > 1 │ 
-      │ 
-  > 2 │     function f() {arguments;}
-      │     ^^^^^^^^^^
-    3 │     const FOO = "FOO";
-    4 │     var x, y;
-  
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
-  
-  i Add a return type annotation.
-  
-
-```
-
-```block
 fix.js:2:14 lint/correctness/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This function is unused.
@@ -138,5 +119,5 @@ fix.js:4:12 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes applied.
-Found 5 warnings.
+Found 4 warnings.
 ```

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -3,7 +3,9 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_js_semantic::HasClosureAstNode;
-use biome_js_syntax::{AnyJsBinding, AnyJsExpression, AnyJsFunctionBody, AnyTsType, JsSyntaxKind};
+use biome_js_syntax::{
+    AnyJsBinding, AnyJsExpression, AnyJsFunctionBody, AnyTsType, JsFileSource, JsSyntaxKind,
+};
 use biome_js_syntax::{
     AnyJsFunction, JsGetterClassMember, JsGetterObjectMember, JsMethodClassMember,
     JsMethodObjectMember,
@@ -128,6 +130,14 @@ impl Rule for UseExplicitFunctionReturnType {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let source_type = ctx.source_type::<JsFileSource>().language();
+        let is_ts_source = source_type.is_typescript();
+        let is_declaration = source_type.is_definition_file();
+
+        if is_declaration || !is_ts_source {
+            return None;
+        }
+
         let node = ctx.query();
         match node {
             AnyJsFunctionWithReturnType::AnyJsFunction(func) => {

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -131,10 +131,7 @@ impl Rule for UseExplicitFunctionReturnType {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let source_type = ctx.source_type::<JsFileSource>().language();
-        let is_ts_source = source_type.is_typescript();
-        let is_declaration = source_type.is_definition_file();
-
-        if is_declaration || !is_ts_source {
+        if !source_type.is_typescript() || source_type.is_definition_file() {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.d.ts
@@ -1,0 +1,48 @@
+/* should not generate diagnostics */
+declare class Test {
+	constructor();
+	get prop();
+	set prop(value: any);
+	method(): void;
+	arrow: () => string;
+	private method(): void;
+}
+
+declare function test(): void;
+
+declare var fn: () => number;
+
+declare var arrowFn: () => string;
+
+declare const obj: {
+	method(): string;
+};
+
+declare const obj: {
+	readonly method: string;
+};
+
+declare const _default: () => void;
+export default _default;
+
+declare const func: (value: number) => {
+	readonly foo: "bar";
+	readonly value: number;
+};
+declare const func: () => { readonly x: typeof x };
+
+declare const node: any;
+declare const arr: any[];
+declare const foo: number[];
+
+declare function fn(callback: () => void): void;
+
+declare const IIFE1: void;
+declare const IIFE2: void;
+
+declare function test(a: number, b: number): void;
+declare function test(): void;
+
+declare var fn: () => number;
+
+declare var arrowFn: () => string;

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.d.ts.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.d.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+declare class Test {
+	constructor();
+	get prop();
+	set prop(value: any);
+	method(): void;
+	arrow: () => string;
+	private method(): void;
+}
+
+declare function test(): void;
+
+declare var fn: () => number;
+
+declare var arrowFn: () => string;
+
+declare const obj: {
+	method(): string;
+};
+
+declare const obj: {
+	readonly method: string;
+};
+
+declare const _default: () => void;
+export default _default;
+
+declare const func: (value: number) => {
+	readonly foo: "bar";
+	readonly value: number;
+};
+declare const func: () => { readonly x: typeof x };
+
+declare const node: any;
+declare const arr: any[];
+declare const foo: number[];
+
+declare function fn(callback: () => void): void;
+
+declare const IIFE1: void;
+declare const IIFE2: void;
+
+declare function test(a: number, b: number): void;
+declare function test(): void;
+
+declare var fn: () => number;
+
+declare var arrowFn: () => string;
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.js
@@ -1,0 +1,38 @@
+/* should not generate diagnostics */
+function test() {
+  return;
+}
+
+var fn = function () {
+  return 1;
+};
+
+var arrowFn = () => 'test';
+
+class Test {
+  constructor() {}
+  get prop() {
+    return 1;
+  }
+  set prop() {}
+  method() {
+    return;
+  }
+  arrow = () => 'arrow';
+}
+
+const obj = {
+	method() {
+		return "test"
+	}
+}
+
+export default () => {};
+export default function () {}
+
+const func = (value) => ({ foo: 'bar', value });
+const func = () => x;
+
+
+node.addEventListener('click', () => {});
+node.addEventListener('click', function () {});

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.js.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+function test() {
+  return;
+}
+
+var fn = function () {
+  return 1;
+};
+
+var arrowFn = () => 'test';
+
+class Test {
+  constructor() {}
+  get prop() {
+    return 1;
+  }
+  set prop() {}
+  method() {
+    return;
+  }
+  arrow = () => 'arrow';
+}
+
+const obj = {
+	method() {
+		return "test"
+	}
+}
+
+export default () => {};
+export default function () {}
+
+const func = (value) => ({ foo: 'bar', value });
+const func = () => x;
+
+
+node.addEventListener('click', () => {});
+node.addEventListener('click', function () {});
+```


### PR DESCRIPTION
… files, excluding declaration files

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
closes: https://github.com/biomejs/biome/issues/4089

run `useExplicitFunctionReturnType` only on TypeScript-enabled files, excluding declaration files

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
