### PR TITLE
perf: upgrade Grit and remove `im` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - The `--summary` reporter now reports parsing diagnostics too. Contributed by @ematipico
 
+- Improved performance of GritQL queries by roughly 25-30%. Contributed by @arendjr
+
 ### Configuration
 
 #### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,6 @@ dependencies = [
 name = "biome_grit_patterns"
 version = "0.0.1"
 dependencies = [
- "anyhow",
  "biome_console",
  "biome_diagnostics",
  "biome_grit_parser",
@@ -654,7 +653,6 @@ dependencies = [
  "biome_test_utils",
  "grit-pattern-matcher",
  "grit-util",
- "im",
  "insta",
  "path-absolutize",
  "rand 0.8.5",
@@ -1268,15 +1266,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "bitvec"
@@ -2094,14 +2083,12 @@ dependencies = [
 
 [[package]]
 name = "grit-pattern-matcher"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb91ad25bb8557f3be40899becf5db27e8431e359d69d5b67104f1d1a12c8d9a"
+checksum = "8430b130e086a1764789402b34685336f2e3f6ec37cd188535bede892f88e65b"
 dependencies = [
- "anyhow",
  "elsa",
  "grit-util",
- "im",
  "itertools",
  "rand 0.8.5",
  "regex",
@@ -2109,14 +2096,15 @@ dependencies = [
 
 [[package]]
 name = "grit-util"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d302f12945a38d464183a6ffe49b8b778876f82ab753174324cd7aae74b24a"
+checksum = "99b005c4c15ce0c47022554c41a01fe2441d3622e586a82614a6fe681833d5d4"
 dependencies = [
  "derive_builder",
  "once_cell",
  "regex",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2201,20 +2189,6 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -3015,15 +2989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,16 +3407,6 @@ checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
 dependencies = [
  "console",
  "similar",
-]
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
 ]
 
 [[package]]
@@ -3950,12 +3905,6 @@ dependencies = [
  "termcolor",
  "toml",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version              = "0.0.1"
 
 [dependencies]
-anyhow               = { workspace = true }
 biome_console        = { workspace = true }
 biome_diagnostics    = { workspace = true }
 biome_grit_parser    = { workspace = true }
@@ -22,9 +21,8 @@ biome_js_syntax      = { workspace = true }
 biome_parser         = { workspace = true }
 biome_rowan          = { workspace = true }
 biome_string_case    = { workspace = true }
-grit-pattern-matcher = { version = "0.3" }
-grit-util            = { version = "0.3" }
-im                   = { version = "15.1.0" }
+grit-pattern-matcher = { version = "0.4" }
+grit-util            = { version = "0.4" }
 path-absolutize      = { version = "3.1.1", optional = false, features = ["use_unix_paths_on_wasm"] }
 rand                 = { version = "0.8.5" }
 regex                = { workspace = true }

--- a/crates/biome_grit_patterns/src/grit_built_in_functions.rs
+++ b/crates/biome_grit_patterns/src/grit_built_in_functions.rs
@@ -2,29 +2,40 @@ use crate::{
     grit_context::{GritExecContext, GritQueryContext},
     grit_resolved_pattern::GritResolvedPattern,
 };
-use anyhow::{anyhow, bail, Result};
 use biome_string_case::StrOnlyExtension;
 use grit_pattern_matcher::{
     binding::Binding,
     constant::Constant,
     context::ExecContext,
     pattern::{
-        get_absolute_file_name, CallBuiltIn, JoinFn, LazyBuiltIn, Pattern, ResolvedPattern,
-        ResolvedSnippet, State,
+        get_absolute_file_name, CallBuiltIn, CallbackPattern, JoinFn, LazyBuiltIn, Pattern,
+        ResolvedPattern, ResolvedSnippet, State,
     },
 };
-use grit_util::AnalysisLogs;
+use grit_util::{
+    error::{GritPatternError, GritResult},
+    AnalysisLogs,
+};
 use path_absolutize::Absolutize;
 use rand::{seq::SliceRandom, Rng};
-use std::borrow::Cow;
 use std::path::Path;
+use std::{borrow::Cow, fmt::Debug, num::TryFromIntError};
 
 pub type CallableFn = dyn for<'a> Fn(
         &'a [Option<Pattern<GritQueryContext>>],
         &'a GritExecContext<'a>,
         &mut State<'a, GritQueryContext>,
         &mut AnalysisLogs,
-    ) -> Result<GritResolvedPattern<'a>>
+    ) -> GritResult<GritResolvedPattern<'a>>
+    + Send
+    + Sync;
+
+pub type CallbackFn = dyn for<'a, 'b> Fn(
+        &'b GritResolvedPattern<'a>,
+        &'a GritExecContext<'a>,
+        &mut State<'a, GritQueryContext>,
+        &mut AnalysisLogs,
+    ) -> GritResult<bool>
     + Send
     + Sync;
 
@@ -41,7 +52,7 @@ impl BuiltInFunction {
         context: &'a GritExecContext<'a>,
         state: &mut State<'a, GritQueryContext>,
         logs: &mut AnalysisLogs,
-    ) -> Result<GritResolvedPattern<'a>> {
+    ) -> GritResult<GritResolvedPattern<'a>> {
         (self.func)(args, context, state, logs)
     }
 
@@ -59,8 +70,19 @@ impl std::fmt::Debug for BuiltInFunction {
     }
 }
 
-#[derive(Debug)]
-pub struct BuiltIns(Vec<BuiltInFunction>);
+pub struct BuiltIns {
+    built_ins: Vec<BuiltInFunction>,
+    callbacks: Vec<Box<CallbackFn>>,
+}
+
+impl Debug for BuiltIns {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "BuiltIns {{ built_ins: {:?} }}",
+            self.built_ins
+        ))
+    }
+}
 
 impl Default for BuiltIns {
     fn default() -> Self {
@@ -89,18 +111,40 @@ impl BuiltIns {
         context: &'a GritExecContext<'a>,
         state: &mut State<'a, GritQueryContext>,
         logs: &mut AnalysisLogs,
-    ) -> Result<GritResolvedPattern<'a>> {
-        self.0[call.index].call(&call.args, context, state, logs)
+    ) -> GritResult<GritResolvedPattern<'a>> {
+        self.built_ins[call.index].call(&call.args, context, state, logs)
+    }
+
+    pub(crate) fn call_callback<'a>(
+        &self,
+        call: &'a CallbackPattern,
+        context: &'a GritExecContext<'a>,
+        binding: &GritResolvedPattern<'a>,
+        state: &mut State<'a, GritQueryContext>,
+        logs: &mut AnalysisLogs,
+    ) -> GritResult<bool> {
+        (self.callbacks[call.callback_index])(binding, context, state, logs)
+    }
+
+    /// Add an anonymous built-in, used for callbacks
+    /// Returns a pattern that can be used to call the callback
+    pub fn add_callback(&mut self, func: Box<CallbackFn>) -> Pattern<GritQueryContext> {
+        self.callbacks.push(func);
+        let index = self.callbacks.len() - 1;
+        Pattern::CallbackPattern(Box::new(CallbackPattern::new(index)))
     }
 
     pub(crate) fn get_built_ins(&self) -> &[BuiltInFunction] {
-        &self.0
+        &self.built_ins
     }
 }
 
 impl From<Vec<BuiltInFunction>> for BuiltIns {
     fn from(built_ins: Vec<BuiltInFunction>) -> Self {
-        Self(built_ins)
+        Self {
+            built_ins,
+            callbacks: Vec::new(),
+        }
     }
 }
 
