### PR TITLE
fix(linter): false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Linter
 
+- Biome no longer crashes when it encounters a string that contain a multibyte character ([#4181](https://github.com/biomejs/biome/issues/4181)).
+
+  This fixes a regression introduced in Biome 1.9.3
+  The regression affected the following linter rules:
+
+  - nursery/useSortedClasses
+  - nursery/useTrimStartEnd
+  - style/useTemplate
+  - suspicious/noMisleadingCharacterClass
+
+  Contributed by @Conaclos
+
+- Fix [#4190](https://github.com/biomejs/biome/issues/4190), where the rule `noMissingVarFunction` wrongly reported a variable as missing when used inside a `var()`  function that was a newline. Contributed by @ematipico
+
+### Parser
+
 #### Bug Fixes
 
 - The CSS parser now accepts more emoji in identifiers ([#3627](https://github.com/biomejs/biome/issues/3627#issuecomment-2392388022)).
@@ -45,19 +61,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   }
   ```
 
-- Biome no longer crashes when it encounters a string that contain a multibyte character ([#4181](https://github.com/biomejs/biome/issues/4181)).
-
-  This fixes a regression introduced in Biome 1.9.3
-  The regression affected the following linter rules:
-
-  - nursery/useSortedClasses
-  - nursery/useTrimStartEnd
-  - style/useTemplate
-  - suspicious/noMisleadingCharacterClass
-
   Contributed by @Conaclos
-
-### Parser
 
 ## v1.9.3 (2024-10-01)
 

--- a/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
@@ -222,7 +222,7 @@ fn is_wrapped_in_var(node: &CssDashedIdentifier) -> bool {
             // e.g `color: --custom-property;`
             //             ^^^^^^^^^^^^^^^^ CSS_GENERIC_COMPONENT_VALUE_LIST
             CssSyntaxKind::CSS_GENERIC_COMPONENT_VALUE_LIST => return false,
-            CssSyntaxKind::CSS_FUNCTION => return parent.text().starts_with("var"),
+            CssSyntaxKind::CSS_FUNCTION => return parent.text_trimmed().starts_with("var"),
             _ => {}
         }
         current_node = parent.parent();

--- a/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
@@ -66,3 +66,10 @@ a {
         --foo: red;
     }
 }
+
+:root {
+	--colors-gray-a7: black;
+	/* The formatter breaks the line */
+	--broken-shadow: 0px 0px 1px
+	var(--colors-gray-a7);
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css.snap
@@ -73,4 +73,11 @@ a {
     }
 }
 
+:root {
+	--colors-gray-a7: black;
+	/* The formatter breaks the line */
+	--broken-shadow: 0px 0px 1px
+	var(--colors-gray-a7);
+}
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #4190 

We were not using `text_trimmed()` to check the `var` text. Instead, we were using `text`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

____

cc @Conaclos I moved a changelog paragraph. It was incorrectly listed as a linter fix, but it was a parser fix.

<!-- What demonstrates that your implementation is correct? -->
