### PR TITLE
fix(noTypeOnlyImportAttributes): ignore .cts files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,23 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - `noSuspiciousSemicolonInJsx` now catches suspicious semicolons in React fragments. Contributed by @vasucp1207
 
+- The syntax rule `noTypeOnlyImportAttributes` now ignores `.cts` files ([#4361](https://github.com/biomejs/biome/issues/4361)).
+
+  Since TypeScript 5.3, type-only imports can be associated to an import attribute in CommonJS-enabled files.
+  See the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html#stable-support-resolution-mode-in-import-types).
+
+  The following code is no longer reported as a syntax error:
+
+  ```cts
+  import type { TypeFromRequire } from "pkg" with {
+      "resolution-mode": "require"
+  };
+  ```
+
+  Note that this is only allowed in files ending with the `cts` extension.
+
+  Contributed by @Conaclos
+
 ### CLI
 
 #### Enhancements

--- a/crates/biome_js_analyze/src/syntax/correctness/no_initializer_with_definite.rs
+++ b/crates/biome_js_analyze/src/syntax/correctness/no_initializer_with_definite.rs
@@ -7,7 +7,7 @@ declare_syntax_rule! {
     ///
     /// ## Examples
     ///
-    /// ```js
+    /// ```ts
     /// let foo!: string = "bar";
     /// ```
     pub NoInitializerWithDefinite {

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -13,8 +13,8 @@ use biome_test_utils::{
 use std::ops::Deref;
 use std::{ffi::OsStr, fs::read_to_string, path::Path, slice};
 
-tests_macros::gen_tests! {"tests/specs/**/*.{cjs,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
-tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
+tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_suppression_test, "module"}
 
 fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     register_leak_checker();

--- a/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid.cts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid.cts
@@ -1,0 +1,3 @@
+import type { TypeFromRequire } from "pkg" with {
+    "resolution-mode": "require"
+};

--- a/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid.cts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid.cts.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.cts
+---
+# Input
+```cts
+import type { TypeFromRequire } from "pkg" with {
+    "resolution-mode": "require"
+};
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.package.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -281,10 +281,16 @@ impl JsFileSource {
                 }
             }
             Language::TypeScript { .. } => {
-                if matches!(self.variant, LanguageVariant::Jsx) {
-                    "tsx"
-                } else {
-                    "ts"
+                match self.variant {
+                    LanguageVariant::Standard => "ts",
+                    LanguageVariant::StandardRestricted => {
+                        // This could also be `mts`.
+                        // We choose `cts` because we expect this extension to be more widely used.
+                        // Moreover, it allows more valid syntax such as `import type` with import
+                        // attributes (See `noTypeOnlyImportAttributes` syntax rule).
+                        "cts"
+                    }
+                    LanguageVariant::Jsx => "tsx",
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/4361

`noTypeOnlyImportAttributes` reports `import type` with `import attributes` because this is a syntax error in TypeScript.
However, since TypeScript 5.3, [this is allowed in CommonJS files](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-3.html#stable-support-resolution-mode-in-import-types).

This PR makes `noTypeOnlyImportAttributes` to ignore files ending the `.cts` extension.

I notes that the test snapshot outputted the wrong  Markdown language (`ts` instead of `cts`). Thus, I changed how we output the Markdown language in tests in order to output `cts` for `cts` files. As a side effect this also translates `mts` to `cts`. However, we have no test using this extension and this should not create any issue.

## Test Plan

I added a test.