### PR TITLE
chore: normalize Windows paths in plugin tests

### DIFF
--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -113,6 +113,9 @@ mod test {
     fn snap_diagnostic(test_name: &str, diagnostic: Error) {
         let content = print_diagnostic_to_string(&diagnostic);
 
+        // Normalize Windows paths...
+        let content = content.replace('\\', "/");
+
         insta::with_settings!({
             prepend_module_to_snapshot => false,
         }, {


### PR DESCRIPTION
Should fix the snapshot tests on the Windows runner.