### PR TITLE
fix(formatter): incompatibility for class and implements 

### DIFF
--- a/crates/biome_js_formatter/src/utils/format_class.rs
+++ b/crates/biome_js_formatter/src/utils/format_class.rs
@@ -133,7 +133,10 @@ impl Format<JsFormatContext> for FormatClass<'_> {
             let heritage_id = f.group_id("heritageGroup");
             write!(
                 f,
-                [group(&indented).with_group_id(Some(heritage_id)), hard_space()]
+                [
+                    group(&indented).with_group_id(Some(heritage_id)),
+                    hard_space()
+                ]
             )?;
 
             if !members.is_empty() {

--- a/crates/biome_js_formatter/src/utils/format_class.rs
+++ b/crates/biome_js_formatter/src/utils/format_class.rs
@@ -133,7 +133,7 @@ impl Format<JsFormatContext> for FormatClass<'_> {
             let heritage_id = f.group_id("heritageGroup");
             write!(
                 f,
-                [group(&indented).with_group_id(Some(heritage_id)), space()]
+                [group(&indented).with_group_id(Some(heritage_id)), hard_space()]
             )?;
 
             if !members.is_empty() {

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts
@@ -1,3 +1,7 @@
 class ClassName implements Interface { }
 
 class LongClassName implements Interface1, Interface2, Interface3, Interface4, Interface5 { }
+
+class LongClassName implements InterfaceNameLengthIsSixtySevenCharactersssssssssssssssssssssssssss {
+    constructer(){}
+  }

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts
@@ -2,6 +2,10 @@ class ClassName implements Interface { }
 
 class LongClassName implements Interface1, Interface2, Interface3, Interface4, Interface5 { }
 
+class LongClassName implements InterfaceNameLengthIsSixtySixCharacterssssssssssssssssssssssssssss {
+    constructer(){}
+  }
+
 class LongClassName implements InterfaceNameLengthIsSixtySevenCharactersssssssssssssssssssssssssss {
     constructer(){}
   }

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -8,6 +8,14 @@ info: ts/class/implements_clause.ts
 class ClassName implements Interface { }
 
 class LongClassName implements Interface1, Interface2, Interface3, Interface4, Interface5 { }
+
+class LongClassName implements InterfaceNameLengthIsSixtySixCharacterssssssssssssssssssssssssssss {
+    constructer(){}
+  }
+
+class LongClassName implements InterfaceNameLengthIsSixtySevenCharactersssssssssssssssssssssssssss {
+    constructer(){}
+  }
 ```
 
 
@@ -38,4 +46,17 @@ class ClassName implements Interface {}
 
 class LongClassName
 	implements Interface1, Interface2, Interface3, Interface4, Interface5 {}
+
+class LongClassName
+	implements InterfaceNameLengthIsSixtySixCharacterssssssssssssssssssssssssssss
+{
+	constructer() {}
+}
+
+class LongClassName
+	implements
+		InterfaceNameLengthIsSixtySevenCharactersssssssssssssssssssssssssss
+{
+	constructer() {}
+}
 ```


### PR DESCRIPTION
fixes #4143 
## Summary
```
  "class",
  group("#1", [
    indent([
      " LongClassName",
      soft_line_break_or_space,
      "implements",
      group([
        indent([
          soft_line_break_or_space,
          "InterfaceNameLengthIsSixtySixCharacterssssssssssssssssssssssssssss"
        ])
      ])
    ])
  ]),
  " ",  <===== this
  if_group_breaks("#1", [hard_line_break]),
  "{",
  indent([hard_line_break, " constructer", group(["()"]), " {}"]),
  hard_line_break,
  "}",
```
When checking the operation of Prettier, the fits function calculates the width of an empty string as 1 instead of 0. The empty string refers to line 15 in the code, and we are using it as a space.
So i changed space to hardspace


## Test Plan

add test case
