### PR TITLE
perf(js_analyze): use Box<str>/Box<[_]> to reduce memory usage

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -170,7 +170,7 @@ use biome_deserialize_macros::Deserializable;
 pub struct MyRuleOptions {
     behavior: Behavior,
     threshold: u8,
-    behavior_exceptions: Vec<String>
+    behavior_exceptions: Box<[Box<str>]>
 }
 
 #[derive(Clone, Debug, Default, Deserializable)]
@@ -181,6 +181,9 @@ pub enum Behavior {
     C,
 }
 ```
+
+Note that we use a boxed slice `Box<[Box<str>]>` instead of `Vec<String>`.
+This allows saving memory: [boxed slices and boxed str use 2 words instead of three words](https://nnethercote.github.io/perf-book/type-sizes.html#boxed-slices).
 
 To allow deserializing instances of the types `MyRuleOptions` and `Behavior`,
 they have to implement the `Deserializable` trait from the `biome_deserialize` crate.
@@ -432,8 +435,10 @@ impl Rule for ForLoopCountReferences {
 #### Multiple signals
 
 Some rules require you to find all possible cases upfront in `run` function.
-To achieve that you can change Signals type from `Option<()>` to `Vec<()>`.
-This will call the diagnostic/action function for every item of the vec.
+To achieve that you can change Signals type from `Option<Self::State>` to an iterable data structure such as `Vec<Self::State>` or `Box<[Self::State]>`.
+This will call the diagnostic/action function for every item of the data structure.
+We prefer to use `Box<[_]>` over `Vec<_>` because it takes less memory.
+You can easily convert a `Vec<_>` into a `Box<[_]>` using the `Vec::into_boxed_slice()` method.
 
 Taking previous example and modifying it a bit we can apply diagnostic for each item easily.
 
@@ -441,7 +446,7 @@ Taking previous example and modifying it a bit we can apply diagnostic for each 
 impl Rule for ForLoopCountReferences {
     type Query = Semantic<JsForStatement>;
     type State = TextRange;
-    type Signals = Vec<Self::State>; // Replaced Option with Vec
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -462,7 +467,7 @@ impl Rule for ForLoopCountReferences {
             Some(range)
         }).collect::<Vec<_>>();
 
-        write_ranges
+        write_ranges.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -424,7 +424,7 @@ where
                     suppression
                         .suppressed_instances
                         .iter()
-                        .any(|(filter, v)| *filter == entry.rule && v == value)
+                        .any(|(filter, v)| *filter == entry.rule && v == value.as_ref())
                 })
             });
 

--- a/crates/biome_analyze/src/matcher.rs
+++ b/crates/biome_analyze/src/matcher.rs
@@ -138,7 +138,7 @@ pub struct SignalEntry<'phase, L: Language> {
     /// Unique identifier for the rule that emitted this signal
     pub rule: RuleKey,
     /// Optional rule instances being suppressed
-    pub instances: Vec<String>,
+    pub instances: Box<[Box<str>]>,
     /// Text range in the document this signal covers
     pub text_range: TextRange,
 }

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -800,8 +800,8 @@ pub trait Rule: RuleMeta + Sized {
     /// *Note: For `noUnusedVariables` the above may not seem very useful (and
     /// indeed it's not implemented), but for rules such as
     /// `useExhaustiveDependencies` this is actually desirable.*
-    fn instances_for_signal(_signal: &Self::State) -> Vec<String> {
-        Vec::new()
+    fn instances_for_signal(_signal: &Self::State) -> Box<[Box<str>]> {
+        Vec::new().into_boxed_slice()
     }
 
     /// Used by the analyzer to associate a range of source text to a signal in

--- a/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_eslint.rs
@@ -537,7 +537,7 @@ impl Deserializable for Rules {
 #[derive(Debug, Default, Deserializable)]
 pub struct NoConsoleOptions {
     /// Allowed calls on the console object.
-    pub allow: Vec<String>,
+    pub allow: Box<[Box<str>]>,
 }
 impl From<NoConsoleOptions> for biome_js_analyze::lint::suspicious::no_console::NoConsoleOptions {
     fn from(val: NoConsoleOptions) -> Self {

--- a/crates/biome_cli/src/execute/migrate/eslint_jsxa11y.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_jsxa11y.rs
@@ -7,7 +7,7 @@ use biome_js_analyze::lint::a11y::use_valid_aria_role;
 
 #[derive(Debug, Default, Deserializable)]
 pub(crate) struct AriaRoleOptions {
-    allowed_invalid_roles: Vec<String>,
+    allowed_invalid_roles: Box<[Box<str>]>,
     #[deserializable(rename = "ignoreNonDOM")]
     ignore_non_dom: bool,
 }

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -224,13 +224,16 @@ fn migrate_eslint_rule(
         eslint_eslint::Rule::NoRestrictedGlobals(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 let severity = conf.severity();
-                let globals = conf.into_vec().into_iter().map(|g| g.into_name());
+                let globals = conf
+                    .into_vec()
+                    .into_iter()
+                    .map(|g| g.into_name().into_boxed_str());
                 let group = rules.style.get_or_insert_with(Default::default);
                 group.no_restricted_globals = Some(biome_config::RuleConfiguration::WithOptions(
                     biome_config::RuleWithOptions {
                         level: severity.into(),
                         options: Box::new(no_restricted_globals::RestrictedGlobalsOptions {
-                            denied_globals: globals.collect(),
+                            denied_globals: globals.collect::<Vec<_>>().into_boxed_slice(),
                         }),
                     },
                 ));

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -160,7 +160,7 @@ impl From<NamingConventionOptions> for use_naming_convention::NamingConventionOp
         use_naming_convention::NamingConventionOptions {
             strict_case: false,
             require_ascii: false,
-            conventions,
+            conventions: conventions.into_boxed_slice(),
             enum_member_case: use_naming_convention::Format::default(),
         }
     }

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_position_at_import_rule.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_position_at_import_rule.rs
@@ -38,10 +38,10 @@ declare_lint_rule! {
 impl Rule for NoInvalidPositionAtImportRule {
     type Query = Ast<CssRuleList>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let mut is_invalid_position = false;
         let mut invalid_import_list = Vec::new();
@@ -73,7 +73,7 @@ impl Rule for NoInvalidPositionAtImportRule {
                 is_invalid_position = true;
             }
         }
-        invalid_import_list
+        invalid_import_list.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_css_analyze/src/lint/nursery/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_descending_specificity.rs
@@ -163,7 +163,7 @@ fn find_descending_selector(
 impl Rule for NoDescendingSpecificity {
     type Query = Semantic<CssRoot>;
     type State = DescendingSelector;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -180,8 +180,7 @@ impl Rule for NoDescendingSpecificity {
                 &mut descending_selectors,
             );
         }
-
-        descending_selectors
+        descending_selectors.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, node: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_css_analyze/src/lint/nursery/no_irregular_whitespace.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_irregular_whitespace.rs
@@ -51,12 +51,12 @@ declare_lint_rule! {
 impl Rule for NoIrregularWhitespace {
     type Query = Ast<AnyCssRule>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        get_irregular_whitespace(node)
+        get_irregular_whitespace(node).into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -498,6 +498,16 @@ impl Deserializable for String {
     }
 }
 
+impl Deserializable for Box<str> {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        String::deserialize(value, name, diagnostics).map(|s| s.into_boxed_str())
+    }
+}
+
 impl Deserializable for PathBuf {
     fn deserialize(
         value: &impl DeserializableValue,
@@ -553,6 +563,16 @@ impl<T: Deserializable> Deserializable for Vec<T> {
             }
         }
         value.deserialize(Visitor(PhantomData), name, diagnostics)
+    }
+}
+
+impl<T: Deserializable> Deserializable for Box<[T]> {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        Deserializable::deserialize(value, name, diagnostics).map(Vec::into_boxed_slice)
     }
 }
 

--- a/crates/biome_deserialize/src/validator.rs
+++ b/crates/biome_deserialize/src/validator.rs
@@ -50,8 +50,20 @@ impl IsEmpty for String {
     }
 }
 
+impl IsEmpty for Box<str> {
+    fn is_empty(&self) -> bool {
+        str::is_empty(self)
+    }
+}
+
 impl<T> IsEmpty for Vec<T> {
     fn is_empty(&self) -> bool {
         Vec::is_empty(self)
+    }
+}
+
+impl<T> IsEmpty for Box<[T]> {
+    fn is_empty(&self) -> bool {
+        <[_]>::is_empty(self)
     }
 }

--- a/crates/biome_graphql_analyze/src/lint/nursery/no_duplicated_fields.rs
+++ b/crates/biome_graphql_analyze/src/lint/nursery/no_duplicated_fields.rs
@@ -49,10 +49,10 @@ declare_lint_rule! {
 impl Rule for NoDuplicatedFields {
     type Query = Ast<AnyGraphqlOperationDefinition>;
     type State = DuplicatedField;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let operation = ctx.query();
         let mut duplicated_fields = vec![];
         match operation {
@@ -68,8 +68,7 @@ impl Rule for NoDuplicatedFields {
                 duplicated_fields.extend(check_duplicated_selection_fields(selection_set))
             }
         };
-
-        duplicated_fields
+        duplicated_fields.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/assists/source/sort_jsx_props.rs
+++ b/crates/biome_js_analyze/src/assists/source/sort_jsx_props.rs
@@ -52,7 +52,7 @@ declare_source_rule! {
 impl Rule for SortJsxProps {
     type Query = Ast<JsxAttributeList>;
     type State = PropGroup;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -72,7 +72,7 @@ impl Rule for SortJsxProps {
             }
         }
         prop_groups.push(current_prop_group);
-        prop_groups
+        prop_groups.into_boxed_slice()
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
@@ -155,11 +155,11 @@ impl Rule for NoLabelWithoutControl {
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct NoLabelWithoutControlOptions {
     /// Array of component names that should be considered the same as an `input` element.
-    pub input_components: Vec<String>,
+    pub input_components: Box<[Box<str>]>,
     /// Array of attributes that should be treated as the `label` accessible text content.
-    pub label_attributes: Vec<String>,
+    pub label_attributes: Box<[Box<str>]>,
     /// Array of component names that should be considered the same as a `label` element.
-    pub label_components: Vec<String>,
+    pub label_components: Box<[Box<str>]>,
 }
 
 impl NoLabelWithoutControlOptions {
@@ -175,7 +175,7 @@ impl NoLabelWithoutControlOptions {
             && !self
                 .label_attributes
                 .iter()
-                .any(|name| name == attribute_name)
+                .any(|name| name.as_ref() == attribute_name)
         {
             return false;
         }
@@ -245,7 +245,7 @@ impl NoLabelWithoutControlOptions {
                             || self
                                 .input_components
                                 .iter()
-                                .any(|name| name == element_name)
+                                .any(|name| name.as_ref() == element_name)
                         {
                             return true;
                         }
@@ -260,7 +260,7 @@ impl NoLabelWithoutControlOptions {
     fn has_element_name(&self, element_name: &str) -> bool {
         self.label_components
             .iter()
-            .any(|label_component_name| label_component_name == element_name)
+            .any(|label_component_name| label_component_name.as_ref() == element_name)
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
 
 #[derive(Default, Debug)]
 pub struct UseAriaPropsForRoleState {
-    missing_aria_props: Vec<String>,
+    missing_aria_props: Box<[String]>,
     attribute: Option<(JsxAttribute, String)>,
 }
 
@@ -121,7 +121,7 @@ impl Rule for UseAriaPropsForRole {
             if !missing_aria_props.is_empty() {
                 return Some(UseAriaPropsForRoleState {
                     attribute: Some((role_attribute, name.text().to_string())),
-                    missing_aria_props,
+                    missing_aria_props: missing_aria_props.into_boxed_slice(),
                 });
             }
         }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -37,7 +37,7 @@ declare_lint_rule! {
 impl Rule for UseValidAriaProps {
     type Query = Aria<AnyJsxElement>;
     type State = JsxAttribute;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -64,11 +64,11 @@ impl Rule for UseValidAriaProps {
                     }
                 })
                 .collect();
-
             attributes
         } else {
-            vec![]
+            Vec::new()
         }
+        .into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, attribute: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -78,7 +78,7 @@ declare_lint_rule! {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct ValidAriaRoleOptions {
-    pub allow_invalid_roles: Vec<String>,
+    pub allow_invalid_roles: Box<[Box<str>]>,
     pub ignore_non_dom: bool,
 }
 
@@ -107,7 +107,10 @@ impl Rule for UseValidAriaRole {
 
         let is_valid = role_attribute_value.all(|val| {
             let role_data = aria_roles.get_role(val);
-            allowed_invalid_roles.contains(&val.to_string()) || role_data.is_some()
+            allowed_invalid_roles
+                .iter()
+                .any(|role| role.as_ref() == val)
+                || role_data.is_some()
         });
 
         if is_valid {

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -13,9 +13,7 @@ use biome_js_syntax::{
     JsParenthesizedExpression, JsSyntaxKind, JsxChildList, JsxElement, JsxExpressionAttributeValue,
     JsxExpressionChild, JsxFragment, JsxTagExpression, JsxText, T,
 };
-use biome_rowan::{
-    declare_node_union, AstNode, AstNodeList, BatchMutation, BatchMutationExt, SyntaxNodeText,
-};
+use biome_rowan::{declare_node_union, AstNode, AstNodeList, BatchMutation, BatchMutationExt};
 
 declare_lint_rule! {
     /// Disallow unnecessary fragments

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
@@ -71,7 +71,7 @@ declare_lint_rule! {
 impl Rule for NoUselessSwitchCase {
     type Query = Ast<JsDefaultClause>;
     type State = JsCaseClause;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -107,10 +107,11 @@ impl Rule for NoUselessSwitchCase {
                     .filter_map(JsCaseClause::cast)
                     .find(|case| !case.consequent().is_empty()),
             )
-            .collect()
+            .collect::<Vec<_>>()
         } else {
-            it.collect()
+            it.collect::<Vec<_>>()
         }
+        .into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, useless_case: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
@@ -57,28 +57,28 @@ declare_lint_rule! {
 pub enum NumberLiteral {
     Binary {
         node: JsLiteralMemberName,
-        value: String,
+        value: Box<str>,
         big_int: bool,
     },
     Decimal {
         node: JsLiteralMemberName,
-        value: String,
+        value: Box<str>,
         big_int: bool,
         underscore: bool,
     },
     Octal {
         node: JsLiteralMemberName,
-        value: String,
+        value: Box<str>,
         big_int: bool,
     },
     Hexadecimal {
         node: JsLiteralMemberName,
-        value: String,
+        value: Box<str>,
         big_int: bool,
     },
     FloatingPoint {
         node: JsLiteralMemberName,
-        value: String,
+        value: Box<str>,
         exponent: bool,
         underscore: bool,
     },
@@ -149,7 +149,7 @@ impl TryFrom<AnyJsObjectMember> for NumberLiteral {
                 if contains_dot {
                     return Ok(Self::FloatingPoint {
                         node: literal_member_name,
-                        value,
+                        value: value.into_boxed_str(),
                         exponent,
                         underscore,
                     });
@@ -157,7 +157,7 @@ impl TryFrom<AnyJsObjectMember> for NumberLiteral {
                 if !is_first_char_zero {
                     return Ok(Self::Decimal {
                         node: literal_member_name,
-                        value,
+                        value: value.into_boxed_str(),
                         big_int,
                         underscore,
                     });
@@ -167,21 +167,21 @@ impl TryFrom<AnyJsObjectMember> for NumberLiteral {
                     Some(b'b' | b'B') => {
                         return Ok(Self::Binary {
                             node: literal_member_name,
-                            value,
+                            value: value.into_boxed_str(),
                             big_int,
                         })
                     }
                     Some(b'o' | b'O') => {
                         return Ok(Self::Octal {
                             node: literal_member_name,
-                            value,
+                            value: value.into_boxed_str(),
                             big_int,
                         })
                     }
                     Some(b'x' | b'X') => {
                         return Ok(Self::Hexadecimal {
                             node: literal_member_name,
-                            value,
+                            value: value.into_boxed_str(),
                             big_int,
                         })
                     }
@@ -191,14 +191,14 @@ impl TryFrom<AnyJsObjectMember> for NumberLiteral {
                 if largest_digit < b'8' {
                     return Ok(Self::Octal {
                         node: literal_member_name,
-                        value,
+                        value: value.into_boxed_str(),
                         big_int,
                     });
                 }
 
                 Ok(Self::Decimal {
                     node: literal_member_name,
-                    value,
+                    value: value.into_boxed_str(),
                     big_int,
                     underscore,
                 })
@@ -229,13 +229,13 @@ impl NumberLiteral {
         }
     }
 
-    fn value(&self) -> &String {
+    fn value(&self) -> &str {
         match self {
-            Self::Decimal { value, .. } => value,
-            Self::Binary { value, .. } => value,
-            Self::FloatingPoint { value, .. } => value,
-            Self::Octal { value, .. } => value,
-            Self::Hexadecimal { value, .. } => value,
+            Self::Decimal { value, .. } => value.as_ref(),
+            Self::Binary { value, .. } => value.as_ref(),
+            Self::FloatingPoint { value, .. } => value.as_ref(),
+            Self::Octal { value, .. } => value.as_ref(),
+            Self::Hexadecimal { value, .. } => value.as_ref(),
         }
     }
 }
@@ -267,13 +267,12 @@ pub struct RuleState(WrongNumberLiteralName, NumberLiteral);
 impl Rule for UseSimpleNumberKeys {
     type Query = Ast<JsObjectExpression>;
     type State = RuleState;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut signals: Self::Signals = Vec::new();
+        let mut result = Vec::new();
         let node = ctx.query();
-
         for number_literal in node
             .members()
             .into_iter()
@@ -282,32 +281,31 @@ impl Rule for UseSimpleNumberKeys {
         {
             match number_literal {
                 NumberLiteral::Decimal { big_int: true, .. } => {
-                    signals.push(RuleState(WrongNumberLiteralName::BigInt, number_literal))
+                    result.push(RuleState(WrongNumberLiteralName::BigInt, number_literal))
                 }
                 NumberLiteral::FloatingPoint {
                     underscore: true, ..
                 }
                 | NumberLiteral::Decimal {
                     underscore: true, ..
-                } => signals.push(RuleState(
+                } => result.push(RuleState(
                     WrongNumberLiteralName::WithUnderscore,
                     number_literal,
                 )),
                 NumberLiteral::Binary { .. } => {
-                    signals.push(RuleState(WrongNumberLiteralName::Binary, number_literal))
+                    result.push(RuleState(WrongNumberLiteralName::Binary, number_literal))
                 }
-                NumberLiteral::Hexadecimal { .. } => signals.push(RuleState(
+                NumberLiteral::Hexadecimal { .. } => result.push(RuleState(
                     WrongNumberLiteralName::Hexadecimal,
                     number_literal,
                 )),
                 NumberLiteral::Octal { .. } => {
-                    signals.push(RuleState(WrongNumberLiteralName::Octal, number_literal))
+                    result.push(RuleState(WrongNumberLiteralName::Octal, number_literal))
                 }
                 _ => (),
             }
         }
-
-        signals
+        result.into_boxed_slice()
     }
 
     fn diagnostic(

--- a/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
@@ -52,14 +52,14 @@ declare_lint_rule! {
 impl Rule for NoEmptyCharacterClassInRegex {
     type Query = Ast<JsRegexLiteralExpression>;
     type State = Range<usize>;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let mut empty_classes = vec![];
         let regex = ctx.query();
         let Ok((pattern, flags)) = regex.decompose() else {
-            return empty_classes;
+            return empty_classes.into_boxed_slice();
         };
         let has_v_flag = flags.text().contains('v');
         let trimmed_text = pattern.text();
@@ -95,7 +95,7 @@ impl Rule for NoEmptyCharacterClassInRegex {
                 _ => {}
             }
         }
-        empty_classes
+        empty_classes.into_boxed_slice()
     }
 
     fn diagnostic(

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -72,7 +72,7 @@ declare_lint_rule! {
 impl Rule for NoInvalidUseBeforeDeclaration {
     type Query = SemanticServices;
     type State = InvalidUseBeforeDeclaration;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -156,7 +156,7 @@ impl Rule for NoInvalidUseBeforeDeclaration {
                 }
             }
         }
-        result
+        result.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
@@ -78,7 +78,7 @@ declare_lint_rule! {
 impl Rule for NoSelfAssign {
     type Query = Ast<JsAssignmentExpression>;
     type State = IdentifiersLike;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -86,8 +86,7 @@ impl Rule for NoSelfAssign {
         let left = node.left().ok();
         let right = node.right().ok();
         let operator = node.operator().ok();
-
-        let mut state = vec![];
+        let mut result = vec![];
         if let Some(operator) = operator {
             if matches!(
                 operator,
@@ -98,12 +97,12 @@ impl Rule for NoSelfAssign {
             ) {
                 if let (Some(left), Some(right)) = (left, right) {
                     if let Ok(pair) = AnyAssignmentLike::try_from((left, right)) {
-                        compare_assignment_like(pair, &mut state);
+                        compare_assignment_like(pair, &mut result);
                     }
                 }
             }
         }
-        state
+        result.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, identifier_like: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -48,10 +48,10 @@ declare_lint_rule! {
 impl Rule for NoStringCaseMismatch {
     type Query = Ast<QueryCandidate>;
     type State = CaseMismatchInfo;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let query = ctx.query();
         match query {
             QueryCandidate::JsBinaryExpression(expr) => CaseMismatchInfo::from_binary_expr(expr)
@@ -59,6 +59,7 @@ impl Rule for NoStringCaseMismatch {
                 .collect(),
             QueryCandidate::JsSwitchStatement(stmt) => CaseMismatchInfo::from_switch_stmt(stmt),
         }
+        .into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
@@ -83,7 +83,7 @@ declare_lint_rule! {
 impl Rule for NoSwitchDeclarations {
     type Query = Ast<AnyJsSwitchClause>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -101,7 +101,8 @@ impl Rule for NoSwitchDeclarations {
                     None
                 }
             })
-            .collect()
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, decl_range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
@@ -92,7 +92,7 @@ impl Rule for NoUnreachable {
         // Pluralize and adapt the error message accordingly based on the
         // number and position of secondary labels
         match state.terminators.as_slice() {
-            // The CFG didn't contain enough informations to determine a cause
+            // The CFG didn't contain enough information to determine a cause
             // for this range being unreachable
             [] => {}
             // A single node is responsible for this range being unreachable
@@ -137,7 +137,7 @@ impl Rule for NoUnreachable {
             }
             // The range has three or more dominating terminator instructions
             terminators => {
-                // SAFETY: This substraction is safe since the match expression
+                // SAFETY: This subtraction is safe since the match expression
                 // ensures the slice has at least 3 elements
                 let last = terminators.len() - 1;
 
@@ -206,7 +206,7 @@ impl Rule for NoUnreachable {
 const COMPLEXITY_THRESHOLD: u32 = 20;
 
 /// Returns true if the "complexity score" for the [JsControlFlowGraph] is higher
-/// than [COMPLEXITY_THRESHOLD]. This score is an arbritrary value (the formula
+/// than [COMPLEXITY_THRESHOLD]. This score is an arbitrary value (the formula
 /// is similar to the cyclomatic complexity of the function but this is only
 /// approximative) used to determine whether the NoDeadCode rule should perform
 /// a fine reachability analysis or fall back to a simpler algorithm to avoid
@@ -656,7 +656,7 @@ impl UnreachableRanges {
 
                 if let Some(terminator) = terminator {
                     // Terminator labels are also stored in ascending order to
-                    // faciliate the generation of labels when the diagnostic
+                    // facilitate the generation of labels when the diagnostic
                     // gets emitted
                     let terminator_insertion = entry
                         .terminators

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -77,18 +77,18 @@ declare_node_union! {
 impl Rule for NoUnusedPrivateClassMembers {
     type Query = Ast<JsClassDeclaration>;
     type State = AnyMember;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let private_members: FxHashSet<AnyMember> = get_all_declared_private_members(node);
-
         if private_members.is_empty() {
-            return vec![];
+            Vec::new()
+        } else {
+            traverse_members_usage(node.syntax(), private_members)
         }
-
-        traverse_members_usage(node.syntax(), private_members)
+        .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -103,7 +103,7 @@ impl AnyJsFunctionOrMethod {
 pub enum Suggestion {
     None {
         hook_name_range: TextRange,
-        path: Vec<TextRange>,
+        path: Box<[TextRange]>,
         early_return: Option<TextRange>,
         is_nested: bool,
     },
@@ -233,12 +233,12 @@ fn is_nested_function_inside_component_or_hook(function: &AnyJsFunctionOrMethod)
     })
 }
 
-/// Model for tracking which function calls are preceeded by an early return.
+/// Model for tracking which function calls are preceded by an early return.
 ///
 /// The keys in the model are call sites and each value is the text range of an
-/// early return that preceeds such call site. Call sites without preceeding
+/// early return that precedes such call site. Call sites without preceding
 /// early returns are not included in the model. For call sites that are
-/// preceeded by multiple early returns, the return statement that we map to is
+/// preceded by multiple early returns, the return statement that we map to is
 /// implementation-defined.
 #[derive(Clone, Default)]
 struct EarlyReturnsModel(FxHashMap<JsCallExpression, TextRange>);
@@ -440,7 +440,7 @@ impl Rule for UseHookAtTopLevel {
                     // hooks to be called from the top-level.
                     return Some(Suggestion::None {
                         hook_name_range: get_hook_name_range()?,
-                        path,
+                        path: path.into_boxed_slice(),
                         early_return: None,
                         is_nested: true,
                     });
@@ -449,7 +449,7 @@ impl Rule for UseHookAtTopLevel {
                 if let Some(early_return) = early_returns.get(&call) {
                     return Some(Suggestion::None {
                         hook_name_range: get_hook_name_range()?,
-                        path,
+                        path: path.into_boxed_slice(),
                         early_return: Some(*early_return),
                         is_nested: false,
                     });
@@ -468,7 +468,7 @@ impl Rule for UseHookAtTopLevel {
             } else {
                 return Some(Suggestion::None {
                     hook_name_range: get_hook_name_range()?,
-                    path,
+                    path: path.into_boxed_slice(),
                     early_return: None,
                     is_nested: false,
                 });

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -130,7 +130,7 @@ declare_lint_rule! {
 pub struct UseImportExtensionsOptions {
     /// A map of custom import extension mappings, where the key is the inspected file extension,
     /// and the value is a pair of `module` extension and `component` import extension
-    pub suggested_extensions: FxHashMap<String, SuggestedExtensionMapping>,
+    pub suggested_extensions: FxHashMap<Box<str>, SuggestedExtensionMapping>,
 }
 
 #[derive(Debug, Clone, Default, Deserializable, Deserialize, Serialize, Eq, PartialEq)]
@@ -138,9 +138,9 @@ pub struct UseImportExtensionsOptions {
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct SuggestedExtensionMapping {
     /// Extension that should be used for module imports
-    pub module: String,
+    pub module: Box<str>,
     /// Extension that should be used for component file imports
-    pub component: String,
+    pub component: Box<str>,
 }
 
 impl Rule for UseImportExtensions {
@@ -209,7 +209,7 @@ pub struct UseImportExtensionsState {
 fn get_extensionless_import(
     file_ext: &str,
     node: &AnyJsImportLike,
-    custom_suggested_imports: &FxHashMap<String, SuggestedExtensionMapping>,
+    custom_suggested_imports: &FxHashMap<Box<str>, SuggestedExtensionMapping>,
 ) -> Option<UseImportExtensionsState> {
     let module_name_token = node.module_name_token()?;
     let module_path = inner_string_text(&module_name_token);
@@ -293,7 +293,7 @@ fn get_extensionless_import(
 fn resolve_import_extension<'a>(
     file_ext: &str,
     path: &Path,
-    custom_suggested_imports: &'a FxHashMap<String, SuggestedExtensionMapping>,
+    custom_suggested_imports: &'a FxHashMap<Box<str>, SuggestedExtensionMapping>,
 ) -> &'a str {
     let (potential_ext, potential_component_ext): (&str, &str) =
         if let Some(custom_mapping) = custom_suggested_imports.get(file_ext) {

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -56,19 +56,19 @@ declare_node_union! {
 impl Rule for UseJsxKeyInIterable {
     type Query = Semantic<UseJsxKeyInIterableQuery>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let model = ctx.model();
-
         match node {
             UseJsxKeyInIterableQuery::JsArrayExpression(node) => handle_collections(node, model),
             UseJsxKeyInIterableQuery::JsCallExpression(node) => {
                 handle_iterators(node, model).unwrap_or_default()
             }
         }
+        .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
@@ -58,7 +58,6 @@ declare_lint_rule! {
 impl Rule for NoDuplicateElseIf {
     type Query = Ast<JsIfStatement>;
     type State = TextRange;
-
     type Signals = Option<Self::State>;
     type Options = ();
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_dynamic_namespace_import_access.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_dynamic_namespace_import_access.rs
@@ -67,11 +67,13 @@ declare_lint_rule! {
 impl Rule for NoDynamicNamespaceImportAccess {
     type Query = Semantic<JsImportNamespaceClause>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        find_dynamic_namespace_import_accesses(ctx).map_or(vec![], |range| range)
+        find_dynamic_namespace_import_accesses(ctx)
+            .map_or(Vec::new(), |x| x)
+            .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/nursery/no_irregular_whitespace.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_irregular_whitespace.rs
@@ -50,12 +50,12 @@ declare_lint_rule! {
 impl Rule for NoIrregularWhitespace {
     type Query = Ast<JsModule>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        get_irregular_whitespace(node)
+        get_irregular_whitespace(node).into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -43,7 +43,7 @@ declare_lint_rule! {
 pub struct RestrictedImportsOptions {
     /// A list of names that should trigger the rule
     #[serde(skip_serializing_if = "FxHashMap::is_empty")]
-    paths: FxHashMap<String, String>,
+    paths: FxHashMap<Box<str>, Box<str>>,
 }
 
 impl Rule for NoRestrictedImports {

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
@@ -126,7 +126,7 @@ impl Rule for NoRestrictedTypes {
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct NoRestrictedTypesOptions {
-    types: FxHashMap<String, CustomRestrictedType>,
+    types: FxHashMap<Box<str>, CustomRestrictedType>,
 }
 
 #[derive(

--- a/crates/biome_js_analyze/src/lint/nursery/use_adjacent_overload_signatures.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_adjacent_overload_signatures.rs
@@ -99,7 +99,7 @@ declare_lint_rule! {
 
 impl Rule for UseAdjacentOverloadSignatures {
     type Query = Ast<DeclarationOrModuleNode>;
-    type State = Vec<(TokenText, TextRange)>;
+    type State = Box<[(TokenText, TextRange)]>;
     type Signals = Option<Self::State>;
     type Options = ();
 
@@ -136,7 +136,7 @@ impl Rule for UseAdjacentOverloadSignatures {
         };
 
         if !methods.is_empty() {
-            Some(methods)
+            Some(methods.into_boxed_slice())
         } else {
             None
         }

--- a/crates/biome_js_analyze/src/lint/nursery/use_valid_autocomplete.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_valid_autocomplete.rs
@@ -140,7 +140,7 @@ const BILLING_AND_SHIPPING_ADDRESS: &[&str; 11] = &[
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct UseValidAutocompleteOptions {
     /// `input` like custom components that should be checked.
-    pub input_components: Vec<String>,
+    pub input_components: Box<[Box<str>]>,
 }
 
 impl Rule for UseValidAutocomplete {
@@ -156,7 +156,9 @@ impl Rule for UseValidAutocomplete {
             UseValidAutocompleteQuery::JsxOpeningElement(elem) => {
                 let elem_name = elem.name().ok()?.name_value_token()?;
                 let elem_name = elem_name.text_trimmed();
-                if !(elem_name == "input" || input_components.contains(&elem_name.to_string())) {
+                if !(elem_name == "input"
+                    || input_components.iter().any(|x| x.as_ref() == elem_name))
+                {
                     return None;
                 }
                 let attributes = elem.attributes();
@@ -183,7 +185,9 @@ impl Rule for UseValidAutocomplete {
             UseValidAutocompleteQuery::JsxSelfClosingElement(elem) => {
                 let elem_name = elem.name().ok()?.name_value_token()?;
                 let elem_name = elem_name.text_trimmed();
-                if !(elem_name == "input" || input_components.contains(&elem_name.to_string())) {
+                if !(elem_name == "input"
+                    || input_components.iter().any(|x| x.as_ref() == elem_name))
+                {
                     return None;
                 }
                 let attributes = elem.attributes();

--- a/crates/biome_js_analyze/src/lint/style/no_arguments.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_arguments.rs
@@ -36,12 +36,11 @@ declare_lint_rule! {
 impl Rule for NoArguments {
     type Query = SemanticServices;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let model = ctx.query();
-
         let mut found_arguments = vec![];
 
         for unresolved_reference in model.all_unresolved_references() {
@@ -51,7 +50,7 @@ impl Rule for NoArguments {
             }
         }
 
-        found_arguments
+        found_arguments.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_globals.rs
@@ -62,14 +62,14 @@ const RESTRICTED_GLOBALS: [&str; 2] = ["event", "error"];
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct RestrictedGlobalsOptions {
     /// A list of names that should trigger the rule
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub denied_globals: Vec<String>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub denied_globals: Box<[Box<str>]>,
 }
 
 impl Rule for NoRestrictedGlobals {
     type Query = SemanticServices;
-    type State = (TextRange, String);
-    type Signals = Vec<Self::State>;
+    type State = (TextRange, Box<str>);
+    type Signals = Box<[Self::State]>;
     type Options = Box<RestrictedGlobalsOptions>;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -103,9 +103,10 @@ impl Rule for NoRestrictedGlobals {
                 let denied_globals: Vec<_> =
                     options.denied_globals.iter().map(AsRef::as_ref).collect();
                 is_restricted(text, &binding, denied_globals.as_slice())
-                    .map(|text| (token.text_trimmed_range(), text))
+                    .map(|text| (token.text_trimmed_range(), text.into_boxed_str()))
             })
-            .collect()
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, (span, text): &Self::State) -> Option<RuleDiagnostic> {
@@ -114,7 +115,7 @@ impl Rule for NoRestrictedGlobals {
                 rule_category!(),
                 *span,
                 markup! {
-                    "Do not use the global variable "<Emphasis>{text}</Emphasis>"."
+                    "Do not use the global variable "<Emphasis>{text.as_ref()}</Emphasis>"."
                 },
             )
             .note(markup! {

--- a/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
@@ -101,15 +101,15 @@ declare_lint_rule! {
 impl Rule for NoUselessElse {
     type Query = Ast<JsIfStatement>;
     type State = JsIfStatement;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut result = vec![];
+        let mut result = Vec::new();
         let if_stmt = ctx.query();
         // Check an `if` statement only once.
         if if_stmt.syntax().parent().kind() == Some(JsSyntaxKind::JS_ELSE_CLAUSE) {
-            return result;
+            return result.into_boxed_slice();
         }
         let mut if_stmt = Cow::Borrowed(if_stmt);
         while let (Ok(if_consequent), Some(else_clause)) =
@@ -131,7 +131,7 @@ impl Rule for NoUselessElse {
             };
             if_stmt = Cow::Owned(stmt);
         }
-        result
+        result.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, if_stmt: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
@@ -75,7 +75,7 @@ declare_lint_rule! {
 impl Rule for UseLiteralEnumMembers {
     type Query = Ast<TsEnumDeclaration>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -83,13 +83,13 @@ impl Rule for UseLiteralEnumMembers {
         let mut result = Vec::new();
         let mut enum_member_names = FxHashSet::default();
         let Ok(enum_name) = enum_declaration.id() else {
-            return result;
+            return result.into_boxed_slice();
         };
         let Some(enum_name) = enum_name
             .as_js_identifier_binding()
             .and_then(|x| x.name_token().ok())
         else {
-            return result;
+            return result.into_boxed_slice();
         };
         let enum_name = enum_name.text_trimmed();
         for enum_member in enum_declaration.members() {
@@ -111,7 +111,7 @@ impl Rule for UseLiteralEnumMembers {
                 }
             }
         }
-        result
+        result.into_boxed_slice()
     }
 
     fn diagnostic(

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -946,7 +946,7 @@ fn renamable(
 pub struct NamingConventionOptions {
     /// If `false`, then consecutive uppercase are allowed in _camel_ and _pascal_ cases.
     /// This does not affect other [Case].
-    #[serde(default = "enabled", skip_serializing_if = "is_enabled")]
+    #[serde(default = "enabled", skip_serializing_if = "bool::clone")]
     pub strict_case: bool,
 
     /// If `false`, then non-ASCII characters are allowed.
@@ -954,8 +954,8 @@ pub struct NamingConventionOptions {
     pub require_ascii: bool,
 
     /// Custom conventions.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub conventions: Vec<Convention>,
+    #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+    pub conventions: Box<[Convention]>,
 
     /// Allowed cases for _TypeScript_ `enum` member names.
     #[serde(default, skip_serializing_if = "is_default")]
@@ -966,7 +966,7 @@ impl Default for NamingConventionOptions {
         Self {
             strict_case: true,
             require_ascii: false,
-            conventions: Vec::new(),
+            conventions: Vec::new().into_boxed_slice(),
             enum_member_case: Format::default(),
         }
     }
@@ -974,9 +974,6 @@ impl Default for NamingConventionOptions {
 
 const fn enabled() -> bool {
     true
-}
-const fn is_enabled(value: &bool) -> bool {
-    *value
 }
 fn is_default<T: Default + Eq>(value: &T) -> bool {
     value == &T::default()

--- a/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
@@ -52,13 +52,12 @@ impl Rule for NoCatchAssign {
     // The first element of `State` is the reassignment of catch parameter,
     // the second element of `State` is the declaration of catch clause.
     type State = (TextRange, TextRange);
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let catch_clause = ctx.query();
         let model = ctx.model();
-
         catch_clause
             .declaration()
             .and_then(|decl| {
@@ -69,7 +68,7 @@ impl Rule for NoCatchAssign {
                     .as_any_js_binding()?
                     .as_js_identifier_binding()?;
                 let catch_binding_syntax = catch_binding.syntax();
-                let mut invalid_assignment = vec![];
+                let mut invalid_assignment = Vec::new();
                 for reference in identifier_binding.all_writes(model) {
                     invalid_assignment.push((
                         reference.syntax().text_trimmed_range(),
@@ -80,6 +79,7 @@ impl Rule for NoCatchAssign {
                 Some(invalid_assignment)
             })
             .unwrap_or_default()
+            .into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
@@ -77,7 +77,7 @@ declare_lint_rule! {
 impl Rule for NoClassAssign {
     type Query = Semantic<AnyJsClass>;
     type State = Reference;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -86,11 +86,14 @@ impl Rule for NoClassAssign {
 
         if let Some(id) = node.id() {
             if let Some(id_binding) = id.as_js_identifier_binding() {
-                return id_binding.all_writes(model).collect();
+                return id_binding
+                    .all_writes(model)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
             }
         }
 
-        Vec::new()
+        Vec::new().into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, reference: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
@@ -70,7 +70,7 @@ impl Rule for NoConsole {
                 .options()
                 .allow
                 .iter()
-                .any(|allowed| allowed == member_name)
+                .any(|allowed| allowed.as_ref() == member_name)
             {
                 return None;
             }
@@ -122,5 +122,5 @@ impl Rule for NoConsole {
 #[serde(deny_unknown_fields)]
 pub struct NoConsoleOptions {
     /// Allowed calls on the console object.
-    pub allow: Vec<String>,
+    pub allow: Box<[Box<str>]>,
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
@@ -90,7 +90,7 @@ fn collect_control_characters(
     flags: &str,
     is_pattern_in_str: bool,
 ) -> Option<Vec<TextRange>> {
-    let mut control_chars: Vec<TextRange> = Vec::new();
+    let mut control_chars = Vec::new();
     let is_unicode_flag_set = flags.contains('u') || flags.contains('v');
     let bytes = pattern.as_bytes();
     let mut iter = pattern.bytes().enumerate();
@@ -196,7 +196,7 @@ fn collect_control_characters_from_expression(
 impl Rule for NoControlCharactersInRegex {
     type Query = Ast<AnyRegexExpression>;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -223,6 +223,7 @@ impl Rule for NoControlCharactersInRegex {
                     .unwrap_or_default()
             }
         }
+        .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
@@ -92,7 +92,7 @@ declare_lint_rule! {
 impl Rule for NoDuplicateCase {
     type Query = Ast<JsSwitchStatement>;
     type State = (TextRange, TextRange);
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -113,7 +113,7 @@ impl Rule for NoDuplicateCase {
                 }
             }
         }
-        signals
+        signals.into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
@@ -179,7 +179,7 @@ struct MemberState {
 impl Rule for NoDuplicateClassMembers {
     type Query = Ast<JsClassMemberList>;
     type State = AnyClassMemberDefinition;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -215,7 +215,8 @@ impl Rule for NoDuplicateClassMembers {
 
                 None
             })
-            .collect()
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -213,14 +213,14 @@ impl DefinedProperty {
 impl Rule for NoDuplicateObjectKeys {
     type Query = Ast<JsObjectExpression>;
     type State = PropertyConflict;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
         let mut defined_properties = FxHashMap::default();
-        let mut signals: Self::Signals = Vec::new();
+        let mut signals = Vec::new();
 
         for member_definition in node
             .members()
@@ -251,7 +251,7 @@ impl Rule for NoDuplicateObjectKeys {
             }
         }
 
-        signals
+        signals.into_boxed_slice()
     }
 
     fn diagnostic(

--- a/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
@@ -66,16 +66,16 @@ declare_lint_rule! {
 impl Rule for NoFallthroughSwitchClause {
     type Query = ControlFlowGraph;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let cfg = ctx.query();
-        let mut fallthrough: Vec<TextRange> = vec![];
+        let mut fallthrough = Vec::new();
         // Return early if the graph doesn't contain any switch statements.
         // This avoids to allocate some memory.
         if !has_switch_statement(&cfg.node) {
-            return fallthrough;
+            return fallthrough.into_boxed_slice();
         }
         // block to process.
         let mut block_stack = vec![ROOT_BLOCK_ID];
@@ -189,7 +189,7 @@ impl Rule for NoFallthroughSwitchClause {
             }
             switch_clauses.clear();
         }
-        fallthrough
+        fallthrough.into_boxed_slice()
     }
 
     fn diagnostic(

--- a/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
@@ -104,7 +104,7 @@ declare_lint_rule! {
 
 pub struct State {
     id: JsIdentifierBinding,
-    all_writes: Vec<Reference>,
+    all_writes: Box<[Reference]>,
 }
 
 impl Rule for NoFunctionAssign {
@@ -126,7 +126,7 @@ impl Rule for NoFunctionAssign {
         } else {
             Some(State {
                 id: id.clone(),
-                all_writes,
+                all_writes: all_writes.into_boxed_slice(),
             })
         }
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -50,12 +50,12 @@ declare_lint_rule! {
 impl Rule for NoGlobalAssign {
     type Query = SemanticServices;
     type State = TextRange;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let global_refs = ctx.query().all_unresolved_references();
-        let mut result = vec![];
+        let mut result = Vec::new();
         for global_ref in global_refs {
             let is_write = global_ref.syntax().kind() == JsSyntaxKind::JS_IDENTIFIER_ASSIGNMENT;
             if is_write {
@@ -67,7 +67,7 @@ impl Rule for NoGlobalAssign {
                 }
             }
         }
-        result
+        result.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
@@ -59,12 +59,12 @@ impl Rule for NoImportAssign {
     type Query = Semantic<AnyJsImportSpecifier>;
     /// The first element of the tuple is the invalid `JsIdentifierAssignment`, the second element of the tuple is the imported `JsIdentifierBinding`.
     type State = (JsIdentifierAssignment, JsIdentifierBinding);
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
-    fn run(ctx: &RuleContext<Self>) -> Vec<Self::State> {
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let label_statement = ctx.query();
-        let mut invalid_assign_list = vec![];
+        let mut invalid_assign_list = Vec::new();
         let local_name_binding = match label_statement {
             // `import {x as xx} from 'y'`
             //          ^^^^^^^
@@ -102,6 +102,7 @@ impl Rule for NoImportAssign {
                 Some(invalid_assign_list)
             })
             .unwrap_or_default()
+            .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
@@ -69,7 +69,7 @@ declare_lint_rule! {
 impl Rule for UseGetterReturn {
     type Query = ControlFlowGraph;
     type State = InvalidGetterReturn;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -78,7 +78,7 @@ impl Rule for UseGetterReturn {
         let mut invalid_returns = Vec::new();
         if !JsGetterClassMember::can_cast(node_kind) && !JsGetterObjectMember::can_cast(node_kind) {
             // The node is not a getter.
-            return invalid_returns;
+            return invalid_returns.into_boxed_slice();
         }
         // stack of blocks to process
         let mut block_stack = vec![ROOT_BLOCK_ID];
@@ -130,7 +130,7 @@ impl Rule for UseGetterReturn {
                 }
             }
         }
-        invalid_returns
+        invalid_returns.into_boxed_slice()
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, invalid_return: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_duplicate_private_class_members.rs
@@ -30,13 +30,12 @@ enum MemberType {
 
 impl Rule for NoDuplicatePrivateClassMembers {
     type Query = Ast<JsClassMemberList>;
-    type State = (String, TextRange);
-    type Signals = Vec<Self::State>;
+    type State = (Box<str>, TextRange);
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let mut defined_members: FxHashMap<String, FxHashSet<MemberType>> = FxHashMap::default();
-
+        let mut defined_members: FxHashMap<Box<str>, FxHashSet<MemberType>> = FxHashMap::default();
         let node = ctx.query();
         node.into_iter()
             .filter_map(|member| {
@@ -44,7 +43,11 @@ impl Rule for NoDuplicatePrivateClassMembers {
                     .name()
                     .ok()??
                     .as_js_private_class_member_name()?
-                    .text();
+                    .id_token()
+                    .ok()?
+                    .text_trimmed()
+                    .to_string()
+                    .into_boxed_str();
                 let member_type = match member {
                     AnyJsClassMember::JsGetterClassMember(_) => MemberType::Getter,
                     AnyJsClassMember::JsMethodClassMember(_) => MemberType::Normal,
@@ -71,17 +74,16 @@ impl Rule for NoDuplicatePrivateClassMembers {
 
                 None
             })
-            .collect()
+            .collect::<Vec<_>>()
+            .into_boxed_slice()
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let (member_name, range) = state;
-        let diagnostic = RuleDiagnostic::new(
+        Some(RuleDiagnostic::new(
             rule_category!(),
             range,
-            format!("Duplicate private class member {member_name:?}"),
-        );
-
-        Some(diagnostic)
+            format!("Duplicate private class member \"#{member_name}\""),
+        ))
     }
 }

--- a/crates/biome_js_syntax/src/export_ext.rs
+++ b/crates/biome_js_syntax/src/export_ext.rs
@@ -11,6 +11,22 @@ declare_node_union! {
     pub AnyIdentifier = AnyJsBindingPattern | AnyTsIdentifierBinding | JsIdentifierExpression | JsLiteralExportName | JsReferenceIdentifier
 }
 
+impl AnyIdentifier {
+    pub fn name_token(&self) -> Option<JsSyntaxToken> {
+        match self {
+            Self::AnyJsBindingPattern(id) => id
+                .as_any_js_binding()?
+                .as_js_identifier_binding()?
+                .name_token(),
+            Self::AnyTsIdentifierBinding(id) => id.as_ts_identifier_binding()?.name_token(),
+            Self::JsIdentifierExpression(id) => id.name().ok()?.value_token(),
+            Self::JsLiteralExportName(id) => id.value(),
+            Self::JsReferenceIdentifier(id) => id.value_token(),
+        }
+        .ok()
+    }
+}
+
 declare_node_union! {
     pub AnyJsExported = AnyJsExpression | AnyJsExportClause | AnyIdentifier | AnyTsType | TsEnumDeclaration
 }

--- a/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -37,7 +37,7 @@ declare_lint_rule! {
 impl Rule for NoDuplicateObjectKeys {
     type Query = Ast<JsonObjectValue>;
     type State = (JsonMemberName, Vec<TextRange>);
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
@@ -62,10 +62,8 @@ impl Rule for NoDuplicateObjectKeys {
                 }
             }
         }
-
         let duplicated_keys: Vec<_> = names.into_iter().collect();
-
-        duplicated_keys
+        duplicated_keys.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_migrate/src/analyzers/nursery_rules.rs
+++ b/crates/biome_migrate/src/analyzers/nursery_rules.rs
@@ -135,12 +135,12 @@ const RULES_TO_MIGRATE: &[(&str, (&str, &str))] = &[
 impl Rule for NurseryRules {
     type Query = Ast<JsonRoot>;
     type State = MigrateRuleState;
-    type Signals = Vec<Self::State>;
+    type Signals = Box<[Self::State]>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let mut rules_to_migrate = vec![];
+        let mut rules_to_migrate = Vec::new();
 
         if let Some(nursery_group) = find_group_by_name(node, "nursery") {
             let mut rules_should_be_migrated = FxHashMap::default();
@@ -153,7 +153,7 @@ impl Rule for NurseryRules {
                 .ok()
                 .and_then(|node| node.as_json_object_value().cloned())
             else {
-                return rules_to_migrate;
+                return rules_to_migrate.into_boxed_slice();
             };
 
             let mut separator_iterator = nursery_group_object
@@ -195,7 +195,7 @@ impl Rule for NurseryRules {
             }
         }
 
-        rules_to_migrate
+        rules_to_migrate.into_boxed_slice()
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -4132,7 +4132,6 @@
 			"properties": {
 				"attributes": {
 					"description": "Additional attributes that will be sorted.",
-					"default": ["class", "className"],
 					"type": ["array", "null"],
 					"items": { "type": "string" }
 				},


### PR DESCRIPTION
## Summary

This PR replace `Vec<_>` and `String` with their boxed versions `Box<[_]>` and `Box<str>` in Rules' `Options` and `Signals`. This allows reducing memory usage and could improve perf in some scenario.

To do so I implemented `Deserializable` for `Box<[_]>` and `Box<str>`.

Also, I found some use of `text` instead of `trimmed_text`.
I took the opportunity of replacing `text` with `trimmed_text`.

## Test Plan

CI must pass.
