### PR TITLE
docs(useNamingConvention): fix typo cas eof -> case of

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -248,7 +248,7 @@ declare_lint_rule! {
     ///
     /// Note that some declarations are always ignored.
     /// You cannot apply a convention to them.
-    /// This is the cas eof:
+    /// This is the case of:
     ///
     /// - Member names that are not identifiers
     ///


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR replaces the occurrence of "cas eof" in the [`useNamingConvention` documentation](https://biomejs.dev/linter/rules/use-naming-convention/#ignored-declarations) to "case of".

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

N/A
