### PR TITLE
refactor(lint,actions): avoid duplicated filters

### DIFF
--- a/crates/biome_configuration/src/analyzer/assists/actions.rs
+++ b/crates/biome_configuration/src/analyzer/assists/actions.rs
@@ -86,12 +86,10 @@ impl Actions {
     #[doc = r" The enabled rules are calculated from the difference with the disabled rules."]
     pub fn as_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut enabled_rules = FxHashSet::default();
-        let mut disabled_rules = FxHashSet::default();
         if let Some(group) = self.source.as_ref() {
             enabled_rules.extend(&group.get_enabled_rules());
-            disabled_rules.extend(&group.get_disabled_rules());
         }
-        enabled_rules.difference(&disabled_rules).copied().collect()
+        enabled_rules
     }
 }
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
@@ -130,25 +128,6 @@ impl Source {
         }
         if let Some(rule) = self.use_sorted_keys.as_ref() {
             if rule.is_enabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
-            }
-        }
-        index_set
-    }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
-        let mut index_set = FxHashSet::default();
-        if let Some(rule) = self.organize_imports.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
-            }
-        }
-        if let Some(rule) = self.use_sorted_attributes.as_ref() {
-            if rule.is_disabled() {
-                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
-            }
-        }
-        if let Some(rule) = self.use_sorted_keys.as_ref() {
-            if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
             }
         }

--- a/xtask/codegen/src/generate_configuration.rs
+++ b/xtask/codegen/src/generate_configuration.rs
@@ -260,7 +260,6 @@ fn generate_for_groups(
             quote! {
                 if let Some(group) = self.#group_ident.as_ref() {
                     enabled_rules.extend(&group.get_enabled_rules());
-                    disabled_rules.extend(&group.get_disabled_rules());
                 }
             }
         });
@@ -418,10 +417,8 @@ fn generate_for_groups(
                 /// The enabled rules are calculated from the difference with the disabled rules.
                 pub fn as_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
                     let mut enabled_rules = FxHashSet::default();
-                    let mut disabled_rules = FxHashSet::default();
                     #( #group_as_default_rules )*
-
-                    enabled_rules.difference(&disabled_rules).copied().collect()
+                    enabled_rules
                 }
             }
 
@@ -838,12 +835,6 @@ fn generate_group_struct(
                 pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
                    let mut index_set = FxHashSet::default();
                    #( #rule_enabled_check_line )*
-                   index_set
-                }
-
-                pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
-                   let mut index_set = FxHashSet::default();
-                   #( #rule_disabled_check_line )*
                    index_set
                 }
 


### PR DESCRIPTION
## Summary

- Use `HashSet` instead of `Vec` to avoid duplicated filters.
- Remove `get_disabled_rules` for assist actions.
  In contrast to lint rules, `as_enabled_rules` doesn't need `get_disabled_rules` to compute enabled rules,
  because the system is simpler (no `all` and `recommended` flags)

## Test Plan

CI must pass.
