### PR TITLE
fix(css_formatter): keep @charset double quote in single quote config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 #### Bug fixes
 
 - Fix [#4121](https://github.com/biomejs/biome/issues/4121). Respect line width when printing multiline strings. Contributed by @ah-yu
+- Fix [#4384](https://github.com/biomejs/biome/issues/4384). Keep `@charset` dobule quote under any situation for css syntax rule. Contributed by @fireairforce
 
 ### JavaScript APIs
 

--- a/crates/biome_css_formatter/src/css/auxiliary/attribute_matcher_value.rs
+++ b/crates/biome_css_formatter/src/css/auxiliary/attribute_matcher_value.rs
@@ -1,4 +1,7 @@
-use crate::{prelude::*, utils::string_utils::FormatLiteralStringToken};
+use crate::{
+    prelude::*,
+    utils::string_utils::{FormatLiteralStringToken, StringLiteralParentKind},
+};
 use biome_css_syntax::{
     AnyCssAttributeMatcherValue, CssAttributeMatcherValue, CssAttributeMatcherValueFields,
 };
@@ -35,7 +38,10 @@ impl FormatNodeRule<CssAttributeMatcherValue> for FormatCssAttributeMatcherValue
                         // does not get converted to lowercase. Once it's quoted, it
                         // will be parsed as a CssString on the next pass, at which
                         // point casing is preserved no matter what.
-                        FormatLiteralStringToken::new(&ident.value_token()?),
+                        FormatLiteralStringToken::new(
+                            &ident.value_token()?,
+                            StringLiteralParentKind::Others
+                        ),
                         format_trailing_comments(ident.syntax()),
                         format_dangling_comments(ident.syntax())
                     ]

--- a/crates/biome_css_formatter/src/css/value/string.rs
+++ b/crates/biome_css_formatter/src/css/value/string.rs
@@ -1,13 +1,35 @@
-use crate::{prelude::*, utils::string_utils::FormatLiteralStringToken};
-use biome_css_syntax::{CssString, CssStringFields};
+use crate::{
+    prelude::*,
+    utils::string_utils::{FormatLiteralStringToken, StringLiteralParentKind},
+};
+use biome_css_syntax::{CssString, CssStringFields, CssSyntaxKind};
 use biome_formatter::write;
+use biome_rowan::SyntaxNodeOptionExt;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatCssString;
 impl FormatNodeRule<CssString> for FormatCssString {
     fn fmt_fields(&self, node: &CssString, f: &mut CssFormatter) -> FormatResult<()> {
         let CssStringFields { value_token } = node.as_fields();
-
-        write!(f, [FormatLiteralStringToken::new(&value_token?)])
+        if matches!(
+            node.syntax().parent().kind(),
+            Some(CssSyntaxKind::CSS_CHARSET_AT_RULE)
+        ) {
+            write!(
+                f,
+                [FormatLiteralStringToken::new(
+                    &value_token?,
+                    StringLiteralParentKind::CharsetAtRule
+                )]
+            )
+        } else {
+            write!(
+                f,
+                [FormatLiteralStringToken::new(
+                    &value_token?,
+                    StringLiteralParentKind::Others
+                )]
+            )
+        }
     }
 }

--- a/crates/biome_css_formatter/src/utils/string_utils.rs
+++ b/crates/biome_css_formatter/src/utils/string_utils.rs
@@ -43,17 +43,29 @@ impl Format<CssFormatContext> for FormatTokenAsLowercase {
     }
 }
 
+#[derive(Eq, PartialEq, Debug)]
+pub(crate) enum StringLiteralParentKind {
+    /// Variants to track tokens that are inside a CssCharasetRule
+    /// @charset must always have double quotes: https://www.w3.org/TR/css-syntax-3/#determine-the-fallback-encoding
+    CharsetAtRule,
+    /// other types, will add more later
+    Others,
+}
+
 /// Data structure of convenience to format string literals. This is copied
 /// from the JS formatter, but should eventually have the logic made generic
 /// and reusable since many languages will have the same needs.
 pub(crate) struct FormatLiteralStringToken<'token> {
     /// The current token
     token: &'token CssSyntaxToken,
