### PR TITLE
fix(analyze): improve diagnostic message for unused suppression comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Analyzer
 
+#### Bug fixes
+
+- Improved the message for unused suppression comments. Contributed by @dyc3
+
 ### CLI
 
 ### Configuration

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -182,7 +182,7 @@ where
                 SuppressionDiagnostic::new(
                     category!("suppressions/unused"),
                     suppression.comment_span,
-                    "Suppression comment is not being used",
+                    "Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.",
                 )
             });
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnreachable/SuppressionComments.js.snap
@@ -92,7 +92,7 @@ SuppressionComments.js:11:5 suppressions/deprecatedSuppressionComment  FIXABLE  
 ```
 SuppressionComments.js:1:1 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Suppression comment is not being used
+  ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
   
   > 1 │ // rome-ignore lint/correctness/noUnreachable: this comment does nothing
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
@@ -57,7 +57,7 @@ ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies ━━━�
 ```
 ignoredDependencies.js:16:5 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Suppression comment is not being used
+  ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
   
     14 │ function IgnoredDependencies2() {
     15 │     let a = 1;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The previous message says "Suppression comment is unused". This is confusing for some users because you "use" suppression comments to suppress diagnostics (aka the effect), but the message is telling them it's not being "used". The previous message also does not explain how to resolve the issue at all.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->


## Test Plan

<!-- What demonstrates that your implementation is correct? -->
