### PR TITLE
fix(useFilenamingConvention): take export renaming into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,27 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [useFilenamingConvention](https://biomejs.dev/linter/rules/use-filenaming-convention) now correctly handles renamed exports ([#4254](https://github.com/biomejs/biome/issues/4254)).
+
+  The rule allows the filename to be named as one of the exports of the module.
+  For instance, the file containing the following export can be named `Button`.
+
+  ```js
+  class Button {}
+  export { Button }
+  ```
+
+  The rule now correctly handles the renaming of an export.
+  For example, the file containing the following export can only be named `Button`.
+  Previously the rule expected the file to be named `A`.
+
+  ```js
+  class A {}
+  export { A as Button }
+  ```
+
+  Contributed by @Conaclos
+
 ### Parser
 
 #### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "biome_rowan",
  "rust-lapper",
  "rustc-hash 1.1.0",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Invalid_Renamed_Export.js
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Invalid_Renamed_Export.js
@@ -1,0 +1,2 @@
+class Invalid_Renamed_Export {}
+export { Invalid_Renamed_Export as A }

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Invalid_Renamed_Export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Invalid_Renamed_Export.js.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: Invalid_Renamed_Export.js
+---
+# Input
+```jsx
+class Invalid_Renamed_Export {}
+export { Invalid_Renamed_Export as A }
+```
+
+# Diagnostics
+```
+Invalid_Renamed_Export.js lint/style/useFilenamingConvention ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The filename should be in camelCase or kebab-case or snake_case or equal to the name of an export.
+  
+  i The filename could be renamed to one of the following names:
+    invalid-renamed-export.js
+    invalidRenamedExport.js
+    invalid_renamed_export.js
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.js
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.js
@@ -1,0 +1,2 @@
+class A {}
+export { A as Valid_Renamed_Export }

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.js.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: Valid_Renamed_Export.js
+---
+# Input
+```jsx
+class A {}
+export { A as Valid_Renamed_Export }
+```

--- a/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useFilenamingConvention/Valid_Renamed_Export.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: Valid_Renamed_Export.js
+---
+# Input
+```jsx
+class A {}
+export { A as Valid_Renamed_Export }
+```

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -15,6 +15,7 @@ biome_js_syntax = { workspace = true }
 biome_rowan     = { workspace = true }
 rust-lapper     = "1.1.0"
 rustc-hash      = { workspace = true }
+smallvec        = { workspace = true }
 
 [dev-dependencies]
 biome_console     = { path = "../biome_console" }

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -175,7 +175,8 @@ impl SemanticModelBuilder {
                 let binding_id = BindingId::new(self.bindings.len());
                 self.bindings.push(SemanticModelBindingData {
                     range,
-                    references: vec![],
+                    references: Vec::new(),
+                    export_by_start: smallvec::SmallVec::new(),
                 });
                 self.bindings_by_start.insert(range.start(), binding_id);
 
@@ -308,8 +309,15 @@ impl SemanticModelBuilder {
                         .push(SemanticModelUnresolvedReference { range }),
                 }
             }
-            Export { declaration_at, .. } => {
+            Export {
+                declaration_at,
+                range,
+            } => {
                 self.exported.insert(declaration_at);
+
+                let binding_id = self.bindings_by_start[&declaration_at];
+                let binding = &mut self.bindings[binding_id.index()];
+                binding.export_by_start.push(range.start());
             }
         }
     }

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -251,6 +251,17 @@ impl SemanticModel {
             })
     }
 
+    pub fn all_exported_bindings(&self) -> impl Iterator<Item = Binding> + '_ {
+        self.data
+            .exported
+            .iter()
+            .filter_map(|declared_at| self.data.bindings_by_start.get(declared_at).copied())
+            .map(|id| Binding {
+                data: self.data.clone(),
+                id,
+            })
+    }
+
     /// Returns the [Binding] of a reference.
     /// Can also be called from "binding" extension method.
     ///


### PR DESCRIPTION
## Summary

Fix #4254

To fix the issue, I added to the semantic model the capability of retrieving exports of a given binding.

Unfortunately, this adds 24 bytes of overhead to every binding data.
It should be possible to remove this overhead by distinguishing between read and export references.
However, this is a bigger change than the one I introduced here.
I left it for a future PR, unless the perf impact is visible.

Also, I took the opportunity of introducing a small optimization: instead of iterating over all bindings, we now iterate only over bindings that are actually exported.

## Test Plan

I added some tests.