### PR TITLE
build: reduce binary size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,4 +37,7 @@ lint = "clippy --workspace --all-targets -- --deny warnings"
 new-crate = "run -p xtask_codegen -- new-crate"
 
 [profile.release]
-lto = true
+codegen-units = 1
+lto           = true
+opt-level     = 3
+strip         = "symbols"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,7 +37,4 @@ lint = "clippy --workspace --all-targets -- --deny warnings"
 new-crate = "run -p xtask_codegen -- new-crate"
 
 [profile.release]
-codegen-units = 1
-lto           = true
-opt-level     = 3
-strip         = "symbols"
+lto = true

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -126,7 +126,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
           # Strip all debug symbols from the resulting binaries
-          RUSTFLAGS: "-C strip=symbols"
+          RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
           # Inline the version of the npm package in the CLI binary
           BIOME_VERSION: ${{ env.version }}
 

--- a/.github/workflows/release_knope.yml
+++ b/.github/workflows/release_knope.yml
@@ -113,7 +113,7 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
           # Strip all debug symbols from the resulting binaries
-          RUSTFLAGS: "-C strip=symbols"
+          RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
           # Inline the version of the npm package in the CLI binary
           BIOME_VERSION: ${{ env.version }}
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. --> Biome recently reached 5M downloads! However, with the current npm binary size of 29MB (v1.9.4), this translates to 100TB+ of cumulative download data. This PR aims to optimize the binary size to reduce bandwidth usage.

Binary size optimization results (tested on commit 3401663efea3a3c45a7d9240d72b92c981285fb2):
- Before: 32.9MB (only lto)
- After: 30.45MB (codegen-units=1)

All options are explained here : https://doc.rust-lang.org/cargo/reference/profiles.html

- Set `codegen-units = 1`: Can reduces binary size and improves runtime performance

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested on Sentry repo like ecosystem-ci (6164 files)
