### PR TITLE
refactor: order lint rules in rage output

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -791,7 +791,7 @@ pub struct SuppressionCommentEmitterPayload<'a, L: Language> {
 type SignalHandler<'a, L, Break> = &'a mut dyn FnMut(&dyn AnalyzerSignal<L>) -> ControlFlow<Break>;
 
 /// Allow filtering a single rule or group of rules by their names
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum RuleFilter<'a> {
     Group(&'a str),
     Rule(&'a str, &'a str),

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -303,7 +303,7 @@ impl Display for RageConfiguration<'_, '_> {
                             {KeyValuePair("GraphQL enabled", markup!({DebugDisplay(graphq_linter.enabled)}))}
                             {KeyValuePair("Recommended", markup!({DebugDisplay(linter_configuration.recommended.unwrap_or_default())}))}
                             {KeyValuePair("All", markup!({DebugDisplay(linter_configuration.all.unwrap_or_default())}))}
-                            {RageConfigurationLintRules("Enabled rules",linter_configuration)}
+                            {RageConfigurationLintRules("Enabled rules", linter_configuration)}
                         ).fmt(fmt)?;
                     }
                 }
@@ -328,6 +328,7 @@ impl Display for RageConfigurationLintRules<'_> {
         fmt.write_markup(markup! {{padding}{rules_str}":"})?;
         fmt.write_markup(markup! {{SOFT_LINE}})?;
         let rules = self.1.as_enabled_rules();
+        let rules = rules.iter().collect::<std::collections::BTreeSet<_>>();
         for rule in rules {
             fmt.write_markup(markup! {{padding}{rule}})?;
             fmt.write_markup(markup! {{SOFT_LINE}})?;

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_linter_configuration.snap
@@ -67,33 +67,33 @@ Linter:
   Recommended:                  false
   All:                          false
   Enabled rules:
-  complexity/noMultipleSpacesInRegularExpressionLiterals
-  complexity/noExcessiveNestedTestSuites
-  complexity/noUselessRename
-  complexity/useArrowFunction
-  complexity/noUselessEmptyExport
-  complexity/noWith
-  complexity/noUselessLoneBlockStatements
-  complexity/useFlatMap
-  complexity/noForEach
-  complexity/noUselessSwitchCase
-  complexity/useOptionalChain
-  complexity/noUselessCatch
   complexity/noBannedTypes
+  complexity/noEmptyTypeParameters
+  complexity/noExcessiveNestedTestSuites
   complexity/noExtraBooleanCast
-  suspicious/noCommentText
-  complexity/noUselessTypeConstraint
-  complexity/useSimpleNumberKeys
+  complexity/noForEach
+  complexity/noMultipleSpacesInRegularExpressionLiterals
+  complexity/noStaticOnlyClass
+  complexity/noThisInStatic
+  complexity/noUselessCatch
+  complexity/noUselessConstructor
+  complexity/noUselessEmptyExport
   complexity/noUselessFragments
   complexity/noUselessLabel
-  complexity/noThisInStatic
-  complexity/noUselessConstructor
-  complexity/noEmptyTypeParameters
-  complexity/noStaticOnlyClass
-  complexity/noUselessThisAlias
+  complexity/noUselessLoneBlockStatements
+  complexity/noUselessRename
+  complexity/noUselessSwitchCase
   complexity/noUselessTernary
+  complexity/noUselessThisAlias
+  complexity/noUselessTypeConstraint
+  complexity/noWith
+  complexity/useArrowFunction
+  complexity/useFlatMap
   complexity/useLiteralKeys
+  complexity/useOptionalChain
   complexity/useRegexLiterals
+  complexity/useSimpleNumberKeys
+  suspicious/noCommentText
 
 Server:
   Version:                      0.0.0


### PR DESCRIPTION
## Summary

Order lint rules reported by `biome rage`.
This makes finding if a rule is enabled easier and avoids changes when we use a different hash function. 

## Test Plan

I updated the snapshots.
