### PR TITLE
docs(useAtIndex): fix typo chatAt -> charAt

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
@@ -20,7 +20,7 @@ declare_lint_rule! {
     /// A more convenient way to achieve the same thing is to use the `at()` method with a negative index.
     /// To access the last element of an array or a string just write `array.at(-1)`.
     ///
-    /// This rule enforces the usage of `at()` over index access, `chatAt()`, and `slice()[0]` when `at()` is more convenient.
+    /// This rule enforces the usage of `at()` over index access, `charAt()`, and `slice()[0]` when `at()` is more convenient.
     ///
     ///
     /// ## Examples


### PR DESCRIPTION
## Summary
I looked through the changelog and checked the new rules to determine if they might be relevant to my project. In the documentation for the new `useAtIndex` rule (https://biomejs.dev/linter/rules/use-at-index) I noticed a typo at first glance, so I thought it might be a good idea to fix it right away. The typo was introduced in https://github.com/biomejs/biome/pull/4120#discussion_r1790270327

## Test Plan
N/A