### PR TITLE
feat(lint): add `useGoogleFontPreconnect` rule

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -24,6 +24,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@next/google-font-preconnect" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .use_google_font_preconnect
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@next/no-document-import-in-page" => {
             if !options.include_nursery {
                 return false;

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3425,7 +3425,7 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_google_font_display:
         Option<RuleConfiguration<biome_js_analyze::options::UseGoogleFontDisplay>>,
-    #[doc = "Ensure preconnect is used with Google Fonts."]
+    #[doc = "Ensure the preconnect attribute is used when using Google Fonts."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_google_font_preconnect:
         Option<RuleFixConfiguration<biome_js_analyze::options::UseGoogleFontPreconnect>>,

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3425,6 +3425,10 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_google_font_display:
         Option<RuleConfiguration<biome_js_analyze::options::UseGoogleFontDisplay>>,
+    #[doc = "Ensure preconnect is used with Google Fonts."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_google_font_preconnect:
+        Option<RuleFixConfiguration<biome_js_analyze::options::UseGoogleFontPreconnect>>,
     #[doc = "Require for-in loops to include an if statement."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_guard_for_in: Option<RuleConfiguration<biome_js_analyze::options::UseGuardForIn>>,
@@ -3507,6 +3511,7 @@ impl Nursery {
         "useDeprecatedReason",
         "useExplicitType",
         "useGoogleFontDisplay",
+        "useGoogleFontPreconnect",
         "useGuardForIn",
         "useImportRestrictions",
         "useSortedClasses",
@@ -3544,7 +3549,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -3595,6 +3600,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -3821,34 +3827,39 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
         index_set
@@ -4065,34 +4076,39 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
         index_set
@@ -4297,6 +4313,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "useGoogleFontDisplay" => self
                 .use_google_font_display
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "useGoogleFontPreconnect" => self
+                .use_google_font_preconnect
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "useGuardForIn" => self

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -197,6 +197,7 @@ define_categories! {
     "lint/nursery/useExplicitFunctionReturnType": "https://biomejs.dev/linter/rules/use-explicit-function-return-type",
     "lint/nursery/useExplicitType": "https://biomejs.dev/linter/rules/use-explicit-function-return-type",
     "lint/nursery/useGoogleFontDisplay": "https://biomejs.dev/linter/rules/use-google-font-display",
+    "lint/nursery/useGoogleFontPreconnect": "https://biomejs.dev/linter/rules/use-google-font-preconnect",
     "lint/nursery/useGuardForIn": "https://biomejs.dev/linter/rules/use-guard-for-in",
     "lint/nursery/useImportRestrictions": "https://biomejs.dev/linter/rules/use-import-restrictions",
     "lint/nursery/useJsxCurlyBraceConvention": "https://biomejs.dev/linter/rules/use-jsx-curly-brace-convention",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -34,6 +34,7 @@ pub mod use_consistent_curly_braces;
 pub mod use_consistent_member_accessibility;
 pub mod use_explicit_type;
 pub mod use_google_font_display;
+pub mod use_google_font_preconnect;
 pub mod use_guard_for_in;
 pub mod use_import_restrictions;
 pub mod use_sorted_classes;
@@ -77,6 +78,7 @@ declare_lint_group! {
             self :: use_consistent_member_accessibility :: UseConsistentMemberAccessibility ,
             self :: use_explicit_type :: UseExplicitType ,
             self :: use_google_font_display :: UseGoogleFontDisplay ,
+            self :: use_google_font_preconnect :: UseGoogleFontPreconnect ,
             self :: use_guard_for_in :: UseGuardForIn ,
             self :: use_import_restrictions :: UseImportRestrictions ,
             self :: use_sorted_classes :: UseSortedClasses ,

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -81,11 +81,18 @@ impl Rule for UseGoogleFontPreconnect {
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
-        return Some(RuleDiagnostic::new(
-            rule_category!(),
-            range,
-            markup! { ""<Emphasis>"rel=\"preconnect\""</Emphasis>" is missing from Google Font." },
-        ));
+        return Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                range,
+                markup! {
+                    "Attribute "<Emphasis>"rel=\"preconnect\""</Emphasis>" is missing from Google Font link."
+                },
+            )
+            .note(markup!{
+                "Not using "<Emphasis>"preconnect"</Emphasis>" can cause slower font loading and increase latency."
+            })
+        );
     }
 
     fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -1,0 +1,126 @@
+use biome_analyze::{
+    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
+    RuleSource, RuleSourceKind,
+};
+use biome_console::markup;
+use biome_js_factory::make;
+use biome_js_syntax::{
+    jsx_ext::AnyJsxElement, AnyJsxAttribute, AnyJsxAttributeName, AnyJsxAttributeValue, T,
+};
+use biome_rowan::{AstNode, BatchMutationExt, TextRange, TriviaPieceKind};
+
+use crate::JsRuleAction;
+
+declare_lint_rule! {
+    /// Ensure `preconnect` is used with Google Fonts.
+    ///
+    /// When using Google Fonts, adding the `rel="preconnect"` attribute to the `<link>` tag
+    /// that points to `https://fonts.gstatic.com` is recommended to initiate an early
+    /// connection to the font's origin. This improves page load performance by reducing latency.
+    ///
+    /// Failing to use `preconnect` may result in slower font loading times, affecting user experience.
+    ///
+    /// Note: Next.js automatically adds this preconnect link starting from version 12.0.1, but in cases
+    /// where it's manually added, this rule ensures the `preconnect` attribute is properly used.
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <link href="https://fonts.gstatic.com"/>
+    /// ```
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <link rel="preload" href="https://fonts.gstatic.com"/>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <link rel="preconnect" href="https://fonts.gstatic.com"/>
+    /// ```
+    ///
+    /// ```jsx
+    /// <link href="/logo.svg" rel="icon" />
+    /// ```
+    ///
+    pub UseGoogleFontPreconnect {
+        version: "next",
+        name: "useGoogleFontPreconnect",
+        language: "jsx",
+        sources: &[RuleSource::EslintNext("google-font-preconnect")],
+        source_kind: RuleSourceKind::SameLogic,
+        recommended: false,
+        fix_kind: FixKind::Safe,
+    }
+}
+
+impl Rule for UseGoogleFontPreconnect {
+    type Query = Ast<AnyJsxElement>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+
+        if node.name().ok()?.name_value_token()?.text_trimmed() != "link" {
+            return None;
+        }
+
+        if node
+            .get_attribute_inner_string_text("href")
+            .map_or(false, |href| href.starts_with("https://fonts.gstatic.com"))
+            && node
+                .get_attribute_inner_string_text("rel")
+                .map_or(true, |rel| rel != "preconnect")
+        {
+            return Some(node.syntax().text_range());
+        }
+
+        None
+    }
+
+    fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
+        return Some(RuleDiagnostic::new(
+            rule_category!(),
+            range,
+            markup! { ""<Emphasis>"rel=\"preconnect\""</Emphasis>" is missing from Google Font." },
+        ));
+    }
+
+    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
+        let node = ctx.query();
+
+        if node.find_attribute_by_name("rel").is_some() {
+            return None;
+        }
+
+        let mut mutation = ctx.root().begin();
+        let mut attributes: Vec<_> = node.attributes().into_iter().collect();
+
+        let new_attribute = AnyJsxAttribute::from(
+            make::jsx_attribute(AnyJsxAttributeName::JsxName(make::jsx_name(
+                make::jsx_ident("rel").with_leading_trivia([(TriviaPieceKind::Whitespace, " ")]),
+            )))
+            .with_initializer(make::jsx_attribute_initializer_clause(
+                make::token(T![=]),
+                AnyJsxAttributeValue::JsxString(make::jsx_string(make::jsx_string_literal(
+                    "preconnect",
+                ))),
+            ))
+            .build(),
+        );
+
+        attributes.push(new_attribute);
+        mutation.replace_node(node.attributes(), make::jsx_attribute_list(attributes));
+
+        Some(JsRuleAction::new(
+            ActionCategory::QuickFix,
+            ctx.metadata().applicability(),
+            markup! { "Add "<Emphasis>"rel=\"preconnect\""</Emphasis>" attribute." }.to_owned(),
+            mutation,
+        ))
+    }
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -12,7 +12,7 @@ use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TextRange, TriviaPiece
 use crate::JsRuleAction;
 
 declare_lint_rule! {
-    /// Ensure `preconnect` is used with Google Fonts.
+    /// Ensure the `preconnect` attribute is used when using Google Fonts.
     ///
     /// When using Google Fonts, adding the `rel="preconnect"` attribute to the `<link>` tag
     /// that points to `https://fonts.gstatic.com` is recommended to initiate an early
@@ -86,7 +86,7 @@ impl Rule for UseGoogleFontPreconnect {
                 rule_category!(),
                 range,
                 markup! {
-                    "Attribute "<Emphasis>"rel=\"preconnect\""</Emphasis>" is missing from Google Font link."
+                    "The attribute "<Emphasis>"rel=\"preconnect\""</Emphasis>" is missing from the Google Font."
                 },
             )
             .note(markup!{
@@ -134,7 +134,7 @@ impl Rule for UseGoogleFontPreconnect {
         Some(JsRuleAction::new(
             ActionCategory::QuickFix,
             ctx.metadata().applicability(),
-            markup! { "Add "<Emphasis>"rel=\"preconnect\""</Emphasis>" attribute." }.to_owned(),
+            markup! { "Add the "<Emphasis>"rel=\"preconnect\""</Emphasis>" attribute." }.to_owned(),
             mutation,
         ))
     }

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -72,7 +72,8 @@ impl Rule for UseGoogleFontPreconnect {
         let href = node.get_attribute_inner_string_text("href")?;
         let rel = node.get_attribute_inner_string_text("rel");
 
-        if href.starts_with("https://fonts.gstatic.com") && (rel.is_none() || rel? != "preconnect")
+        if href.starts_with("https://fonts.gstatic.com")
+            && !matches!(rel.as_deref(), Some("preconnect"))
         {
             return Some(node.syntax().text_range());
         }

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -337,6 +337,7 @@ pub type UseGetterReturn =
     <lint::suspicious::use_getter_return::UseGetterReturn as biome_analyze::Rule>::Options;
 pub type UseGoogleFontDisplay =
     <lint::nursery::use_google_font_display::UseGoogleFontDisplay as biome_analyze::Rule>::Options;
+pub type UseGoogleFontPreconnect = < lint :: nursery :: use_google_font_preconnect :: UseGoogleFontPreconnect as biome_analyze :: Rule > :: Options ;
 pub type UseGuardForIn =
     <lint::nursery::use_guard_for_in::UseGuardForIn as biome_analyze::Rule>::Options;
 pub type UseHeadingContent =

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx
@@ -1,0 +1,4 @@
+<>
+	<link href="https://fonts.gstatic.com"/>
+	<link rel="preload" href="https://fonts.gstatic.com"/>
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx
@@ -1,4 +1,11 @@
 <>
 	<link href="https://fonts.gstatic.com"/>
 	<link rel="preload" href="https://fonts.gstatic.com"/>
+	<link
+		rel="preload"
+		href="https://fonts.gstatic.com"
+	/>
+	<link
+		href="https://fonts.gstatic.com"
+	/>
 </>

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
@@ -8,6 +8,13 @@ expression: invalid.jsx
 <>
 	<link href="https://fonts.gstatic.com"/>
 	<link rel="preload" href="https://fonts.gstatic.com"/>
+	<link
+		rel="preload"
+		href="https://fonts.gstatic.com"
+	/>
+	<link
+		href="https://fonts.gstatic.com"
+	/>
 </>
 ```
 
@@ -21,7 +28,7 @@ invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
   > 2 │ 	<link href="https://fonts.gstatic.com"/>
       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
-    4 │ </>
+    4 │ 	<link
   
   i Safe fix: Add rel="preconnect" attribute.
   
@@ -39,7 +46,54 @@ invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━
     2 │ 	<link href="https://fonts.gstatic.com"/>
   > 3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    4 │ </>
+    4 │ 	<link
+    5 │ 		rel="preload"
+  
+
+```
+
+```
+invalid.jsx:4:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! rel="preconnect" is missing from Google Font.
+  
+    2 │ 	<link href="https://fonts.gstatic.com"/>
+    3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
+  > 4 │ 	<link
+      │ 	^^^^^
+  > 5 │ 		rel="preload"
+  > 6 │ 		href="https://fonts.gstatic.com"
+  > 7 │ 	/>
+      │ 	^^
+    8 │ 	<link
+    9 │ 		href="https://fonts.gstatic.com"
+  
+
+```
+
+```
+invalid.jsx:8:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! rel="preconnect" is missing from Google Font.
+  
+     6 │ 		href="https://fonts.gstatic.com"
+     7 │ 	/>
+   > 8 │ 	<link
+       │ 	^^^^^
+   > 9 │ 		href="https://fonts.gstatic.com"
+  > 10 │ 	/>
+       │ 	^^
+    11 │ </>
+  
+  i Safe fix: Add rel="preconnect" attribute.
+  
+     7  7 │   	/>
+     8  8 │   	<link
+     9    │ - → → href="https://fonts.gstatic.com"
+        9 │ + → → href="https://fonts.gstatic.com"
+       10 │ + → → rel="preconnect"
+    10 11 │   	/>
+    11 12 │   </>
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 86
+expression: invalid.jsx
+---
+# Input
+```jsx
+<>
+	<link href="https://fonts.gstatic.com"/>
+	<link rel="preload" href="https://fonts.gstatic.com"/>
+</>
+```
+
+# Diagnostics
+```
+invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! rel="preconnect" is missing from Google Font.
+  
+    1 │ <>
+  > 2 │ 	<link href="https://fonts.gstatic.com"/>
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
+    4 │ </>
+  
+  i Safe fix: Add rel="preconnect" attribute.
+  
+    2 │ → <link·href="https://fonts.gstatic.com"·rel="preconnect"/>
+      │                                         +++++++++++++++++  
+
+```
+
+```
+invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! rel="preconnect" is missing from Google Font.
+  
+    1 │ <>
+    2 │ 	<link href="https://fonts.gstatic.com"/>
+  > 3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ </>
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
@@ -22,13 +22,15 @@ expression: invalid.jsx
 ```
 invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! rel="preconnect" is missing from Google Font.
+  ! Attribute rel="preconnect" is missing from Google Font link.
   
     1 │ <>
   > 2 │ 	<link href="https://fonts.gstatic.com"/>
       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
     4 │ 	<link
+  
+  i Not using preconnect can cause slower font loading and increase latency.
   
   i Safe fix: Add rel="preconnect" attribute.
   
@@ -40,7 +42,7 @@ invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
 ```
 invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! rel="preconnect" is missing from Google Font.
+  ! Attribute rel="preconnect" is missing from Google Font link.
   
     1 │ <>
     2 │ 	<link href="https://fonts.gstatic.com"/>
@@ -49,13 +51,15 @@ invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━
     4 │ 	<link
     5 │ 		rel="preload"
   
+  i Not using preconnect can cause slower font loading and increase latency.
+  
 
 ```
 
 ```
 invalid.jsx:4:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! rel="preconnect" is missing from Google Font.
+  ! Attribute rel="preconnect" is missing from Google Font link.
   
     2 │ 	<link href="https://fonts.gstatic.com"/>
     3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
@@ -68,13 +72,15 @@ invalid.jsx:4:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━
     8 │ 	<link
     9 │ 		href="https://fonts.gstatic.com"
   
+  i Not using preconnect can cause slower font loading and increase latency.
+  
 
 ```
 
 ```
 invalid.jsx:8:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! rel="preconnect" is missing from Google Font.
+  ! Attribute rel="preconnect" is missing from Google Font link.
   
      6 │ 		href="https://fonts.gstatic.com"
      7 │ 	/>
@@ -84,6 +90,8 @@ invalid.jsx:8:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
   > 10 │ 	/>
        │ 	^^
     11 │ </>
+  
+  i Not using preconnect can cause slower font loading and increase latency.
   
   i Safe fix: Add rel="preconnect" attribute.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/invalid.jsx.snap
@@ -22,7 +22,7 @@ expression: invalid.jsx
 ```
 invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Attribute rel="preconnect" is missing from Google Font link.
+  ! The attribute rel="preconnect" is missing from the Google Font.
   
     1 │ <>
   > 2 │ 	<link href="https://fonts.gstatic.com"/>
@@ -32,7 +32,7 @@ invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
   
   i Not using preconnect can cause slower font loading and increase latency.
   
-  i Safe fix: Add rel="preconnect" attribute.
+  i Safe fix: Add the rel="preconnect" attribute.
   
     2 │ → <link·href="https://fonts.gstatic.com"·rel="preconnect"/>
       │                                         +++++++++++++++++  
@@ -42,7 +42,7 @@ invalid.jsx:2:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
 ```
 invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Attribute rel="preconnect" is missing from Google Font link.
+  ! The attribute rel="preconnect" is missing from the Google Font.
   
     1 │ <>
     2 │ 	<link href="https://fonts.gstatic.com"/>
@@ -59,7 +59,7 @@ invalid.jsx:3:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━
 ```
 invalid.jsx:4:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Attribute rel="preconnect" is missing from Google Font link.
+  ! The attribute rel="preconnect" is missing from the Google Font.
   
     2 │ 	<link href="https://fonts.gstatic.com"/>
     3 │ 	<link rel="preload" href="https://fonts.gstatic.com"/>
@@ -80,7 +80,7 @@ invalid.jsx:4:2 lint/nursery/useGoogleFontPreconnect ━━━━━━━━━
 ```
 invalid.jsx:8:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Attribute rel="preconnect" is missing from Google Font link.
+  ! The attribute rel="preconnect" is missing from the Google Font.
   
      6 │ 		href="https://fonts.gstatic.com"
      7 │ 	/>
@@ -93,7 +93,7 @@ invalid.jsx:8:2 lint/nursery/useGoogleFontPreconnect  FIXABLE  ━━━━━�
   
   i Not using preconnect can cause slower font loading and increase latency.
   
-  i Safe fix: Add rel="preconnect" attribute.
+  i Safe fix: Add the rel="preconnect" attribute.
   
      7  7 │   	/>
      8  8 │   	<link

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/valid.jsx
@@ -1,0 +1,5 @@
+<>
+	<link />
+	<link href />
+	<link rel="preconnect" href="https://fonts.gstatic.com" />
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useGoogleFontPreconnect/valid.jsx.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 86
+expression: valid.jsx
+---
+# Input
+```jsx
+<>
+	<link />
+	<link href />
+	<link rel="preconnect" href="https://fonts.gstatic.com" />
+</>
+```

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -408,6 +408,15 @@ impl AnyJsxElement {
         }
     }
 
+    pub fn get_attribute_inner_string_text(&self, name_to_lookup: &str) -> Option<String> {
+        if let Some(attr) = self.find_attribute_by_name(name_to_lookup) {
+            let initializer = attr.initializer()?.value().ok()?;
+            let binding = initializer.as_jsx_string()?.inner_string_text().ok()?;
+            return Some(binding.to_string());
+        };
+        None
+    }
+
     pub fn has_truthy_attribute(&self, name_to_lookup: &str) -> bool {
         self.find_attribute_by_name(name_to_lookup)
             .map_or(false, |attribute| {

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -408,6 +408,56 @@ impl AnyJsxElement {
         }
     }
 
+    /// Returns the attribute value of JsxString attributes
+    ///
+    /// ```
+    /// use biome_js_syntax::jsx_ext::AnyJsxElement;
+    /// use biome_js_factory::make::{ident, js_boolean_literal_expression, jsx_attribute, jsx_attribute_initializer_clause, jsx_attribute_list, jsx_expression_attribute_value, jsx_name, jsx_self_closing_element, jsx_string, jsx_string_literal, token};
+    /// use biome_js_syntax::{AnyJsExpression, AnyJsLiteralExpression, AnyJsxAttribute, AnyJsxAttributeName, AnyJsxAttributeValue, AnyJsxElementName, T};
+    ///
+    /// let string_attr = AnyJsxAttribute::JsxAttribute(
+    ///     jsx_attribute(AnyJsxAttributeName::JsxName(jsx_name(ident("type"))))
+    ///         .with_initializer(jsx_attribute_initializer_clause(
+    ///             token(T![=]),
+    ///             AnyJsxAttributeValue::JsxString(jsx_string(jsx_string_literal("button"))),
+    ///         ))
+    ///         .build()
+    /// );
+    ///
+    /// let boolean_attr = AnyJsxAttribute::JsxAttribute(
+    ///     jsx_attribute(AnyJsxAttributeName::JsxName(jsx_name(ident("disabled"))))
+    ///         .with_initializer(jsx_attribute_initializer_clause(
+    ///             token(T![=]),
+    ///             AnyJsxAttributeValue::JsxExpressionAttributeValue(
+    ///                 jsx_expression_attribute_value(
+    ///                     token(T!['{']),
+    ///                     AnyJsExpression::AnyJsLiteralExpression(AnyJsLiteralExpression::JsBooleanLiteralExpression(js_boolean_literal_expression(token(T![true])))),
+    ///                     token(T!['}']),
+    ///                 )
+    ///             ))
+    ///         )
+    ///         .build()
+    /// );
+    ///
+    /// let attributes = jsx_attribute_list(vec![boolean_attr, string_attr]);
+    ///
+    /// let jsx_element = AnyJsxElement::JsxSelfClosingElement(
+    ///   jsx_self_closing_element(
+    ///       token(T![<]),
+    ///       AnyJsxElementName::JsxName(
+    ///           jsx_name(ident("button"))
+    ///       ),
+    ///       attributes,
+    ///       token(T![/]),
+    ///       token(T![>]),
+    ///   ).build()
+    /// );
+    ///
+    /// assert_eq!(jsx_element.get_attribute_inner_string_text("unknown").is_none(), true);
+    /// assert_eq!(jsx_element.get_attribute_inner_string_text("disabled").is_none(), true);
+    /// assert_eq!(jsx_element.get_attribute_inner_string_text("type").unwrap(), "button");
+    ///```
+    ///
     pub fn get_attribute_inner_string_text(&self, name_to_lookup: &str) -> Option<String> {
         if let Some(attr) = self.find_attribute_by_name(name_to_lookup) {
             let initializer = attr.initializer()?.value().ok()?;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1391,6 +1391,10 @@ export interface Nursery {
 	 */
 	useGoogleFontDisplay?: RuleConfiguration_for_Null;
 	/**
+	 * Ensure preconnect is used with Google Fonts.
+	 */
+	useGoogleFontPreconnect?: RuleFixConfiguration_for_Null;
+	/**
 	 * Require for-in loops to include an if statement.
 	 */
 	useGuardForIn?: RuleConfiguration_for_Null;
@@ -3004,6 +3008,7 @@ export type Category =
 	| "lint/nursery/useExplicitFunctionReturnType"
 	| "lint/nursery/useExplicitType"
 	| "lint/nursery/useGoogleFontDisplay"
+	| "lint/nursery/useGoogleFontPreconnect"
 	| "lint/nursery/useGuardForIn"
 	| "lint/nursery/useImportRestrictions"
 	| "lint/nursery/useJsxCurlyBraceConvention"

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1391,7 +1391,7 @@ export interface Nursery {
 	 */
 	useGoogleFontDisplay?: RuleConfiguration_for_Null;
 	/**
-	 * Ensure preconnect is used with Google Fonts.
+	 * Ensure the preconnect attribute is used when using Google Fonts.
 	 */
 	useGoogleFontPreconnect?: RuleFixConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2391,6 +2391,13 @@
 						{ "type": "null" }
 					]
 				},
+				"useGoogleFontPreconnect": {
+					"description": "Ensure preconnect is used with Google Fonts.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"useGuardForIn": {
 					"description": "Require for-in loops to include an if statement.",
 					"anyOf": [

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2392,7 +2392,7 @@
 					]
 				},
 				"useGoogleFontPreconnect": {
-					"description": "Ensure preconnect is used with Google Fonts.",
+					"description": "Ensure the preconnect attribute is used when using Google Fonts.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
Implement [google-font-preconnect](https://nextjs.org/docs/messages/google-font-preconnect) from eslint-plugin-next.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Snapshots + CI