### PR TITLE
feat: move biome_lsp/converters to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "biome_deserialize",
  "biome_diagnostics",
  "biome_fs",
+ "biome_lsp_converters",
  "biome_rowan",
  "biome_service",
  "biome_text_edit",
@@ -975,6 +976,17 @@ dependencies = [
  "tower",
  "tower-lsp",
  "tracing",
+]
+
+[[package]]
+name = "biome_lsp_converters"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "biome_rowan",
+ "rustc-hash 1.1.0",
+ "tower",
+ "tower-lsp",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ biome_json_factory           = { version = "0.5.7", path = "./crates/biome_json_
 biome_json_formatter         = { version = "0.5.7", path = "./crates/biome_json_formatter" }
 biome_json_parser            = { version = "0.5.7", path = "./crates/biome_json_parser" }
 biome_json_syntax            = { version = "0.5.7", path = "./crates/biome_json_syntax" }
+biome_lsp_converters         = { version = "0.1.0", path = "./crates/biome_lsp_converters" }
 biome_markdown_factory       = { version = "0.0.1", path = "./crates/biome_markdown_factory" }
 biome_markdown_parser        = { version = "0.0.1", path = "./crates/biome_markdown_parser" }
 biome_markdown_syntax        = { version = "0.0.1", path = "./crates/biome_markdown_syntax" }

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -14,23 +14,24 @@ version              = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow              = { workspace = true }
-biome_analyze       = { workspace = true }
-biome_configuration = { workspace = true }
-biome_console       = { workspace = true }
-biome_deserialize   = { workspace = true }
-biome_diagnostics   = { workspace = true }
-biome_fs            = { workspace = true }
-biome_rowan         = { workspace = true }
-biome_service       = { workspace = true }
-biome_text_edit     = { workspace = true }
-futures             = "0.3.30"
-rustc-hash          = { workspace = true }
-serde               = { workspace = true, features = ["derive"] }
-serde_json          = { workspace = true }
-tokio               = { workspace = true, features = ["rt", "io-std"] }
-tower-lsp           = { version = "0.20.0" }
-tracing             = { workspace = true, features = ["attributes"] }
+anyhow               = { workspace = true }
+biome_analyze        = { workspace = true }
+biome_configuration  = { workspace = true }
+biome_console        = { workspace = true }
+biome_deserialize    = { workspace = true }
+biome_diagnostics    = { workspace = true }
+biome_fs             = { workspace = true }
+biome_lsp_converters = { workspace = true }
+biome_rowan          = { workspace = true }
+biome_service        = { workspace = true }
+biome_text_edit      = { workspace = true }
+futures              = "0.3.30"
+rustc-hash           = { workspace = true }
+serde                = { workspace = true, features = ["derive"] }
+serde_json           = { workspace = true }
+tokio                = { workspace = true, features = ["rt", "io-std"] }
+tower-lsp            = { version = "0.20.0" }
+tracing              = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -1,5 +1,5 @@
-use crate::converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use biome_analyze::SUPPRESSION_ACTION_CATEGORY;
+use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use tower_lsp::lsp_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     DocumentOnTypeFormattingOptions, OneOf, PositionEncodingKind, ServerCapabilities,

--- a/crates/biome_lsp/src/documents.rs
+++ b/crates/biome_lsp/src/documents.rs
@@ -1,4 +1,4 @@
-use crate::converters::line_index::LineIndex;
+use biome_lsp_converters::line_index::LineIndex;
 
 /// Represents an open [`textDocument`]. Can be cheaply cloned.
 ///

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -1,5 +1,3 @@
-use crate::converters::from_proto;
-use crate::converters::line_index::LineIndex;
 use crate::diagnostics::LspError;
 use crate::session::Session;
 use crate::utils;
@@ -7,6 +5,8 @@ use anyhow::{Context, Result};
 use biome_analyze::{ActionCategory, RuleCategoriesBuilder, SourceActionKind};
 use biome_diagnostics::Applicability;
 use biome_fs::BiomePath;
+use biome_lsp_converters::from_proto;
+use biome_lsp_converters::line_index::LineIndex;
 use biome_rowan::{TextRange, TextSize};
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::workspace::{

--- a/crates/biome_lsp/src/handlers/formatting.rs
+++ b/crates/biome_lsp/src/handlers/formatting.rs
@@ -1,9 +1,9 @@
-use crate::converters::from_proto;
 use crate::diagnostics::LspError;
 use crate::session::Session;
 use crate::utils::text_edit;
 use anyhow::Context;
 use biome_fs::BiomePath;
+use biome_lsp_converters::from_proto;
 use biome_rowan::{TextRange, TextSize};
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::workspace::{

--- a/crates/biome_lsp/src/handlers/rename.rs
+++ b/crates/biome_lsp/src/handlers/rename.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::converters::from_proto;
+use biome_lsp_converters::from_proto;
 use crate::diagnostics::LspError;
 use crate::{session::Session, utils};
 use anyhow::{Context, Result};

--- a/crates/biome_lsp/src/handlers/rename.rs
+++ b/crates/biome_lsp/src/handlers/rename.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use biome_lsp_converters::from_proto;
 use crate::diagnostics::LspError;
 use crate::{session::Session, utils};
 use anyhow::{Context, Result};
+use biome_lsp_converters::from_proto;
 use tower_lsp::lsp_types::{RenameParams, WorkspaceEdit};
 use tracing::trace;
 

--- a/crates/biome_lsp/src/lib.rs
+++ b/crates/biome_lsp/src/lib.rs
@@ -1,5 +1,4 @@
 mod capabilities;
-mod converters;
 mod diagnostics;
 mod documents;
 mod extension_settings;

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -1,4 +1,4 @@
-use crate::converters::{negotiated_encoding, PositionEncoding, WideEncoding};
+use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use crate::diagnostics::LspError;
 use crate::documents::Document;
 use crate::extension_settings::ExtensionSettings;

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -1,4 +1,3 @@
-use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use crate::diagnostics::LspError;
 use crate::documents::Document;
 use crate::extension_settings::ExtensionSettings;
@@ -11,6 +10,7 @@ use biome_console::markup;
 use biome_deserialize::Merge;
 use biome_diagnostics::{DiagnosticExt, Error, PrintDescription};
 use biome_fs::{BiomePath, FileSystem};
+use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use biome_service::configuration::{
     load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
 };

--- a/crates/biome_lsp/src/utils.rs
+++ b/crates/biome_lsp/src/utils.rs
@@ -1,5 +1,3 @@
-use crate::converters::line_index::LineIndex;
-use crate::converters::{from_proto, to_proto, PositionEncoding};
 use anyhow::{ensure, Context, Result};
 use biome_analyze::ActionCategory;
 use biome_console::fmt::Termcolor;
@@ -9,6 +7,8 @@ use biome_diagnostics::termcolor::NoColor;
 use biome_diagnostics::{
     Applicability, {Diagnostic, DiagnosticTags, Location, PrintDescription, Severity, Visit},
 };
+use biome_lsp_converters::line_index::LineIndex;
+use biome_lsp_converters::{from_proto, to_proto, PositionEncoding};
 use biome_rowan::{TextRange, TextSize};
 use biome_service::workspace::CodeAction;
 use biome_text_edit::{CompressedOp, DiffOp, TextEdit};
@@ -380,8 +380,8 @@ pub(crate) fn apply_document_changes(
 #[cfg(test)]
 mod tests {
     use super::apply_document_changes;
-    use crate::converters::line_index::LineIndex;
-    use crate::converters::{PositionEncoding, WideEncoding};
+    use biome_lsp_converters::line_index::LineIndex;
+    use biome_lsp_converters::{PositionEncoding, WideEncoding};
     use biome_text_edit::TextEdit;
     use tower_lsp::lsp_types as lsp;
     use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent};

--- a/crates/biome_lsp_converters/Cargo.toml
+++ b/crates/biome_lsp_converters/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+authors.workspace    = true
+categories.workspace = true
+description          = "Biome's tools to convert between LSP and Biome's data structures"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_lsp_converters"
+repository.workspace = true
+version              = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow              = { workspace = true }
+biome_rowan         = { workspace = true }
+rustc-hash          = { workspace = true }
+tower-lsp           = { version = "0.20.0" }
+
+[dev-dependencies]
+tower = { version = "0.4.13", features = ["timeout"] }
+
+[lints]
+workspace = true

--- a/crates/biome_lsp_converters/Cargo.toml
+++ b/crates/biome_lsp_converters/Cargo.toml
@@ -13,10 +13,10 @@ version              = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow              = { workspace = true }
-biome_rowan         = { workspace = true }
-rustc-hash          = { workspace = true }
-tower-lsp           = { version = "0.20.0" }
+anyhow      = { workspace = true }
+biome_rowan = { workspace = true }
+rustc-hash  = { workspace = true }
+tower-lsp   = { version = "0.20.0" }
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["timeout"] }

--- a/crates/biome_lsp_converters/README.md
+++ b/crates/biome_lsp_converters/README.md
@@ -1,0 +1,3 @@
+# `biome_lsp_converters`
+
+The crate contains a set of converters to translate between `lsp-types` and `biome_rowan` (and vice versa) types.

--- a/crates/biome_lsp_converters/src/from_proto.rs
+++ b/crates/biome_lsp_converters/src/from_proto.rs
@@ -1,11 +1,11 @@
-use crate::converters::line_index::LineIndex;
-use crate::converters::{LineCol, PositionEncoding, WideLineCol};
+use crate::line_index::LineIndex;
+use crate::{LineCol, PositionEncoding, WideLineCol};
 use anyhow::{Context, Result};
 use biome_rowan::{TextRange, TextSize};
 use tower_lsp::lsp_types;
 
 /// The function is used to convert a LSP position to TextSize.
-pub(crate) fn offset(
+pub fn offset(
     line_index: &LineIndex,
     position: lsp_types::Position,
     position_encoding: PositionEncoding,
@@ -30,7 +30,7 @@ pub(crate) fn offset(
 }
 
 /// The function is used to convert a LSP range to TextRange.
-pub(crate) fn text_range(
+pub fn text_range(
     line_index: &LineIndex,
     range: lsp_types::Range,
     position_encoding: PositionEncoding,

--- a/crates/biome_lsp_converters/src/lib.rs
+++ b/crates/biome_lsp_converters/src/lib.rs
@@ -1,11 +1,11 @@
 use biome_rowan::TextSize;
 use tower_lsp::lsp_types::{ClientCapabilities, PositionEncodingKind};
 
-pub(crate) mod from_proto;
-pub(crate) mod line_index;
-pub(crate) mod to_proto;
+pub mod from_proto;
+pub mod line_index;
+pub mod to_proto;
 
-pub(crate) fn negotiated_encoding(capabilities: &ClientCapabilities) -> PositionEncoding {
+pub fn negotiated_encoding(capabilities: &ClientCapabilities) -> PositionEncoding {
     let client_encodings = match &capabilities.general {
         Some(general) => general.position_encodings.as_deref().unwrap_or_default(),
         None => &[],
@@ -36,11 +36,11 @@ pub enum WideEncoding {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct LineCol {
+pub struct LineCol {
     /// Zero-based
-    pub(crate) line: u32,
+    pub line: u32,
     /// Zero-based utf8 offset
-    pub(crate) col: u32,
+    pub col: u32,
 }
 
 /// Deliberately not a generic type and different from `LineCol`.
@@ -53,11 +53,11 @@ pub struct WideLineCol {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub(crate) struct WideChar {
+pub struct WideChar {
     /// Start offset of a character inside a line, zero-based
-    pub(crate) start: TextSize,
+    pub start: TextSize,
     /// End offset of a character inside a line, zero-based
-    pub(crate) end: TextSize,
+    pub end: TextSize,
 }
 
 impl WideChar {
@@ -84,11 +84,11 @@ impl WideChar {
 
 #[cfg(test)]
 mod tests {
-    use crate::converters::from_proto::offset;
-    use crate::converters::line_index::LineIndex;
-    use crate::converters::to_proto::position;
-    use crate::converters::WideEncoding::{Utf16, Utf32};
-    use crate::converters::{LineCol, PositionEncoding, WideEncoding};
+    use crate::from_proto::offset;
+    use crate::line_index::LineIndex;
+    use crate::to_proto::position;
+    use crate::WideEncoding::{Utf16, Utf32};
+    use crate::{LineCol, PositionEncoding, WideEncoding};
     use biome_rowan::TextSize;
     use tower_lsp::lsp_types::Position;
 

--- a/crates/biome_lsp_converters/src/line_index.rs
+++ b/crates/biome_lsp_converters/src/line_index.rs
@@ -3,16 +3,17 @@
 
 use std::mem;
 
-use crate::converters::{LineCol, WideChar, WideEncoding, WideLineCol};
 use biome_rowan::TextSize;
 use rustc_hash::FxHashMap;
 
+use crate::{LineCol, WideChar, WideEncoding, WideLineCol};
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct LineIndex {
+pub struct LineIndex {
     /// Offset the beginning of each line, zero-based.
-    pub(crate) newlines: Vec<TextSize>,
+    pub newlines: Vec<TextSize>,
     /// List of non-ASCII characters on each line.
-    pub(crate) line_wide_chars: FxHashMap<u32, Vec<WideChar>>,
+    pub line_wide_chars: FxHashMap<u32, Vec<WideChar>>,
 }
 
 impl LineIndex {
@@ -67,7 +68,7 @@ impl LineIndex {
     }
 
     /// Return the number of lines in the index, clamped to [u32::MAX]
-    pub(crate) fn len(&self) -> u32 {
+    pub fn len(&self) -> u32 {
         self.newlines.len().try_into().unwrap_or(u32::MAX)
     }
 

--- a/crates/biome_lsp_converters/src/line_index.rs
+++ b/crates/biome_lsp_converters/src/line_index.rs
@@ -72,6 +72,11 @@ impl LineIndex {
         self.newlines.len().try_into().unwrap_or(u32::MAX)
     }
 
+    /// Return `true` if the index contains no lines.
+    pub fn is_empty(&self) -> bool {
+        self.newlines.is_empty()
+    }
+
     pub fn line_col(&self, offset: TextSize) -> Option<LineCol> {
         let line = self.newlines.partition_point(|&it| it <= offset) - 1;
         let line_start_offset = self.newlines.get(line)?;

--- a/crates/biome_lsp_converters/src/to_proto.rs
+++ b/crates/biome_lsp_converters/src/to_proto.rs
@@ -1,11 +1,11 @@
-use crate::converters::line_index::LineIndex;
-use crate::converters::PositionEncoding;
+use crate::line_index::LineIndex;
+use crate::PositionEncoding;
 use anyhow::{Context, Result};
 use biome_rowan::{TextRange, TextSize};
 use tower_lsp::lsp_types;
 
 /// The function is used to convert TextSize to a LSP position.
-pub(crate) fn position(
+pub fn position(
     line_index: &LineIndex,
     offset: TextSize,
     position_encoding: PositionEncoding,
@@ -28,7 +28,7 @@ pub(crate) fn position(
 }
 
 /// The function is used to convert TextRange to a LSP range.
-pub(crate) fn range(
+pub fn range(
     line_index: &LineIndex,
     range: TextRange,
     position_encoding: PositionEncoding,

--- a/knope.toml
+++ b/knope.toml
@@ -152,6 +152,9 @@ versioned_files = ["crates/biome_json_parser/Cargo.toml"]
 [packages.biome_json_syntax]
 changelog       = "crates/biome_json_syntax/CHANGELOG.md"
 versioned_files = ["crates/biome_json_syntax/Cargo.toml"]
+[packages.biome_lsp_converters]
+changelog       = "crates/biome_lsp_converters/CHANGELOG.md"
+versioned_files = ["crates/biome_lsp_converters/Cargo.toml"]
 [packages.biome_markup]
 changelog       = "crates/biome_markup/CHANGELOG.md"
 versioned_files = ["crates/biome_markup/Cargo.toml"]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

`biome_lsp` has a lot of nifty converters and tools for working with `biome_rowan`'s structs and converting them to LSP formats. Unfortunately, `biome_lsp` is a private crate, so none of those tools were exported.

This PR moves those utilities into a separate `biome_lsp_converters` crate that is public, so that people (just me, maybe) can use them.

## Test Plan

Moved the tests as well, so the same testing strategy still applies.
