### PR TITLE
ci: automatic issue closer

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_formatter_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_formatter_bug.yml
@@ -1,7 +1,7 @@
 name: 📝 Formatter bug report
 description: Report a bug or regression of the formatter
 title: "📝 <TITLE>"
-labels: [ "S-To triage" ]
+labels: [ "S-Needs triage" ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02_lint_bug.yml
+++ b/.github/ISSUE_TEMPLATE/02_lint_bug.yml
@@ -1,7 +1,7 @@
 name: 💅 Linter bug report
 description: Report a bug or regression of the linter
 title: "💅 <TITLE>"
-labels: [ "S-To triage" ]
+labels: [ "S-Needs triage" ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03_bug.yml
+++ b/.github/ISSUE_TEMPLATE/03_bug.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Report a possible bug or regression
 title: "🐛 <TITLE>"
-labels: [ "S-To triage" ]
+labels: [ "S-Needs triage" ]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,0 +1,18 @@
+name: Close issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'biomejs/biome'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issue without reproduction
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "S-Needs repro"
+          inactive-day: 3

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -1,0 +1,35 @@
+name: Needs reproduction
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  reply-labeled:
+    if: github.repository == 'biomejs/biome'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove triaging label
+        if: contains(github.event.issue.labels.*.name, 'S-Bug-confirmed') && contains(github.event.issue.labels.*.name, 'S-Needs triage')
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "S-Needs triage"
+
+      - name: Needs reproduction
+        if: github.event.label.name == 'S-Needs repro'
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "create-comment, remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}, please provide a minimal reproduction. You can use one of the following options:
+
+            - Provide a link to [our playground](https://biomejs.dev/playground), if it's applicable.
+            - Provide a link to GitHub repository. To easily create a reproduction, you can use our interactive CLI via `npm create @biomejs/biome-reproduction`
+
+            Issues marked with `S-Needs repro` will be **closed** if they have **no activity within 3 days**.
+          labels: "S-Needs triage"


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I took inspiration from the Astro workflow, and I like it.

This PR adds three two workflows: 
- One that writes a comment when we use the label `S-Needs repro`. When this label is added to an issue, an automatic message is sent and asks the user to provide a reproduction.
- One that closes issues that have the `S-Needs repro` label, and they are inactive for three days.
- One that removes the label `S-Needs triage` once the label `S-Bug confirmed` is added


I also update the issue templates with the correct label to assign (which I just created)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge and check

<!-- What demonstrates that your implementation is correct? -->
