### PR TITLE
feat(useExplicitFunctionReturnType): support higher-order function

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
@@ -44,3 +44,40 @@ const func = (value: number) => ({ type: 'X', value }) as Action;
 
 export default () => {};
 export default function () {}
+
+// check higher order functions
+const arrowFn = () => () => {};
+const arrowFn = () => function() {}
+function fn() {
+  let str = "hey";
+  return function () {
+      return str;
+  };
+}
+const arrowFn = () => {
+  return () => { };
+}
+
+// does not support detecting a return of a function inside other statements like if, switch, etc.
+const arrowFn = (a: number) => {
+  if (a === 1) {
+    return (): void => { };
+  } else {
+    return (): number => {
+      return a + 2
+    }
+  }
+}
+const arrowFn = (a: number) => {
+  switch (a) {
+    case 1: {
+      return (): void => { };
+    }
+    case 2: {
+      return (): void => { };
+    }
+    default: {
+      return (): void => { };
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
@@ -48,17 +48,12 @@ export default function () {}
 // check higher order functions
 const arrowFn = () => () => {};
 const arrowFn = () => function() {}
-function fn() {
-  let str = "hey";
-  return function () {
-      return str;
-  };
-}
 const arrowFn = () => {
   return () => { };
 }
 
 // does not support detecting a return of a function inside other statements like if, switch, etc.
+// we check only the first statment 
 const arrowFn = (a: number) => {
   if (a === 1) {
     return (): void => { };
@@ -80,4 +75,18 @@ const arrowFn = (a: number) => {
       return (): void => { };
     }
   }
+}
+
+function f() {
+  if (x) {
+    return 0;
+  }
+  return (): void => {}
+}
+
+function fn() {
+  let str = "hey";
+  return function (): string {
+      return str;
+  };
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
@@ -50,6 +50,43 @@ const func = (value: number) => ({ type: 'X', value }) as Action;
 
 export default () => {};
 export default function () {}
+
+// check higher order functions
+const arrowFn = () => () => {};
+const arrowFn = () => function() {}
+function fn() {
+  let str = "hey";
+  return function () {
+      return str;
+  };
+}
+const arrowFn = () => {
+  return () => { };
+}
+
+// does not support detecting a return of a function inside other statements like if, switch, etc.
+const arrowFn = (a: number) => {
+  if (a === 1) {
+    return (): void => { };
+  } else {
+    return (): number => {
+      return a + 2
+    }
+  }
+}
+const arrowFn = (a: number) => {
+  switch (a) {
+    case 1: {
+      return (): void => { };
+    }
+    case 2: {
+      return (): void => { };
+    }
+    default: {
+      return (): void => { };
+    }
+  }
+}
 ```
 
 # Diagnostics
@@ -307,6 +344,7 @@ invalid.ts:45:16 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
   > 45 │ export default () => {};
        │                ^^^^^^^^
     46 │ export default function () {}
+    47 │ 
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -323,6 +361,133 @@ invalid.ts:46:16 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
     45 │ export default () => {};
   > 46 │ export default function () {}
        │                ^^^^^^^^^^^^^^
+    47 │ 
+    48 │ // check higher order functions
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:49:23 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    48 │ // check higher order functions
+  > 49 │ const arrowFn = () => () => {};
+       │                       ^^^^^^^^
+    50 │ const arrowFn = () => function() {}
+    51 │ function fn() {
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:50:23 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    48 │ // check higher order functions
+    49 │ const arrowFn = () => () => {};
+  > 50 │ const arrowFn = () => function() {}
+       │                       ^^^^^^^^^^^^^
+    51 │ function fn() {
+    52 │   let str = "hey";
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:53:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    51 │ function fn() {
+    52 │   let str = "hey";
+  > 53 │   return function () {
+       │          ^^^^^^^^^^^^^
+  > 54 │       return str;
+  > 55 │   };
+       │   ^
+    56 │ }
+    57 │ const arrowFn = () => {
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:58:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    56 │ }
+    57 │ const arrowFn = () => {
+  > 58 │   return () => { };
+       │          ^^^^^^^^^
+    59 │ }
+    60 │ 
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:62:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    61 │ // does not support detecting a return of a function inside other statements like if, switch, etc.
+  > 62 │ const arrowFn = (a: number) => {
+       │                 ^^^^^^^^^^^^^^^^
+  > 63 │   if (a === 1) {
+        ...
+  > 69 │   }
+  > 70 │ }
+       │ ^
+    71 │ const arrowFn = (a: number) => {
+    72 │   switch (a) {
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:71:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    69 │   }
+    70 │ }
+  > 71 │ const arrowFn = (a: number) => {
+       │                 ^^^^^^^^^^^^^^^^
+  > 72 │   switch (a) {
+        ...
+  > 80 │       return (): void => { };
+  > 81 │     }
+  > 82 │   }
+  > 83 │ }
+       │ ^
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
@@ -54,17 +54,12 @@ export default function () {}
 // check higher order functions
 const arrowFn = () => () => {};
 const arrowFn = () => function() {}
-function fn() {
-  let str = "hey";
-  return function () {
-      return str;
-  };
-}
 const arrowFn = () => {
   return () => { };
 }
 
 // does not support detecting a return of a function inside other statements like if, switch, etc.
+// we check only the first statment 
 const arrowFn = (a: number) => {
   if (a === 1) {
     return (): void => { };
@@ -86,6 +81,20 @@ const arrowFn = (a: number) => {
       return (): void => { };
     }
   }
+}
+
+function f() {
+  if (x) {
+    return 0;
+  }
+  return (): void => {}
+}
+
+function fn() {
+  let str = "hey";
+  return function (): string {
+      return str;
+  };
 }
 ```
 
@@ -380,7 +389,7 @@ invalid.ts:49:23 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
   > 49 │ const arrowFn = () => () => {};
        │                       ^^^^^^^^
     50 │ const arrowFn = () => function() {}
-    51 │ function fn() {
+    51 │ const arrowFn = () => {
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -398,8 +407,8 @@ invalid.ts:50:23 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
     49 │ const arrowFn = () => () => {};
   > 50 │ const arrowFn = () => function() {}
        │                       ^^^^^^^^^^^^^
-    51 │ function fn() {
-    52 │   let str = "hey";
+    51 │ const arrowFn = () => {
+    52 │   return () => { };
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -409,38 +418,16 @@ invalid.ts:50:23 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
 ```
 
 ```
-invalid.ts:53:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:52:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Missing return type on function.
   
-    51 │ function fn() {
-    52 │   let str = "hey";
-  > 53 │   return function () {
-       │          ^^^^^^^^^^^^^
-  > 54 │       return str;
-  > 55 │   };
-       │   ^
-    56 │ }
-    57 │ const arrowFn = () => {
-  
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
-  
-  i Add a return type annotation.
-  
-
-```
-
-```
-invalid.ts:58:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Missing return type on function.
-  
-    56 │ }
-    57 │ const arrowFn = () => {
-  > 58 │   return () => { };
+    50 │ const arrowFn = () => function() {}
+    51 │ const arrowFn = () => {
+  > 52 │   return () => { };
        │          ^^^^^^^^^
-    59 │ }
-    60 │ 
+    53 │ }
+    54 │ 
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -450,20 +437,21 @@ invalid.ts:58:10 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
 ```
 
 ```
-invalid.ts:62:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:57:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Missing return type on function.
   
-    61 │ // does not support detecting a return of a function inside other statements like if, switch, etc.
-  > 62 │ const arrowFn = (a: number) => {
+    55 │ // does not support detecting a return of a function inside other statements like if, switch, etc.
+    56 │ // we check only the first statment·
+  > 57 │ const arrowFn = (a: number) => {
        │                 ^^^^^^^^^^^^^^^^
-  > 63 │   if (a === 1) {
+  > 58 │   if (a === 1) {
         ...
-  > 69 │   }
-  > 70 │ }
+  > 64 │   }
+  > 65 │ }
        │ ^
-    71 │ const arrowFn = (a: number) => {
-    72 │   switch (a) {
+    66 │ const arrowFn = (a: number) => {
+    67 │   switch (a) {
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -473,21 +461,65 @@ invalid.ts:62:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━�
 ```
 
 ```
-invalid.ts:71:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:66:17 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Missing return type on function.
   
-    69 │   }
-    70 │ }
-  > 71 │ const arrowFn = (a: number) => {
+    64 │   }
+    65 │ }
+  > 66 │ const arrowFn = (a: number) => {
        │                 ^^^^^^^^^^^^^^^^
-  > 72 │   switch (a) {
+  > 67 │   switch (a) {
         ...
-  > 80 │       return (): void => { };
-  > 81 │     }
-  > 82 │   }
-  > 83 │ }
+  > 77 │   }
+  > 78 │ }
        │ ^
+    79 │ 
+    80 │ function f() {
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:78:2 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    76 │     }
+    77 │   }
+  > 78 │ }
+       │  
+  > 79 │ 
+  > 80 │ function f() {
+       │ ^^^^^^^^^^
+    81 │   if (x) {
+    82 │     return 0;
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:85:2 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    83 │   }
+    84 │   return (): void => {}
+  > 85 │ }
+       │  
+  > 86 │ 
+  > 87 │ function fn() {
+       │ ^^^^^^^^^^^
+    88 │   let str = "hey";
+    89 │   return function (): string {
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -60,12 +60,6 @@ setTimeout(function() { console.log("Hello!"); }, 1000);
 // check higher order functions
 const arrowFn = () => (): void => {};
 const arrowFn = () => function(): void {}
-function fn() {
-  let str = "hey";
-  return function (): string {
-      return str;
-  };
-}
 const arrowFn = () => {
   return (): void => { };
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -55,3 +55,17 @@ fn(function () {});
   console.log("This is an IIFE");
 })();
 setTimeout(function() { console.log("Hello!"); }, 1000);
+
+
+// check higher order functions
+const arrowFn = () => (): void => {};
+const arrowFn = () => function(): void {}
+function fn() {
+  let str = "hey";
+  return function (): string {
+      return str;
+  };
+}
+const arrowFn = () => {
+  return (): void => { };
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -61,4 +61,18 @@ fn(function () {});
   console.log("This is an IIFE");
 })();
 setTimeout(function() { console.log("Hello!"); }, 1000);
+
+
+// check higher order functions
+const arrowFn = () => (): void => {};
+const arrowFn = () => function(): void {}
+function fn() {
+  let str = "hey";
+  return function (): string {
+      return str;
+  };
+}
+const arrowFn = () => {
+  return (): void => { };
+}
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -66,12 +66,6 @@ setTimeout(function() { console.log("Hello!"); }, 1000);
 // check higher order functions
 const arrowFn = () => (): void => {};
 const arrowFn = () => function(): void {}
-function fn() {
-  let str = "hey";
-  return function (): string {
-      return str;
-  };
-}
 const arrowFn = () => {
   return (): void => { };
 }


### PR DESCRIPTION

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
related: https://github.com/biomejs/biome/issues/2017

This PR introduces the ability to detect higher-order functions in the `useExplicitFunctionReturnType` rule, specifically functions that return other functions.


### Limitations:
Nested statement handling is not implemented: The current implementation does not cover cases where functions are returned inside conditional or branching logic (e.g., if statements or switch statements). 

Example of unsupported case:
```
function example() {
    if (condition) {
        return function() {}; // This return inside the 'if' statement is not detected
    }
}

```

### Question:
Should biome support nested statements like if or switch when checking for higher-order functions? 
This would involve inspecting return statements within those control structures, adding complexity but potentially broadening the detection capability.


