### PR TITLE
refactor(cli): command runner

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -85,7 +85,7 @@ impl TryFrom<FixKind> for Applicability {
 }
 
 #[derive(Debug, Clone, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum RuleSource {
     /// Rules from [Rust Clippy](https://rust-lang.github.io/rust-clippy/master/index.html)
@@ -286,7 +286,7 @@ impl RuleSource {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum RuleSourceKind {
     /// The rule implements the same logic of the source

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -1,28 +1,17 @@
+use super::{determine_fix_file_mode, FixFileModeOptions, LoadEditorConfig};
 use crate::cli_options::CliOptions;
-use crate::commands::{
-    get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
-};
-use crate::execute::VcsTargeted;
-use crate::{
-    execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
-};
+use crate::commands::{get_files_to_process, CommandRunner};
+use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::analyzer::assists::PartialAssistsConfiguration;
 use biome_configuration::{
     organize_imports::PartialOrganizeImports, PartialConfiguration, PartialFormatterConfiguration,
     PartialLinterConfiguration,
 };
-use biome_console::{markup, ConsoleExt};
+use biome_console::Console;
 use biome_deserialize::Merge;
-use biome_diagnostics::PrintDiagnostic;
-use biome_service::configuration::{load_editorconfig, PartialConfigurationExt};
-use biome_service::workspace::RegisterProjectFolderParams;
-use biome_service::{
-    configuration::{load_configuration, LoadedConfiguration},
-    workspace::UpdateSettingsParams,
-};
+use biome_fs::FileSystem;
+use biome_service::{configuration::LoadedConfiguration, DynRef, Workspace, WorkspaceError};
 use std::ffi::OsString;
-
-use super::{determine_fix_file_mode, FixFileModeOptions};
 
 pub(crate) struct CheckCommandPayload {
     pub(crate) apply: bool,
@@ -30,7 +19,6 @@ pub(crate) struct CheckCommandPayload {
     pub(crate) write: bool,
     pub(crate) fix: bool,
     pub(crate) unsafe_: bool,
-    pub(crate) cli_options: CliOptions,
     pub(crate) configuration: Option<PartialConfiguration>,
     pub(crate) paths: Vec<OsString>,
     pub(crate) stdin_file_path: Option<String>,
@@ -43,174 +31,128 @@ pub(crate) struct CheckCommandPayload {
     pub(crate) since: Option<String>,
 }
 
-/// Handler for the "check" command of the Biome CLI
-pub(crate) fn check(
-    session: CliSession,
-    payload: CheckCommandPayload,
-) -> Result<(), CliDiagnostic> {
-    let CheckCommandPayload {
-        apply,
-        apply_unsafe,
-        write,
-        fix,
-        unsafe_,
-        cli_options,
-        configuration,
-        paths,
-        stdin_file_path,
-        linter_enabled,
-        organize_imports_enabled,
-        formatter_enabled,
-        since,
-        assists_enabled,
-        staged,
-        changed,
-    } = payload;
-    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
+impl LoadEditorConfig for CheckCommandPayload {
+    fn should_load_editor_config(&self, fs_configuration: &PartialConfiguration) -> bool {
+        self.configuration
+            .as_ref()
+            .and_then(|c| c.use_editorconfig())
+            .unwrap_or(fs_configuration.use_editorconfig().unwrap_or_default())
+    }
+}
 
-    let fix_file_mode = determine_fix_file_mode(
-        FixFileModeOptions {
-            apply,
-            apply_unsafe,
-            write,
-            fix,
-            unsafe_,
-        },
-        session.app.console,
-    )?;
+impl CommandRunner for CheckCommandPayload {
+    const COMMAND_NAME: &'static str = "check";
 
-    let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
-    validate_configuration_diagnostics(
-        &loaded_configuration,
-        session.app.console,
-        cli_options.verbose,
-    )?;
+    fn merge_configuration(
+        &mut self,
+        loaded_configuration: LoadedConfiguration,
+        fs: &DynRef<'_, dyn FileSystem>,
+        console: &mut dyn Console,
+    ) -> Result<PartialConfiguration, WorkspaceError> {
+        let editorconfig_search_path = loaded_configuration.directory_path.clone();
+        let LoadedConfiguration {
+            configuration: biome_configuration,
+            ..
+        } = loaded_configuration;
+        let mut fs_configuration =
+            self.load_editor_config(editorconfig_search_path, &biome_configuration, fs, console)?;
+        // this makes biome configuration take precedence over editorconfig configuration
+        fs_configuration.merge_with(biome_configuration);
 
-    let editorconfig_search_path = loaded_configuration.directory_path.clone();
-    let LoadedConfiguration {
-        configuration: biome_configuration,
-        directory_path: configuration_path,
-        ..
-    } = loaded_configuration;
+        let formatter = fs_configuration
+            .formatter
+            .get_or_insert_with(PartialFormatterConfiguration::default);
 
-    let should_use_editorconfig = configuration
-        .as_ref()
-        .and_then(|c| c.use_editorconfig())
-        .unwrap_or(biome_configuration.use_editorconfig().unwrap_or_default());
-    let mut fs_configuration = if should_use_editorconfig {
-        let (editorconfig, editorconfig_diagnostics) = {
-            let search_path = editorconfig_search_path.unwrap_or_else(|| {
-                let fs = &session.app.fs;
-                fs.working_directory().unwrap_or_default()
-            });
-            load_editorconfig(&session.app.fs, search_path)?
-        };
-        for diagnostic in editorconfig_diagnostics {
-            session.app.console.error(markup! {
-                {PrintDiagnostic::simple(&diagnostic)}
-            })
+        if self.formatter_enabled.is_some() {
+            formatter.enabled = self.formatter_enabled;
         }
-        editorconfig.unwrap_or_default()
-    } else {
-        Default::default()
-    };
-    // this makes biome configuration take precedence over editorconfig configuration
-    fs_configuration.merge_with(biome_configuration);
 
-    let formatter = fs_configuration
-        .formatter
-        .get_or_insert_with(PartialFormatterConfiguration::default);
+        let linter = fs_configuration
+            .linter
+            .get_or_insert_with(PartialLinterConfiguration::default);
 
-    if formatter_enabled.is_some() {
-        formatter.enabled = formatter_enabled;
-    }
-
-    let linter = fs_configuration
-        .linter
-        .get_or_insert_with(PartialLinterConfiguration::default);
-
-    if linter_enabled.is_some() {
-        linter.enabled = linter_enabled;
-    }
-
-    let organize_imports = fs_configuration
-        .organize_imports
-        .get_or_insert_with(PartialOrganizeImports::default);
-
-    if organize_imports_enabled.is_some() {
-        organize_imports.enabled = organize_imports_enabled;
-    }
-
-    let assists = fs_configuration
-        .assists
-        .get_or_insert_with(PartialAssistsConfiguration::default);
-
-    if assists_enabled.is_some() {
-        assists.enabled = assists_enabled;
-    }
-
-    if let Some(mut configuration) = configuration {
-        if let Some(linter) = configuration.linter.as_mut() {
-            // Don't overwrite rules from the CLI configuration.
-            // Otherwise, rules that are disabled in the config file might
-            // become re-enabled due to the defaults included in the CLI
-            // configuration.
-            linter.rules = None;
+        if self.linter_enabled.is_some() {
+            linter.enabled = self.linter_enabled;
         }
-        fs_configuration.merge_with(configuration);
+
+        let organize_imports = fs_configuration
+            .organize_imports
+            .get_or_insert_with(PartialOrganizeImports::default);
+
+        if self.organize_imports_enabled.is_some() {
+            organize_imports.enabled = self.organize_imports_enabled;
+        }
+
+        let assists = fs_configuration
+            .assists
+            .get_or_insert_with(PartialAssistsConfiguration::default);
+
+        if self.assists_enabled.is_some() {
+            assists.enabled = self.assists_enabled;
+        }
+
+        if let Some(mut configuration) = self.configuration.clone() {
+            if let Some(linter) = configuration.linter.as_mut() {
+                // Don't overwrite rules from the CLI configuration.
+                // Otherwise, rules that are disabled in the config file might
+                // become re-enabled due to the defaults included in the CLI
+                // configuration.
+                linter.rules = None;
+            }
+            fs_configuration.merge_with(configuration);
+        }
+
+        Ok(fs_configuration)
     }
 
-    // check if support of git ignore files is enabled
-    let vcs_base_path = configuration_path.or(session.app.fs.working_directory());
-    let (vcs_base_path, gitignore_matches) =
-        fs_configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
-
-    let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "check")?;
-
-    let vcs_targeted_paths = get_files_to_process(
-        since.as_deref(),
-        changed,
-        staged,
-        &session.app.fs,
-        &fs_configuration,
-    )?;
-
-    session
-        .app
-        .workspace
-        .register_project_folder(RegisterProjectFolderParams {
-            path: session.app.fs.working_directory(),
-            set_as_current_workspace: true,
-        })?;
-    let manifest_data = resolve_manifest(&session.app.fs)?;
-
-    if let Some(manifest_data) = manifest_data {
-        session
-            .app
-            .workspace
-            .set_manifest_for_project(manifest_data.into())?;
+    fn get_files_to_process(
+        &self,
+        fs: &DynRef<'_, dyn FileSystem>,
+        configuration: &PartialConfiguration,
+    ) -> Result<Vec<OsString>, CliDiagnostic> {
+        if let Some(paths) = get_files_to_process(
+            self.since.as_deref(),
+            self.changed,
+            self.staged,
+            fs,
+            configuration,
+        )? {
+            Ok(paths)
+        } else {
+            Ok(self.paths.clone())
+        }
     }
 
-    session
-        .app
-        .workspace
-        .update_settings(UpdateSettingsParams {
-            workspace_directory: session.app.fs.working_directory(),
-            configuration: fs_configuration,
-            vcs_base_path,
-            gitignore_matches,
-        })?;
+    fn get_stdin_file_path(&self) -> Option<&str> {
+        self.stdin_file_path.as_deref()
+    }
 
-    execute_mode(
-        Execution::new(TraversalMode::Check {
+    fn should_write(&self) -> bool {
+        self.write || self.fix
+    }
+
+    fn get_execution(
+        &self,
+        cli_options: &CliOptions,
+        console: &mut dyn Console,
+        _workspace: &dyn Workspace,
+    ) -> Result<Execution, CliDiagnostic> {
+        let fix_file_mode = determine_fix_file_mode(
+            FixFileModeOptions {
+                apply: self.apply,
+                apply_unsafe: self.apply_unsafe,
+                write: self.write,
+                fix: self.fix,
+                unsafe_: self.unsafe_,
+            },
+            console,
+        )?;
+
+        Ok(Execution::new(TraversalMode::Check {
             fix_file_mode,
-            stdin,
-            vcs_targeted: VcsTargeted { staged, changed },
+            stdin: self.get_stdin(console)?,
+            vcs_targeted: (self.staged, self.changed).into(),
         })
-        .set_report(&cli_options),
-        session,
-        &cli_options,
-        vcs_targeted_paths.unwrap_or(paths),
-    )
+        .set_report(cli_options))
+    }
 }

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -1,6 +1,6 @@
 use super::{determine_fix_file_mode, FixFileModeOptions, LoadEditorConfig};
 use crate::cli_options::CliOptions;
-use crate::commands::{get_files_to_process, CommandRunner};
+use crate::commands::{get_files_to_process_with_cli_options, CommandRunner};
 use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::analyzer::assists::PartialAssistsConfiguration;
 use biome_configuration::{
@@ -110,17 +110,16 @@ impl CommandRunner for CheckCommandPayload {
         fs: &DynRef<'_, dyn FileSystem>,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
-        if let Some(paths) = get_files_to_process(
+        let paths = get_files_to_process_with_cli_options(
             self.since.as_deref(),
             self.changed,
             self.staged,
             fs,
             configuration,
-        )? {
-            Ok(paths)
-        } else {
-            Ok(self.paths.clone())
-        }
+        )?
+        .unwrap_or(self.paths.clone());
+
+        Ok(paths)
     }
 
     fn get_stdin_file_path(&self) -> Option<&str> {

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -1,18 +1,15 @@
 use crate::changed::get_changed_files;
 use crate::cli_options::CliOptions;
-use crate::commands::{resolve_manifest, validate_configuration_diagnostics};
-use crate::execute::VcsTargeted;
-use crate::{execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution};
+use crate::commands::{CommandRunner, LoadEditorConfig};
+use crate::{CliDiagnostic, Execution};
 use biome_configuration::analyzer::assists::PartialAssistsConfiguration;
 use biome_configuration::{organize_imports::PartialOrganizeImports, PartialConfiguration};
 use biome_configuration::{PartialFormatterConfiguration, PartialLinterConfiguration};
-use biome_console::{markup, ConsoleExt};
+use biome_console::Console;
 use biome_deserialize::Merge;
-use biome_diagnostics::PrintDiagnostic;
-use biome_service::configuration::{
-    load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
-};
-use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
+use biome_fs::FileSystem;
+use biome_service::configuration::LoadedConfiguration;
+use biome_service::{DynRef, Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct CiCommandPayload {
@@ -22,163 +19,124 @@ pub(crate) struct CiCommandPayload {
     pub(crate) assists_enabled: Option<bool>,
     pub(crate) paths: Vec<OsString>,
     pub(crate) configuration: Option<PartialConfiguration>,
-    pub(crate) cli_options: CliOptions,
     pub(crate) changed: bool,
     pub(crate) since: Option<String>,
 }
 
-/// Handler for the "ci" command of the Biome CLI
-pub(crate) fn ci(session: CliSession, payload: CiCommandPayload) -> Result<(), CliDiagnostic> {
-    let CiCommandPayload {
-        cli_options,
-        formatter_enabled,
-        linter_enabled,
-        organize_imports_enabled,
-        assists_enabled,
-        configuration,
-        mut paths,
-        since,
-        changed,
-    } = payload;
-    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
+impl LoadEditorConfig for CiCommandPayload {
+    fn should_load_editor_config(&self, fs_configuration: &PartialConfiguration) -> bool {
+        self.configuration
+            .as_ref()
+            .and_then(|c| c.use_editorconfig())
+            .unwrap_or(fs_configuration.use_editorconfig().unwrap_or_default())
+    }
+}
 
-    let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
+impl CommandRunner for CiCommandPayload {
+    const COMMAND_NAME: &'static str = "ci";
 
-    validate_configuration_diagnostics(
-        &loaded_configuration,
-        session.app.console,
-        cli_options.verbose,
-    )?;
+    fn merge_configuration(
+        &mut self,
+        loaded_configuration: LoadedConfiguration,
+        fs: &DynRef<'_, dyn FileSystem>,
+        console: &mut dyn Console,
+    ) -> Result<PartialConfiguration, WorkspaceError> {
+        let LoadedConfiguration {
+            configuration: biome_configuration,
+            directory_path: configuration_path,
+            ..
+        } = loaded_configuration;
 
-    let LoadedConfiguration {
-        configuration: biome_configuration,
-        directory_path: configuration_path,
-        ..
-    } = loaded_configuration;
+        let mut fs_configuration =
+            self.load_editor_config(configuration_path, &biome_configuration, fs, console)?;
+        // this makes biome configuration take precedence over editorconfig configuration
+        fs_configuration.merge_with(biome_configuration);
 
-    let should_use_editorconfig = configuration
-        .as_ref()
-        .and_then(|c| c.use_editorconfig())
-        .unwrap_or(biome_configuration.use_editorconfig().unwrap_or_default());
-    let mut fs_configuration = if should_use_editorconfig {
-        let (editorconfig, editorconfig_diagnostics) = {
-            let search_path = configuration_path.clone().unwrap_or_else(|| {
-                let fs = &session.app.fs;
-                fs.working_directory().unwrap_or_default()
-            });
-            load_editorconfig(&session.app.fs, search_path)?
-        };
-        for diagnostic in editorconfig_diagnostics {
-            session.app.console.error(markup! {
-                {PrintDiagnostic::simple(&diagnostic)}
-            })
+        let formatter = fs_configuration
+            .formatter
+            .get_or_insert_with(PartialFormatterConfiguration::default);
+
+        if self.formatter_enabled.is_some() {
+            formatter.enabled = self.formatter_enabled;
         }
-        editorconfig.unwrap_or_default()
-    } else {
-        Default::default()
-    };
-    // this makes biome configuration take precedence over editorconfig configuration
-    fs_configuration.merge_with(biome_configuration);
 
-    let formatter = fs_configuration
-        .formatter
-        .get_or_insert_with(PartialFormatterConfiguration::default);
+        let linter = fs_configuration
+            .linter
+            .get_or_insert_with(PartialLinterConfiguration::default);
 
-    if formatter_enabled.is_some() {
-        formatter.enabled = formatter_enabled;
-    }
-
-    let linter = fs_configuration
-        .linter
-        .get_or_insert_with(PartialLinterConfiguration::default);
-
-    if linter_enabled.is_some() {
-        linter.enabled = linter_enabled;
-    }
-
-    let organize_imports = fs_configuration
-        .organize_imports
-        .get_or_insert_with(PartialOrganizeImports::default);
-
-    if organize_imports_enabled.is_some() {
-        organize_imports.enabled = organize_imports_enabled;
-    }
-
-    let assists = fs_configuration
-        .assists
-        .get_or_insert_with(PartialAssistsConfiguration::default);
-
-    if assists_enabled.is_some() {
-        assists.enabled = assists_enabled;
-    }
-
-    // no point in doing the traversal if all the checks have been disabled
-    if fs_configuration.is_formatter_disabled()
-        && fs_configuration.is_linter_disabled()
-        && fs_configuration.is_organize_imports_disabled()
-    {
-        return Err(CliDiagnostic::incompatible_end_configuration("Formatter, linter and organize imports are disabled, can't perform the command. This is probably and error."));
-    }
-
-    if let Some(mut configuration) = configuration {
-        if let Some(linter) = configuration.linter.as_mut() {
-            // Don't overwrite rules from the CLI configuration.
-            // Otherwise, rules that are disabled in the config file might
-            // become re-enabled due to the defaults included in the CLI
-            // configuration.
-            linter.rules = None;
+        if self.linter_enabled.is_some() {
+            linter.enabled = self.linter_enabled;
         }
-        fs_configuration.merge_with(configuration);
+
+        let organize_imports = fs_configuration
+            .organize_imports
+            .get_or_insert_with(PartialOrganizeImports::default);
+
+        if self.organize_imports_enabled.is_some() {
+            organize_imports.enabled = self.organize_imports_enabled;
+        }
+
+        let assists = fs_configuration
+            .assists
+            .get_or_insert_with(PartialAssistsConfiguration::default);
+
+        if self.assists_enabled.is_some() {
+            assists.enabled = self.assists_enabled;
+        }
+
+        if let Some(mut configuration) = self.configuration.clone() {
+            if let Some(linter) = configuration.linter.as_mut() {
+                // Don't overwrite rules from the CLI configuration.
+                // Otherwise, rules that are disabled in the config file might
+                // become re-enabled due to the defaults included in the CLI
+                // configuration.
+                linter.rules = None;
+            }
+            fs_configuration.merge_with(configuration);
+        }
+
+        Ok(fs_configuration)
     }
 
-    // check if support of git ignore files is enabled
-    let vcs_base_path = configuration_path.or(session.app.fs.working_directory());
-    let (vcs_base_path, gitignore_matches) =
-        fs_configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
-
-    if since.is_some() && !changed {
-        return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+    fn get_files_to_process(
+        &self,
+        fs: &DynRef<'_, dyn FileSystem>,
+        configuration: &PartialConfiguration,
+    ) -> Result<Vec<OsString>, CliDiagnostic> {
+        if self.changed {
+            get_changed_files(fs, configuration, self.since.as_deref())
+        } else {
+            Ok(self.paths.clone())
+        }
     }
 
-    if changed {
-        paths = get_changed_files(&session.app.fs, &fs_configuration, since.as_deref())?;
+    fn get_stdin_file_path(&self) -> Option<&str> {
+        None
     }
 
-    session
-        .app
-        .workspace
-        .register_project_folder(RegisterProjectFolderParams {
-            path: session.app.fs.working_directory(),
-            set_as_current_workspace: true,
-        })?;
-
-    let manifest_data = resolve_manifest(&session.app.fs)?;
-
-    if let Some(manifest_data) = manifest_data {
-        session
-            .app
-            .workspace
-            .set_manifest_for_project(manifest_data.into())?;
+    fn should_write(&self) -> bool {
+        false
     }
-    session
-        .app
-        .workspace
-        .update_settings(UpdateSettingsParams {
-            configuration: fs_configuration,
-            workspace_directory: session.app.fs.working_directory(),
-            vcs_base_path,
-            gitignore_matches,
-        })?;
 
-    execute_mode(
-        Execution::new_ci(VcsTargeted {
-            staged: false,
-            changed,
-        })
-        .set_report(&cli_options),
-        session,
-        &cli_options,
-        paths,
-    )
+    fn get_execution(
+        &self,
+        cli_options: &CliOptions,
+        _console: &mut dyn Console,
+        _workspace: &dyn Workspace,
+    ) -> Result<Execution, CliDiagnostic> {
+        Ok(Execution::new_ci((false, self.changed).into()).set_report(cli_options))
+    }
+
+    fn check_incompatible_arguments(&self) -> Result<(), CliDiagnostic> {
+        if matches!(self.formatter_enabled, Some(false))
+            && matches!(self.linter_enabled, Some(false))
+            && matches!(self.organize_imports_enabled, Some(false))
+        {
+            return Err(CliDiagnostic::incompatible_end_configuration("Formatter, linter and organize imports are disabled, can't perform the command. At least one feature needs to be enabled. This is probably and error."));
+        }
+        if self.since.is_some() && !self.changed {
+            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+        }
+        Ok(())
+    }
 }

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -1,5 +1,5 @@
 use crate::cli_options::CliOptions;
-use crate::commands::{get_files_to_process, CommandRunner, LoadEditorConfig};
+use crate::commands::{get_files_to_process_with_cli_options, CommandRunner, LoadEditorConfig};
 use crate::diagnostics::DeprecatedArgument;
 use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::vcs::PartialVcsConfiguration;
@@ -170,17 +170,16 @@ impl CommandRunner for FormatCommandPayload {
         fs: &DynRef<'_, dyn FileSystem>,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
-        if let Some(paths) = get_files_to_process(
+        let paths = get_files_to_process_with_cli_options(
             self.since.as_deref(),
             self.changed,
             self.staged,
             fs,
             configuration,
-        )? {
-            Ok(paths)
-        } else {
-            Ok(self.paths.clone())
-        }
+        )?
+        .unwrap_or(self.paths.clone());
+
+        Ok(paths)
     }
 
     fn get_stdin_file_path(&self) -> Option<&str> {

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -1,7 +1,6 @@
 use crate::cli_options::CliOptions;
-use crate::commands::{get_files_to_process, CommandRunner};
+use crate::commands::{get_files_to_process, CommandRunner, LoadEditorConfig};
 use crate::diagnostics::DeprecatedArgument;
-use crate::execute::VcsTargeted;
 use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::vcs::PartialVcsConfiguration;
 use biome_configuration::{
@@ -13,8 +12,8 @@ use biome_console::{markup, Console, ConsoleExt};
 use biome_deserialize::Merge;
 use biome_diagnostics::PrintDiagnostic;
 use biome_fs::FileSystem;
-use biome_service::configuration::{load_editorconfig, LoadedConfiguration};
-use biome_service::{DynRef, WorkspaceError};
+use biome_service::configuration::LoadedConfiguration;
+use biome_service::{DynRef, Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct FormatCommandPayload {
@@ -34,6 +33,15 @@ pub(crate) struct FormatCommandPayload {
     pub(crate) since: Option<String>,
 }
 
+impl LoadEditorConfig for FormatCommandPayload {
+    fn should_load_editor_config(&self, fs_configuration: &PartialConfiguration) -> bool {
+        self.formatter_configuration
+            .as_ref()
+            .and_then(|c| c.use_editorconfig)
+            .unwrap_or(fs_configuration.use_editorconfig().unwrap_or_default())
+    }
+}
+
 impl CommandRunner for FormatCommandPayload {
     const COMMAND_NAME: &'static str = "format";
 
@@ -49,26 +57,8 @@ impl CommandRunner for FormatCommandPayload {
             ..
         } = loaded_configuration;
         let editorconfig_search_path = configuration_path.clone();
-        let should_use_editorconfig = self
-            .formatter_configuration
-            .as_ref()
-            .and_then(|c| c.use_editorconfig)
-            .unwrap_or(biome_configuration.use_editorconfig().unwrap_or_default());
-        let mut fs_configuration = if should_use_editorconfig {
-            let (editorconfig, editorconfig_diagnostics) = {
-                let search_path = editorconfig_search_path
-                    .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
-                load_editorconfig(fs, search_path)?
-            };
-            for diagnostic in editorconfig_diagnostics {
-                console.error(markup! {
-                    {PrintDiagnostic::simple(&diagnostic)}
-                })
-            }
-            editorconfig.unwrap_or_default()
-        } else {
-            Default::default()
-        };
+        let mut fs_configuration =
+            self.load_editor_config(editorconfig_search_path, &biome_configuration, fs, console)?;
         // this makes biome configuration take precedence over editorconfig configuration
         fs_configuration.merge_with(biome_configuration);
         let mut configuration = fs_configuration;
@@ -193,8 +183,8 @@ impl CommandRunner for FormatCommandPayload {
         }
     }
 
-    fn get_stdin_file_path(&self) -> Option<&String> {
-        self.stdin_file_path.as_ref()
+    fn get_stdin_file_path(&self) -> Option<&str> {
+        self.stdin_file_path.as_deref()
     }
 
     fn should_write(&self) -> bool {
@@ -205,15 +195,13 @@ impl CommandRunner for FormatCommandPayload {
         &self,
         cli_options: &CliOptions,
         console: &mut dyn Console,
+        _workspace: &dyn Workspace,
     ) -> Result<Execution, CliDiagnostic> {
         Ok(Execution::new(TraversalMode::Format {
             ignore_errors: cli_options.skip_errors,
             write: self.should_write(),
             stdin: self.get_stdin(console)?,
-            vcs_targeted: VcsTargeted {
-                staged: self.staged,
-                changed: self.changed,
-            },
+            vcs_targeted: (self.staged, self.changed).into(),
         })
         .set_report(cli_options))
     }

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -1,11 +1,7 @@
+use super::{determine_fix_file_mode, FixFileModeOptions};
 use crate::cli_options::CliOptions;
-use crate::commands::{
-    get_files_to_process, get_stdin, resolve_manifest, validate_configuration_diagnostics,
-};
-use crate::execute::VcsTargeted;
-use crate::{
-    execute_mode, setup_cli_subscriber, CliDiagnostic, CliSession, Execution, TraversalMode,
-};
+use crate::commands::{get_files_to_process, CommandRunner};
+use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::analyzer::RuleSelector;
 use biome_configuration::css::PartialCssLinter;
 use biome_configuration::javascript::PartialJavascriptLinter;
@@ -15,14 +11,12 @@ use biome_configuration::{
     PartialConfiguration, PartialFilesConfiguration, PartialGraphqlLinter,
     PartialLinterConfiguration,
 };
+use biome_console::Console;
 use biome_deserialize::Merge;
-use biome_service::configuration::{
-    load_configuration, LoadedConfiguration, PartialConfigurationExt,
-};
-use biome_service::workspace::{RegisterProjectFolderParams, UpdateSettingsParams};
+use biome_fs::FileSystem;
+use biome_service::configuration::LoadedConfiguration;
+use biome_service::{DynRef, Workspace, WorkspaceError};
 use std::ffi::OsString;
-
-use super::{determine_fix_file_mode, FixFileModeOptions};
 
 pub(crate) struct LintCommandPayload {
     pub(crate) apply: bool,
@@ -30,7 +24,6 @@ pub(crate) struct LintCommandPayload {
     pub(crate) write: bool,
     pub(crate) fix: bool,
     pub(crate) unsafe_: bool,
-    pub(crate) cli_options: CliOptions,
     pub(crate) linter_configuration: Option<PartialLinterConfiguration>,
     pub(crate) vcs_configuration: Option<PartialVcsConfiguration>,
     pub(crate) files_configuration: Option<PartialFilesConfiguration>,
@@ -47,149 +40,113 @@ pub(crate) struct LintCommandPayload {
     pub(crate) graphql_linter: Option<PartialGraphqlLinter>,
 }
 
-/// Handler for the "lint" command of the Biome CLI
-pub(crate) fn lint(session: CliSession, payload: LintCommandPayload) -> Result<(), CliDiagnostic> {
-    let LintCommandPayload {
-        apply,
-        apply_unsafe,
-        write,
-        fix,
-        unsafe_,
-        cli_options,
-        mut linter_configuration,
-        paths,
-        only,
-        skip,
-        stdin_file_path,
-        vcs_configuration,
-        files_configuration,
-        staged,
-        changed,
-        since,
-        javascript_linter,
-        css_linter,
-        json_linter,
-        graphql_linter,
-    } = payload;
-    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
+impl CommandRunner for LintCommandPayload {
+    const COMMAND_NAME: &'static str = "lint";
 
-    let fix_file_mode = determine_fix_file_mode(
-        FixFileModeOptions {
-            apply,
-            apply_unsafe,
-            write,
-            fix,
-            unsafe_,
-        },
-        session.app.console,
-    )?;
+    fn merge_configuration(
+        &mut self,
+        loaded_configuration: LoadedConfiguration,
+        _fs: &DynRef<'_, dyn FileSystem>,
+        _console: &mut dyn Console,
+    ) -> Result<PartialConfiguration, WorkspaceError> {
+        let LoadedConfiguration {
+            configuration: mut fs_configuration,
+            ..
+        } = loaded_configuration;
 
-    let loaded_configuration =
-        load_configuration(&session.app.fs, cli_options.as_configuration_path_hint())?;
-    validate_configuration_diagnostics(
-        &loaded_configuration,
-        session.app.console,
-        cli_options.verbose,
-    )?;
+        fs_configuration.merge_with(PartialConfiguration {
+            linter: if fs_configuration
+                .linter
+                .as_ref()
+                .is_some_and(PartialLinterConfiguration::is_disabled)
+            {
+                None
+            } else {
+                if let Some(linter) = self.linter_configuration.as_mut() {
+                    // Don't overwrite rules from the CLI configuration.
+                    linter.rules = None;
+                }
+                self.linter_configuration.clone()
+            },
+            files: self.files_configuration.clone(),
+            vcs: self.vcs_configuration.clone(),
+            ..Default::default()
+        });
 
-    let LoadedConfiguration {
-        configuration: mut fs_configuration,
-        directory_path: configuration_path,
-        ..
-    } = loaded_configuration;
-    fs_configuration.merge_with(PartialConfiguration {
-        linter: if fs_configuration
-            .linter
-            .as_ref()
-            .is_some_and(PartialLinterConfiguration::is_disabled)
-        {
-            None
+        if self.css_linter.is_some() {
+            let css = fs_configuration.css.get_or_insert_with(Default::default);
+            css.linter.merge_with(self.css_linter.clone());
+        }
+
+        if self.graphql_linter.is_some() {
+            let graphql = fs_configuration
+                .graphql
+                .get_or_insert_with(Default::default);
+            graphql.linter.merge_with(self.graphql_linter.clone());
+        }
+        if self.javascript_linter.is_some() {
+            let javascript = fs_configuration
+                .javascript
+                .get_or_insert_with(Default::default);
+            javascript.linter.merge_with(self.javascript_linter.clone());
+        }
+        if self.json_linter.is_some() {
+            let json = fs_configuration.json.get_or_insert_with(Default::default);
+            json.linter.merge_with(self.json_linter.clone());
+        }
+
+        Ok(fs_configuration)
+    }
+
+    fn get_files_to_process(
+        &self,
+        fs: &DynRef<'_, dyn FileSystem>,
+        configuration: &PartialConfiguration,
+    ) -> Result<Vec<OsString>, CliDiagnostic> {
+        if let Some(paths) = get_files_to_process(
+            self.since.as_deref(),
+            self.changed,
+            self.staged,
+            fs,
+            configuration,
+        )? {
+            Ok(paths)
         } else {
-            if let Some(linter) = linter_configuration.as_mut() {
-                // Don't overwrite rules from the CLI configuration.
-                linter.rules = None;
-            }
-            linter_configuration
-        },
-        files: files_configuration,
-        vcs: vcs_configuration,
-        ..Default::default()
-    });
-
-    if css_linter.is_some() {
-        let css = fs_configuration.css.get_or_insert_with(Default::default);
-        css.linter.merge_with(css_linter);
+            Ok(self.paths.clone())
+        }
     }
 
-    if graphql_linter.is_some() {
-        let graphql = fs_configuration
-            .graphql
-            .get_or_insert_with(Default::default);
-        graphql.linter.merge_with(graphql_linter);
-    }
-    if javascript_linter.is_some() {
-        let javascript = fs_configuration
-            .javascript
-            .get_or_insert_with(Default::default);
-        javascript.linter.merge_with(javascript_linter);
-    }
-    if json_linter.is_some() {
-        let json = fs_configuration.json.get_or_insert_with(Default::default);
-        json.linter.merge_with(json_linter);
+    fn get_stdin_file_path(&self) -> Option<&str> {
+        self.stdin_file_path.as_deref()
     }
 
-    let vcs_targeted_paths = get_files_to_process(
-        since.as_deref(),
-        changed,
-        staged,
-        &session.app.fs,
-        &fs_configuration,
-    )?;
-
-    // check if support of git ignore files is enabled
-    let vcs_base_path = configuration_path.or(session.app.fs.working_directory());
-    let (vcs_base_path, gitignore_matches) =
-        fs_configuration.retrieve_gitignore_matches(&session.app.fs, vcs_base_path.as_deref())?;
-
-    let stdin = get_stdin(stdin_file_path, &mut *session.app.console, "lint")?;
-
-    session
-        .app
-        .workspace
-        .register_project_folder(RegisterProjectFolderParams {
-            path: session.app.fs.working_directory(),
-            set_as_current_workspace: true,
-        })?;
-    let manifest_data = resolve_manifest(&session.app.fs)?;
-
-    if let Some(manifest_data) = manifest_data {
-        session
-            .app
-            .workspace
-            .set_manifest_for_project(manifest_data.into())?;
+    fn should_write(&self) -> bool {
+        self.write || self.fix
     }
 
-    session
-        .app
-        .workspace
-        .update_settings(UpdateSettingsParams {
-            workspace_directory: session.app.fs.working_directory(),
-            configuration: fs_configuration,
-            vcs_base_path,
-            gitignore_matches,
-        })?;
-
-    execute_mode(
-        Execution::new(TraversalMode::Lint {
+    fn get_execution(
+        &self,
+        cli_options: &CliOptions,
+        console: &mut dyn Console,
+        _workspace: &dyn Workspace,
+    ) -> Result<Execution, CliDiagnostic> {
+        let fix_file_mode = determine_fix_file_mode(
+            FixFileModeOptions {
+                apply: self.apply,
+                apply_unsafe: self.apply_unsafe,
+                write: self.write,
+                fix: self.fix,
+                unsafe_: self.unsafe_,
+            },
+            console,
+        )?;
+        Ok(Execution::new(TraversalMode::Lint {
             fix_file_mode,
-            stdin,
-            only,
-            skip,
-            vcs_targeted: VcsTargeted { staged, changed },
+            stdin: self.get_stdin(console)?,
+            only: self.only.clone(),
+            skip: self.skip.clone(),
+            vcs_targeted: (self.staged, self.changed).into(),
         })
-        .set_report(&cli_options),
-        session,
-        &cli_options,
-        vcs_targeted_paths.unwrap_or(paths),
-    )
+        .set_report(cli_options))
+    }
 }

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -1,6 +1,6 @@
 use super::{determine_fix_file_mode, FixFileModeOptions};
 use crate::cli_options::CliOptions;
-use crate::commands::{get_files_to_process, CommandRunner};
+use crate::commands::{get_files_to_process_with_cli_options, CommandRunner};
 use crate::{CliDiagnostic, Execution, TraversalMode};
 use biome_configuration::analyzer::RuleSelector;
 use biome_configuration::css::PartialCssLinter;
@@ -103,17 +103,16 @@ impl CommandRunner for LintCommandPayload {
         fs: &DynRef<'_, dyn FileSystem>,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
-        if let Some(paths) = get_files_to_process(
+        let paths = get_files_to_process_with_cli_options(
             self.since.as_deref(),
             self.changed,
             self.staged,
             fs,
             configuration,
-        )? {
-            Ok(paths)
-        } else {
-            Ok(self.paths.clone())
-        }
+        )?
+        .unwrap_or(self.paths.clone());
+
+        Ok(paths)
     }
 
     fn get_stdin_file_path(&self) -> Option<&str> {

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -1,65 +1,89 @@
+use super::{
+    check_fix_incompatible_arguments, CommandRunner, FixFileModeOptions, MigrateSubCommand,
+};
 use crate::cli_options::CliOptions;
 use crate::diagnostics::MigrationDiagnostic;
-use crate::execute::{execute_mode, Execution, TraversalMode};
-use crate::{setup_cli_subscriber, CliDiagnostic, CliSession};
-use biome_console::{markup, ConsoleExt};
-use biome_service::configuration::{load_configuration, LoadedConfiguration};
-use biome_service::workspace::RegisterProjectFolderParams;
+use crate::execute::{Execution, TraversalMode};
+use crate::CliDiagnostic;
+use biome_configuration::PartialConfiguration;
+use biome_console::{markup, Console, ConsoleExt};
+use biome_fs::FileSystem;
+use biome_service::configuration::LoadedConfiguration;
+use biome_service::{DynRef, Workspace, WorkspaceError};
+use std::ffi::OsString;
+use std::path::PathBuf;
 
-use super::{check_fix_incompatible_arguments, FixFileModeOptions, MigrateSubCommand};
+pub(crate) struct MigrateCommandPayload {
+    pub(crate) write: bool,
+    pub(crate) fix: bool,
+    pub(crate) sub_command: Option<MigrateSubCommand>,
+    pub(crate) configuration_file_path: Option<PathBuf>,
+    pub(crate) configuration_directory_path: Option<PathBuf>,
+}
 
-/// Handler for the "migrate" command of the Biome CLI
-pub(crate) fn migrate(
-    session: CliSession,
-    cli_options: CliOptions,
-    write: bool,
-    fix: bool,
-    sub_command: Option<MigrateSubCommand>,
-) -> Result<(), CliDiagnostic> {
-    let base_path = cli_options.as_configuration_path_hint();
-    let LoadedConfiguration {
-        configuration: _,
-        diagnostics: _,
-        directory_path,
-        file_path,
-    } = load_configuration(&session.app.fs, base_path)?;
-    setup_cli_subscriber(cli_options.log_level, cli_options.log_kind);
+impl CommandRunner for MigrateCommandPayload {
+    const COMMAND_NAME: &'static str = "migrate";
 
-    check_fix_incompatible_arguments(FixFileModeOptions {
-        apply: false,
-        apply_unsafe: false,
-        write,
-        fix,
-        unsafe_: false,
-    })?;
+    fn merge_configuration(
+        &mut self,
+        loaded_configuration: LoadedConfiguration,
+        _fs: &DynRef<'_, dyn FileSystem>,
+        _console: &mut dyn Console,
+    ) -> Result<PartialConfiguration, WorkspaceError> {
+        self.configuration_file_path = loaded_configuration.file_path;
+        self.configuration_directory_path = loaded_configuration.directory_path;
+        Ok(loaded_configuration.configuration)
+    }
 
-    session
-        .app
-        .workspace
-        .register_project_folder(RegisterProjectFolderParams {
-            path: session.app.fs.working_directory(),
-            set_as_current_workspace: true,
-        })?;
+    fn get_files_to_process(
+        &self,
+        _fs: &DynRef<'_, dyn FileSystem>,
+        _configuration: &PartialConfiguration,
+    ) -> Result<Vec<OsString>, CliDiagnostic> {
+        Ok(vec![])
+    }
 
-    if let (Some(path), Some(directory_path)) = (file_path, directory_path) {
-        execute_mode(
-            Execution::new(TraversalMode::Migrate {
-                write: write || fix,
+    fn get_stdin_file_path(&self) -> Option<&str> {
+        None
+    }
+
+    fn should_write(&self) -> bool {
+        self.write || self.fix
+    }
+
+    fn get_execution(
+        &self,
+        _cli_options: &CliOptions,
+        console: &mut dyn Console,
+        _workspace: &dyn Workspace,
+    ) -> Result<Execution, CliDiagnostic> {
+        if let (Some(path), Some(directory_path)) = (
+            self.configuration_file_path.clone(),
+            self.configuration_directory_path.clone(),
+        ) {
+            Ok(Execution::new(TraversalMode::Migrate {
+                write: self.should_write(),
                 configuration_file_path: path,
                 configuration_directory_path: directory_path,
-                sub_command,
-            }),
-            session,
-            &cli_options,
-            vec![],
-        )
-    } else {
-        let console = session.app.console;
-        console.log(markup! {
+                sub_command: self.sub_command.clone(),
+            }))
+        } else {
+            console.log(markup! {
             <Info>"If this project has not yet been set up with Biome yet, please follow the "<Hyperlink href="https://biomejs.dev/guides/getting-started/">"Getting Started guide"</Hyperlink>" first."</Info>
         });
-        Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
-            reason: "Biome couldn't find the Biome configuration file.".to_string(),
-        }))
+            Err(CliDiagnostic::MigrateError(MigrationDiagnostic {
+                reason: "Biome couldn't find the Biome configuration file.".to_string(),
+            }))
+        }
+    }
+
+    fn check_incompatible_arguments(&self) -> Result<(), CliDiagnostic> {
+        check_fix_incompatible_arguments(FixFileModeOptions {
+            apply: false,
+            apply_unsafe: false,
+            write: self.write,
+            fix: self.fix,
+            unsafe_: false,
+        })
     }
 }

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -86,4 +86,8 @@ impl CommandRunner for MigrateCommandPayload {
             unsafe_: false,
         })
     }
+
+    fn should_validate_configuration_diagnostics(&self) -> bool {
+        false
+    }
 }

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -25,7 +25,7 @@ use biome_console::{markup, Console, ConsoleExt};
 use biome_diagnostics::{Diagnostic, PrintDiagnostic};
 use biome_fs::{BiomePath, FileSystem};
 use biome_service::configuration::{
-    load_configuration, LoadedConfiguration, PartialConfigurationExt,
+    load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
 };
 use biome_service::documentation::Doc;
 use biome_service::workspace::{FixFileMode, RegisterProjectFolderParams, UpdateSettingsParams};
@@ -670,31 +670,6 @@ fn resolve_manifest(
     Ok(None)
 }
 
-/// Computes [Stdin] if the CLI has the necessary information.
-///
-/// ## Errors
-/// - If the user didn't provide anything via `stdin` but the option `--stdin-file-path` is passed.
-pub(crate) fn get_stdin(
-    stdin_file_path: Option<String>,
-    console: &mut dyn Console,
-    command_name: &str,
-) -> Result<Option<Stdin>, CliDiagnostic> {
-    let stdin = if let Some(stdin_file_path) = stdin_file_path {
-        let input_code = console.read();
-        if let Some(input_code) = input_code {
-            let path = PathBuf::from(stdin_file_path);
-            Some((path, input_code).into())
-        } else {
-            // we provided the argument without a piped stdin, we bail
-            return Err(CliDiagnostic::missing_argument("stdin", command_name));
-        }
-    } else {
-        None
-    };
-
-    Ok(stdin)
-}
-
 fn get_files_to_process(
     since: Option<&str>,
     changed: bool,
@@ -874,7 +849,7 @@ pub(crate) trait CommandRunner: Sized {
             gitignore_matches,
         })?;
 
-        let execution = self.get_execution(cli_options, console)?;
+        let execution = self.get_execution(cli_options, console, workspace)?;
         Ok((execution, paths))
     }
 
@@ -919,7 +894,7 @@ pub(crate) trait CommandRunner: Sized {
     ) -> Result<Vec<OsString>, CliDiagnostic>;
 
     /// It returns the file path to use in `stdin` mode.
-    fn get_stdin_file_path(&self) -> Option<&String>;
+    fn get_stdin_file_path(&self) -> Option<&str>;
 
     /// Whether the command should write the files.
     fn should_write(&self) -> bool;
@@ -929,6 +904,7 @@ pub(crate) trait CommandRunner: Sized {
         &self,
         cli_options: &CliOptions,
         console: &mut dyn Console,
+        workspace: &dyn Workspace,
     ) -> Result<Execution, CliDiagnostic>;
 
     // Below, methods that consumers can implement
@@ -938,6 +914,34 @@ pub(crate) trait CommandRunner: Sized {
     /// The method is called before loading the configuration from disk.
     fn check_incompatible_arguments(&self) -> Result<(), CliDiagnostic> {
         Ok(())
+    }
+}
+
+pub trait LoadEditorConfig: CommandRunner {
+    fn should_load_editor_config(&self, fs_configuration: &PartialConfiguration) -> bool;
+    fn load_editor_config(
+        &self,
+        configuration_path: Option<PathBuf>,
+        fs_configuration: &PartialConfiguration,
+        fs: &DynRef<'_, dyn FileSystem>,
+        console: &mut dyn Console,
+    ) -> Result<PartialConfiguration, WorkspaceError> {
+        Ok(if self.should_load_editor_config(fs_configuration) {
+            let (editorconfig, editorconfig_diagnostics) = {
+                let search_path = configuration_path
+                    .clone()
+                    .unwrap_or_else(|| fs.working_directory().unwrap_or_default());
+                load_editorconfig(fs, search_path)?
+            };
+            for diagnostic in editorconfig_diagnostics {
+                console.error(markup! {
+                    {PrintDiagnostic::simple(&diagnostic)}
+                })
+            }
+            editorconfig.unwrap_or_default()
+        } else {
+            Default::default()
+        })
     }
 }
 

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -115,6 +115,12 @@ pub struct VcsTargeted {
     pub changed: bool,
 }
 
+impl From<(bool, bool)> for VcsTargeted {
+    fn from((staged, changed): (bool, bool)) -> Self {
+        Self { staged, changed }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TraversalMode {
     /// This mode is enabled when running the command `biome check`

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -28,6 +28,7 @@ use crate::commands::check::CheckCommandPayload;
 use crate::commands::ci::CiCommandPayload;
 use crate::commands::format::FormatCommandPayload;
 use crate::commands::lint::LintCommandPayload;
+use crate::commands::migrate::MigrateCommandPayload;
 use crate::commands::CommandRunner;
 pub use crate::commands::{biome_command, BiomeCommand};
 pub use crate::logging::{setup_cli_subscriber, LoggingLevel};
@@ -104,15 +105,15 @@ impl<'app> CliSession<'app> {
                 staged,
                 changed,
                 since,
-            } => commands::check::check(
+            } => run_command(
                 self,
+                &cli_options,
                 CheckCommandPayload {
                     apply_unsafe,
                     apply,
                     write,
                     fix,
                     unsafe_,
-                    cli_options,
                     configuration,
                     paths,
                     stdin_file_path,
@@ -146,15 +147,15 @@ impl<'app> CliSession<'app> {
                 javascript_linter,
                 json_linter,
                 graphql_linter,
-            } => commands::lint::lint(
+            } => run_command(
                 self,
+                &cli_options,
                 LintCommandPayload {
                     apply_unsafe,
                     apply,
                     write,
                     fix,
                     unsafe_,
-                    cli_options,
                     linter_configuration,
                     paths,
                     only,
@@ -181,8 +182,9 @@ impl<'app> CliSession<'app> {
                 cli_options,
                 changed,
                 since,
-            } => commands::ci::ci(
+            } => run_command(
                 self,
+                &cli_options,
                 CiCommandPayload {
                     linter_enabled,
                     formatter_enabled,
@@ -190,7 +192,6 @@ impl<'app> CliSession<'app> {
                     assists_enabled,
                     configuration,
                     paths,
-                    cli_options,
                     changed,
                     since,
                 },
@@ -244,7 +245,17 @@ impl<'app> CliSession<'app> {
                 write,
                 fix,
                 sub_command,
-            } => commands::migrate::migrate(self, cli_options, write, fix, sub_command),
+            } => run_command(
+                self,
+                &cli_options,
+                MigrateCommandPayload {
+                    write,
+                    fix,
+                    sub_command,
+                    configuration_directory_path: None,
+                    configuration_file_path: None,
+                },
+            ),
             BiomeCommand::Search {
                 cli_options,
                 files_configuration,
@@ -252,10 +263,10 @@ impl<'app> CliSession<'app> {
                 pattern,
                 stdin_file_path,
                 vcs_configuration,
-            } => commands::search::search(
+            } => run_command(
                 self,
+                &cli_options,
                 SearchCommandPayload {
-                    cli_options,
                     files_configuration,
                     paths,
                     pattern,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fs_files_ignore_symlink.snap
@@ -5,17 +5,17 @@ expression: content
 # Emitted Messages
 
 ```block
-internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The argument --apply-unsafe is deprecated, it will be removed in the next major release. Use --write --unsafe instead.
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
   
 
 ```
 
 ```block
-rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+internalError/fs  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The configuration file rome.json is deprecated. Use biome.json instead.
+  ! The argument --apply-unsafe is deprecated, it will be removed in the next major release. Use --write --unsafe instead.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_errors_for_all_disabled_checks.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_errors_for_all_disabled_checks.snap
@@ -30,10 +30,8 @@ statement(    ) ; let a = !b || !c;
 internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The combination of configuration and arguments is invalid: 
-    Formatter, linter and organize imports are disabled, can't perform the command. This is probably and error.
+    Formatter, linter and organize imports are disabled, can't perform the command. At least one feature needs to be enabled. This is probably and error.
   
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/emit_diagnostic_for_rome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/emit_diagnostic_for_rome_json.snap
@@ -11,6 +11,14 @@ expression: content
 # Emitted Messages
 
 ```block
+rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
+  
+
+```
+
+```block
 rome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Configuration file can be updated.

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/emit_diagnostic_for_rome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/emit_diagnostic_for_rome_json.snap
@@ -11,14 +11,6 @@ expression: content
 # Emitted Messages
 
 ```block
-rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The configuration file rome.json is deprecated. Use biome.json instead.
-  
-
-```
-
-```block
 rome.json migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Configuration file can be updated.

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/should_create_biome_json_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/should_create_biome_json_file.snap
@@ -17,13 +17,5 @@ expression: content
 # Emitted Messages
 
 ```block
-rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The configuration file rome.json is deprecated. Use biome.json instead.
-  
-
-```
-
-```block
 The configuration rome.json has been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/should_create_biome_json_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/should_create_biome_json_file.snap
@@ -17,7 +17,13 @@ expression: content
 # Emitted Messages
 
 ```block
-The configuration rome.json has been successfully migrated.
+rome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The configuration file rome.json is deprecated. Use biome.json instead.
+  
+
 ```
 
-
+```block
+The configuration rome.json has been successfully migrated.
+```

--- a/crates/biome_css_analyze/src/utils.rs
+++ b/crates/biome_css_analyze/src/utils.rs
@@ -219,14 +219,14 @@ pub fn get_reset_to_initial_properties(shorthand_property: &str) -> &'static [&'
 }
 
 fn is_custom_element(prop: &str) -> bool {
-    prop.contains('-') && prop.eq(prop.to_lowercase().as_str())
+    prop.contains('-') && prop.eq(prop.to_lowercase_cow().as_ref())
 }
 
 /// Check if the input string is a known type selector.
 pub fn is_known_type_selector(prop: &str) -> bool {
-    let input = prop.to_lowercase();
-    HTML_TAGS.binary_search(&input.as_str()).is_ok()
+    let input = prop.to_lowercase_cow();
+    HTML_TAGS.binary_search(&input.as_ref()).is_ok()
         || SVG_TAGS.binary_search(&prop).is_ok()
-        || MATH_ML_TAGS.binary_search(&input.as_str()).is_ok()
+        || MATH_ML_TAGS.binary_search(&input.as_ref()).is_ok()
         || is_custom_element(prop)
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR migrates the majority of commands to use the `CommandRunner` trait.

I also created a new trait called `LoadEditorConfig` to share the same logic only for the `format`, `check` and `ci` commands, where we load the `.editorconfig` file.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI should work. Checked that the updated snapshots are correct.

<!-- What demonstrates that your implementation is correct? -->
