### PR TITLE
fix(js_parser): fix "expected a declaration as guaranteed by is_at_ts_declare_statement" error for declare interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @denbezrukov
 
+- Fix [#342](https://github.com/biomejs/biome/issues/342), "expected a declaration as guaranteed by is_at_ts_declare_statement" error for declare interface:
+
+  ```ts
+  declare interface
+  ```
+
+  Contributed by @denbezrukov
+
+
 ## v1.9.4 (2024-10-17)
 
 ### Analyzer

--- a/crates/biome_js_parser/src/syntax/auxiliary.rs
+++ b/crates/biome_js_parser/src/syntax/auxiliary.rs
@@ -8,8 +8,9 @@ use crate::syntax::stmt::{
     VariableDeclarationParent,
 };
 use crate::syntax::typescript::{
-    is_nth_at_any_ts_namespace_declaration, parse_any_ts_namespace_declaration_clause,
-    parse_ts_enum_declaration, parse_ts_interface_declaration, parse_ts_type_alias_declaration,
+    is_nth_at_any_ts_namespace_declaration, is_nth_at_ts_interface_declaration,
+    parse_any_ts_namespace_declaration_clause, parse_ts_enum_declaration,
+    parse_ts_interface_declaration, parse_ts_type_alias_declaration,
 };
 use crate::{Absent, JsParser, ParsedSyntax};
 use biome_js_syntax::JsSyntaxKind::{JS_BOGUS_STATEMENT, JS_VARIABLE_DECLARATION_CLAUSE};
@@ -59,7 +60,7 @@ pub(crate) fn is_nth_at_declaration_clause(p: &mut JsParser, n: usize) -> bool {
         return true;
     }
 
-    if p.nth_at(n, T![interface]) {
+    if is_nth_at_ts_interface_declaration(p, n) {
         return true;
     }
 

--- a/crates/biome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/statement.rs
@@ -265,11 +265,16 @@ pub(crate) fn is_at_ts_declare_statement(p: &mut JsParser) -> bool {
 
 #[inline]
 pub(crate) fn is_at_ts_interface_declaration(p: &mut JsParser) -> bool {
-    if !p.at(T![interface]) || p.has_nth_preceding_line_break(1) {
+    is_nth_at_ts_interface_declaration(p, 0)
+}
+
+#[inline]
+pub(crate) fn is_nth_at_ts_interface_declaration(p: &mut JsParser, n: usize) -> bool {
+    if !p.nth_at(n, T![interface]) || p.has_nth_preceding_line_break(n + 1) {
         return false;
     }
 
-    is_nth_at_identifier_binding(p, 1) || p.nth_at(1, T!['{'])
+    is_nth_at_identifier_binding(p, n + 1) || p.nth_at(n + 1, T!['{'])
 }
 
 // test ts ts_interface

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_declare_interface_err.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_declare_interface_err.ts
@@ -1,0 +1,1 @@
+declare interface

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_declare_interface_err.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_declare_interface_err.ts.snap
@@ -1,0 +1,91 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```ts
+declare interface
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsExpressionStatement {
+            expression: JsIdentifierExpression {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@0..8 "declare" [] [Whitespace(" ")],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsExpressionStatement {
+            expression: JsBogusExpression {
+                items: [
+                    JsBogus {
+                        items: [
+                            IDENT@8..17 "interface" [] [],
+                        ],
+                    },
+                ],
+            },
+            semicolon_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@17..18 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..18
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..17
+    0: JS_EXPRESSION_STATEMENT@0..8
+      0: JS_IDENTIFIER_EXPRESSION@0..8
+        0: JS_REFERENCE_IDENTIFIER@0..8
+          0: IDENT@0..8 "declare" [] [Whitespace(" ")]
+      1: (empty)
+    1: JS_EXPRESSION_STATEMENT@8..17
+      0: JS_BOGUS_EXPRESSION@8..17
+        0: JS_BOGUS@8..17
+          0: IDENT@8..17 "interface" [] []
+      1: (empty)
+  4: EOF@17..18 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+ts_declare_interface_err.ts:1:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+  
+  > 1 │ declare interface
+      │         ^^^^^^^^^
+    2 │ 
+  
+  i An explicit or implicit semicolon is expected here...
+  
+  > 1 │ declare interface
+      │         ^^^^^^^^^
+    2 │ 
+  
+  i ...Which is required to end this statement
+  
+  > 1 │ declare interface
+      │ ^^^^^^^^^^^^^^^^^
+    2 │ 
+  
+```


### PR DESCRIPTION
## Summary

Another problem from https://github.com/biomejs/biome/issues/342

Biome failed to parse 
```
declare interface
```

Because the `is_nth_at_declaration_clause` function, which was a guarantee of valid parsing, has deviated from `is_nth_at_ts_interface_declaration`.

https://github.com/biomejs/biome/blob/b02d6c9cd03dcd29b8696c1da0ccd8af274530ab/crates/biome_js_parser/src/syntax/typescript/statement.rs#L231-L249

## Test Plan
Added a new error test case
`cargo test -p biome_js_parser`
