### PR TITLE
feat(formatter): implement formatting for GritQL root node

### DIFF
--- a/crates/biome_grit_formatter/src/cst.rs
+++ b/crates/biome_grit_formatter/src/cst.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use biome_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult};
-use biome_grit_syntax::{map_syntax_node, GritSyntaxNode};
+use biome_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatToken};
+use biome_grit_syntax::{map_syntax_node, GritSyntaxNode, GritSyntaxToken};
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct FormatGritSyntaxNode;
@@ -26,5 +26,24 @@ impl IntoFormat<GritFormatContext> for GritSyntaxNode {
 
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule::new(self, FormatGritSyntaxNode)
+    }
+}
+
+/// Format implementation specific to GritQL tokens.
+pub(crate) type FormatGritSyntaxToken = FormatToken<GritFormatContext>;
+
+impl AsFormat<GritFormatContext> for GritSyntaxToken {
+    type Format<'a> = FormatRefWithRule<'a, GritSyntaxToken, FormatGritSyntaxToken>;
+
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatGritSyntaxToken::default())
+    }
+}
+
+impl IntoFormat<GritFormatContext> for GritSyntaxToken {
+    type Format = FormatOwnedWithRule<GritSyntaxToken, FormatGritSyntaxToken>;
+
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatGritSyntaxToken::default())
     }
 }

--- a/crates/biome_grit_formatter/src/grit/auxiliary/root.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/root.rs
@@ -1,10 +1,30 @@
 use crate::prelude::*;
-use biome_grit_syntax::GritRoot;
-use biome_rowan::AstNode;
+use biome_formatter::write;
+use biome_grit_syntax::{GritRoot, GritRootFields};
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritRoot;
+
 impl FormatNodeRule<GritRoot> for FormatGritRoot {
     fn fmt_fields(&self, node: &GritRoot, f: &mut GritFormatter) -> FormatResult<()> {
-        format_verbatim_node(node.syntax()).fmt(f)
+        let GritRootFields {
+            bom_token,
+            version,
+            language,
+            definitions,
+            eof_token,
+        } = node.as_fields();
+
+        write!(
+            f,
+            [
+                bom_token.format(),
+                version.format(),
+                language.format(),
+                definitions.format(),
+                hard_line_break(),
+                format_removed(&eof_token?),
+            ]
+        )
     }
 }

--- a/crates/biome_grit_formatter/tests/quick_test.rs
+++ b/crates/biome_grit_formatter/tests/quick_test.rs
@@ -1,0 +1,44 @@
+use biome_formatter::{IndentStyle, LineWidth, QuoteStyle};
+use biome_formatter_test::check_reformat::CheckReformat;
+use biome_grit_formatter::context::GritFormatOptions;
+use biome_grit_formatter::{format_node, GritFormatLanguage};
+use biome_grit_parser::parse_grit;
+
+mod language {
+    include!("language.rs");
+}
+
+#[ignore]
+#[test]
+// use this test check if your snippet prints as you wish, without using a snapshot
+fn quick_test() {
+    let src = r#"
+`$method('$message')` where {
+  if ($message <: r"Hello, .*!") {
+    $method => `console.info`
+  } else {
+    $method => `console.warn`
+  }
+}
+"#;
+    let tree = parse_grit(src);
+    let options = GritFormatOptions::new()
+        .with_indent_style(IndentStyle::Space)
+        .with_line_width(LineWidth::try_from(80).unwrap())
+        .with_quote_style(QuoteStyle::Double);
+
+    let doc = format_node(options.clone(), &tree.syntax()).unwrap();
+    let result = doc.print().unwrap();
+
+    println!("{}", doc.into_document());
+    eprintln!("{}", result.as_code());
+
+    CheckReformat::new(
+        &tree.syntax(),
+        result.as_code(),
+        "testing",
+        &language::GritTestFormatLanguage,
+        GritFormatLanguage::new(options),
+    )
+    .check_reformat();
+}

--- a/crates/biome_grit_formatter/tests/specs/grit/file_node.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/file_node.grit.snap
@@ -24,7 +24,8 @@ Attribute Position: Auto
 -----
 
 ```grit
-file(body = contains `console.$method` => `println`)```
+file(body = contains `console.$method` => `println`)
+```
 
 
 

--- a/crates/biome_grit_formatter/tests/specs/grit/patterns/if_pattern.grit
+++ b/crates/biome_grit_formatter/tests/specs/grit/patterns/if_pattern.grit
@@ -1,0 +1,7 @@
+`$method('$message')` where {
+  if ($message <: r"Hello, .*!") {
+    $method => `console.info`
+  } else {
+    $method => `console.warn`
+  }
+}

--- a/crates/biome_grit_formatter/tests/specs/grit/patterns/if_pattern.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/patterns/if_pattern.grit.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: grit/patterns/if_pattern.grit
+---
+# Input
+
+```grit
+`$method('$message')` where {
+  if ($message <: r"Hello, .*!") {
+    $method => `console.info`
+  } else {
+    $method => `console.warn`
+  }
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+-----
+
+```grit
+`$method('$message')` where {
+  if ($message <: r"Hello, .*!") {
+    $method => `console.info`
+  } else {
+    $method => `console.warn`
+  }
+}
+```
+
+
+
+## Unimplemented nodes/tokens
+
+"`$method('$message')` where {\n  if ($message <: r\"Hello, .*!\") {\n    $method => `console.info`\n  } else {\n    $method => `console.warn`\n  }\n}" => 0..141


### PR DESCRIPTION
## Summary

Implements formatting for the GritQL root node. This helps to resolve the issue where the GritQL formatter trims the trailing newline, which caused the spec tests to panic. cc @branberry 

Admittedly I'm not entirely sure why the default, verbatim node formatting strips the trailing newline. It creates some hard-to-debug behavior, so hopefully someone more familiar with our formatter infra has a suggestion how to resolve that.

Also added a `quick_test.rs` for the GritQL formatter, even though it didn't end up helping.

## Test Plan

Test added.
