### PR TITLE
fix(useExportType): remove useless inline type exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,18 +51,32 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#4041](https://github.com/biomejs/biome/issues/4041). Now the rule `useSortedClasses` won't be triggered if `className` is composed only by inlined variables. Contributed by @ematipico
 
-- [useImportType](https://biomejs.dev/linter/rules/use-import-type/) now reports useless inline type qualifiers ([#4178](https://github.com/biomejs/biome/issues/4178)).
+- [useImportType](https://biomejs.dev/linter/rules/use-import-type/) and [useExportType](https://biomejs.dev/linter/rules/use-export-type/) now report useless inline type qualifiers ([#4178](https://github.com/biomejs/biome/issues/4178)).
 
   The following fix is now proposed:
 
   ```diff
   - import type { type A, B } from "";
   + import type { A, B } from "";
+
+  - export type { type C, D };
+  + export type { C, D };
   ```
 
   Contributed by @Conaclos
 
-- [noVoidTypeReturn](https://biomejs.dev/linter/rules/no-void-type-return/) now accept `void` expressions in return position ([#4173](https://github.com/biomejs/biome/issues/4173)).
+- [useExportType](https://biomejs.dev/linter/rules/use-export-type/) now reports ungrouped `export from`.
+
+  The following fix is now proposed:
+
+  ```diff
+  - export { type A, type B } from "";
+  + export type { A, B } from "";
+  ```
+
+  Contributed by @Conaclos
+
+- [noVoidTypeReturn](https://biomejs.dev/linter/rules/no-void-type-return/) now accepts `void` expressions in return position ([#4173](https://github.com/biomejs/biome/issues/4173)).
 
   The following code is now accepted:
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -13,9 +13,7 @@ use biome_js_syntax::{
     JsParenthesizedExpression, JsSyntaxKind, JsxChildList, JsxElement, JsxExpressionAttributeValue,
     JsxExpressionChild, JsxFragment, JsxTagExpression, JsxText, T,
 };
-use biome_rowan::{
-    declare_node_union, AstNode, AstNodeList, BatchMutation, BatchMutationExt, SyntaxNodeText,
-};
+use biome_rowan::{declare_node_union, AstNode, AstNodeList, BatchMutation, BatchMutationExt};
 
 declare_lint_rule! {
     /// Disallow unnecessary fragments

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -5,17 +5,20 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_js_factory::make;
-use biome_js_syntax::{AnyJsExportNamedSpecifier, JsExportNamedClause, JsFileSource, T};
+use biome_js_syntax::{
+    AnyJsExportNamedSpecifier, JsExportNamedClause, JsExportNamedFromClause, JsFileSource,
+    JsSyntaxToken, T,
+};
 use biome_rowan::{
-    chain_trivia_pieces, trim_leading_trivia_pieces, AstNode, AstSeparatedList, BatchMutationExt,
-    TriviaPieceKind,
+    chain_trivia_pieces, declare_node_union, trim_leading_trivia_pieces, AstNode, AstSeparatedList,
+    BatchMutationExt, TriviaPieceKind,
 };
 
 declare_lint_rule! {
     /// Promotes the use of `export type` for types.
     ///
-    /// _TypeScript_ allows specifying a `type` marker on an `export` to indicate that the `export` doesn't exist at runtime.
-    /// This allows transpilers to safely drop exports of types without looking for their definition.
+    /// _TypeScript_ allows adding the `type` keyword on an `export` to indicate that the `export` doesn't exist at runtime.
+    /// This allows compilers to safely drop exports of types without looking for their definition.
     ///
     /// The rule ensures that types are exported using a type-only `export`.
     /// It also groups inline type exports into a grouped `export type`.
@@ -69,7 +72,7 @@ declare_lint_rule! {
 }
 
 impl Rule for UseExportType {
-    type Query = Semantic<JsExportNamedClause>;
+    type Query = Semantic<AnyJsExportNamedClause>;
     type State = ExportTypeFix;
     type Signals = Option<Self::State>;
     type Options = ();
@@ -80,77 +83,127 @@ impl Rule for UseExportType {
             return None;
         }
         let export_named_clause = ctx.query();
-        if export_named_clause.type_token().is_some() {
-            // `export type {}`
-            return None;
-        }
-        let mut exports_only_types = true;
-        let mut specifiers_requiring_type_marker = Vec::new();
-        let specifiers = export_named_clause.specifiers();
-        if specifiers.is_empty() {
-            // Don't report `export {}`
-            return None;
-        }
-        for specifier in specifiers {
-            let Ok((ref_name, specifier)) =
-                specifier.and_then(|specifier| Ok((specifier.local_name()?, specifier)))
-            else {
-                exports_only_types = false;
-                continue;
-            };
-            if specifier.type_token().is_some() {
-                // `export { type <specifier> }`
-                continue;
+        match export_named_clause {
+            AnyJsExportNamedClause::JsExportNamedClause(clause) => {
+                let specifiers = clause.specifiers();
+                if specifiers.is_empty() {
+                    // Don't report `export {}`
+                    None
+                } else if clause.type_token().is_some() {
+                    // `export type { ... }`
+                    let useless_type_tokens: Vec<_> = specifiers
+                        .iter()
+                        .filter_map(|specifier| specifier.ok()?.type_token())
+                        .collect();
+                    if useless_type_tokens.is_empty() {
+                        None
+                    } else {
+                        Some(ExportTypeFix::RemoveInlineTypeQualifiers(
+                            useless_type_tokens,
+                        ))
+                    }
+                } else {
+                    let mut exports_only_types = true;
+                    let mut specifiers_requiring_type_marker = Vec::new();
+                    for specifier in specifiers {
+                        let Ok((ref_name, specifier)) = specifier
+                            .and_then(|specifier| Ok((specifier.local_name()?, specifier)))
+                        else {
+                            exports_only_types = false;
+                            continue;
+                        };
+                        if specifier.type_token().is_some() {
+                            // `export { type <specifier> }`
+                            continue;
+                        }
+                        let model = ctx.model();
+                        let binding = model.binding(&ref_name)?;
+                        let binding = binding.tree();
+                        if binding.is_type_only() {
+                            specifiers_requiring_type_marker.push(specifier);
+                        } else {
+                            exports_only_types = false;
+                        }
+                    }
+                    if exports_only_types {
+                        Some(ExportTypeFix::UseExportType)
+                    } else if specifiers_requiring_type_marker.is_empty() {
+                        None
+                    } else {
+                        Some(ExportTypeFix::AddInlineTypeQualifiers(
+                            specifiers_requiring_type_marker,
+                        ))
+                    }
+                }
             }
-            let model = ctx.model();
-            let binding = model.binding(&ref_name)?;
-            let binding = binding.tree();
-            if binding.is_type_only() {
-                specifiers_requiring_type_marker.push(specifier);
-            } else {
-                exports_only_types = false;
+            AnyJsExportNamedClause::JsExportNamedFromClause(clause) => {
+                let specifiers = clause.specifiers();
+                if specifiers.is_empty() {
+                    None
+                } else if clause.type_token().is_some() {
+                    let useless_type_tokens: Vec<_> = specifiers
+                        .iter()
+                        .filter_map(|specifier| specifier.ok()?.type_token())
+                        .collect();
+                    if useless_type_tokens.is_empty() {
+                        None
+                    } else {
+                        Some(ExportTypeFix::RemoveInlineTypeQualifiers(
+                            useless_type_tokens,
+                        ))
+                    }
+                } else if specifiers
+                    .iter()
+                    .all(|x| x.is_ok_and(|x| x.type_token().is_some()))
+                {
+                    Some(ExportTypeFix::UseExportType)
+                } else {
+                    None
+                }
             }
-        }
-        if exports_only_types {
-            Some(ExportTypeFix::UseExportType)
-        } else if specifiers_requiring_type_marker.is_empty() {
-            None
-        } else {
-            Some(ExportTypeFix::AddInlineTypeQualifiers(
-                specifiers_requiring_type_marker,
-            ))
         }
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        let range = ctx.query().range();
-        let (diagnostic_range, diagnostic_message) = match state {
-            ExportTypeFix::UseExportType => (
-                range,
-                markup! {
-                    "All exports are only types and should thus use "<Emphasis>"export type"</Emphasis>"."
-                },
+        let named_export_clause = ctx.query();
+        let diagnostic = match state {
+            ExportTypeFix::UseExportType => RuleDiagnostic::new(
+                rule_category!(),
+                named_export_clause.range(),
+                "All exports are only types.",
             ),
             ExportTypeFix::AddInlineTypeQualifiers(specifiers) => {
-                let range = specifiers
-                    .iter()
-                    .map(|x| x.range())
-                    .reduce(|acc, x| acc.cover(x))
-                    .unwrap_or(range);
-                (
-                    range,
+                let mut diagnostic = RuleDiagnostic::new(
+                    rule_category!(),
+                    named_export_clause.range(),
+                    "Some exports are only types.",
+                );
+                for specifier in specifiers {
+                    diagnostic = diagnostic.detail(specifier.range(), "This export is a type.")
+                }
+                diagnostic
+            }
+            ExportTypeFix::RemoveInlineTypeQualifiers(type_tokens) => {
+                let mut diagnostic = RuleDiagnostic::new(
+                    rule_category!(),
+                    named_export_clause.type_token()?.text_trimmed_range(),
                     markup! {
-                        "Several exports are only types and should thus use "<Emphasis>"export type"</Emphasis>"."
+                        "This "<Emphasis>"type"</Emphasis>" keyword makes all inline "<Emphasis>"type"</Emphasis>" keywords useless."
                     },
-                )
+                );
+                for type_token in type_tokens {
+                    diagnostic = diagnostic.detail(
+                        type_token.text_trimmed_range(),
+                        markup! {
+                            "This inline "<Emphasis>"type"</Emphasis>" keyword is useless."
+                        },
+                    )
+                }
+                return Some(diagnostic);
             }
         };
-        Some(RuleDiagnostic::new(
-            rule_category!(),
-            diagnostic_range,
-            diagnostic_message,
-        ).note(markup! {
-            "Using "<Emphasis>"export type"</Emphasis>" allows transpilers to safely drop exports of types without looking for their definition."
+        Some(diagnostic.note(markup! {
+            "Using "<Emphasis>"export type"</Emphasis>" allows compilers to safely drop exports of types without looking for their definition."
         }))
     }
 
@@ -159,43 +212,86 @@ impl Rule for UseExportType {
         let mut mutation = ctx.root().begin();
         let diagnostic = match state {
             ExportTypeFix::UseExportType => {
-                let specifier_list = export_named_clause.specifiers();
-                let mut new_specifiers = Vec::new();
-                for specifier in specifier_list.iter().filter_map(|x| x.ok()) {
-                    if let Some(type_token) = specifier.type_token() {
-                        let new_specifier = specifier
-                            .with_type_token(None)
-                            .trim_leading_trivia()?
-                            .prepend_trivia_pieces(chain_trivia_pieces(
-                                type_token.leading_trivia().pieces(),
-                                trim_leading_trivia_pieces(type_token.trailing_trivia().pieces()),
-                            ))?;
-                        new_specifiers.push(new_specifier);
-                    } else {
-                        new_specifiers.push(specifier)
+                match export_named_clause {
+                    AnyJsExportNamedClause::JsExportNamedClause(clause) => {
+                        let specifier_list = clause.specifiers();
+                        let mut new_specifiers = Vec::new();
+                        for specifier in specifier_list.iter().filter_map(|x| x.ok()) {
+                            if let Some(type_token) = specifier.type_token() {
+                                let new_specifier = specifier
+                                    .with_type_token(None)
+                                    .trim_leading_trivia()?
+                                    .prepend_trivia_pieces(chain_trivia_pieces(
+                                        type_token.leading_trivia().pieces(),
+                                        trim_leading_trivia_pieces(
+                                            type_token.trailing_trivia().pieces(),
+                                        ),
+                                    ))?;
+                                new_specifiers.push(new_specifier);
+                            } else {
+                                new_specifiers.push(specifier)
+                            }
+                        }
+                        let new_specifier_list = make::js_export_named_specifier_list(
+                            new_specifiers,
+                            specifier_list
+                                .separators()
+                                .filter_map(|sep| sep.ok())
+                                .collect::<Vec<_>>(),
+                        );
+                        mutation.replace_node(
+                            clause.clone(),
+                            clause
+                                .clone()
+                                .with_type_token(Some(
+                                    make::token(T![type])
+                                        .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
+                                ))
+                                .with_specifiers(new_specifier_list),
+                        );
+                    }
+                    AnyJsExportNamedClause::JsExportNamedFromClause(clause) => {
+                        let specifier_list = clause.specifiers();
+                        let mut new_specifiers = Vec::new();
+                        for specifier in specifier_list.iter().filter_map(|x| x.ok()) {
+                            if let Some(type_token) = specifier.type_token() {
+                                let new_specifier = specifier
+                                    .with_type_token(None)
+                                    .trim_leading_trivia()?
+                                    .prepend_trivia_pieces(chain_trivia_pieces(
+                                        type_token.leading_trivia().pieces(),
+                                        trim_leading_trivia_pieces(
+                                            type_token.trailing_trivia().pieces(),
+                                        ),
+                                    ))?;
+                                new_specifiers.push(new_specifier);
+                            } else {
+                                new_specifiers.push(specifier)
+                            }
+                        }
+                        let new_specifier_list = make::js_export_named_from_specifier_list(
+                            new_specifiers,
+                            specifier_list
+                                .separators()
+                                .filter_map(|sep| sep.ok())
+                                .collect::<Vec<_>>(),
+                        );
+                        mutation.replace_node(
+                            clause.clone(),
+                            clause
+                                .clone()
+                                .with_type_token(Some(
+                                    make::token(T![type])
+                                        .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
+                                ))
+                                .with_specifiers(new_specifier_list),
+                        );
                     }
                 }
-                let new_specifier_list = make::js_export_named_specifier_list(
-                    new_specifiers,
-                    specifier_list
-                        .separators()
-                        .filter_map(|sep| sep.ok())
-                        .collect::<Vec<_>>(),
-                );
-                mutation.replace_node(
-                    export_named_clause.clone(),
-                    export_named_clause
-                        .clone()
-                        .with_type_token(Some(
-                            make::token(T![type])
-                                .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
-                        ))
-                        .with_specifiers(new_specifier_list),
-                );
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Use a grouped "<Emphasis>"export type"</Emphasis>"." }.to_owned(),
+                    markup! { "Use "<Emphasis>"export type"</Emphasis>"." }.to_owned(),
                     mutation,
                 )
             }
@@ -218,12 +314,37 @@ impl Rule for UseExportType {
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Use inline "<Emphasis>"type"</Emphasis>" exports." }.to_owned(),
+                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
+                    mutation,
+                )
+            }
+            ExportTypeFix::RemoveInlineTypeQualifiers(type_tokens) => {
+                for type_token in type_tokens {
+                    mutation.remove_token(type_token.clone());
+                }
+                JsRuleAction::new(
+                    ActionCategory::QuickFix,
+                    ctx.metadata().applicability(),
+                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
+                        .to_owned(),
                     mutation,
                 )
             }
         };
         Some(diagnostic)
+    }
+}
+
+declare_node_union! {
+    pub AnyJsExportNamedClause = JsExportNamedClause | JsExportNamedFromClause
+}
+
+impl AnyJsExportNamedClause {
+    fn type_token(&self) -> Option<JsSyntaxToken> {
+        match self {
+            Self::JsExportNamedClause(clause) => clause.type_token(),
+            Self::JsExportNamedFromClause(clause) => clause.type_token(),
+        }
     }
 }
 
@@ -234,4 +355,5 @@ pub enum ExportTypeFix {
      */
     UseExportType,
     AddInlineTypeQualifiers(Vec<AnyJsExportNamedSpecifier>),
+    RemoveInlineTypeQualifiers(Vec<JsSyntaxToken>),
 }

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -17,7 +17,7 @@ use biome_rowan::{
 declare_lint_rule! {
     /// Promotes the use of `export type` for types.
     ///
-    /// _TypeScript_ allows adding the `type` keyword on an `export` to indicate that the `export` doesn't exist at runtime.
+    /// _TypeScript_ allows adding the `type` modifier on an `export` to indicate that the `export` doesn't exist at runtime.
     /// This allows compilers to safely drop exports of types without looking for their definition.
     ///
     /// The rule ensures that types are exported using a type-only `export`.
@@ -188,14 +188,14 @@ impl Rule for UseExportType {
                     rule_category!(),
                     named_export_clause.type_token()?.text_trimmed_range(),
                     markup! {
-                        "This "<Emphasis>"type"</Emphasis>" keyword makes all inline "<Emphasis>"type"</Emphasis>" keywords useless."
+                        "This "<Emphasis>"type"</Emphasis>" modifier makes all inline "<Emphasis>"type"</Emphasis>" modifiers useless."
                     },
                 );
                 for type_token in type_tokens {
                     diagnostic = diagnostic.detail(
                         type_token.text_trimmed_range(),
                         markup! {
-                            "This inline "<Emphasis>"type"</Emphasis>" keyword is useless."
+                            "This inline "<Emphasis>"type"</Emphasis>" modifier is useless."
                         },
                     )
                 }
@@ -314,7 +314,7 @@ impl Rule for UseExportType {
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
+                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" modifiers." }.to_owned(),
                     mutation,
                 )
             }
@@ -325,7 +325,7 @@ impl Rule for UseExportType {
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
+                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" modifiers." }
                         .to_owned(),
                     mutation,
                 )

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -17,7 +17,7 @@ use biome_rowan::{
 declare_lint_rule! {
     /// Promotes the use of `export type` for types.
     ///
-    /// _TypeScript_ allows adding the `type` modifier on an `export` to indicate that the `export` doesn't exist at runtime.
+    /// _TypeScript_ allows adding the `type` keyword on an `export` to indicate that the `export` doesn't exist at runtime.
     /// This allows compilers to safely drop exports of types without looking for their definition.
     ///
     /// The rule ensures that types are exported using a type-only `export`.
@@ -188,14 +188,14 @@ impl Rule for UseExportType {
                     rule_category!(),
                     named_export_clause.type_token()?.text_trimmed_range(),
                     markup! {
-                        "This "<Emphasis>"type"</Emphasis>" modifier makes all inline "<Emphasis>"type"</Emphasis>" modifiers useless."
+                        "This "<Emphasis>"type"</Emphasis>" keyword makes all inline "<Emphasis>"type"</Emphasis>" keywords useless."
                     },
                 );
                 for type_token in type_tokens {
                     diagnostic = diagnostic.detail(
                         type_token.text_trimmed_range(),
                         markup! {
-                            "This inline "<Emphasis>"type"</Emphasis>" modifier is useless."
+                            "This inline "<Emphasis>"type"</Emphasis>" keyword is useless."
                         },
                     )
                 }
@@ -314,7 +314,7 @@ impl Rule for UseExportType {
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" modifiers." }.to_owned(),
+                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
                     mutation,
                 )
             }
@@ -325,7 +325,7 @@ impl Rule for UseExportType {
                 JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" modifiers." }
+                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
                         .to_owned(),
                     mutation,
                 )

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -26,7 +26,7 @@ use rustc_hash::FxHashSet;
 declare_lint_rule! {
     /// Promotes the use of `import type` for types.
     ///
-    /// _TypeScript_ allows specifying a `type` modifier on an `import` to indicate that the `import` doesn't exist at runtime.
+    /// _TypeScript_ allows specifying a `type` keyword on an `import` to indicate that the `import` doesn't exist at runtime.
     /// This allows compilers to safely drop imports of types without looking for their definition.
     /// This also ensures that some modules are not loaded at runtime.
     ///
@@ -37,7 +37,7 @@ declare_lint_rule! {
     /// then you can disable this rule, as TSC can remove imports only used as types.
     /// However, for consistency and compatibility with other compilers, you may want to enable this rule.
     /// In that case we recommend to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
-    /// This configuration ensures that TSC preserves imports not marked with the `type` modifier.
+    /// This configuration ensures that TSC preserves imports not marked with the `type` keyword.
     ///
     /// You may also want to enable the editor setting [`typescript.preferences.preferTypeOnlyAutoImports`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-rc/#settings-to-prefer-type-auto-imports) from the TypeScript LSP.
     /// This setting is available in Visual Studio Code.
@@ -164,7 +164,7 @@ impl Rule for UseImportType {
                                     // when the default import is not only used as a type.
                                     None
                                 } else {
-                                    // Prefer adding type modifier instead of
+                                    // Prefer adding type keyword instead of
                                     // splitting the import statement into two import statements
                                     Some(ImportTypeFix::AddInlineTypeQualifiers(specifiers))
                                 }
@@ -320,14 +320,14 @@ impl Rule for UseImportType {
                     rule_category!(),
                     import_clause.type_token()?.text_trimmed_range(),
                     markup! {
-                        "This "<Emphasis>"type"</Emphasis>" modifier makes all inline "<Emphasis>"type"</Emphasis>" modifiers useless."
+                        "This "<Emphasis>"type"</Emphasis>" keyword makes all inline "<Emphasis>"type"</Emphasis>" keywords useless."
                     },
                 );
                 for type_token in type_tokens {
                     diagnostic = diagnostic.detail(
                         type_token.text_trimmed_range(),
                         markup! {
-                            "This inline "<Emphasis>"type"</Emphasis>" modifier is useless."
+                            "This inline "<Emphasis>"type"</Emphasis>" keyword is useless."
                         },
                     )
                 }
@@ -562,7 +562,7 @@ impl Rule for UseImportType {
                 return Some(JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" modifiers." }.to_owned(),
+                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
                     mutation,
                 ));
             }
@@ -573,7 +573,7 @@ impl Rule for UseImportType {
                 return Some(JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" modifiers." }
+                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
                         .to_owned(),
                     mutation,
                 ));

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -26,7 +26,7 @@ use rustc_hash::FxHashSet;
 declare_lint_rule! {
     /// Promotes the use of `import type` for types.
     ///
-    /// _TypeScript_ allows specifying a `type` keyword on an `import` to indicate that the `import` doesn't exist at runtime.
+    /// _TypeScript_ allows specifying a `type` modifier on an `import` to indicate that the `import` doesn't exist at runtime.
     /// This allows compilers to safely drop imports of types without looking for their definition.
     /// This also ensures that some modules are not loaded at runtime.
     ///
@@ -37,7 +37,7 @@ declare_lint_rule! {
     /// then you can disable this rule, as TSC can remove imports only used as types.
     /// However, for consistency and compatibility with other compilers, you may want to enable this rule.
     /// In that case we recommend to enable TSC's [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax).
-    /// This configuration ensures that TSC preserves imports not marked with the `type` keyword.
+    /// This configuration ensures that TSC preserves imports not marked with the `type` modifier.
     ///
     /// You may also want to enable the editor setting [`typescript.preferences.preferTypeOnlyAutoImports`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3-rc/#settings-to-prefer-type-auto-imports) from the TypeScript LSP.
     /// This setting is available in Visual Studio Code.
@@ -164,7 +164,7 @@ impl Rule for UseImportType {
                                     // when the default import is not only used as a type.
                                     None
                                 } else {
-                                    // Prefer adding type keyword instead of
+                                    // Prefer adding type modifier instead of
                                     // splitting the import statement into two import statements
                                     Some(ImportTypeFix::AddInlineTypeQualifiers(specifiers))
                                 }
@@ -320,14 +320,14 @@ impl Rule for UseImportType {
                     rule_category!(),
                     import_clause.type_token()?.text_trimmed_range(),
                     markup! {
-                        "This "<Emphasis>"type"</Emphasis>" keyword makes all inline "<Emphasis>"type"</Emphasis>" keywords useless."
+                        "This "<Emphasis>"type"</Emphasis>" modifier makes all inline "<Emphasis>"type"</Emphasis>" modifiers useless."
                     },
                 );
                 for type_token in type_tokens {
                     diagnostic = diagnostic.detail(
                         type_token.text_trimmed_range(),
                         markup! {
-                            "This inline "<Emphasis>"type"</Emphasis>" keyword is useless."
+                            "This inline "<Emphasis>"type"</Emphasis>" modifier is useless."
                         },
                     )
                 }
@@ -562,7 +562,7 @@ impl Rule for UseImportType {
                 return Some(JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
+                    markup! { "Add inline "<Emphasis>"type"</Emphasis>" modifiers." }.to_owned(),
                     mutation,
                 ));
             }
@@ -573,7 +573,7 @@ impl Rule for UseImportType {
                 return Some(JsRuleAction::new(
                     ActionCategory::QuickFix,
                     ctx.metadata().applicability(),
-                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
+                    markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" modifiers." }
                         .to_owned(),
                     mutation,
                 ));

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts
@@ -38,3 +38,8 @@ export {
 
 import type * as Ns from ""
 export { Ns }
+
+import { type T9, type T10 } from "./mod.ts";
+export { type T9, type T10 };
+
+export { type T11, type T12 } from "./mod.ts";

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
@@ -45,13 +45,26 @@ export {
 import type * as Ns from ""
 export { Ns }
 
+import { type T9, type T10 } from "./mod.ts";
+export { type T9, type T10 };
+
+export { type T11, type T12 } from "./mod.ts";
+
 ```
 
 # Diagnostics
 ```
-invalid.ts:2:10 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:2:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Several exports are only types and should thus use export type.
+  ! Some exports are only types.
+  
+    1 │ import { type T1, V1 } from "./mod.ts";
+  > 2 │ export { T1, V1 };
+      │        ^^^^^^^^^^^
+    3 │ 
+    4 │ import type { T2, T3 } from "./mod.ts";
+  
+  i This export is a type.
   
     1 │ import { type T1, V1 } from "./mod.ts";
   > 2 │ export { T1, V1 };
@@ -59,9 +72,9 @@ invalid.ts:2:10 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
     3 │ 
     4 │ import type { T2, T3 } from "./mod.ts";
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use inline type exports.
+  i Safe fix: Add inline type keywords.
   
     2 │ export·{·type·T1,·V1·};
       │          +++++         
@@ -71,7 +84,7 @@ invalid.ts:2:10 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 invalid.ts:5:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
     4 │ import type { T2, T3 } from "./mod.ts";
   > 5 │ export { T2, T3 };
@@ -79,9 +92,9 @@ invalid.ts:5:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
     6 │ 
     7 │ import type T4 from "./mod.ts";
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     5 │ export·type·{·T2,·T3·};
       │        +++++           
@@ -91,7 +104,7 @@ invalid.ts:5:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
 ```
 invalid.ts:8:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
      7 │ import type T4 from "./mod.ts";
    > 8 │ export { T4 };
@@ -99,9 +112,9 @@ invalid.ts:8:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
      9 │ 
     10 │ // multiline
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     8 │ export·type·{·T4·};
       │        +++++       
@@ -109,22 +122,44 @@ invalid.ts:8:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
 ```
 
 ```
-invalid.ts:14:5 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:12:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Several exports are only types and should thus use export type.
+  ! Some exports are only types.
+  
+    10 │ // multiline
+    11 │ import { type T5, type T6, V2 } from "./mod.ts";
+  > 12 │ export {
+       │        ^
+  > 13 │     // leading comment
+  > 14 │     T5,
+  > 15 │     T6,
+  > 16 │     V2,
+  > 17 │ };
+       │ ^^
+    18 │ 
+    19 │ import type * as ns from "./mod.ts";
+  
+  i This export is a type.
   
     12 │ export {
     13 │     // leading comment
   > 14 │     T5,
-       │     ^^^
+       │     ^^
+    15 │     T6,
+    16 │     V2,
+  
+  i This export is a type.
+  
+    13 │     // leading comment
+    14 │     T5,
   > 15 │     T6,
        │     ^^
     16 │     V2,
     17 │ };
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use inline type exports.
+  i Safe fix: Add inline type keywords.
   
     12 12 │   export {
     13 13 │       // leading comment
@@ -141,7 +176,7 @@ invalid.ts:14:5 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 invalid.ts:20:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
     19 │ import type * as ns from "./mod.ts";
   > 20 │ export { ns };
@@ -149,9 +184,9 @@ invalid.ts:20:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
     21 │ 
     22 │ interface Interface {}
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     20 │ export·type·{·ns·};
        │        +++++       
@@ -159,20 +194,38 @@ invalid.ts:20:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 
 ```
-invalid.ts:27:10 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:27:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Several exports are only types and should thus use export type.
+  ! Some exports are only types.
   
     25 │ function func() {}
     26 │ class Class {}
   > 27 │ export { Interface, TypeAlias, Enum, func as f, Class };
-       │          ^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     28 │ 
     29 │ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i This export is a type.
   
-  i Safe fix: Use inline type exports.
+    25 │ function func() {}
+    26 │ class Class {}
+  > 27 │ export { Interface, TypeAlias, Enum, func as f, Class };
+       │          ^^^^^^^^^
+    28 │ 
+    29 │ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
+  
+  i This export is a type.
+  
+    25 │ function func() {}
+    26 │ class Class {}
+  > 27 │ export { Interface, TypeAlias, Enum, func as f, Class };
+       │                     ^^^^^^^^^
+    28 │ 
+    29 │ export /*0*/ { /*1*/ type /*2*/ func /*3*/, /*4*/ type Class as C /*5*/ } /*6*/;
+  
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
+  
+  i Safe fix: Add inline type keywords.
   
     27 │ export·{·type·Interface,·type·TypeAlias,·Enum,·func·as·f,·Class·};
        │          +++++           +++++                                    
@@ -182,7 +235,7 @@ invalid.ts:27:10 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 invalid.ts:29:14 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
     27 │ export { Interface, TypeAlias, Enum, func as f, Class };
     28 │ 
@@ -191,9 +244,9 @@ invalid.ts:29:14 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
     30 │ 
     31 │ import { type T7, type T8 } from "./mod.ts";
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     27 27 │   export { Interface, TypeAlias, Enum, func as f, Class };
     28 28 │   
@@ -208,7 +261,7 @@ invalid.ts:29:14 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 invalid.ts:32:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
     31 │ import { type T7, type T8 } from "./mod.ts";
   > 32 │ export {
@@ -222,9 +275,9 @@ invalid.ts:32:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
     38 │ 
     39 │ import type * as Ns from ""
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     30 30 │   
     31 31 │   import { type T7, type T8 } from "./mod.ts";
@@ -245,18 +298,68 @@ invalid.ts:32:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
 ```
 invalid.ts:40:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! All exports are only types and should thus use export type.
+  ! All exports are only types.
   
     39 │ import type * as Ns from ""
   > 40 │ export { Ns }
        │        ^^^^^^
     41 │ 
+    42 │ import { type T9, type T10 } from "./mod.ts";
   
-  i Using export type allows transpilers to safely drop exports of types without looking for their definition.
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Use a grouped export type.
+  i Safe fix: Use export type.
   
     40 │ export·type·{·Ns·}
        │        +++++      
+
+```
+
+```
+invalid.ts:43:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! All exports are only types.
+  
+    42 │ import { type T9, type T10 } from "./mod.ts";
+  > 43 │ export { type T9, type T10 };
+       │        ^^^^^^^^^^^^^^^^^^^^^^
+    44 │ 
+    45 │ export { type T11, type T12 } from "./mod.ts";
+  
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
+  
+  i Safe fix: Use export type.
+  
+    41 41 │   
+    42 42 │   import { type T9, type T10 } from "./mod.ts";
+    43    │ - export·{·type·T9,·type·T10·};
+       43 │ + export·type·{·T9,·T10·};
+    44 44 │   
+    45 45 │   export { type T11, type T12 } from "./mod.ts";
+  
+
+```
+
+```
+invalid.ts:45:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! All exports are only types.
+  
+    43 │ export { type T9, type T10 };
+    44 │ 
+  > 45 │ export { type T11, type T12 } from "./mod.ts";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    46 │ 
+  
+  i Using export type allows compilers to safely drop exports of types without looking for their definition.
+  
+  i Safe fix: Use export type.
+  
+    43 43 │   export { type T9, type T10 };
+    44 44 │   
+    45    │ - export·{·type·T11,·type·T12·}·from·"./mod.ts";
+       45 │ + export·type·{·T11,·T12·}·from·"./mod.ts";
+    46 46 │   
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
@@ -74,7 +74,7 @@ invalid.ts:2:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     2 │ export·{·type·T1,·V1·};
       │          +++++         
@@ -159,7 +159,7 @@ invalid.ts:12:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     12 12 │   export {
     13 13 │       // leading comment
@@ -225,7 +225,7 @@ invalid.ts:27:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     27 │ export·{·type·Interface,·type·TypeAlias,·Enum,·func·as·f,·Class·};
        │          +++++           +++++                                    

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/invalid.ts.snap
@@ -74,7 +74,7 @@ invalid.ts:2:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━━
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     2 │ export·{·type·T1,·V1·};
       │          +++++         
@@ -159,7 +159,7 @@ invalid.ts:12:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     12 12 │   export {
     13 13 │       // leading comment
@@ -225,7 +225,7 @@ invalid.ts:27:8 lint/style/useExportType  FIXABLE  ━━━━━━━━━�
   
   i Using export type allows compilers to safely drop exports of types without looking for their definition.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     27 │ export·{·type·Interface,·type·TypeAlias,·Enum,·func·as·f,·Class·};
        │          +++++           +++++                                    

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts
@@ -41,3 +41,12 @@ declare class AmbientFunction {}
 export { AmbientClass, AmbientEnum, AmbientFunction }
 
 export {}
+
+function f3() {}
+class Class3 {}
+export { type Class3, f3 }
+
+function f4() {}
+export { f4 }
+
+export { type T1, V1 } from "./mod.ts";

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/valid.ts.snap
@@ -48,4 +48,13 @@ export { AmbientClass, AmbientEnum, AmbientFunction }
 
 export {}
 
+function f3() {}
+class Class3 {}
+export { type Class3, f3 }
+
+function f4() {}
+export { f4 }
+
+export { type T1, V1 } from "./mod.ts";
+
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
@@ -37,20 +37,20 @@ export { T, type U };
 
 # Diagnostics
 ```
-invalid-combined.ts:2:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:2:12 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
     1 │ // Leading comment
   > 2 │ import/*1*/A/*2*/
-      │ ^^^^^^^^^^^^^^^^^
+      │            ^^^^^^
   > 3 │ // Comma comment
   > 4 │ ,/*3*/{ B }/*4*/from/*5*/""/*6*/; // Trailing comment
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     5 │ // Comment
     6 │ export type { A, B };
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -67,14 +67,14 @@ invalid-combined.ts:2:1 lint/style/useImportType  FIXABLE  ━━━━━━━
 ```
 
 ```
-invalid-combined.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:8:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The default import and some named imports are only used as types.
   
      6 │ export type { A, B };
      7 │ 
    > 8 │ import C, { D, E, F } from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^^^^^^^
      9 │ export { type C, type D, type E, F };
     10 │ 
   
@@ -96,7 +96,7 @@ invalid-combined.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━━━
      9 │ export { type C, type D, type E, F };
     10 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -112,18 +112,18 @@ invalid-combined.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━━━
 ```
 
 ```
-invalid-combined.ts:11:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:11:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
      9 │ export { type C, type D, type E, F };
     10 │ 
   > 11 │ import G, { type H, I } from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^
     12 │ export type { G, H, I };
     13 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -139,20 +139,20 @@ invalid-combined.ts:11:1 lint/style/useImportType  FIXABLE  ━━━━━━�
 ```
 
 ```
-invalid-combined.ts:15:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:15:13 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
     14 │ // Leading comment
   > 15 │ import /*1*/M/*2*/
-       │ ^^^^^^^^^^^^^^^^^^
+       │             ^^^^^^
   > 16 │ // Comma comment
   > 17 │ ,/*3*/*/*4*/as/*5*/N/*6*/from/*7*/""/*8*/;/*9*/
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     18 │ // Comment
     19 │ export type { M, N };
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -170,18 +170,18 @@ invalid-combined.ts:15:1 lint/style/useImportType  FIXABLE  ━━━━━━�
 ```
 
 ```
-invalid-combined.ts:21:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:21:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The default import is only used as a type.
   
     19 │ export type { M, N };
     20 │ 
   > 21 │ import O, * as P from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^^
     22 │ export { type O, P };
     23 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -208,7 +208,7 @@ invalid-combined.ts:24:11 lint/style/useImportType  FIXABLE  ━━━━━━�
     25 │ export { Q, type R };
     26 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -224,14 +224,14 @@ invalid-combined.ts:24:11 lint/style/useImportType  FIXABLE  ━━━━━━�
 ```
 
 ```
-invalid-combined.ts:27:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-combined.ts:27:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Some named imports are only used as types.
   
     25 │ export { Q, type R };
     26 │ 
   > 27 │ import T, { U } from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^
     28 │ export { T, type U };
     29 │ 
   
@@ -244,13 +244,11 @@ invalid-combined.ts:27:1 lint/style/useImportType  FIXABLE  ━━━━━━�
     28 │ export { T, type U };
     29 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Use import type.
+  i Safe fix: Add inline type keywords.
   
     27 │ import·T,·{·type·U·}·from·"";
        │             +++++            
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
@@ -246,7 +246,7 @@ invalid-combined.ts:27:8 lint/style/useImportType  FIXABLE  ━━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     27 │ import·T,·{·type·U·}·from·"";
        │             +++++            

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-combined.ts.snap
@@ -246,7 +246,7 @@ invalid-combined.ts:27:8 lint/style/useImportType  FIXABLE  ━━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     27 │ import·T,·{·type·U·}·from·"";
        │             +++++            

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-default-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-default-imports.ts.snap
@@ -13,16 +13,16 @@ let a: A;
 
 # Diagnostics
 ```
-invalid-default-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-default-imports.ts:1:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
   > 1 │ import A from ""
-      │ ^^^^^^^^^^^^^^^^
+      │        ^^^^^^^^^
     2 │ type AA = A;
     3 │ export { type A };
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -30,5 +30,3 @@ invalid-default-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━�
       │        +++++         
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
@@ -65,7 +65,7 @@ invalid-named-imports.ts:1:8 lint/style/useImportType  FIXABLE  ━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     1 │ import·{·type·A,·type·B,·type·C,·D,·E·}·from·"";
       │          +++++   +++++   +++++                  
@@ -95,7 +95,7 @@ invalid-named-imports.ts:8:8 lint/style/useImportType  FIXABLE  ━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     8 │ import·{·type·X,·Y·}·from·"";
       │          +++++               
@@ -131,7 +131,7 @@ invalid-named-imports.ts:12:8 lint/style/useImportType  FIXABLE  ━━━━━
 ```
 invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This type modifier makes all inline type modifiers useless.
+  ! This type keyword makes all inline type keywords useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -140,7 +140,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type modifier is useless.
+  i This inline type keyword is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -149,7 +149,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type modifier is useless.
+  i This inline type keyword is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -158,7 +158,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i Safe fix: Remove useless inline type modifiers.
+  i Safe fix: Remove useless inline type keywords.
   
     15 │ import·type·{·type·M,·N,·type·O·}·from·"";
        │               -----      -----            
@@ -202,7 +202,7 @@ invalid-named-imports.ts:18:8 lint/style/useImportType  FIXABLE  ━━━━━
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     18 18 │   import {
     19 19 │       U,

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
@@ -33,12 +33,12 @@ export { U, type V, type W };
 
 # Diagnostics
 ```
-invalid-named-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-named-imports.ts:1:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Some named imports are only used as types.
   
   > 1 │ import { A, B, C, D, E } from "";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ type AA = A;
     3 │ type BB = typeof B;
   
@@ -63,9 +63,9 @@ invalid-named-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━━�
     2 │ type AA = A;
     3 │ type BB = typeof B;
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Use import type.
+  i Safe fix: Add inline type keywords.
   
     1 │ import·{·type·A,·type·B,·type·C,·D,·E·}·from·"";
       │          +++++   +++++   +++++                  
@@ -73,14 +73,14 @@ invalid-named-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid-named-imports.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-named-imports.ts:8:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Some named imports are only used as types.
   
      6 │ const EE = E;
      7 │ 
    > 8 │ import { X, Y } from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^
      9 │ type XX = X;
     10 │ const YY = Y;
   
@@ -93,9 +93,9 @@ invalid-named-imports.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━�
      9 │ type XX = X;
     10 │ const YY = Y;
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Use import type.
+  i Safe fix: Add inline type keywords.
   
     8 │ import·{·type·X,·Y·}·from·"";
       │          +++++               
@@ -103,18 +103,18 @@ invalid-named-imports.ts:8:1 lint/style/useImportType  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid-named-imports.ts:12:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-named-imports.ts:12:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
     10 │ const YY = Y;
     11 │ 
   > 12 │ import { type H, type I, type J } from "";
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     13 │ export type { H, I, J };
     14 │ 
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -131,7 +131,7 @@ invalid-named-imports.ts:12:1 lint/style/useImportType  FIXABLE  ━━━━━
 ```
 invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! The import has this type qualifier that makes all inline type qualifiers useless.
+  ! This type keyword makes all inline type keywords useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -140,7 +140,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type qualifier is useless.
+  i This inline type keyword is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -149,7 +149,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type qualifier is useless.
+  i This inline type keyword is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -158,7 +158,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i Safe fix: Use import type.
+  i Safe fix: Remove useless inline type keywords.
   
     15 │ import·type·{·type·M,·N,·type·O·}·from·"";
        │               -----      -----            
@@ -166,19 +166,19 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
 ```
 
 ```
-invalid-named-imports.ts:18:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-named-imports.ts:18:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Some named imports are only used as types.
   
     17 │ // multiline
   > 18 │ import {
-       │ ^^^^^^^^
+       │        ^
   > 19 │     U,
   > 20 │     V,
   > 21 │     // leading comment
   > 22 │     W,
   > 23 │ } from "";
-       │ ^^^^^^^^^^
+       │ ^^^^^^^^^
     24 │ export { U, type V, type W };
     25 │ 
   
@@ -200,9 +200,9 @@ invalid-named-imports.ts:18:1 lint/style/useImportType  FIXABLE  ━━━━━
     23 │ } from "";
     24 │ export { U, type V, type W };
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Use import type.
+  i Safe fix: Add inline type keywords.
   
     18 18 │   import {
     19 19 │       U,

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-named-imports.ts.snap
@@ -65,7 +65,7 @@ invalid-named-imports.ts:1:8 lint/style/useImportType  FIXABLE  ━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     1 │ import·{·type·A,·type·B,·type·C,·D,·E·}·from·"";
       │          +++++   +++++   +++++                  
@@ -95,7 +95,7 @@ invalid-named-imports.ts:8:8 lint/style/useImportType  FIXABLE  ━━━━━�
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     8 │ import·{·type·X,·Y·}·from·"";
       │          +++++               
@@ -131,7 +131,7 @@ invalid-named-imports.ts:12:8 lint/style/useImportType  FIXABLE  ━━━━━
 ```
 invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! This type keyword makes all inline type keywords useless.
+  ! This type modifier makes all inline type modifiers useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -140,7 +140,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type keyword is useless.
+  i This inline type modifier is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -149,7 +149,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i This inline type keyword is useless.
+  i This inline type modifier is useless.
   
     13 │ export type { H, I, J };
     14 │ 
@@ -158,7 +158,7 @@ invalid-named-imports.ts:15:8 lint/style/useImportType  FIXABLE  ━━━━━
     16 │ 
     17 │ // multiline
   
-  i Safe fix: Remove useless inline type keywords.
+  i Safe fix: Remove useless inline type modifiers.
   
     15 │ import·type·{·type·M,·N,·type·O·}·from·"";
        │               -----      -----            
@@ -202,7 +202,7 @@ invalid-named-imports.ts:18:8 lint/style/useImportType  FIXABLE  ━━━━━
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     18 18 │   import {
     19 19 │       U,

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-namesapce-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-namesapce-imports.ts.snap
@@ -13,16 +13,16 @@ let a: A.Type1;
 
 # Diagnostics
 ```
-invalid-namesapce-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-namesapce-imports.ts:1:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
   > 1 │ import * as A from "";
-      │ ^^^^^^^^^^^^^^^^^^^^^^
+      │        ^^^^^^^^^^^^^^
     2 │ export { type A }
     3 │ type AA = typeof A.Class;
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   
@@ -30,5 +30,3 @@ invalid-namesapce-imports.ts:1:1 lint/style/useImportType  FIXABLE  ━━━━
       │        +++++               
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/invalid-unused-react-types.tsx.snap
@@ -16,16 +16,16 @@ function Component() {
 
 # Diagnostics
 ```
-invalid-unused-react-types.tsx:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-unused-react-types.tsx:1:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! All these imports are only used as types.
   
   > 1 │ import * as ReactTypes from "react";
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ 
     3 │ function Component() {
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
   i Safe fix: Use import type.
   

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
@@ -17,12 +17,12 @@ function Component() {
 
 # Diagnostics
 ```
-valid-unused-react-combined.tsx:1:1 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+valid-unused-react-combined.tsx:1:8 lint/style/useImportType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Some named imports are only used as types.
   
   > 1 │ import React, { MouseEvent } from 'react';
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     2 │ 
     3 │ function Component() {
   
@@ -33,9 +33,9 @@ valid-unused-react-combined.tsx:1:1 lint/style/useImportType  FIXABLE  ━━━
     2 │ 
     3 │ function Component() {
   
-  i Importing the types with import type ensures that they are removed by the transpilers and avoids loading unnecessary modules.
+  i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Use import type.
+  i Safe fix: Add inline type keywords.
   
     1 │ import·React,·{·type·MouseEvent·}·from·'react';
       │                 +++++                          

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
@@ -35,7 +35,7 @@ valid-unused-react-combined.tsx:1:8 lint/style/useImportType  FIXABLE  ━━━
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type modifiers.
+  i Safe fix: Add inline type keywords.
   
     1 │ import·React,·{·type·MouseEvent·}·from·'react';
       │                 +++++                          

--- a/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useImportType/valid-unused-react-combined.tsx.snap
@@ -35,7 +35,7 @@ valid-unused-react-combined.tsx:1:8 lint/style/useImportType  FIXABLE  ━━━
   
   i Importing the types with import type ensures that they are removed by the compilers and avoids loading unnecessary modules.
   
-  i Safe fix: Add inline type keywords.
+  i Safe fix: Add inline type modifiers.
   
     1 │ import·React,·{·type·MouseEvent·}·from·'react';
       │                 +++++                          


### PR DESCRIPTION
## Summary

This is a followup of #4201 that concerns exports.

This suggests the following fixes:

```diff
- export type { type C, D };
+ export type { C, D };
```

This also bring the following suggestion:

```diff
- export { type A, type B } from "";
+ export type { A, B } from "";
```

Also, I took the opportunity of harmonizing diagnostics between `useExportType` and `useImportType`.

## Test Plan

I added some tests.
