### PR TITLE
feat(grit): support Grit queries targeting CSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,8 @@ version = "0.0.1"
 dependencies = [
  "biome_analyze",
  "biome_console",
+ "biome_css_parser",
+ "biome_css_syntax",
  "biome_diagnostics",
  "biome_grit_parser",
  "biome_grit_syntax",

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -14,6 +14,8 @@ version              = "0.0.1"
 [dependencies]
 biome_analyze        = { workspace = true }
 biome_console        = { workspace = true }
+biome_css_parser     = { workspace = true }
+biome_css_syntax     = { workspace = true }
 biome_diagnostics    = { workspace = true }
 biome_grit_parser    = { workspace = true }
 biome_grit_syntax    = { workspace = true }

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -316,3 +316,12 @@ pub struct GritTargetFile {
     pub path: PathBuf,
     pub parse: AnyParse,
 }
+
+impl GritTargetFile {
+    pub fn parse(source: &str, path: PathBuf, target_language: GritTargetLanguage) -> Self {
+        let parser = target_language.get_parser();
+        let parse = parser.parse_with_path(source, &path);
+
+        Self { parse, path }
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language.rs
@@ -1,0 +1,120 @@
+mod constants;
+
+use super::{
+    normalize_quoted_string, DisregardedSlotCondition, GritTargetLanguageImpl,
+    LeafEquivalenceClass, LeafNormalizer,
+};
+use crate::{
+    grit_target_node::{GritTargetNode, GritTargetSyntaxKind},
+    CompileError,
+};
+use biome_css_syntax::{CssLanguage, CssSyntaxKind};
+use biome_rowan::{RawSyntaxKind, SyntaxKindSet};
+use constants::DISREGARDED_SNIPPET_SLOTS;
+
+const COMMENT_KINDS: SyntaxKindSet<CssLanguage> =
+    SyntaxKindSet::from_raw(RawSyntaxKind(CssSyntaxKind::COMMENT as u16)).union(
+        SyntaxKindSet::from_raw(RawSyntaxKind(CssSyntaxKind::MULTILINE_COMMENT as u16)),
+    );
+
+const EQUIVALENT_LEAF_NODES: &[&[LeafNormalizer]] = &[&[LeafNormalizer::new(
+    GritTargetSyntaxKind::CssSyntaxKind(CssSyntaxKind::CSS_STRING_LITERAL),
+    normalize_quoted_string,
+)]];
+
+#[derive(Clone, Debug)]
+pub struct CssTargetLanguage;
+
+impl GritTargetLanguageImpl for CssTargetLanguage {
+    type Kind = CssSyntaxKind;
+
+    fn language_name(&self) -> &'static str {
+        "CSS"
+    }
+
+    /// Returns the syntax kind for a node by name.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_for_name()`.
+    fn kind_by_name(&self, _node_name: &str) -> Option<CssSyntaxKind> {
+        // TODO: See [super::JsTargetLanguage::kind_by_name()].
+        None
+    }
+
+    /// Returns the node name for a given syntax kind.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_symbol_name()`.
+    fn name_for_kind(&self, _kind: GritTargetSyntaxKind) -> &'static str {
+        // TODO: See [super::JsTargetLanguage::name_for_kind()].
+        "(unknown node)"
+    }
+
+    /// Returns the slots with their names for the given node kind.
+    ///
+    /// For compatibility with existing Grit snippets (as well as the online
+    /// Grit playground), node names should be aligned with TreeSitter's
+    /// `ts_language_field_name_for_id()`.
+    fn named_slots_for_kind(&self, _kind: GritTargetSyntaxKind) -> &'static [(&'static str, u32)] {
+        // TODO: See [super::JsTargetLanguage::named_slots_for_kind()].
+        &[]
+    }
+
+    fn snippet_context_strings(&self) -> &[(&'static str, &'static str)] {
+        &[
+            ("", ""),
+            ("GRIT_BLOCK { ", " }"),
+            ("GRIT_BLOCK { GRIT_PROPERTY: ", " }"),
+        ]
+    }
+
+    fn is_comment_kind(kind: GritTargetSyntaxKind) -> bool {
+        kind.as_css_kind()
+            .map_or(false, |kind| COMMENT_KINDS.matches(kind))
+    }
+
+    fn metavariable_kind() -> Self::Kind {
+        CssSyntaxKind::CSS_METAVARIABLE
+    }
+
+    fn is_disregarded_snippet_field(
+        &self,
+        kind: GritTargetSyntaxKind,
+        slot_index: u32,
+        node: Option<GritTargetNode<'_>>,
+    ) -> bool {
+        DISREGARDED_SNIPPET_SLOTS.iter().any(
+            |(disregarded_kind, disregarded_slot_index, condition)| {
+                if GritTargetSyntaxKind::from(*disregarded_kind) != kind
+                    || *disregarded_slot_index != slot_index
+                {
+                    return false;
+                }
+
+                match condition {
+                    DisregardedSlotCondition::Always => true,
+                    DisregardedSlotCondition::OnlyIf(node_texts) => node_texts.iter().any(|text| {
+                        *text == node.as_ref().map(|node| node.text()).unwrap_or_default()
+                    }),
+                }
+            },
+        )
+    }
+
+    fn get_equivalence_class(
+        &self,
+        kind: GritTargetSyntaxKind,
+        text: &str,
+    ) -> Result<Option<LeafEquivalenceClass>, CompileError> {
+        if let Some(class) = EQUIVALENT_LEAF_NODES
+            .iter()
+            .find(|v| v.iter().any(|normalizer| normalizer.kind() == kind))
+        {
+            LeafEquivalenceClass::new(text, kind, class)
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language/constants.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language/constants.rs
@@ -1,0 +1,7 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use crate::grit_target_language::DisregardedSlotCondition::{self, *};
+use biome_css_syntax::CssSyntaxKind::{self, *};
+
+pub(crate) const DISREGARDED_SNIPPET_SLOTS: &[(CssSyntaxKind, u32, DisregardedSlotCondition)] =
+    &[(CSS_DECLARATION_WITH_SEMICOLON, 1, Always)];

--- a/crates/biome_grit_patterns/src/lib.rs
+++ b/crates/biome_grit_patterns/src/lib.rs
@@ -5,6 +5,7 @@ mod grit_binding;
 mod grit_built_in_functions;
 mod grit_code_snippet;
 mod grit_context;
+mod grit_css_parser;
 mod grit_definitions;
 mod grit_file;
 mod grit_js_parser;

--- a/crates/biome_grit_patterns/tests/specs/css/colors.css
+++ b/crates/biome_grit_patterns/tests/specs/css/colors.css
@@ -1,0 +1,11 @@
+span {
+    color: red;
+}
+
+div {
+    color: blue;
+}
+
+p {
+    color: green;
+}

--- a/crates/biome_grit_patterns/tests/specs/css/colors.grit
+++ b/crates/biome_grit_patterns/tests/specs/css/colors.grit
@@ -1,0 +1,6 @@
+`color: $color` where {
+    $color <: or {
+        `red`,
+        `green`,
+    }
+}

--- a/crates/biome_grit_patterns/tests/specs/css/colors.snap
+++ b/crates/biome_grit_patterns/tests/specs/css/colors.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: colors
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "2:5-2:15",
+        "10:5-10:17",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/xtask/codegen/src/generate_target_language_constants.rs
+++ b/xtask/codegen/src/generate_target_language_constants.rs
@@ -7,7 +7,7 @@ use xtask::Result;
 
 pub fn generate_target_language_constants(
     ast: &AstSrc,
-    _language_kind: LanguageKind,
+    language_kind: LanguageKind,
 ) -> Result<String> {
     let disregarded_slots: Vec<String> = ast
         .nodes
@@ -33,11 +33,22 @@ pub fn generate_target_language_constants(
         .collect();
     let disregarded_slots = disregarded_slots.join("\n    ");
 
+    let syntax_kind = match language_kind {
+        LanguageKind::Css => "CssSyntaxKind",
+        LanguageKind::Js => "JsSyntaxKind",
+        _ => unimplemented!(),
+    };
+    let syntax_kind_module = match language_kind {
+        LanguageKind::Css => "biome_css_syntax",
+        LanguageKind::Js => "biome_js_syntax",
+        _ => unimplemented!(),
+    };
+
     let result = format!(
         "use crate::grit_target_language::DisregardedSlotCondition::{{self, *}};
-use biome_js_syntax::JsSyntaxKind::{{self, *}};
+use {syntax_kind_module}::{syntax_kind}::{{self, *}};
 
-pub(crate) const DISREGARDED_SNIPPET_SLOTS: &[(JsSyntaxKind, u32, DisregardedSlotCondition)] = &[
+pub(crate) const DISREGARDED_SNIPPET_SLOTS: &[({syntax_kind}, u32, DisregardedSlotCondition)] = &[
     {disregarded_slots}
 ];
 "

--- a/xtask/codegen/src/language_kind.rs
+++ b/xtask/codegen/src/language_kind.rs
@@ -162,6 +162,6 @@ impl LanguageKind {
     }
 
     pub fn supports_grit(&self) -> bool {
-        matches!(self, Self::Js)
+        matches!(self, Self::Css | Self::Js)
     }
 }


### PR DESCRIPTION
## Summary

Adds CSS support to our Grit bindings.

Note this doesn't yet fix the assumptions in our search command and the plugin loader, so a few places still need to be updated before CSS support in plugins/search is fully complete. 

## Test Plan

Test added.
