### PR TITLE
feat(cli): output report to file

### DIFF
--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -84,6 +84,13 @@ pub struct CliOptions {
     )]
     /// The level of diagnostics to show. In order, from the lowest to the most important: info, warn, error. Passing `--diagnostic-level=error` will cause Biome to print only diagnostics that contain only errors.
     pub diagnostic_level: Severity,
+
+    #[bpaf(
+        long("output-to-file"),
+        short('o'),
+        argument("<FILE>"),
+    )]
+    pub output_to_file: String,
 }
 
 impl CliOptions {

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -86,12 +86,7 @@ pub struct CliOptions {
     pub diagnostic_level: Severity,
 
     /// Specify file to write report to
-    #[bpaf(
-        long("report-output-file"),
-        short('o'),
-        argument("<FILE>"),
-        optional
-    )]
+    #[bpaf(long("report-output-file"), short('o'), argument("<FILE>"), optional)]
     pub report_output_file: Option<String>,
 }
 

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -85,12 +85,14 @@ pub struct CliOptions {
     /// The level of diagnostics to show. In order, from the lowest to the most important: info, warn, error. Passing `--diagnostic-level=error` will cause Biome to print only diagnostics that contain only errors.
     pub diagnostic_level: Severity,
 
+    /// Specify file to write report to
     #[bpaf(
-        long("output-to-file"),
+        long("report-output-file"),
         short('o'),
         argument("<FILE>"),
+        optional
     )]
-    pub output_to_file: String,
+    pub report_output_file: Option<String>,
 }
 
 impl CliOptions {

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -27,6 +27,7 @@ use biome_service::workspace::{
 use std::borrow::Borrow;
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
+use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::info;
 
@@ -521,6 +522,11 @@ pub fn execute_mode(
                     console.log(markup! {
                         {code.as_code()}
                     });
+
+                    if let Some(report_output_file) = &cli_options.report_output_file {
+                        fs::write(report_output_file.clone(), code.as_code())
+                            .expect("Unable to write report file");
+                    }
                 } else {
                     console.log(markup! {
                         {buffer}

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -152,6 +152,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -154,6 +154,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -111,6 +111,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available positional items:
     PATH                      Single file, single path or list of paths.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -71,6 +71,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available positional items:
     PATH                      Single file, single path or list of paths

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -42,6 +42,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available options:
         --write               Writes the new configuration file to disk

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -42,6 +42,7 @@ Global options applied to all commands
                               `--diagnostic-level=error` will cause Biome to print only diagnostics
                               that contain only errors.
                               [default: info]
+    -o, --report-output-file=<<FILE>>  Specify file to write report to
 
 Available options:
         --daemon-logs         Prints the Biome daemon server logs


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Adds a CLI option to output a `json-pretty` report to a given file, similar to ESLint [output option](https://eslint.org/docs/latest/use/command-line-interface#output). I would really appreciate any sugestion on how to improve this.

## Test Plan

Run `biome lint --reporter=json-pretty --report-output-file=report.json` . The JSON file should contain the Report that was genereated