@@ -109,10 +153,12 @@ fn capitalize_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("capitalize() takes 1 argument: string");
+        return Err(GritPatternError::new(
+            "capitalize() takes 1 argument: string",
+        ));
     };
 
     let string = arg1.text(&state.files, context.language())?;
@@ -126,10 +172,10 @@ fn distinct_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("distinct() takes 1 argument: list");
+        return Err(GritPatternError::new("distinct() takes 1 argument: list"));
     };
 
     match arg1 {
@@ -145,7 +191,9 @@ fn distinct_fn<'a>(
         GritResolvedPattern::Binding(binding) => match binding.last() {
             Some(binding) => {
                 let Some(list_items) = binding.list_items() else {
-                    bail!("distinct() requires a list as the first argument");
+                    return Err(GritPatternError::new(
+                        "distinct() requires a list as the first argument",
+                    ));
                 };
 
                 let mut unique_list = Vec::new();
@@ -159,7 +207,11 @@ fn distinct_fn<'a>(
             }
             None => Ok(GritResolvedPattern::Binding(binding)),
         },
-        _ => bail!("distinct() requires a list as the first argument"),
+        _ => {
+            return Err(GritPatternError::new(
+                "distinct() requires a list as the first argument",
+            ))
+        }
     }
 }
 
@@ -168,11 +220,13 @@ fn join_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let mut args = args.into_iter();
     let (Some(Some(arg1)), Some(Some(arg2))) = (args.next(), args.next()) else {
-        bail!("join() takes 2 arguments: list and separator");
+        return Err(GritPatternError::new(
+            "join() takes 2 arguments: list and separator",
+        ));
     };
 
     let separator = arg2.text(&state.files, context.language())?;
@@ -181,7 +235,9 @@ fn join_fn<'a>(
     } else if let Some(items) = arg1.get_list_binding_items() {
         JoinFn::from_patterns(items, separator.to_string())
     } else {
-        bail!("join() requires a list as the first argument");
+        return Err(GritPatternError::new(
+            "join() requires a list as the first argument",
+        ));
     };
 
     let snippet = ResolvedSnippet::LazyFn(Box::new(LazyBuiltIn::Join(join)));
@@ -193,33 +249,51 @@ fn length_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("length() takes 1 argument: list or string");
+        return Err(GritPatternError::new(
+            "length() takes 1 argument: list or string",
+        ));
     };
 
     Ok(match arg1 {
-        GritResolvedPattern::List(list) => {
-            ResolvedPattern::from_constant(Constant::Integer(list.len().try_into()?))
-        }
-        GritResolvedPattern::Binding(binding) => match binding.last() {
-            Some(resolved_pattern) => {
-                let length = if let Some(list_items) = resolved_pattern.list_items() {
-                    list_items.count()
-                } else {
-                    resolved_pattern.text(context.language())?.len()
-                };
-                ResolvedPattern::from_constant(Constant::Integer(length.try_into()?))
+        GritResolvedPattern::List(list) => ResolvedPattern::from_constant(Constant::Integer(
+            list.len()
+                .try_into()
+                .map_err(|error: TryFromIntError| GritPatternError::new(error.to_string()))?,
+        )),
+        GritResolvedPattern::Binding(binding) => {
+            match binding.last() {
+                Some(resolved_pattern) => {
+                    let length = if let Some(list_items) = resolved_pattern.list_items() {
+                        list_items.count()
+                    } else {
+                        resolved_pattern.text(context.language())?.len()
+                    };
+                    ResolvedPattern::from_constant(Constant::Integer(length.try_into().map_err(
+                        |error: TryFromIntError| GritPatternError::new(error.to_string()),
+                    )?))
+                }
+                None => {
+                    return Err(GritPatternError::new(
+                        "length() requires a list or string as the first argument",
+                    ))
+                }
             }
-            None => bail!("length() requires a list or string as the first argument"),
-        },
+        }
         resolved_pattern => {
             let Ok(text) = resolved_pattern.text(&state.files, context.language()) else {
-                bail!("length() requires a list or string as the first argument");
+                return Err(GritPatternError::new(
+                    "length() requires a list or string as the first argument",
+                ));
             };
 
-            ResolvedPattern::from_constant(Constant::Integer(text.len().try_into()?))
+            ResolvedPattern::from_constant(Constant::Integer(
+                text.len()
+                    .try_into()
+                    .map_err(|error: TryFromIntError| GritPatternError::new(error.to_string()))?,
+            ))
         }
     })
 }
@@ -229,10 +303,12 @@ fn lowercase_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("lowercase() takes 1 argument: string");
+        return Err(GritPatternError::new(
+            "lowercase() takes 1 argument: string",
+        ));
     };
 
     let string = arg1.text(&state.files, context.language())?;
@@ -246,7 +322,7 @@ fn random_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
 
     match args.as_slice() {
@@ -263,7 +339,11 @@ fn random_fn<'a>(
             let value = state.get_rng().gen::<f64>();
             Ok(ResolvedPattern::from_constant(Constant::Float(value)))
         }
-        _ => bail!("random() takes 0 or 2 arguments: an optional start and end"),
+        _ => {
+            return Err(GritPatternError::new(
+                "random() takes 0 or 2 arguments: an optional start and end",
+            ))
+        }
     }
 }
 
@@ -273,10 +353,10 @@ fn resolve_path_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("resolve() takes 1 argument: path");
+        return Err(GritPatternError::new("resolve() takes 1 argument: path"));
     };
 
     let current_file = get_absolute_file_name(state, context.language())?;
@@ -292,10 +372,10 @@ fn shuffle_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("shuffle() takes 1 argument: list");
+        return Err(GritPatternError::new("shuffle() takes 1 argument: list"));
     };
 
     let mut list: Vec<_> = if let Some(items) = arg1.get_list_items() {
@@ -303,7 +383,9 @@ fn shuffle_fn<'a>(
     } else if let Some(items) = arg1.get_list_binding_items() {
         items.collect()
     } else {
-        bail!("shuffle() requires a list as the first argument");
+        return Err(GritPatternError::new(
+            "shuffle() requires a list as the first argument",
+        ));
     };
 
     list.shuffle(state.get_rng());
@@ -315,11 +397,13 @@ fn split_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let mut args = args.into_iter();
     let (Some(Some(arg1)), Some(Some(arg2))) = (args.next(), args.next()) else {
-        bail!("split() takes 2 arguments: string and separator");
+        return Err(GritPatternError::new(
+            "split() takes 2 arguments: string and separator",
+        ));
     };
 
     let separator = arg2.text(&state.files, context.language())?;
@@ -337,10 +421,10 @@ fn text_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("text() takes 1 argument: string");
+        return Err(GritPatternError::new("text() takes 1 argument: string"));
     };
 
     let string = arg1.text(&state.files, context.language())?;
@@ -352,11 +436,13 @@ fn trim_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let mut args = args.into_iter();
     let (Some(Some(arg1)), Some(Some(arg2))) = (args.next(), args.next()) else {
-        bail!("trim() takes 2 arguments: string and trim_chars");
+        return Err(GritPatternError::new(
+            "trim() takes 2 arguments: string and trim_chars",
+        ));
     };
 
     let trim_chars = arg2.text(&state.files, context.language())?;
@@ -373,10 +459,12 @@ fn uppercase_fn<'a>(
     context: &'a GritExecContext<'a>,
     state: &mut State<'a, GritQueryContext>,
     logs: &mut AnalysisLogs,
