### PR TITLE
fix(noUndeclaredDependencies): ignore NodeJS modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
-- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) no lonjger reports NodeJSs builtin modules as undeclared dependencies.
+- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) no longer reports Node.js builtin modules as undeclared dependencies.
 
   The rule no longer reports the following code:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) no lonjger reports NodeJSs builtin modules as undeclared dependencies.
+
+  The rule no longer reports the following code:
+
+  ```js
+  import * as fs from "fs";
+  ```
+
+  Contributed by @Conaclos
+
 - [noUselessEscapeInRegex](https://biomejs.dev/linter/rules/no-useless-escape-in-regex/) no longer panics on regexes that start with an empty character class. Contributed by @Conaclos
 
 - [noUselessStringConcat](https://biomejs.dev/linter/rules/no-useless-string-concat/) no longer panics when it encounters malformed code. Contributed by @Conaclos

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -1,4 +1,4 @@
-use crate::services::manifest::Manifest;
+use crate::{globals::is_node_builtin_module, services::manifest::Manifest};
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike};
@@ -64,6 +64,8 @@ impl Rule for NoUndeclaredDependencies {
             // TODO: we should also check that an `.` exports exists.
             // See https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name
             || ctx.name() == Some(package_name)
+            // ignore NodeJS builtin modules
+            || is_node_builtin_module(package_name)
             // Ignore `bun` import
             || package_name == "bun"
         {

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -64,7 +64,7 @@ impl Rule for NoUndeclaredDependencies {
             // TODO: we should also check that an `.` exports exists.
             // See https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name
             || ctx.name() == Some(package_name)
-            // ignore NodeJS builtin modules
+            // ignore Node.js builtin modules
             || is_node_builtin_module(package_name)
             // Ignore `bun` import
             || package_name == "bun"

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
@@ -28,3 +28,9 @@ import "#internal";
 import type * as jest from "lodash";
 
 import "bun";
+
+// NodeJS builtin
+import "fs";
+import "os";
+import "path";
+import "process";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
@@ -34,4 +34,10 @@ import "#internal";
 import type * as jest from "lodash";
 
 import "bun";
+
+// NodeJS builtin
+import "fs";
+import "os";
+import "path";
+import "process";
 ```


### PR DESCRIPTION
## Summary

`noUndeclaredDependencies` now ignores NodeJS modules.

## Test Plan

I added some tests.
