### PR TITLE
feat(lint): add variable assignment tracking to `noDocumentCookie` rule

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/invalid.js
@@ -5,3 +5,19 @@ window.document.cookie = "foo=bar";
 globalThis.window.document.cookie = "foo=bar";
 
 document["cookie"] = "foo=bar"
+
+function document_is_global1(){
+    const doc = document;
+    doc.cookie = "bar=foo"
+}
+
+function document_is_global2(){
+    const foo = window.document;
+    const bar = foo;
+    bar.cookie = "foo=bar";
+}
+
+const global_doc = globalThis.document;
+function document_is_global3(){
+    global_doc.cookie = "foo=bar";
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/invalid.js.snap
@@ -11,6 +11,22 @@ window.document.cookie = "foo=bar";
 globalThis.window.document.cookie = "foo=bar";
 
 document["cookie"] = "foo=bar"
+
+function document_is_global1(){
+    const doc = document;
+    doc.cookie = "bar=foo"
+}
+
+function document_is_global2(){
+    const foo = window.document;
+    const bar = foo;
+    bar.cookie = "foo=bar";
+}
+
+const global_doc = globalThis.document;
+function document_is_global3(){
+    global_doc.cookie = "foo=bar";
+}
 ```
 
 # Diagnostics
@@ -87,6 +103,58 @@ invalid.js:7:1 lint/nursery/noDocumentCookie ━━━━━━━━━━━�
     6 │ 
   > 7 │ document["cookie"] = "foo=bar"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ function document_is_global1(){
+  
+  i Consider using the Cookie Store API.
+  
+
+```
+
+```
+invalid.js:11:5 lint/nursery/noDocumentCookie ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Direct assigning to document.cookie is not recommended.
+  
+     9 │ function document_is_global1(){
+    10 │     const doc = document;
+  > 11 │     doc.cookie = "bar=foo"
+       │     ^^^^^^^^^^^^^^^^^^^^^^
+    12 │ }
+    13 │ 
+  
+  i Consider using the Cookie Store API.
+  
+
+```
+
+```
+invalid.js:17:5 lint/nursery/noDocumentCookie ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Direct assigning to document.cookie is not recommended.
+  
+    15 │     const foo = window.document;
+    16 │     const bar = foo;
+  > 17 │     bar.cookie = "foo=bar";
+       │     ^^^^^^^^^^^^^^^^^^^^^^
+    18 │ }
+    19 │ 
+  
+  i Consider using the Cookie Store API.
+  
+
+```
+
+```
+invalid.js:22:5 lint/nursery/noDocumentCookie ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Direct assigning to document.cookie is not recommended.
+  
+    20 │ const global_doc = globalThis.document;
+    21 │ function document_is_global3(){
+  > 22 │     global_doc.cookie = "foo=bar";
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │ }
   
   i Consider using the Cookie Store API.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/valid.js
@@ -15,8 +15,3 @@ cookieStore
 function document_is_not_global1(document){
     document.cookie = "bar=foo"
 }
-
-function document_is_not_global2(){
-    const document = "foo";
-    document.cookie = "bar=foo"
-}

--- a/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noDocumentCookie/valid.js.snap
@@ -22,8 +22,4 @@ function document_is_not_global1(document){
     document.cookie = "bar=foo"
 }
 
-function document_is_not_global2(){
-    const document = "foo";
-    document.cookie = "bar=foo"
-}
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This is followup PR to #4204 .

This PR extends the implementation of `noDocumentCookie` by adding support for tracking assignments to variables.

Now, the following code will be supported.
```js
const doc = document;
doc.cookie = "foo = bar";
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
- Added tests to verify the handling of variable assignments.

<!-- What demonstrates that your implementation is correct? -->