-) -> Result<GritResolvedPattern<'a>> {
+) -> GritResult<GritResolvedPattern<'a>> {
     let args = GritResolvedPattern::from_patterns(args, state, context, logs)?;
     let Some(Some(arg1)) = args.into_iter().next() else {
-        bail!("uppercase() takes 1 argument: string");
+        return Err(GritPatternError::new(
+            "uppercase() takes 1 argument: string",
+        ));
     };
 
     let string = arg1.text(&state.files, context.language())?;
@@ -393,14 +481,19 @@ fn capitalize(s: &str) -> Cow<str> {
     Cow::Borrowed(s)
 }
 
-fn resolve<'a>(target_path: Cow<'a, str>, from_file: Cow<'a, str>) -> Result<String> {
+fn resolve<'a>(target_path: Cow<'a, str>, from_file: Cow<'a, str>) -> GritResult<String> {
     let Some(source_path) = Path::new(from_file.as_ref()).parent() else {
-        bail!("could not get parent directory of file name {}", &from_file);
+        return Err(GritPatternError::new(format!(
+            "could not get parent directory of file name {}",
+            &from_file,
+        )));
     };
     let our_path = Path::new(target_path.as_ref());
     let absolutized = our_path.absolutize_from(source_path)?;
     Ok(absolutized
         .to_str()
-        .ok_or_else(|| anyhow!("could not build absolute path from file name {target_path}"))?
+        .ok_or_else(|| {
+            GritPatternError::new("could not build absolute path from file name {target_path}")
+        })?
         .to_owned())
 }

--- a/crates/biome_grit_patterns/src/grit_built_in_functions.rs
+++ b/crates/biome_grit_patterns/src/grit_built_in_functions.rs
@@ -207,11 +207,9 @@ fn distinct_fn<'a>(
             }
             None => Ok(GritResolvedPattern::Binding(binding)),
         },
-        _ => {
-            return Err(GritPatternError::new(
-                "distinct() requires a list as the first argument",
-            ))
-        }
+        _ => Err(GritPatternError::new(
+            "distinct() requires a list as the first argument",
+        )),
     }
 }
 
@@ -339,11 +337,9 @@ fn random_fn<'a>(
             let value = state.get_rng().gen::<f64>();
             Ok(ResolvedPattern::from_constant(Constant::Float(value)))
         }
-        _ => {
-            return Err(GritPatternError::new(
-                "random() takes 0 or 2 arguments: an optional start and end",
-            ))
-        }
+        _ => Err(GritPatternError::new(
+            "random() takes 0 or 2 arguments: an optional start and end",
+        )),
     }
 }
 

--- a/crates/biome_grit_patterns/src/grit_code_snippet.rs
+++ b/crates/biome_grit_patterns/src/grit_code_snippet.rs
@@ -1,12 +1,12 @@
 use crate::grit_context::{GritExecContext, GritQueryContext};
 use crate::grit_resolved_pattern::GritResolvedPattern;
 use crate::grit_target_node::GritTargetSyntaxKind;
-use anyhow::Result;
 use grit_pattern_matcher::binding::Binding;
 use grit_pattern_matcher::context::ExecContext;
 use grit_pattern_matcher::pattern::{
     CodeSnippet, DynamicPattern, Matcher, Pattern, PatternName, ResolvedPattern, State,
 };
+use grit_util::error::GritResult;
 use grit_util::AnalysisLogs;
 
 #[derive(Clone, Debug)]
