### PR TITLE
chore: setup GritQL benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,6 +4500,7 @@ dependencies = [
  "biome_graphql_formatter",
  "biome_graphql_parser",
  "biome_graphql_syntax",
+ "biome_grit_patterns",
  "biome_js_analyze",
  "biome_js_formatter",
  "biome_js_parser",

--- a/xtask/bench/Cargo.toml
+++ b/xtask/bench/Cargo.toml
@@ -15,6 +15,7 @@ biome_formatter         = { workspace = true }
 biome_graphql_formatter = { workspace = true }
 biome_graphql_parser    = { workspace = true }
 biome_graphql_syntax    = { workspace = true }
+biome_grit_patterns     = { workspace = true }
 biome_js_analyze        = { workspace = true }
 biome_js_formatter      = { workspace = true }
 biome_js_parser         = { workspace = true }
@@ -24,7 +25,6 @@ biome_json_parser       = { workspace = true }
 biome_json_syntax       = { workspace = true }
 biome_parser            = { workspace = true }
 biome_rowan             = { workspace = true }
-
 
 ansi_rgb                  = "0.2.0"
 codspeed-criterion-compat = { version = "2.7.2", optional = true }
@@ -84,6 +84,11 @@ name    = "graphql_parser"
 [[bench]]
 harness = false
 name    = "graphql_formatter"
+
+# GritQL benches
+[[bench]]
+harness = false
+name    = "gritql_search"
 
 [lints]
 workspace = true

--- a/xtask/bench/benches/gritql_search.rs
+++ b/xtask/bench/benches/gritql_search.rs
@@ -2,11 +2,16 @@ use biome_grit_patterns::{compile_pattern, GritTargetFile, GritTargetLanguage, J
 use biome_js_parser::{parse, JsParserOptions};
 use biome_js_syntax::JsFileSource;
 use criterion::measurement::WallTime;
-use criterion::{black_box, BenchmarkGroup, BenchmarkId, Throughput};
 use std::collections::HashMap;
 use std::path::Path;
 use xtask_bench::TestCase;
-use xtask_bench::{criterion_group, criterion_main, Criterion};
+
+#[cfg(not(feature = "codspeed"))]
+pub use criterion::*;
+
+#[cfg(feature = "codspeed")]
+pub use codspeed_criterion_compat::*;
+
 #[cfg(target_os = "windows")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/xtask/bench/benches/gritql_search.rs
+++ b/xtask/bench/benches/gritql_search.rs
@@ -1,0 +1,83 @@
+use biome_grit_patterns::{compile_pattern, GritTargetFile, GritTargetLanguage, JsTargetLanguage};
+use biome_js_parser::{parse, JsParserOptions};
+use biome_js_syntax::JsFileSource;
+use criterion::measurement::WallTime;
+use criterion::{black_box, BenchmarkGroup, BenchmarkId, Throughput};
+use std::collections::HashMap;
+use std::path::Path;
+use xtask_bench::TestCase;
+use xtask_bench::{criterion_group, criterion_main, Criterion};
+#[cfg(target_os = "windows")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(
+    any(target_os = "macos", target_os = "linux"),
+    not(target_env = "musl"),
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Jemallocator does not work on aarch64 with musl, so we'll use the system allocator instead
+#[cfg(all(target_env = "musl", target_os = "linux", target_arch = "aarch64"))]
+#[global_allocator]
+static GLOBAL: std::alloc::System = std::alloc::System;
+fn bench_gritql_search(criterion: &mut Criterion) {
+    let mut all_suites = HashMap::new();
+    all_suites.insert("gritql", include_str!("libs-ts.txt"));
+    let mut libs = vec![];
+    libs.extend(all_suites.values().flat_map(|suite| suite.lines()));
+
+    let mut group = criterion.benchmark_group("gritql_search");
+    for lib in libs {
+        let test_case = TestCase::try_from(lib);
+
+        match test_case {
+            Ok(test_case) => {
+                bench_search_group(&mut group, test_case);
+            }
+            Err(error) => println!("{error:?}"),
+        }
+    }
+    group.finish();
+}
+
+pub fn bench_search_group(group: &mut BenchmarkGroup<WallTime>, test_case: TestCase) {
+    let query = compile_pattern(
+        "`getEntityNameForExtendingInterface(errorLocation)`",
+        Some(Path::new("bench.grit")),
+        GritTargetLanguage::JsTargetLanguage(JsTargetLanguage),
+    )
+    .unwrap();
+
+    let code = test_case.code();
+    let source_type = if test_case.extension() == "d.ts" {
+        JsFileSource::d_ts()
+    } else {
+        JsFileSource::ts()
+    };
+
+    let target_file = GritTargetFile {
+        parse: parse(code, source_type, JsParserOptions::default()).into(),
+        path: test_case.path().to_owned(),
+    };
+
+    group.throughput(Throughput::Bytes(code.len() as u64));
+    group.sample_size(10);
+    group.bench_with_input(
+        BenchmarkId::new(test_case.filename(), "execute"),
+        &code,
+        |b, _| {
+            b.iter(|| {
+                let (_results, logs) =
+                    black_box(query.execute(target_file.clone())).expect("Couldn't execute query");
+                for log in logs.logs() {
+                    println!("{log}");
+                }
+            })
+        },
+    );
+}
+
+criterion_group!(gritql_search, bench_gritql_search);
+criterion_main!(gritql_search);


### PR DESCRIPTION
## Summary

Adds benchmarks for GritQL query execution. Runs against the same libs as TypeScript benches.

## Test Plan

CI should pass.
