### PR TITLE
fix(noMisleadingCharacterClass): ignore characters outside of char classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 #### Bug fixes
 
+- [noMisleadingCharacterClass](https://biomejs.dev/linter/rules/no-misleading-character-class/) no longer reports issues outside of character classes.
+
+  The following code is no longer reported:
+
+  ```js
+  /[a-z]👍/;
+  ```
+
+  Contributed by @Conaclos
+
 - [noUndeclaredDependencies](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) no longer reports Node.js builtin modules as undeclared dependencies.
 
   The rule no longer reports the following code:

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js
@@ -71,3 +71,5 @@ var r = RegExp("[👍]", "");
 var r = window.RegExp("[👍]", "");
 var r = global.RegExp("[👍]", "");
 var r = globalThis.RegExp("[👍]", "");
+
+/[\]👍]/;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js.snap
@@ -78,6 +78,7 @@ var r = window.RegExp("[👍]", "");
 var r = global.RegExp("[👍]", "");
 var r = globalThis.RegExp("[👍]", "");
 
+/[\]👍]/;
 ```
 
 # Diagnostics
@@ -1291,6 +1292,7 @@ invalid.js:73:9 lint/suspicious/noMisleadingCharacterClass  FIXABLE  ━━━�
   > 73 │ var r = globalThis.RegExp("[👍]", "");
        │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     74 │ 
+    75 │ /[\]👍]/;
   
   i Safe fix: Add unicode u flag to regex
   
@@ -1299,4 +1301,24 @@ invalid.js:73:9 lint/suspicious/noMisleadingCharacterClass  FIXABLE  ━━━�
 
 ```
 
+```
+invalid.js:75:1 lint/suspicious/noMisleadingCharacterClass  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Unexpected surrogate pair in character class. Use the 'u' flag.
+  
+    73 │ var r = globalThis.RegExp("[👍]", "");
+    74 │ 
+  > 75 │ /[\]👍]/;
+       │ ^^^^^^^^
+  
+  i Safe fix: Add unicode u flag to regex
+  
+    73 73 │   var r = globalThis.RegExp("[👍]", "");
+    74 74 │   
+    75    │ - /[\]👍]/;
+       75 │ + 
+       76 │ + 
+       77 │ + /[\]👍]/u;
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/valid.js
@@ -55,3 +55,7 @@ var r = new globalThis.globalThis.globalThis.RegExp(/[👍]/u);
 
 // Issue: https://github.com/biomejs/biome/issues/1522
 var cyrillicChars = /[\u200E\u2066-\u2069]/gu;
+
+// Unicode char outside the class
+/[a-z]👍/;
+/\[👍]/;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/valid.js.snap
@@ -62,6 +62,7 @@ var r = new globalThis.globalThis.globalThis.RegExp(/[👍]/u);
 // Issue: https://github.com/biomejs/biome/issues/1522
 var cyrillicChars = /[\u200E\u2066-\u2069]/gu;
 
+// Unicode char outside the class
+/[a-z]👍/;
+/\[👍]/;
 ```
-
-


### PR DESCRIPTION
## Summary

While I was working on #4081, I noticed that the rule was inspecting the entire regex from the start of the first char class.
This PR fixes the issue by checking only char classes.

I have suspicions about other parts of the implementation, notably escape handling.
I left the investigation for later.

## Test Plan

I added test.
