### PR TITLE
feat(useExplicitFunctionReturnType): support typed function expressions

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -371,9 +371,7 @@ fn is_function_used_in_argument_or_array(func: &AnyJsFunction) -> bool {
 /// (() => {})();
 /// ```
 fn is_iife(func: &AnyJsFunction) -> bool {
-    func.syntax()
-        .parent()
-        .and_then(JsParenthesizedExpression::cast)
+    func.parent::<JsParenthesizedExpression>()
         .and_then(|expr| expr.parent::<JsCallExpression>())
         .is_some()
 }
@@ -546,7 +544,7 @@ fn is_type_assertion(syntax: &SyntaxNode<JsLanguage>) -> bool {
         if parent.kind() == JsSyntaxKind::JS_PARENTHESIZED_EXPRESSION {
             parent
                 .parent()
-                .map_or(false, |grandparent| is_assertion_kind(grandparent.kind()))
+                .is_some_and(|grandparent| is_assertion_kind(grandparent.kind()))
         } else {
             is_assertion_kind(parent.kind())
         }

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_function_return_type.rs
@@ -431,7 +431,7 @@ fn is_first_statement_function_return(statements: JsStatementList) -> bool {
                 None
             }
         })
-        .map_or(false, |args| {
+        .is_some_and(|args| {
             matches!(
                 args,
                 AnyJsExpression::JsFunctionExpression(_)
@@ -463,7 +463,7 @@ fn is_variable_declarator_with_type_annotation(syntax: &SyntaxNode<JsLanguage>) 
         .parent()
         .and_then(JsInitializerClause::cast)
         .and_then(|init| init.parent::<JsVariableDeclarator>())
-        .map_or(false, |decl| decl.variable_annotation().is_some())
+        .is_some_and(|decl| decl.variable_annotation().is_some())
 }
 
 /// Checks if a function is a default parameter with a type annotation.
@@ -479,7 +479,7 @@ fn is_default_function_parameter_with_type_annotation(syntax: &SyntaxNode<JsLang
         .parent()
         .and_then(JsInitializerClause::cast)
         .and_then(|init| init.parent::<JsFormalParameter>())
-        .map_or(false, |param| param.type_annotation().is_some())
+        .is_some_and(|param| param.type_annotation().is_some())
 }
 
 /// Checks if a function is a class property with a type annotation.
@@ -497,7 +497,7 @@ fn is_class_property_with_type_annotation(syntax: &SyntaxNode<JsLanguage>) -> bo
         .parent()
         .and_then(JsInitializerClause::cast)
         .and_then(|init| init.parent::<JsPropertyClassMember>())
-        .map_or(false, |prop| prop.property_annotation().is_some())
+        .is_some_and(|prop| prop.property_annotation().is_some())
 }
 
 /// Checks if a function is a property or a nested property of a typed object.
@@ -516,7 +516,7 @@ fn is_property_of_object_with_type(syntax: &SyntaxNode<JsLanguage>) -> bool {
         .and_then(JsPropertyObjectMember::cast)
         .and_then(|prop| prop.syntax().grand_parent())
         .and_then(JsObjectExpression::cast)
-        .map_or(false, |obj_expression| {
+        .is_some_and(|obj_expression| {
             let obj_syntax = obj_expression.syntax();
             is_type_assertion(obj_syntax)
                 || is_variable_declarator_with_type_annotation(obj_syntax)

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts
@@ -90,3 +90,6 @@ function fn() {
       return str;
   };
 }
+
+const x = { prop: () => {} }
+const x = { bar: { prop: () => {} } }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/invalid.ts.snap
@@ -96,6 +96,9 @@ function fn() {
       return str;
   };
 }
+
+const x = { prop: () => {} }
+const x = { bar: { prop: () => {} } }
 ```
 
 # Diagnostics
@@ -520,6 +523,40 @@ invalid.ts:85:2 lint/nursery/useExplicitFunctionReturnType ━━━━━━━
        │ ^^^^^^^^^^^
     88 │   let str = "hey";
     89 │   return function (): string {
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:94:19 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    92 │ }
+    93 │ 
+  > 94 │ const x = { prop: () => {} }
+       │                   ^^^^^^^^^
+    95 │ const x = { bar: { prop: () => {} } }
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:95:26 lint/nursery/useExplicitFunctionReturnType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    94 │ const x = { prop: () => {} }
+  > 95 │ const x = { bar: { prop: () => {} } }
+       │                          ^^^^^^^^^
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -47,6 +47,8 @@ node.addEventListener('click', function () {});
 const foo = arr.map(i => i * i);
 fn(() => {});
 fn(function () {});
+new Promise(resolve => {});
+new Foo(1, () => {});
 [function () {}, () => {}];
 (function () {
   console.log("This is an IIFE");

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -86,3 +86,18 @@ type MethodType = () => void;
 class App {
     private method: MethodType = () => { };
 }
+
+// function as a property or a nested property of a typed object
+const x: Foo = { prop: () => {} }
+const x = { prop: () => {} } as Foo
+const x = <Foo>{ prop: () => {} }
+
+const x: Foo = { bar: { prop: () => {} } }
+
+class Accumulator {
+  private count: number = 0;
+  public accumulate(fn: () => number): void {
+      this.count += fn();
+  }
+}
+new Accumulator().accumulate(() => 1);

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts
@@ -63,3 +63,26 @@ const arrowFn = () => function(): void {}
 const arrowFn = () => {
   return (): void => { };
 }
+
+
+// type assertion
+const asTyped = (() => '') as () => string;
+const castTyped = <() => string>(() => '');
+
+// variable declarator with a type annotation 
+type FuncType = () => string;
+const arrowFn: FuncType = () => 'test';
+const funcExpr: FuncType = function () {
+  return 'test';
+};
+
+// default parameter with a type annotation
+type CallBack = () => void;
+const f = (gotcha: CallBack = () => { }): void => { };
+function f(gotcha: CallBack = () => {}): void {}
+
+// class property with a type annotation
+type MethodType = () => void;
+class App {
+    private method: MethodType = () => { };
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -69,4 +69,27 @@ const arrowFn = () => function(): void {}
 const arrowFn = () => {
   return (): void => { };
 }
+
+
+// type assertion
+const asTyped = (() => '') as () => string;
+const castTyped = <() => string>(() => '');
+
+// variable declarator with a type annotation 
+type FuncType = () => string;
+const arrowFn: FuncType = () => 'test';
+const funcExpr: FuncType = function () {
+  return 'test';
+};
+
+// default parameter with a type annotation
+type CallBack = () => void;
+const f = (gotcha: CallBack = () => { }): void => { };
+function f(gotcha: CallBack = () => {}): void {}
+
+// class property with a type annotation
+type MethodType = () => void;
+class App {
+    private method: MethodType = () => { };
+}
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -53,6 +53,8 @@ node.addEventListener('click', function () {});
 const foo = arr.map(i => i * i);
 fn(() => {});
 fn(function () {});
+new Promise(resolve => {});
+new Foo(1, () => {});
 [function () {}, () => {}];
 (function () {
   console.log("This is an IIFE");

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitFunctionReturnType/valid.ts.snap
@@ -92,4 +92,19 @@ type MethodType = () => void;
 class App {
     private method: MethodType = () => { };
 }
+
+// function as a property or a nested property of a typed object
+const x: Foo = { prop: () => {} }
+const x = { prop: () => {} } as Foo
+const x = <Foo>{ prop: () => {} }
+
+const x: Foo = { bar: { prop: () => {} } }
+
+class Accumulator {
+  private count: number = 0;
+  public accumulate(fn: () => number): void {
+      this.count += fn();
+  }
+}
+new Accumulator().accumulate(() => 1);
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
related: https://github.com/biomejs/biome/issues/2017

This PR introduces the ability to detect typed function expressions in the useExplicitFunctionReturnType rule.

todos:
- [x] A function with a type assertion using `as` or `<>`
```
const asTyped = (() => '') as () => string;
const castTyped = <() => string>(() => '');
```
- [x] A variable declarator with a type annotation
```
type FuncType = () => string;
const arrowFn: FuncType = () => 'test';
```
- [x] A function as a default parameter with a type annotation
```
type CallBack = () => void;
const f = (gotcha: CallBack = () => { }): void => { };
```
- [x]  A class property with a type annotation
```
type MethodType = () => void;
  class App {
     private method: MethodType = () => { };
}
```
- [x]  A function as a property or a nested property of a typed object
```
const x: Foo = { prop: () => {} }
const x = { prop: () => {} } as Foo
const x = <Foo>{ prop: () => {} }
const x: Foo = { bar: { prop: () => {} } }
```

<!-- What demonstrates that your implementation is correct? -->
