### PR TITLE
fix(css_formatter): don't indent CSS selector when leading comments before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ### Formatter
 
+### Bug fixes
+
+- Fix [#4121](https://github.com/biomejs/biome/issues/4326), don't ident a CSS selector when has leading comments. Contributed by @fireairforce
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
@@ -13,17 +13,36 @@ impl FormatRule<CssRelativeSelectorList> for FormatCssRelativeSelectorList {
         let mut joiner = f.join_with(&separator);
 
         for formatted in node.format_separated(",") {
-            // Each selector gets `indent` added in case it breaks over multiple
-            // lines. The break is added here rather than in each selector both
-            // for simplicity and to avoid recursively adding indents when
-            // selectors are nested within other rules. The group is then added
-            // around the indent to ensure that it tries using a flat layout
-            // first and only expands when the single selector can't fit the line.
-            //
-            // For example, a selector like `div span a` is structured like
-            // `[div, [span, [a]]]`, so `a` would end up double-indented if it
-            // was handled by the selector rather than here.
-            joiner.entry(&group(&indent(&formatted)));
+            let mut has_comments_before = false;
+            if let Some(relative_selector) = formatted.node()?.as_css_relative_selector() {
+                if let Some(computed_selector) =
+                    relative_selector.selector()?.as_css_compound_selector()
+                {
+                    if let Some(simple_selector) = computed_selector.simple_selector() {
+                        if let Some(type_selector) = simple_selector.as_css_type_selector() {
+                            has_comments_before =
+                                type_selector.ident()?.value_token()?.has_leading_comments();
+                        }
+                    }
+                }
+            }
+
+            if has_comments_before {
+                // Computed Selector which contains a leading comments should be formatted without indent.
+                joiner.entry(&group(&formatted));
+            } else {
+                // Each selector gets `indent` added in case it breaks over multiple
+                // lines. The break is added here rather than in each selector both
+                // for simplicity and to avoid recursively adding indents when
+                // selectors are nested within other rules. The group is then added
+                // around the indent to ensure that it tries using a flat layout
+                // first and only expands when the single selector can't fit the line.
+                //
+                // For example, a selector like `div span a` is structured like
+                // `[div, [span, [a]]]`, so `a` would end up double-indented if it
+                // was handled by the selector rather than here.
+                joiner.entry(&group(&indent(&formatted)));
+            }
         }
 
         joiner.finish()

--- a/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
+++ b/crates/biome_css_formatter/src/css/lists/relative_selector_list.rs
@@ -26,8 +26,7 @@ impl FormatRule<CssRelativeSelectorList> for FormatCssRelativeSelectorList {
                 .and_then(|computed_selector| computed_selector.simple_selector())
                 .and_then(|simple_selector| simple_selector.as_css_type_selector().cloned())
                 .and_then(|type_selector| type_selector.ident().ok()?.value_token().ok())
-                .map(|value_token| value_token.has_leading_comments())
-                .unwrap_or_default();
+                .is_some_and(|value_token| value_token.has_leading_comments());
 
             if has_leading_comments {
                 // Computed Selector which contains a leading comments should be formatted without indent.

--- a/crates/biome_css_formatter/tests/specs/css/declaration_list.css
+++ b/crates/biome_css_formatter/tests/specs/css/declaration_list.css
@@ -35,3 +35,19 @@ a {
 a {
     color: red;;;;
 }
+
+.with-comments {
+  /* hello */
+  a,
+  /* world */
+  button {
+    color: blue;
+  }
+}
+  
+.without-comments {
+  a,
+  button {
+    color: blue;
+  }
+}

--- a/crates/biome_css_formatter/tests/specs/css/declaration_list.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/declaration_list.css.snap
@@ -42,6 +42,22 @@ a {
 a {
     color: red;;;;
 }
+
+.with-comments {
+  /* hello */
+  a,
+  /* world */
+  button {
+    color: blue;
+  }
+}
+  
+.without-comments {
+  a,
+  button {
+    color: blue;
+  }
+}
 ```
 
 
@@ -102,5 +118,21 @@ a {
 
 a {
 	color: red;
+}
+
+.with-comments {
+	/* hello */
+	a,
+	/* world */
+	button {
+		color: blue;
+	}
+}
+
+.without-comments {
+	a,
+	button {
+		color: blue;
+	}
 }
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #4326 

I add special judge for that case:

```css
.a {
  /* hi */
  a,
  /* me */
 div {
   color: red;
  }
}
```

If i get a `CSS_Type_Selector` like: `/* hi */\n  a,\n  div`(you can refer this from above case), i will not add an ident for this to avoid this case, the previous logic at `biome_css_formatter` will add an ident for this case by default.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

add test case like:

```css
.with-comments {
  /* hello */
  a,
  /* world */
  button {
    color: blue;
  }
}

.without-comments {
  a,
  button {
    color: blue;
  }
}
```

my fix as follows:

```diff
.with-comments {
  /* hello */
  a,
  /* world */
-    button {
+  button{
    color: blue;
  }
}
```


<!-- What demonstrates that your implementation is correct? -->
