### PR TITLE
chore: run CI workflows on and against `next` branch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
     types: [ opened, synchronize ]
     branches:
       - main
+      - next
     paths:
       - 'Cargo.lock'
       - 'crates/**_parser/**/*.rs'
@@ -15,6 +16,7 @@ on:
   push:
     branches:
       - main
+      - next
     paths:
       - 'Cargo.lock'
       - 'crates/**_parser/**/*.rs'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 env:
   RUST_LOG: info

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
     paths: # Only run when changes are made to rust code or root Cargo
       - "crates/**"
       - "fuzz/**"

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - next
     paths: # Only run when changes are made to js code
       - 'editors/**'
       #     - 'crates/**'


### PR DESCRIPTION
## Summary

The `next` branch serves as preparation for the 2.0 release, and deserves the same protections as our `main` for now.

## Test Plan

CI should pass.
