### PR TITLE
feat(linter): noRestrictedImports add `patterns` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Add [noImgElement](https://biomejs.dev/linter/rules/no-img-element/). Contributed by @kaioduarte
 - Add [guardForIn](https://biomejs.dev/linter/rules/guard-for-in/). Contributed by @fireairforce
 - Add [noUselessStringRaw](https://github.com/biomejs/biome/pull/4263). Contributed by @fireairforce
+- Add an option `patterns` to [noRestrictedImports](https://biomejs.dev/linter/rules/no-restricted-imports/). Contributed by @nekocode
 
 #### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "biome_unicode_table",
  "bitvec",
  "enumflags2",
+ "ignore",
  "insta",
  "natord",
  "regex",

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -28,6 +28,7 @@ biome_suppression        = { workspace = true }
 biome_unicode_table      = { workspace = true }
 bitvec                   = "1.0.1"
 enumflags2               = { workspace = true }
+ignore                   = { workspace = true }
 natord                   = { workspace = true }
 regex                    = { workspace = true }
 roaring                  = "0.10.6"

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
@@ -1,2 +1,3 @@
 import eslint from 'eslint';
 const l = require('lodash');
+const s = require('lodash/sortBy');

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -6,6 +6,7 @@ expression: invalid.js
 ```jsx
 import eslint from 'eslint';
 const l = require('lodash');
+const s = require('lodash/sortBy');
 
 ```
 
@@ -18,7 +19,7 @@ invalid.js:1:20 lint/nursery/noRestrictedImports ━━━━━━━━━━�
   > 1 │ import eslint from 'eslint';
       │                    ^^^^^^^^
     2 │ const l = require('lodash');
-    3 │ 
+    3 │ const s = require('lodash/sortBy');
   
 
 ```
@@ -31,9 +32,22 @@ invalid.js:2:19 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     1 │ import eslint from 'eslint';
   > 2 │ const l = require('lodash');
       │                   ^^^^^^^^
-    3 │ 
+    3 │ const s = require('lodash/sortBy');
+    4 │ 
   
 
 ```
 
+```
+invalid.js:3:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! It's not recommended to use specific lodash functions
+  
+    1 │ import eslint from 'eslint';
+    2 │ const l = require('lodash');
+  > 3 │ const s = require('lodash/sortBy');
+      │                   ^^^^^^^^^^^^^^^
+    4 │ 
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
@@ -10,7 +10,11 @@
 						"paths": {
 							"eslint": "Importing Eslint is forbidden",
 							"lodash": "It's not recommended to use lodash"
-						}
+						},
+						"patterns": [{
+							"group": ["lodash/*", "!lodash/get"],
+							"message": "It's not recommended to use specific lodash functions"
+						}]
 					}
 				}
 			}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
@@ -1,1 +1,2 @@
 const path = require('lodash');
+const path = require('lodash/get');

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
@@ -5,7 +5,6 @@ expression: valid.js
 # Input
 ```jsx
 const path = require('lodash');
+const path = require('lodash/get');
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
@@ -8,7 +8,11 @@
 					"options": {
 						"paths": {
 							"node:fs": "Importing from node:fs is forbidden"
-						}
+						},
+						"patterns": [{
+							"group": ["lodash/*", "!lodash/get"],
+							"message": "It's not recommended to use lodash"
+						}]
 					}
 				}
 			}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
@@ -1,1 +1,3 @@
 declare module "node:fs" {}
+declare module "lodash/get" {}
+declare module "lodash/sortBy" {}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
@@ -5,4 +5,6 @@ expression: valid.ts
 # Input
 ```ts
 declare module "node:fs" {}
+declare module "lodash/get" {}
+declare module "lodash/sortBy" {}
 ```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2406,6 +2406,10 @@ export interface RestrictedImportsOptions {
 	 * A list of names that should trigger the rule
 	 */
 	paths: {};
+	/**
+	 * A list of gitignore-style patterns that should trigger the rule
+	 */
+	patterns: RestrictedImportsPattern[];
 }
 export interface NoRestrictedTypesOptions {
 	types?: {};
@@ -2537,6 +2541,10 @@ Set to `true` to mark the identity of the hook's return value as stable, or use 
 For example, for React's `useRef()` hook the value would be `true`, while for `useState()` it would be `[1]`. 
 	 */
 	stableResult?: StableHookResult;
+}
+export interface RestrictedImportsPattern {
+	group: string[];
+	message?: string;
 }
 export type Accessibility = "noPublic" | "explicit" | "none";
 export type ConsistentArrayType = "shorthand" | "generic";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2650,7 +2650,20 @@
 					"description": "A list of names that should trigger the rule",
 					"type": "object",
 					"additionalProperties": { "type": "string" }
+				},
+				"patterns": {
+					"description": "A list of gitignore-style patterns that should trigger the rule",
+					"type": "array",
+					"items": { "$ref": "#/definitions/RestrictedImportsPattern" }
 				}
+			},
+			"additionalProperties": false
+		},
+		"RestrictedImportsPattern": {
+			"type": "object",
+			"properties": {
+				"group": { "type": "array", "items": { "type": "string" } },
+				"message": { "default": "", "type": "string" }
 			},
 			"additionalProperties": false
 		},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

This PR add an option `patterns` similar to [no-restricted-imports#patterns](https://eslint.org/docs/latest/rules/no-restricted-imports#patterns) :

```json
"noRestrictedImports": {
    "options": {
        "paths": {
             "import-foo": "Using import-foo is not encouraged"
        },
        "patterns": [{
             "group": ["import-foo/*", "!import-foo/a"],
             "message": "Using import-foo is not encouraged"
        }]
    }
}
```

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Changed snapshots

