### PR TITLE
fix(lint): don’t recommend role="searchbox" suggestions for role="search"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 ## Unreleased
 
+- Fix [#4323](https://github.com/biomejs/biome/issues/4258), where `lint/a11y/useSemanticElement` accidentally showed recommendations for `role="searchbox"` instead of `role="search"`
+
 ### Analyzer
 
 #### Bug fixes

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -1338,7 +1338,7 @@ impl<'a> AriaRoles {
             "row" => &RowRole as &dyn AriaRoleDefinitionWithConcepts,
             "rowgroup" => &RowGroupRole as &dyn AriaRoleDefinitionWithConcepts,
             "rowheader" => &RowHeaderRole as &dyn AriaRoleDefinitionWithConcepts,
-            "search" => &SearchboxRole as &dyn AriaRoleDefinitionWithConcepts,
+            "search" => &SearchRole as &dyn AriaRoleDefinitionWithConcepts,
             "searchbox" => &SearchboxRole as &dyn AriaRoleDefinitionWithConcepts,
             "table" => &TableRole as &dyn AriaRoleDefinitionWithConcepts,
             "term" => &TermRole as &dyn AriaRoleDefinitionWithConcepts,

--- a/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useSemanticElements/invalid.jsx.snap
@@ -585,7 +585,7 @@ invalid.jsx:28:10 lint/a11y/useSemanticElements ━━━━━━━━━━�
 invalid.jsx:29:10 lint/a11y/useSemanticElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The elements with the following roles can be changed to the following elements:
-    <input type="search">
+    <search>
   
   
     27 │     <div role="rowgroup" ></div>


### PR DESCRIPTION
## Summary

Fixes #4323. TL;DR role="search" != role="searchbox"

## Test Plan

- This fixes a simple typo without changing any behavior
- Tests updated; tests should pass