@@ -33,7 +33,7 @@ impl Matcher<GritQueryContext> for GritCodeSnippet {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<bool> {
+    ) -> GritResult<bool> {
         let Some(binding) = resolved.get_last_binding() else {
             return Ok(resolved.text(&state.files, context.language())?.trim() == self.source);
         };

--- a/crates/biome_grit_patterns/src/grit_file.rs
+++ b/crates/biome_grit_patterns/src/grit_file.rs
@@ -7,7 +7,7 @@ use grit_pattern_matcher::{
     constant::Constant,
     pattern::{File, FilePtr, FileRegistry, ResolvedFile, ResolvedPattern},
 };
-use grit_util::Ast;
+use grit_util::{error::GritResult, Ast};
 use path_absolutize::Absolutize;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -28,7 +28,7 @@ impl<'a> File<'a, GritQueryContext> for GritFile<'a> {
         &self,
         files: &FileRegistry<'a, GritQueryContext>,
         language: &GritTargetLanguage,
-    ) -> anyhow::Result<GritResolvedPattern<'a>> {
+    ) -> GritResult<GritResolvedPattern<'a>> {
         match self {
             Self::Resolved(resolved) => {
                 let name = resolved.name.text(files, language)?;

--- a/crates/biome_grit_patterns/src/grit_node.rs
+++ b/crates/biome_grit_patterns/src/grit_node.rs
@@ -1,7 +1,7 @@
 use crate::util::TextRangeGritExt;
 use biome_grit_syntax::GritSyntaxNode;
-use grit_util::{AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
-use std::{borrow::Cow, ops::Deref, str::Utf8Error};
+use grit_util::{error::GritResult, AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
+use std::{borrow::Cow, ops::Deref};
 
 /// Wrapper around `GritSyntaxNode` as produced by our internal Grit parser.
 ///
@@ -71,7 +71,7 @@ impl GritAstNode for GritNode {
         self.0.prev_sibling().map(Into::into)
     }
 
-    fn text(&self) -> Result<Cow<str>, Utf8Error> {
+    fn text(&self) -> GritResult<Cow<str>> {
         Ok(Cow::Owned(self.0.text_trimmed().to_string()))
     }
 

--- a/crates/biome_grit_patterns/src/grit_node_patterns.rs
+++ b/crates/biome_grit_patterns/src/grit_node_patterns.rs
@@ -3,13 +3,13 @@ use crate::grit_resolved_pattern::GritResolvedPattern;
 use crate::grit_target_language::LeafEquivalenceClass;
 use crate::grit_target_node::{GritTargetNode, GritTargetSyntaxKind};
 use crate::{CompileError, GritTargetLanguage};
-use anyhow::Result;
 use grit_pattern_matcher::binding::Binding;
-use grit_pattern_matcher::context::ExecContext;
+use grit_pattern_matcher::context::{ExecContext, StaticDefinitions};
 use grit_pattern_matcher::pattern::{
     AstLeafNodePattern, AstNodePattern, Matcher, Pattern, PatternName, PatternOrPredicate,
     ResolvedPattern, State,
 };
+use grit_util::error::GritResult;
 use grit_util::{AnalysisLogs, Language};
 
 #[derive(Clone, Debug)]
@@ -21,7 +21,10 @@ pub struct GritNodePattern {
 impl AstNodePattern<GritQueryContext> for GritNodePattern {
     const INCLUDES_TRIVIA: bool = true;
 
-    fn children(&self) -> Vec<PatternOrPredicate<GritQueryContext>> {
+    fn children(
+        &self,
+        _definitions: &StaticDefinitions<GritQueryContext>,
+    ) -> Vec<PatternOrPredicate<GritQueryContext>> {
         self.args
             .iter()
             .map(|arg| PatternOrPredicate::Pattern(&arg.pattern))
@@ -40,7 +43,7 @@ impl Matcher<GritQueryContext> for GritNodePattern {
         init_state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<bool> {
+    ) -> GritResult<bool> {
         let Some(binding) = binding.get_last_binding() else {
             return Ok(false);
         };
@@ -161,7 +164,7 @@ impl Matcher<GritQueryContext> for GritLeafNodePattern {
         _state: &mut State<'a, GritQueryContext>,
         _context: &'a GritExecContext,
         _logs: &mut AnalysisLogs,
-    ) -> Result<bool> {
+    ) -> GritResult<bool> {
         let Some(node) = binding.get_last_binding().and_then(Binding::singleton) else {
             return Ok(false);
         };

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -13,18 +13,16 @@ use crate::pattern_compiler::{
 };
 use crate::variables::{VarRegistry, VariableLocations};
 use crate::CompileError;
-use anyhow::bail;
-use anyhow::Result;
 use biome_grit_syntax::{GritRoot, GritRootExt};
 use grit_pattern_matcher::constants::{
     ABSOLUTE_PATH_INDEX, FILENAME_INDEX, NEW_FILES_INDEX, PROGRAM_INDEX,
 };
 use grit_pattern_matcher::file_owners::{FileOwner, FileOwners};
 use grit_pattern_matcher::pattern::{
-    FilePtr, FileRegistry, Matcher, Pattern, ResolvedPattern, State, VariableSourceLocations,
+    FilePtr, FileRegistry, Matcher, Pattern, ResolvedPattern, State, VariableSource,
 };
+use grit_util::error::{GritPatternError, GritResult};
 use grit_util::{AnalysisLogs, Ast, ByteRange, InputRanges, Range, VariableMatch};
-use im::Vector;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -64,7 +62,10 @@ pub struct GritQuery {
 }
 
 impl GritQuery {
-    pub fn execute(&self, file: GritTargetFile) -> Result<(Vec<GritQueryResult>, AnalysisLogs)> {
+    pub fn execute(
+        &self,
+        file: GritTargetFile,
+    ) -> GritResult<(Vec<GritQueryResult>, AnalysisLogs)> {
         let file_owners = FileOwners::new();
         let files = vec![file];
         let file_ptr = FilePtr::new(0, 0);
@@ -125,14 +126,14 @@ impl GritQuery {
 
         let mut vars_array = vec![GLOBAL_VARS
             .iter()
-            .map(|global_var| VariableSourceLocations {
+            .map(|global_var| VariableSource::Compiled {
                 name: global_var.0.to_string(),
                 file: source_path
                     .map(Path::to_string_lossy)
                     .map_or_else(|| "unnamed".to_owned(), |p| p.to_string()),
                 locations: BTreeSet::new(),
             })
-            .collect::<Vec<VariableSourceLocations>>()];
+            .collect::<Vec<VariableSource>>()];
         let mut global_vars: BTreeMap<String, usize> = GLOBAL_VARS
             .iter()
             .map(|(global_var, index)| ((*global_var).to_string(), *index))
@@ -193,9 +194,9 @@ pub enum GritQueryResult {
 }
 
 impl GritQueryResult {
-    pub fn from_file(file: &Vector<&FileOwner<GritTargetTree>>) -> anyhow::Result<Option<Self>> {
+    pub fn from_file(file: &Vec<&FileOwner<GritTargetTree>>) -> GritResult<Option<Self>> {
         if file.is_empty() {
-            bail!("cannot have file with no versions")
+            return Err(GritPatternError::new("cannot have file with no versions"));
         }
 
         let result = if file.len() == 1 {
@@ -218,8 +219,8 @@ impl GritQueryResult {
             }
         } else {
             Some(GritQueryResult::Rewrite(Rewrite::from_file(
-                file.front().unwrap(),
-                file.back().unwrap(),
+                file.first().unwrap(),
+                file.last().unwrap(),
             )?))
         };
 
@@ -296,11 +297,11 @@ impl Rewrite {
     fn from_file(
         initial: &FileOwner<GritTargetTree>,
         rewritten_file: &FileOwner<GritTargetTree>,
-    ) -> anyhow::Result<Self> {
+    ) -> GritResult<Self> {
         let original = if let Some(ranges) = &initial.matches.borrow().input_matches {
             Match::from_file_ranges(ranges, &initial.name)
         } else {
-            bail!("cannot have rewrite without matches")
+            return Err(GritPatternError::new("cannot have rewrite without matches"));
         };
         let rewritten = OutputFile::from_file(rewritten_file);
         Ok(Rewrite::new(original, rewritten))

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -194,7 +194,7 @@ pub enum GritQueryResult {
 }
 
 impl GritQueryResult {
-    pub fn from_file(file: &Vec<&FileOwner<GritTargetTree>>) -> GritResult<Option<Self>> {
+    pub fn from_file(file: &[&FileOwner<GritTargetTree>]) -> GritResult<Option<Self>> {
         if file.is_empty() {
             return Err(GritPatternError::new("cannot have file with no versions"));
         }

--- a/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
+++ b/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
@@ -5,7 +5,6 @@ use crate::grit_target_node::GritTargetNode;
 use crate::grit_tree::GritTargetTree;
 use crate::GritTargetLanguage;
 use crate::{grit_binding::GritBinding, grit_context::GritQueryContext};
-use anyhow::{anyhow, bail, Error, Result};
 use grit_pattern_matcher::binding::Binding;
 use grit_pattern_matcher::constant::Constant;
 use grit_pattern_matcher::context::{ExecContext, QueryContext};
@@ -15,6 +14,7 @@ use grit_pattern_matcher::pattern::{
     FileRegistry, GritCall, ListIndex, Pattern, PatternName, PatternOrResolved, ResolvedFile,
     ResolvedPattern, ResolvedSnippet, State,
 };
+use grit_util::error::{GritPatternError, GritResult};
 use grit_util::{AnalysisLogs, Ast, CodeRange, Range};
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
@@ -39,14 +39,16 @@ impl<'a> GritResolvedPattern<'a> {
         Self::from_binding(GritBinding::from_node(tree.root_node()))
     }
 
-    fn to_snippets(&self) -> Result<Vec<ResolvedSnippet<'a, GritQueryContext>>> {
+    fn to_snippets(&self) -> GritResult<Vec<ResolvedSnippet<'a, GritQueryContext>>> {
         match self {
             Self::Snippets(snippets) => Ok(snippets.clone()),
             Self::Binding(bindings) => Ok(vec![ResolvedSnippet::from_binding(
                 bindings
                     .last()
                     .ok_or_else(|| {
-                        anyhow::anyhow!("cannot create resolved snippet from unresolved binding")
+                        GritPatternError::new(
+                            "cannot create resolved snippet from unresolved binding",
+                        )
                     })?
                     .to_owned(),
             )]),
@@ -72,11 +74,11 @@ impl<'a> GritResolvedPattern<'a> {
                 snippets.push(ResolvedSnippet::Text("}".into()));
                 Ok(snippets)
             }
-            Self::File(_) => Err(anyhow::anyhow!(
-                "cannot convert ResolvedPattern::File to ResolvedSnippet"
+            Self::File(_) => Err(GritPatternError::new(
+                "cannot convert ResolvedPattern::File to ResolvedSnippet",
             )),
-            Self::Files(_) => Err(anyhow::anyhow!(
-                "cannot convert ResolvedPattern::Files to ResolvedSnippet"
+            Self::Files(_) => Err(GritPatternError::new(
+                "cannot convert ResolvedPattern::Files to ResolvedSnippet",
             )),
             Self::Constant(constant) => {
                 Ok(vec![ResolvedSnippet::Text(constant.to_string().into())])
@@ -119,7 +121,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut grit_util::AnalysisLogs,
-    ) -> anyhow::Result<Self> {
+    ) -> GritResult<Self> {
         let mut parts = Vec::new();
         for part in &snippet.parts {
             match part {
@@ -127,17 +129,19 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                     parts.push(ResolvedSnippet::Text(string.into()));
                 }
                 DynamicSnippetPart::Variable(var) => {
-                    let content = &state.bindings[var.scope].last().unwrap()[var.index];
+                    let content = &state.bindings[var.try_scope().unwrap() as usize]
+                        .last()
+                        .unwrap()[var.try_index().unwrap() as usize];
                     let name = &content.name;
                     // feels weird not sure if clone is correct
                     let value = if let Some(value) = &content.value {
-                        value.clone()
+                        value.clone().into()
                     } else if let Some(pattern) = content.pattern {
                         Self::from_pattern(pattern, state, context, logs)?
                     } else {
-                        anyhow::bail!(
+                        return Err(GritPatternError::new(format!(
                             "cannot create resolved snippet from unresolved variable {name}"
-                        )
+                        )));
                     };
                     let value = value.to_snippets()?;
                     parts.extend(value);
@@ -152,10 +156,12 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
+    ) -> GritResult<Self> {
         match pattern {
             DynamicPattern::Variable(var) => {
-                let content = &state.bindings[var.scope].last().unwrap()[var.index];
+                let content = &state.bindings[var.try_scope().unwrap() as usize]
+                    .last()
+                    .unwrap()[var.try_index().unwrap() as usize];
                 let name = &content.name;
                 // feels weird not sure if clone is correct
                 if let Some(value) = &content.value {
@@ -163,7 +169,10 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                 } else if let Some(pattern) = content.pattern {
                     Self::from_pattern(pattern, state, context, logs)
                 } else {
-                    anyhow::bail!("cannot create resolved snippet from unresolved variable {name}")
+                    return Err(GritPatternError::new(format!(
+                        "cannot create resolved snippet from unresolved variable {}",
+                        name
+                    )));
                 }
             }
             DynamicPattern::Accessor(accessor) => {
@@ -191,7 +200,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
+    ) -> GritResult<Self> {
         match accessor.get(state, context.language())? {
             Some(PatternOrResolved::Pattern(pattern)) => {
                 Self::from_pattern(pattern, state, context, logs)
@@ -207,7 +216,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
+    ) -> GritResult<Self> {
         match index.get(state, context.language())? {
             Some(PatternOrResolved::Pattern(pattern)) => {
                 Self::from_pattern(pattern, state, context, logs)
@@ -223,7 +232,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         state: &mut State<'a, GritQueryContext>,
         context: &'a GritExecContext,
         logs: &mut AnalysisLogs,
-    ) -> Result<Self> {
+    ) -> GritResult<Self> {
         match pattern {
             Pattern::Dynamic(pattern) => Self::from_dynamic_pattern(pattern, state, context, logs),
             Pattern::CodeSnippet(GritCodeSnippet {
@@ -233,6 +242,10 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
             Pattern::CallBuiltIn(built_in) => built_in.call(state, context, logs),
             Pattern::CallFunction(func) => func.call(state, context, logs),
             Pattern::CallForeignFunction(_) => unimplemented!(),
+            Pattern::CallbackPattern(callback) => Err(GritPatternError::new(format!(
+                "cannot make resolved pattern from callback pattern {}",
+                callback.name()
+            ))),
             Pattern::StringConstant(string) => Ok(Self::Snippets(vec![ResolvedSnippet::Text(
                 (&string.text).into(),
             )])),
@@ -240,7 +253,9 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
             Pattern::FloatConstant(double) => Ok(Self::Constant(Constant::Float(double.value))),
             Pattern::BooleanConstant(bool) => Ok(Self::Constant(Constant::Boolean(bool.value))),
             Pattern::Variable(var) => {
-                let content = &state.bindings[var.scope].last().unwrap()[var.index];
+                let content = &state.bindings[var.try_scope().unwrap() as usize]
+                    .last()
+                    .unwrap()[var.try_index().unwrap() as usize];
                 let name = &content.name;
                 // feels weird not sure if clone is correct
                 if let Some(value) = &content.value {
@@ -248,14 +263,17 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                 } else if let Some(pattern) = content.pattern {
                     Self::from_pattern(pattern, state, context, logs)
                 } else {
-                    anyhow::bail!("cannot create resolved snippet from unresolved variable {name}")
+                    return Err(GritPatternError::new(format!(
+                        "cannot create resolved snippet from unresolved variable {}",
+                        name
+                    )));
                 }
             }
             Pattern::List(list) => list
                 .patterns
                 .iter()
                 .map(|pattern| Self::from_pattern(pattern, state, context, logs))
-                .collect::<Result<Vec<_>>>()
+                .collect::<GritResult<Vec<_>>>()
                 .map(Self::List),
             Pattern::ListIndex(index) => Self::from_list_index(index, state, context, logs),
             Pattern::Map(map) => map
@@ -267,7 +285,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                         Self::from_pattern(value, state, context, logs)?,
                     ))
                 })
-                .collect::<Result<BTreeMap<_, _>>>()
+                .collect::<GritResult<BTreeMap<_, _>>>()
                 .map(Self::Map),
             Pattern::Accessor(accessor) => Self::from_accessor(accessor, state, context, logs),
             Pattern::File(file_pattern) => {
@@ -320,7 +338,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
             | Pattern::Every(_)
             | Pattern::Dots
             | Pattern::Like(_)
-            | Pattern::Sequential(_) => Err(anyhow::anyhow!(format!(
+            | Pattern::Sequential(_) => Err(GritPatternError::new(format!(
                 "cannot make resolved pattern from arbitrary pattern {}",
                 pattern.name()
             ))),
@@ -330,44 +348,44 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
     fn extend(
         &mut self,
         _with: Self,
-        _effects: &mut im::Vector<Effect<'a, GritQueryContext>>,
+        _effects: &mut Vec<Effect<'a, GritQueryContext>>,
         _language: &<GritQueryContext as QueryContext>::Language<'a>,
-    ) -> anyhow::Result<()> {
-        bail!("Not implemented") // TODO: Implement rewriting
+    ) -> GritResult<()> {
+        Err(GritPatternError::new("Not implemented")) // TODO: Implement rewriting
     }
 
     fn float(
         &self,
         state: &FileRegistry<'a, GritQueryContext>,
         language: &GritTargetLanguage,
-    ) -> Result<f64> {
+    ) -> GritResult<f64> {
         match self {
             Self::Constant(c) => match c {
                 Constant::Float(d) => Ok(*d),
                 Constant::Integer(i) => Ok(*i as f64),
                 Constant::String(s) => Ok(s.parse::<f64>()?),
-                Constant::Boolean(_) | Constant::Undefined => Err(anyhow::anyhow!("Cannot convert constant to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
+                Constant::Boolean(_) | Constant::Undefined => Err(GritPatternError::new("Cannot convert constant to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
             },
             Self::Snippets(s) => {
                 let text = s
                     .iter()
                     .map(|snippet| snippet.text(state, language))
-                    .collect::<Result<Vec<_>>>()?
+                    .collect::<GritResult<Vec<_>>>()?
                     .join("");
                 text.parse::<f64>().map_err(|_| {
-                    anyhow::anyhow!("Failed to convert snippet to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
+                    GritPatternError::new("Failed to convert snippet to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
                 })
             }
             Self::Binding(binding) => {
                 let text = binding
                     .last()
-                    .ok_or_else(|| anyhow::anyhow!("cannot grab text of resolved_pattern with no binding"))?
+                    .ok_or_else(|| GritPatternError::new("cannot grab text of resolved_pattern with no binding"))?
                     .text(language)?;
                 text.parse::<f64>().map_err(|_| {
-                    anyhow::anyhow!("Failed to convert binding to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
+                    GritPatternError::new("Failed to convert binding to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")
                 })
             }
-            Self::List(_) | Self::Map(_) | Self::File(_) | Self::Files(_) => Err(anyhow::anyhow!("Cannot convert type to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
+            Self::List(_) | Self::Map(_) | Self::File(_) | Self::Files(_) => Err(GritPatternError::new("Cannot convert type to double. Ensure that you are only attempting arithmetic operations on numeric-parsable types.")),
         }
     }
 
@@ -481,7 +499,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         &self,
         state: &mut State<'a, GritQueryContext>,
         language: &GritTargetLanguage,
-    ) -> Result<bool> {
+    ) -> GritResult<bool> {
         let truthiness = match self {
             Self::Binding(bindings) => bindings.last().map_or(false, Binding::is_truthy),
             Self::List(elements) => !elements.is_empty(),
@@ -508,8 +526,8 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         _memo: &mut HashMap<CodeRange, Option<String>>,
         _should_pad_snippet: bool,
         _logs: &mut AnalysisLogs,
-    ) -> Result<Cow<'a, str>> {
-        bail!("Not implemented") // TODO: Implement rewriting
+    ) -> GritResult<Cow<'a, str>> {
+        Err(GritPatternError::new("Not implemented")) // TODO: Implement rewriting
     }
 
     fn matches_undefined(&self) -> bool {
@@ -538,8 +556,8 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         _binding: &GritBinding,
         _is_first: bool,
         _language: &GritTargetLanguage,
-    ) -> Result<()> {
-        bail!("Not implemented") // TODO: Implement insertion padding
+    ) -> GritResult<()> {
+        Err(GritPatternError::new("Not implemented")) // TODO: Implement insertion padding
     }
 
     fn position(&self, language: &GritTargetLanguage) -> Option<Range> {
@@ -552,18 +570,18 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         None
     }
 
-    fn push_binding(&mut self, binding: GritBinding<'a>) -> Result<()> {
+    fn push_binding(&mut self, binding: GritBinding<'a>) -> GritResult<()> {
         let Self::Binding(bindings) = self else {
-            bail!("can only push to bindings");
+            return Err(GritPatternError::new("can only push to bindings"));
         };
 
         bindings.push(binding);
         Ok(())
     }
 
-    fn set_list_item_at_mut(&mut self, index: isize, value: Self) -> Result<bool> {
+    fn set_list_item_at_mut(&mut self, index: isize, value: Self) -> GritResult<bool> {
         let Self::List(items) = self else {
-            bail!("can only set items on a list");
+            return Err(GritPatternError::new("can only set items on a list"));
         };
 
         let Some(index) = to_unsigned(index, items.len()) else {
@@ -578,11 +596,13 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
         &self,
         state: &FileRegistry<'a, GritQueryContext>,
         language: &GritTargetLanguage,
-    ) -> Result<Cow<'a, str>> {
+    ) -> GritResult<Cow<'a, str>> {
         match self {
             Self::Binding(bindings) => Ok(bindings
                 .last()
-                .ok_or_else(|| anyhow!("cannot grab text of resolved_pattern with no binding"))?
+                .ok_or_else(|| {
+                    GritPatternError::new("cannot grab text of resolved_pattern with no binding")
+                })?
                 .text(language)?
                 .into_owned()
                 .into()),
@@ -590,13 +610,13 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                 .iter()
                 .try_fold(String::new(), |mut text, snippet| {
                     text.push_str(&snippet.text(state, language)?);
-                    Ok::<String, Error>(text)
+                    Ok::<String, GritPatternError>(text)
                 })?
                 .into()),
             Self::List(list) => Ok(list
                 .iter()
                 .map(|pattern| pattern.text(state, language))
-                .collect::<Result<Vec<_>>>()?
+                .collect::<GritResult<Vec<_>>>()?
                 .join(",")
                 .into()),
             Self::Map(map) => Ok(format!(

--- a/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
+++ b/crates/biome_grit_patterns/src/grit_resolved_pattern.rs
@@ -135,7 +135,7 @@ impl<'a> ResolvedPattern<'a, GritQueryContext> for GritResolvedPattern<'a> {
                     let name = &content.name;
                     // feels weird not sure if clone is correct
                     let value = if let Some(value) = &content.value {
-                        value.clone().into()
+                        value.clone()
                     } else if let Some(pattern) = content.pattern {
                         Self::from_pattern(pattern, state, context, logs)?
                     } else {

--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -2,8 +2,8 @@ use crate::grit_tree::GritTargetTree;
 use crate::util::TextRangeGritExt;
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxNode, JsSyntaxToken};
 use biome_rowan::{NodeOrToken, SyntaxKind, SyntaxSlot, TextRange};
-use grit_util::{AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
-use std::{borrow::Cow, fmt::Debug, ops::Deref, str::Utf8Error};
+use grit_util::{error::GritResult, AstCursor, AstNode as GritAstNode, ByteRange, CodeRange};
+use std::{borrow::Cow, fmt::Debug, ops::Deref};
 
 use NodeOrToken::*;
 
@@ -384,7 +384,7 @@ impl<'a> GritAstNode for GritTargetNode<'a> {
         }
     }
 
-    fn text(&self) -> Result<Cow<str>, Utf8Error> {
+    fn text(&self) -> GritResult<Cow<str>> {
         Ok(Cow::Borrowed(self.text()))
     }
 

--- a/crates/biome_grit_patterns/src/pattern_compiler/accumulate_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/accumulate_compiler.rs
@@ -15,13 +15,13 @@ impl AccumulateCompiler {
     ) -> Result<Accumulate<GritQueryContext>, CompileError> {
         let left = PatternCompiler::from_node(&node.left()?, context)?;
         let right = PatternCompiler::from_node_with_rhs(&node.right()?, context, true)?;
-        let dynamic_right = match &right {
-            Pattern::Dynamic(r) => Some(r.clone()),
+        let dynamic_right = match right.clone() {
+            Pattern::Dynamic(pattern) => Some(pattern),
             Pattern::CodeSnippet(GritCodeSnippet {
-                dynamic_snippet: Some(r),
+                dynamic_snippet: Some(snippet),
                 ..
-            }) => Some(r.clone()),
-            Pattern::Variable(v) => Some(DynamicPattern::Variable(*v)),
+            }) => Some(snippet),
+            Pattern::Variable(variable) => Some(DynamicPattern::Variable(variable)),
             _ => None,
         };
 
@@ -38,13 +38,13 @@ impl PrAccumulateCompiler {
     ) -> Result<Accumulate<GritQueryContext>, CompileError> {
         let left = Pattern::Variable(VariableCompiler::from_node(&node.left()?, context));
         let right = PatternCompiler::from_node_with_rhs(&node.right()?, context, true)?;
-        let dynamic_right = match &right {
-            Pattern::Dynamic(r) => Some(r.clone()),
+        let dynamic_right = match right.clone() {
+            Pattern::Dynamic(pattern) => Some(pattern),
             Pattern::CodeSnippet(GritCodeSnippet {
-                dynamic_snippet: Some(r),
+                dynamic_snippet: Some(snippet),
                 ..
-            }) => Some(r.clone()),
-            Pattern::Variable(v) => Some(DynamicPattern::Variable(*v)),
+            }) => Some(snippet),
+            Pattern::Variable(variable) => Some(DynamicPattern::Variable(variable)),
             _ => None,
         };
 

--- a/crates/biome_grit_patterns/src/pattern_compiler/as_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/as_compiler.rs
@@ -37,7 +37,7 @@ impl AsCompiler {
         let pattern = PatternCompiler::from_node(&pattern, context)?;
         let variable = VariableCompiler::from_node(&variable, context);
         Ok(Where::new(
-            Pattern::Variable(variable),
+            Pattern::Variable(variable.clone()),
             Predicate::Match(Box::new(Match::new(
                 Container::Variable(variable),
                 Some(pattern),

--- a/crates/biome_grit_patterns/src/pattern_compiler/bubble_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/bubble_compiler.rs
@@ -48,13 +48,8 @@ impl BubbleCompiler {
             .map(|(name, range)| Ok(Pattern::Variable(context.register_variable(name, range))))
             .collect::<Result<Vec<_>, CompileError>>()?;
 
-        let pattern_def = PatternDefinition::new(
-            "<bubble>".to_owned(),
-            local_scope_index,
-            params,
-            local_vars.values().copied().collect(),
-            body,
-        );
+        let pattern_def =
+            PatternDefinition::new("<bubble>".to_owned(), local_scope_index, params, body);
 
         Ok(Bubble::new(pattern_def, args))
     }

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -67,7 +67,7 @@ pub(super) fn call_pattern_from_node_with_name(
 
         let params = &built_in.params;
         Ok(Pattern::CallBuiltIn(Box::new(call_built_in_from_args(
-            args, params, index, lang,
+            args, params, index, lang, &name,
         )?)))
     } else if let Some(info) = context.compilation.function_definition_info.get(&name) {
         let args = match_args_to_params(&name, args, &collect_params(&info.parameters), lang)?;
@@ -87,15 +87,13 @@ fn call_built_in_from_args(
     params: &[&str],
     index: usize,
     lang: &impl Language,
+    name: &str,
 ) -> Result<CallBuiltIn<GritQueryContext>, CompileError> {
     let mut pattern_params = Vec::with_capacity(args.len());
     for param in params.iter() {
-        match args.remove(&(lang.metavariable_prefix().to_owned() + param)) {
-            Some(p) => pattern_params.push(Some(p)),
-            None => pattern_params.push(None),
-        }
+        pattern_params.push(args.remove(&(lang.metavariable_prefix().to_owned() + param)));
     }
-    Ok(CallBuiltIn::new(index, pattern_params))
+    Ok(CallBuiltIn::new(index, name, pattern_params))
 }
 
 pub(super) fn collect_params(parameters: &[(String, ByteRange)]) -> Vec<String> {

--- a/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
@@ -1,4 +1,4 @@
-use grit_pattern_matcher::pattern::VariableSourceLocations;
+use grit_pattern_matcher::pattern::VariableSource;
 use grit_util::ByteRange;
 
 use crate::{
@@ -49,7 +49,7 @@ pub(crate) struct NodeCompilationContext<'a> {
     /// The outer vector can be index using `scope_index`, while the individual
     /// variables in a scope can be indexed using the indices stored in `vars`
     /// and `global_vars`.
-    pub vars_array: &'a mut Vec<Vec<VariableSourceLocations>>,
+    pub vars_array: &'a mut Vec<Vec<VariableSource>>,
 
     /// Index of the local scope.
     ///
@@ -69,7 +69,7 @@ impl<'a> NodeCompilationContext<'a> {
     pub(crate) fn new(
         compilation_context: &'a CompilationContext,
         vars: &'a mut BTreeMap<String, usize>,
-        vars_array: &'a mut Vec<Vec<VariableSourceLocations>>,
+        vars_array: &'a mut Vec<Vec<VariableSource>>,
         global_vars: &'a mut BTreeMap<String, usize>,
         diagnostics: &'a mut Vec<CompilerDiagnostic>,
     ) -> Self {
@@ -81,6 +81,10 @@ impl<'a> NodeCompilationContext<'a> {
             global_vars,
             diagnostics,
         }
+    }
+
+    pub(crate) fn get_pattern_definition(&self, name: &str) -> Option<&DefinitionInfo> {
+        self.compilation.pattern_definition_info.get(name)
     }
 
     pub(crate) fn log(&mut self, diagnostic: CompilerDiagnostic) {

--- a/crates/biome_grit_patterns/src/pattern_compiler/log_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/log_compiler.rs
@@ -17,13 +17,19 @@ impl LogCompiler {
             &context.compilation.lang,
             &Some(vec!["message".to_owned(), "variable".to_owned()]),
         )?;
+
+        let var_name = named_args
+            .iter()
+            .find(|(name, _)| name == "variable")
+            .map(|(_, node)| node.to_string());
+
         let mut args = named_args_to_map(named_args, context)?;
         let message = args.remove("$message");
         let variable = args.remove("$variable");
+
         let variable = variable.and_then(|pattern| match pattern {
             Pattern::Variable(variable) => {
-                let source_location = &context.vars_array[variable.scope][variable.index];
-                Some(VariableInfo::new(source_location.name.clone(), variable))
+                Some(VariableInfo::new(var_name.unwrap_or_default(), variable))
             }
             _ => None,
         });

--- a/crates/biome_grit_patterns/src/pattern_compiler/not_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/not_compiler.rs
@@ -5,7 +5,10 @@ use super::{
 use crate::{diagnostics::CompilerDiagnostic, grit_context::GritQueryContext, CompileError};
 use biome_grit_syntax::{GritPatternNot, GritPredicateNot};
 use biome_rowan::AstNode;
-use grit_pattern_matcher::pattern::{Not, Pattern, PatternOrPredicate, PrNot, Predicate};
+use grit_pattern_matcher::{
+    context::StaticDefinitions,
+    pattern::{Not, Pattern, PatternOrPredicate, PrNot, Predicate},
+};
 
 pub(crate) struct NotCompiler;
 
@@ -15,7 +18,7 @@ impl NotCompiler {
         context: &mut NodeCompilationContext,
     ) -> Result<Not<GritQueryContext>, CompileError> {
         let pattern = PatternCompiler::from_node(&node.pattern()?, context)?;
-        if pattern.iter().any(|p| {
+        if pattern.iter(&StaticDefinitions::default()).any(|p| {
             matches!(
                 p,
                 PatternOrPredicate::Pattern(Pattern::Rewrite(_))
@@ -40,7 +43,7 @@ impl PrNotCompiler {
         context: &mut NodeCompilationContext,
     ) -> Result<PrNot<GritQueryContext>, CompileError> {
         let predicate = PredicateCompiler::from_node(&node.predicate()?, context)?;
-        if predicate.iter().any(|p| {
+        if predicate.iter(&StaticDefinitions::default()).any(|p| {
             matches!(
                 p,
                 PatternOrPredicate::Pattern(Pattern::Rewrite(_))

--- a/crates/biome_grit_patterns/src/pattern_compiler/pattern_definition_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/pattern_definition_compiler.rs
@@ -32,13 +32,7 @@ impl PatternDefinitionCompiler {
             &mut context,
         )?));
 
-        let pattern_def = PatternDefinition::new(
-            name.to_owned(),
-            scope_index,
-            params,
-            local_vars.values().copied().collect(),
-            body,
-        );
+        let pattern_def = PatternDefinition::new(name.to_owned(), scope_index, params, body);
         Ok(pattern_def)
     }
 }

--- a/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/snippet_compiler.rs
@@ -11,7 +11,7 @@ use grit_pattern_matcher::{
     constants::GLOBAL_VARS_SCOPE_INDEX,
     pattern::{
         is_reserved_metavariable, DynamicPattern, DynamicSnippet, DynamicSnippetPart, List,
-        Pattern, RegexLike, RegexPattern, Variable,
+        Pattern, RegexLike, RegexPattern, Variable, VariableSource,
     },
 };
 use grit_util::{traverse, Ast, AstNode, ByteRange, GritMetaValue, Language, Order, SnippetTree};
@@ -108,16 +108,18 @@ pub(crate) fn dynamic_snippet_from_source(
             source_range.start + byte_range.start + var.len(),
         );
         if let Some(var) = context.vars.get(var.as_ref()) {
-            context.vars_array[context.scope_index][*var]
-                .locations
-                .insert(range);
+            if let VariableSource::Compiled { locations, .. } =
+                &mut context.vars_array[context.scope_index][*var]
+            {
+                locations.insert(range);
+            }
             parts.push(DynamicSnippetPart::Variable(Variable::new(
                 context.scope_index,
                 *var,
             )));
         } else if let Some(var) = context.global_vars.get(var.as_ref()) {
             parts.push(DynamicSnippetPart::Variable(Variable::new(
-                GLOBAL_VARS_SCOPE_INDEX,
+                GLOBAL_VARS_SCOPE_INDEX.into(),
                 *var,
             )));
         } else if var.starts_with("$GLOBAL_") {
@@ -812,8 +814,12 @@ mod tests {
                                         slot_index: 0,
                                         pattern: Variable(
                                             Variable {
-                                                scope: 0,
-                                                index: 0,
+                                                internal: Static(
+                                                    VariableScope {
+                                                        scope: 0,
+                                                        index: 0,
+                                                    },
+                                                ),
                                             },
                                         ),
                                     },
@@ -877,8 +883,12 @@ mod tests {
                                                                         slot_index: 0,
                                                                         pattern: Variable(
                                                                             Variable {
-                                                                                scope: 0,
-                                                                                index: 0,
+                                                                                internal: Static(
+                                                                                    VariableScope {
+                                                                                        scope: 0,
+                                                                                        index: 0,
+                                                                                    },
+                                                                                ),
                                                                             },
                                                                         ),
                                                                     },
@@ -980,8 +990,12 @@ mod tests {
                                         slot_index: 0,
                                         pattern: Variable(
                                             Variable {
-                                                scope: 0,
-                                                index: 0,
+                                                internal: Static(
+                                                    VariableScope {
+                                                        scope: 0,
+                                                        index: 0,
+                                                    },
+                                                ),
                                             },
                                         ),
                                     },
@@ -1009,8 +1023,12 @@ mod tests {
                                                         slot_index: 0,
                                                         pattern: Variable(
                                                             Variable {
-                                                                scope: 0,
-                                                                index: 0,
+                                                                internal: Static(
+                                                                    VariableScope {
+                                                                        scope: 0,
+                                                                        index: 0,
+                                                                    },
+                                                                ),
                                                             },
                                                         ),
                                                     },
@@ -1134,8 +1152,12 @@ mod tests {
                                         slot_index: 0,
                                         pattern: Variable(
                                             Variable {
-                                                scope: 0,
-                                                index: 0,
+                                                internal: Static(
+                                                    VariableScope {
+                                                        scope: 0,
+                                                        index: 0,
+                                                    },
+                                                ),
                                             },
                                         ),
                                     },
@@ -1199,8 +1221,12 @@ mod tests {
                                                                         slot_index: 0,
                                                                         pattern: Variable(
                                                                             Variable {
-                                                                                scope: 0,
-                                                                                index: 0,
+                                                                                internal: Static(
+                                                                                    VariableScope {
+                                                                                        scope: 0,
+                                                                                        index: 0,
+                                                                                    },
+                                                                                ),
                                                                             },
                                                                         ),
                                                                     },

--- a/crates/biome_grit_patterns/src/pattern_compiler/step_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/step_compiler.rs
@@ -41,6 +41,7 @@ impl StepCompiler {
             | Pattern::CallBuiltIn(_)
             | Pattern::CallFunction(_)
             | Pattern::CallForeignFunction(_)
+            | Pattern::CallbackPattern(_)
             | Pattern::Assignment(_)
             | Pattern::Accumulate(_)
             | Pattern::Any(_)
@@ -99,10 +100,7 @@ impl StepCompiler {
                 }
             }
         }
-        let pattern = wrap_pattern_in_before_and_after_each_file(
-            pattern,
-            &context.compilation.pattern_definition_info,
-        )?;
+        let pattern = wrap_pattern_in_before_and_after_each_file(pattern, context)?;
 
         Ok(Step::new(pattern))
     }

--- a/crates/biome_grit_patterns/src/variables.rs
+++ b/crates/biome_grit_patterns/src/variables.rs
@@ -1,7 +1,6 @@
 use crate::grit_context::GritQueryContext;
-use grit_pattern_matcher::pattern::{VariableContent, VariableSourceLocations};
+use grit_pattern_matcher::pattern::{VariableContent, VariableSource};
 use grit_util::VariableBinding;
-use im::{vector, Vector};
 
 /// List of all variable locations in a query.
 ///
@@ -10,10 +9,10 @@ use im::{vector, Vector};
 /// variable, we track the separate locations (plural) where that variable
 /// occurs.
 #[derive(Clone, Debug, Default)]
-pub struct VariableLocations(Vec<Vec<VariableSourceLocations>>);
+pub struct VariableLocations(Vec<Vec<VariableSource>>);
 
 impl VariableLocations {
-    pub(crate) fn new(locations: Vec<Vec<VariableSourceLocations>>) -> Self {
+    pub(crate) fn new(locations: Vec<Vec<VariableSource>>) -> Self {
         Self(locations)
     }
 
@@ -22,12 +21,14 @@ impl VariableLocations {
         let mut variables = Vec::new();
         for (i, scope) in self.0.iter().enumerate() {
             for (j, var) in scope.iter().enumerate() {
-                if var.file.is_empty() {
-                    let name = &var.name;
+                if let VariableSource::Compiled {
+                    name, locations, ..
+                } = var
+                {
                     variables.push(VariableBinding {
                         name: name.to_owned(),
                         scoped_name: format!("{i}_{j}_{name}"),
-                        ranges: var.locations.iter().copied().collect(),
+                        ranges: locations.iter().copied().collect(),
                     });
                 }
             }
@@ -50,9 +51,9 @@ impl<'a> VarRegistry<'a> {
             .0
             .iter()
             .map(|scope| {
-                vector![scope
+                vec![scope
                     .iter()
-                    .map(|s| Box::new(VariableContent::new(s.name.clone())))
+                    .map(|s| Box::new(VariableContent::new(s.name().to_owned())))
                     .collect()]
             })
             .collect();
@@ -61,8 +62,7 @@ impl<'a> VarRegistry<'a> {
     }
 }
 
-pub(crate) type VarRegistryVector<'a> =
-    Vector<Vector<Vector<Box<VariableContent<'a, GritQueryContext>>>>>;
+pub(crate) type VarRegistryVector<'a> = Vec<Vec<Vec<Box<VariableContent<'a, GritQueryContext>>>>>;
 
 impl<'a> From<VarRegistry<'a>> for VarRegistryVector<'a> {
     fn from(value: VarRegistry<'a>) -> Self {


### PR DESCRIPTION
## Summary

Upgrades Grit crates to 0.4. Main difference is a change I made to [remove the `im` crate](https://github.com/getgrit/gritql/pull/536) as a dependency entirely. This resulted in a rougly 25-30% performance improvement in our Grit benchmarks, at least locally.

Another nice effect is that our `biome_grit_patterns` crate no longer depends on `anyhow`, though other Biome crates still do.

## Test Plan

CI should remain green.
