### PR TITLE
chore: correct options name (ignoreNonDom) in the examples

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
     ///     "//": "...",
     ///     "options": {
     ///         "allowInvalidRoles": ["invalid-role", "text"],
-    ///         "nonIgnoreDom": true
+    ///         "ignoreNonDom": true
     ///     }
     /// }
     /// ```

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
@@ -53,7 +53,7 @@ declare_lint_rule! {
     pub NoUselessThisAlias {
         version: "1.0.0",
         name: "noUselessThisAlias",
-        language: "ts",
+        language: "js",
         sources: &[RuleSource::EslintTypeScript("no-this-alias")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,


### PR DESCRIPTION
fix typo in examples

nonIgnoreDom -> ignoreNonDom

using schemas 1.9.3