+
+    // The parent that holds the token
+    parent_kind: StringLiteralParentKind,
 }
 
 impl<'token> FormatLiteralStringToken<'token> {
-    pub fn new(token: &'token CssSyntaxToken) -> Self {
-        Self { token }
+    pub fn new(token: &'token CssSyntaxToken, parent_kind: StringLiteralParentKind) -> Self {
+        Self { token, parent_kind }
     }
 
     fn token(&self) -> &'token CssSyntaxToken {
@@ -204,18 +216,28 @@ impl<'token> LiteralStringNormaliser<'token> {
     }
 
     fn normalise_text(&mut self) -> Cow<'token, str> {
-        let string_information = self
-            .token
-            .compute_string_information(self.chosen_quote_style);
+        match self.token.parent_kind {
+            StringLiteralParentKind::CharsetAtRule => {
+                let string_information = StringInformation {
+                    preferred_quote: QuoteStyle::Double,
+                };
+                self.normalise_tokens(string_information)
+            }
+            StringLiteralParentKind::Others => {
+                let string_information = self
+                    .token
+                    .compute_string_information(self.chosen_quote_style);
 
-        // Normalize string token and non-string token.
-        //
-        // Add the chosen quotes to any non-string tokensto normalize them into strings.
-        //
-        // CSS has various places where "string-like" tokens can be used without quotes, but the
-        // semantics aren't affected by whether they are present or not. This function lets those
-        // tokens become string literals by safely adding quotes around them.
-        self.normalise_tokens(string_information)
+                // Normalize string token and non-string token.
+                //
+                // Add the chosen quotes to any non-string tokensto normalize them into strings.
+                //
+                // CSS has various places where "string-like" tokens can be used without quotes, but the
+                // semantics aren't affected by whether they are present or not. This function lets those
+                // tokens become string literals by safely adding quotes around them.
+                self.normalise_tokens(string_information)
+            }
+        }
     }
 
     fn get_token(&self) -> &'token CssSyntaxToken {

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -1,7 +1,7 @@
 use biome_css_formatter::format_node;
 use biome_css_formatter::{context::CssFormatOptions, CssFormatLanguage};
 use biome_css_parser::{parse_css, CssParserOptions};
-use biome_formatter::{IndentStyle, LineWidth};
+use biome_formatter::{IndentStyle, LineWidth, QuoteStyle};
 use biome_formatter_test::check_reformat::CheckReformat;
 
 mod language {
@@ -13,18 +13,15 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-.container {
-  &:has(.child) {
-    color: blue;
-  }
-}
+@charset "UTF-8";
 "#;
     let parse = parse_css(src, CssParserOptions::default());
     println!("{parse:#?}");
 
     let options = CssFormatOptions::default()
         .with_line_width(LineWidth::try_from(80).unwrap())
-        .with_indent_style(IndentStyle::Space);
+        .with_indent_style(IndentStyle::Space)
+        .with_quote_style(QuoteStyle::Single);
     let doc = format_node(options.clone(), &parse.syntax()).unwrap();
     let result = doc.print().unwrap();
 

--- a/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css
+++ b/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css
@@ -19,3 +19,7 @@ div {
     --\eeunquoted: green;
     color: var(--\eeunquoted);
 }
+
+@charset·"UTF-8";
+@charset "iso-8859-15";
+@charset "any-string-is-okay";

--- a/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/quote_style/normalize_quotes.css.snap
@@ -26,6 +26,10 @@ div {
     --\eeunquoted: green;
     color: var(--\eeunquoted);
 }
+
+@charset·"UTF-8";
+@charset "iso-8859-15";
+@charset "any-string-is-okay";
 ```
 
 
@@ -65,6 +69,10 @@ div {
 	--\eeunquoted: green;
 	color: var(--\eeunquoted);
 }
+
+@charset· "UTF-8";
+@charset "iso-8859-15";
+@charset "any-string-is-okay";
 ```
 
 ## Output 1
@@ -99,4 +107,8 @@ div {
 	--\eeunquoted: green;
 	color: var(--\eeunquoted);
 }
+
+@charset· "UTF-8";
+@charset "iso-8859-15";
+@charset "any-string-is-okay";
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #4384 

`@charset` must always have double quotes: https://www.w3.org/TR/css-syntax-3/#determine-the-fallback-encoding

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

I add a param `StringLiteralParentKind` for `impl FormatLiteralStringToken` to judge if the `CSS String`'s parent is a `CSS_CHARSET_AT_RULE` which represents the syntax like:`@charset`, i refer the same util at `biome_js_formatter`.

if the string is `StringLiteralParentKind::CharsetAtRule`, i will use the double quote for the string in any case, or we will execute the normal logic of `biome_css_formatter`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Test case as follows: 

```css
@charset·"UTF-8";
@charset "iso-8859-15";
@charset "any-string-is-okay";
```

<!-- What demonstrates that your implementation is correct? -->
