### PR TITLE
feat(grit): implement CSS plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "biome_flags",
  "biome_formatter",
  "biome_fs",
+ "biome_grit_patterns",
  "biome_js_analyze",
  "biome_js_formatter",
  "biome_json_formatter",
@@ -269,6 +270,8 @@ dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
+ "biome_fs",
+ "biome_plugin_loader",
  "biome_rowan",
  "biome_string_case",
  "biome_suppression",
@@ -659,7 +662,9 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rustc-hash 2.0.0",
+ "schemars",
  "serde",
+ "serde_json",
  "tests_macros",
 ]
 

--- a/crates/biome_analyze/src/analyzer_plugin.rs
+++ b/crates/biome_analyze/src/analyzer_plugin.rs
@@ -5,4 +5,8 @@ use std::{fmt::Debug, path::PathBuf};
 /// Definition of an analyzer plugin.
 pub trait AnalyzerPlugin: Debug {
     fn evaluate(&self, root: AnyParse, path: PathBuf) -> Vec<RuleDiagnostic>;
+
+    fn supports_css(&self) -> bool;
+
+    fn supports_js(&self) -> bool;
 }

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -28,6 +28,7 @@ biome_diagnostics        = { workspace = true }
 biome_flags              = { workspace = true }
 biome_formatter          = { workspace = true }
 biome_fs                 = { workspace = true }
+biome_grit_patterns      = { workspace = true }
 biome_js_analyze         = { workspace = true }
 biome_js_formatter       = { workspace = true }
 biome_json_formatter     = { workspace = true }

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ use biome_configuration::{BiomeDiagnostic, PartialConfiguration};
 use biome_console::{markup, Console, ConsoleExt};
 use biome_diagnostics::PrintDiagnostic;
 use biome_fs::{BiomePath, FileSystem};
+use biome_grit_patterns::GritTargetLanguage;
 use biome_service::configuration::{
     load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
 };
@@ -439,6 +440,16 @@ pub enum BiomeCommand {
         /// Example: `echo 'let a;' | biome search '`let $var`' --stdin-file-path=file.js`
         #[bpaf(long("stdin-file-path"), argument("PATH"), hide_usage)]
         stdin_file_path: Option<String>,
+
+        /// The language to which the pattern applies.
+        ///
+        /// Grit queries are specific to the grammar of the language they
+        /// target, so we currently do not support writing queries that apply
+        /// to multiple languages at once.
+        ///
+        /// If none given, the default language is JavaScript.
+        #[bpaf(long("language"), short('l'))]
+        language: Option<GritTargetLanguage>,
 
         /// The GritQL pattern to search for.
         ///

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -21,6 +21,7 @@ use biome_console::{markup, ConsoleExt};
 use biome_diagnostics::adapters::SerdeJsonError;
 use biome_diagnostics::{category, Category};
 use biome_fs::BiomePath;
+use biome_grit_patterns::GritTargetLanguage;
 use biome_service::workspace::{
     FeatureName, FeaturesBuilder, FixFileMode, FormatFileParams, OpenFileParams, PatternId,
 };
@@ -196,6 +197,15 @@ pub enum TraversalMode {
         ///
         /// Note that the search command does not support rewrites.
         pattern: PatternId,
+
+        /// The language to query for.
+        ///
+        /// Grit queries are specific to the grammar of the language they
+        /// target, so we currently do not support writing queries that apply
+        /// to multiple languages at once.
+        ///
+        /// If none given, the default language is JavaScript.
+        language: Option<GritTargetLanguage>,
 
         /// An optional tuple.
         /// 1. The virtual path to the file

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -249,6 +249,7 @@ impl<'app> CliSession<'app> {
                 files_configuration,
                 paths,
                 pattern,
+                language,
                 stdin_file_path,
                 vcs_configuration,
             } => run_command(
@@ -258,6 +259,7 @@ impl<'app> CliSession<'app> {
                     files_configuration,
                     paths,
                     pattern,
+                    language,
                     stdin_file_path,
                     vcs_configuration,
                 },

--- a/crates/biome_cli/tests/commands/mod.rs
+++ b/crates/biome_cli/tests/commands/mod.rs
@@ -9,4 +9,5 @@ mod migrate;
 mod migrate_eslint;
 mod migrate_prettier;
 mod rage;
+mod search;
 mod version;

--- a/crates/biome_cli/tests/commands/search.rs
+++ b/crates/biome_cli/tests/commands/search.rs
@@ -1,0 +1,118 @@
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use biome_service::DynRef;
+use bpaf::Args;
+use std::path::Path;
+
+use crate::{
+    run_cli,
+    snap_test::{assert_cli_snapshot, SnapshotPayload},
+};
+
+// Feel free to add content at the end of this dummy file. It shouldn't affect
+// existing tests.
+const CSS_FILE_CONTENT: &str = r#"div {
+    color: green;
+}"#;
+
+// Feel free to add content at the end of this dummy file. It shouldn't affect
+// existing tests.
+const JS_FILE_CONTENT: &str = r#"const a = 'foo';"#;
+
+#[test]
+fn search_css_pattern() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.css");
+    fs.insert(file_path.into(), CSS_FILE_CONTENT.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "search",
+                "--language=css",
+                "`color: green`",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "search_css_pattern",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn search_css_pattern_shorthand() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.css");
+    fs.insert(file_path.into(), CSS_FILE_CONTENT.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "search",
+                "-lcss",
+                "`color: green`",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "search_css_pattern_shorthand",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn search_js_pattern() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Path::new("file.js");
+    fs.insert(file_path.into(), JS_FILE_CONTENT.as_bytes());
+
+    let result = run_cli(
+        DynRef::Borrowed(&mut fs),
+        &mut console,
+        Args::from(
+            [
+                "search",
+                "`\"foo\"`",
+                file_path.as_os_str().to_str().unwrap(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "search_js_pattern",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_search/search_css_pattern.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_search/search_css_pattern.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.css`
+
+```css
+div {
+    color: green;
+}
+```
+
+# Emitted Messages
+
+```block
+file.css:2:5 search ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  2 │     color: green;
+
+```
+
+```block
+Searched 1 file in <TIME>. Found 1 match.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_search/search_css_pattern_shorthand.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_search/search_css_pattern_shorthand.snap
@@ -1,0 +1,24 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.css`
+
+```css
+div {
+    color: green;
+}
+```
+
+# Emitted Messages
+
+```block
+file.css:2:5 search ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  2 │     color: green;
+
+```
+
+```block
+Searched 1 file in <TIME>. Found 1 match.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_search/search_js_pattern.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_search/search_js_pattern.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+---
+## `file.js`
+
+```js
+const a = 'foo';
+```
+
+# Emitted Messages
+
+```block
+file.js:1:11 search ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  1 │ const a = 'foo';
+
+```
+
+```block
+Searched 1 file in <TIME>. Found 1 match.
+```

--- a/crates/biome_css_analyze/Cargo.toml
+++ b/crates/biome_css_analyze/Cargo.toml
@@ -29,10 +29,12 @@ schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-biome_css_parser = { path = "../biome_css_parser" }
-biome_test_utils = { path = "../biome_test_utils" }
-insta            = { workspace = true, features = ["glob"] }
-tests_macros     = { path = "../tests_macros" }
+biome_css_parser    = { path = "../biome_css_parser" }
+biome_fs            = { workspace = true }
+biome_plugin_loader = { workspace = true }
+biome_test_utils    = { path = "../biome_test_utils" }
+insta               = { workspace = true, features = ["glob"] }
+tests_macros        = { path = "../tests_macros" }
 
 [features]
 schema = ["schemars"]

--- a/crates/biome_css_analyze/tests/plugin/useLowercaseColors.css
+++ b/crates/biome_css_analyze/tests/plugin/useLowercaseColors.css
@@ -1,0 +1,5 @@
+div {
+    color: red;
+    color: #FFF;
+    color: #abcdef;
+}

--- a/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit
+++ b/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit
@@ -1,0 +1,9 @@
+language css;
+
+`color: $color` where {
+    not $color == lowercase($color),
+    register_diagnostic(
+        span = $color,
+        message = "Prefer lowercase colors"
+    )
+}

--- a/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit.snap
+++ b/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: useLowercaseColors.grit
+---
+# Input
+```css
+div {
+    color: red;
+    color: #FFF;
+    color: #abcdef;
+}
+
+```
+
+# Diagnostics
+```
+useLowercaseColors.grit:3:12 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer lowercase colors
+  
+    1 │ div {
+    2 │     color: red;
+  > 3 │     color: #FFF;
+      │            ^^^^
+    4 │     color: #abcdef;
+    5 │ }
+  
+
+```

--- a/crates/biome_css_analyze/tests/spec_tests.rs
+++ b/crates/biome_css_analyze/tests/spec_tests.rs
@@ -1,8 +1,12 @@
-use biome_analyze::{AnalysisFilter, AnalyzerAction, ControlFlow, Never, RuleFilter};
+use biome_analyze::{
+    AnalysisFilter, AnalyzerAction, AnalyzerPlugin, ControlFlow, Never, RuleFilter,
+};
 use biome_css_parser::{parse_css, CssParserOptions};
 use biome_css_syntax::{CssFileSource, CssLanguage};
 use biome_diagnostics::advice::CodeSuggestionAdvice;
 use biome_diagnostics::{DiagnosticExt, Severity};
+use biome_fs::OsFileSystem;
+use biome_plugin_loader::AnalyzerGritPlugin;
 use biome_rowan::AstNode;
 use biome_test_utils::{
     assert_errors_are_absent, code_fix_to_string, create_analyzer_options, diagnostic_to_string,
@@ -14,6 +18,7 @@ use std::{ffi::OsStr, fs::read_to_string, path::Path, slice};
 
 tests_macros::gen_tests! {"tests/specs/**/*.{css,json,jsonc}", crate::run_test, "module"}
 tests_macros::gen_tests! {"tests/suppression/**/*.{css,json,jsonc}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/plugin/*.grit", crate::run_plugin_test, "module"}
 
 fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     register_leak_checker();
@@ -67,6 +72,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
                 input_file,
                 CheckActionType::Lint,
                 parser_options,
+                Vec::new(),
             );
         }
 
@@ -84,6 +90,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
             input_file,
             CheckActionType::Lint,
             parser_options,
+            Vec::new(),
         )
     };
 
@@ -109,6 +116,7 @@ pub(crate) fn analyze_and_snap(
     input_file: &Path,
     check_action_type: CheckActionType,
     parser_options: CssParserOptions,
+    plugins: Vec<Box<dyn AnalyzerPlugin>>,
 ) -> usize {
     let parsed = parse_css(input_code, parser_options);
     let root = parsed.tree();
@@ -117,7 +125,7 @@ pub(crate) fn analyze_and_snap(
     let mut code_fixes = Vec::new();
     let options = create_analyzer_options(input_file, &mut diagnostics);
 
-    let (_, errors) = biome_css_analyze::analyze(&root, filter, &options, |event| {
+    let (_, errors) = biome_css_analyze::analyze(&root, filter, &options, plugins, |event| {
         if let Some(mut diag) = event.diagnostic() {
             for action in event.actions() {
                 if check_action_type.is_suppression() {
@@ -234,11 +242,59 @@ pub(crate) fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &st
         input_file,
         CheckActionType::Suppression,
         CssParserOptions::default(),
+        Vec::new(),
     );
 
     insta::with_settings!({
         prepend_module_to_snapshot => false,
         snapshot_path => input_file.parent().unwrap(),
+    }, {
+        insta::assert_snapshot!(file_name, snapshot, file_name);
+    });
+}
+
+fn run_plugin_test(input: &'static str, _: &str, _: &str, _: &str) {
+    register_leak_checker();
+
+    let plugin_path = Path::new(input);
+    let file_name = plugin_path.file_name().and_then(OsStr::to_str).unwrap();
+    let input_path = plugin_path.with_extension("css");
+
+    let plugin = match AnalyzerGritPlugin::load(
+        &OsFileSystem::new(plugin_path.to_owned()),
+        Path::new(plugin_path),
+    ) {
+        Ok(plugin) => plugin,
+        Err(err) => panic!("Cannot load plugin: {err:?}"),
+    };
+
+    let filter = AnalysisFilter {
+        enabled_rules: Some(&[]),
+        ..AnalysisFilter::default()
+    };
+
+    let mut snapshot = String::new();
+
+    let input_code = read_to_string(&input_path)
+        .unwrap_or_else(|err| panic!("failed to read {input_path:?}: {err:?}"));
+    let Ok(source_type) = input_path.as_path().try_into() else {
+        return;
+    };
+    analyze_and_snap(
+        &mut snapshot,
+        &input_code,
+        source_type,
+        filter,
+        file_name,
+        &input_path,
+        CheckActionType::Lint,
+        CssParserOptions::default(),
+        vec![Box::new(plugin)],
+    );
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        snapshot_path => plugin_path.parent().unwrap(),
     }, {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -30,12 +30,17 @@ path-absolutize      = { version = "3.1.1", optional = false, features = ["use_u
 rand                 = { version = "0.8.5" }
 regex                = { workspace = true }
 rustc-hash           = { workspace = true }
+schemars             = { workspace = true, optional = true }
 serde                = { workspace = true, features = ["derive"] }
+serde_json           = { workspace = true, optional = true }
 
 [dev-dependencies]
 biome_test_utils = { path = "../biome_test_utils" }
 insta            = { workspace = true }
 tests_macros     = { path = "../tests_macros" }
+
+[features]
+schema = ["dep:schemars", "dep:serde_json"]
 
 [lints]
 workspace = true

--- a/crates/biome_grit_patterns/src/grit_query.rs
+++ b/crates/biome_grit_patterns/src/grit_query.rs
@@ -195,6 +195,14 @@ impl GritQuery {
             variable_locations,
         })
     }
+
+    pub fn supports_css(&self) -> bool {
+        matches!(self.language, GritTargetLanguage::CssTargetLanguage(_))
+    }
+
+    pub fn supports_js(&self) -> bool {
+        matches!(self.language, GritTargetLanguage::JsTargetLanguage(_))
+    }
 }
 
 #[derive(Debug)]

--- a/crates/biome_grit_patterns/src/grit_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language.rs
@@ -4,16 +4,23 @@ mod js_target_language;
 pub use css_target_language::CssTargetLanguage;
 pub use js_target_language::JsTargetLanguage;
 
+use std::borrow::Cow;
+use std::path::Path;
+use std::str::FromStr;
+
+use grit_util::{AnalysisLogs, Ast, CodeRange, EffectRange, Language, Parser, SnippetTree};
+use serde::{Deserialize, Serialize};
+
+use biome_grit_syntax::{GritLanguageDeclaration, GritSyntaxKind};
+use biome_parser::AnyParse;
+use biome_rowan::SyntaxKind;
+use biome_string_case::StrOnlyExtension;
+
 use crate::grit_css_parser::GritCssParser;
 use crate::grit_js_parser::GritJsParser;
 use crate::grit_target_node::{GritTargetNode, GritTargetSyntaxKind};
 use crate::grit_tree::GritTargetTree;
 use crate::CompileError;
-use biome_parser::AnyParse;
-use biome_rowan::SyntaxKind;
-use grit_util::{AnalysisLogs, Ast, CodeRange, EffectRange, Language, Parser, SnippetTree};
-use std::borrow::Cow;
-use std::path::Path;
 
 /// Generates the `GritTargetLanguage` enum.
 ///
@@ -22,7 +29,7 @@ use std::path::Path;
 /// implement the slightly more convenient [`GritTargetLanguageImpl`] for
 /// creating language-specific implementations.
 macro_rules! generate_target_language {
-    ($([$language:ident, $parser:ident]),+) => {
+    ($([$language:ident, $parser:ident, $name:literal]),+) => {
         #[derive(Clone, Debug)]
         pub enum GritTargetLanguage {
             $($language($language)),+
@@ -33,6 +40,54 @@ macro_rules! generate_target_language {
                 Self::$language(value)
             }
         })+
+
+        impl Serialize for GritTargetLanguage {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    $(Self::$language(_) => Serialize::serialize($name, serializer)),+
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for GritTargetLanguage {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Self::from_str(String::deserialize(deserializer)?.as_str())
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+
+        impl FromStr for GritTargetLanguage {
+            type Err = String;
+
+            fn from_str(string: &str) -> Result<Self, Self::Err> {
+                match string.to_lowercase_cow() {
+                    $(name if $name.to_lowercase_cow() == name => Ok(Self::$language($language))),+,
+                    other => Err(format!("Unexpected target language: {other}")),
+                }
+            }
+        }
+
+        #[cfg(feature = "schema")]
+        impl schemars::JsonSchema for GritTargetLanguage {
+            fn schema_name() -> String {
+                "GritTargetLanguage".to_owned()
+            }
+
+            fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+                schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+                    enum_values: Some(vec![
+                        $(serde_json::json!($name)),+
+                    ]),
+                    ..Default::default()
+                })
+            }
+        }
 
         impl GritTargetLanguage {
             fn metavariable_kind(&self) -> GritTargetSyntaxKind {
@@ -104,7 +159,7 @@ macro_rules! generate_target_language {
 
             fn language_name(&self) -> &'static str {
                 match self {
-                    $(Self::$language(language) => language.language_name()),+
+                    $(Self::$language(_) => $name),+
                 }
             }
 
@@ -150,11 +205,27 @@ macro_rules! generate_target_language {
 }
 
 generate_target_language! {
-    [CssTargetLanguage, GritCssParser],
-    [JsTargetLanguage, GritJsParser]
+    [CssTargetLanguage, GritCssParser, "CSS"],
+    [JsTargetLanguage, GritJsParser, "JavaScript"]
+}
+
+impl Default for GritTargetLanguage {
+    fn default() -> Self {
+        Self::JsTargetLanguage(JsTargetLanguage)
+    }
 }
 
 impl GritTargetLanguage {
+    /// Returns the target language based on the language declaration given
+    /// inside a Grit pattern.
+    pub fn from_declaration(language_decl: &GritLanguageDeclaration) -> Option<Self> {
+        match language_decl.name().ok()?.language_kind().ok()?.kind() {
+            GritSyntaxKind::CSS_KW => Some(Self::CssTargetLanguage(CssTargetLanguage)),
+            GritSyntaxKind::JS_KW => Some(Self::JsTargetLanguage(JsTargetLanguage)),
+            _ => None,
+        }
+    }
+
     /// Returns the target language to use for the given file extension.
     pub fn from_extension(extension: &str) -> Option<Self> {
         match extension {
@@ -225,8 +296,6 @@ impl GritTargetLanguage {
 /// forcing them to reimplement methods that are common across implementations.
 trait GritTargetLanguageImpl {
     type Kind: SyntaxKind;
-
-    fn language_name(&self) -> &'static str;
 
     /// Returns the syntax kind for a node by name.
     ///

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language.rs
@@ -28,10 +28,6 @@ pub struct CssTargetLanguage;
 impl GritTargetLanguageImpl for CssTargetLanguage {
     type Kind = CssSyntaxKind;
 
-    fn language_name(&self) -> &'static str {
-        "CSS"
-    }
-
     /// Returns the syntax kind for a node by name.
     ///
     /// For compatibility with existing Grit snippets (as well as the online

--- a/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/js_target_language.rs
@@ -34,10 +34,6 @@ pub struct JsTargetLanguage;
 impl GritTargetLanguageImpl for JsTargetLanguage {
     type Kind = JsSyntaxKind;
 
-    fn language_name(&self) -> &'static str {
-        "JavaScript"
-    }
-
     /// Returns the syntax kind for a node by name.
     ///
     /// For compatibility with existing Grit snippets (as well as the online

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -123,7 +123,9 @@ where
     );
 
     for plugin in plugins {
-        analyzer.add_plugin(plugin);
+        if plugin.supports_js() {
+            analyzer.add_plugin(plugin);
+        }
     }
 
     for ((phase, _), visitor) in visitors {

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -631,6 +631,9 @@ impl ServerFactory {
         workspace_method!(builder, fix_file);
         workspace_method!(builder, rename);
         workspace_method!(builder, organize_imports);
+        workspace_method!(builder, parse_pattern);
+        workspace_method!(builder, search_pattern);
+        workspace_method!(builder, drop_pattern);
 
         let (service, socket) = builder.finish();
         ServerConnection { socket, service }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -33,7 +33,7 @@ biome_graphql_parser     = { workspace = true }
 biome_graphql_syntax     = { workspace = true }
 biome_grit_formatter     = { workspace = true }
 biome_grit_parser        = { workspace = true }
-biome_grit_patterns      = { workspace = true }
+biome_grit_patterns      = { workspace = true, features = ["schema"] }
 biome_grit_syntax        = { workspace = true }
 biome_html_formatter     = { workspace = true }
 biome_html_parser        = { workspace = true }

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -1,6 +1,6 @@
 use super::{
-    is_diagnostic_error, AnalyzerVisitorBuilder, CodeActionsParams, ExtensionHandler, FixAllParams,
-    LintParams, LintResults, ParseResult, SearchCapabilities,
+    is_diagnostic_error, search, AnalyzerVisitorBuilder, CodeActionsParams, ExtensionHandler,
+    FixAllParams, LintParams, LintResults, ParseResult, SearchCapabilities,
 };
 use crate::configuration::to_analyzer_rules;
 use crate::file_handlers::DebugCapabilities;
@@ -179,7 +179,9 @@ impl ExtensionHandler for CssFileHandler {
                 format_range: Some(format_range),
                 format_on_type: Some(format_on_type),
             },
-            search: SearchCapabilities { search: None },
+            search: SearchCapabilities {
+                search: Some(search),
+            },
         }
     }
 }
@@ -350,51 +352,52 @@ fn lint(params: LintParams) -> LintResults {
                 .count();
 
             info!("Analyze file {}", params.path.display());
-            let (_, analyze_diagnostics) = analyze(&tree, filter, &analyzer_options, |signal| {
-                if let Some(mut diagnostic) = signal.diagnostic() {
-                    // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
-                    if ignores_suppression_comment
-                        && diagnostic.category() == Some(category!("suppressions/unused"))
-                    {
-                        return ControlFlow::<Never>::Continue(());
-                    }
-
-                    diagnostic_count += 1;
-
-                    // We do now check if the severity of the diagnostics should be changed.
-                    // The configuration allows to change the severity of the diagnostics emitted by rules.
-                    let severity = diagnostic
-                        .category()
-                        .filter(|category| category.name().starts_with("lint/"))
-                        .map_or_else(
-                            || diagnostic.severity(),
-                            |category| {
-                                rules
-                                    .as_ref()
-                                    .and_then(|rules| rules.get_severity_from_code(category))
-                                    .unwrap_or(Severity::Warning)
-                            },
-                        );
-
-                    if severity >= Severity::Error {
-                        errors += 1;
-                    }
-
-                    if diagnostic_count <= params.max_diagnostics {
-                        for action in signal.actions() {
-                            if !action.is_suppression() {
-                                diagnostic = diagnostic.add_code_suggestion(action.into());
-                            }
+            let (_, analyze_diagnostics) =
+                analyze(&tree, filter, &analyzer_options, Vec::new(), |signal| {
+                    if let Some(mut diagnostic) = signal.diagnostic() {
+                        // Do not report unused suppression comment diagnostics if this is a syntax-only analyzer pass
+                        if ignores_suppression_comment
+                            && diagnostic.category() == Some(category!("suppressions/unused"))
+                        {
+                            return ControlFlow::<Never>::Continue(());
                         }
 
-                        let error = diagnostic.with_severity(severity);
+                        diagnostic_count += 1;
 
-                        diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
+                        // We do now check if the severity of the diagnostics should be changed.
+                        // The configuration allows to change the severity of the diagnostics emitted by rules.
+                        let severity = diagnostic
+                            .category()
+                            .filter(|category| category.name().starts_with("lint/"))
+                            .map_or_else(
+                                || diagnostic.severity(),
+                                |category| {
+                                    rules
+                                        .as_ref()
+                                        .and_then(|rules| rules.get_severity_from_code(category))
+                                        .unwrap_or(Severity::Warning)
+                                },
+                            );
+
+                        if severity >= Severity::Error {
+                            errors += 1;
+                        }
+
+                        if diagnostic_count <= params.max_diagnostics {
+                            for action in signal.actions() {
+                                if !action.is_suppression() {
+                                    diagnostic = diagnostic.add_code_suggestion(action.into());
+                                }
+                            }
+
+                            let error = diagnostic.with_severity(severity);
+
+                            diagnostics.push(biome_diagnostics::serde::Diagnostic::new(error));
+                        }
                     }
-                }
 
-                ControlFlow::<Never>::Continue(())
-            });
+                    ControlFlow::<Never>::Continue(())
+                });
 
             diagnostics.extend(
                 analyze_diagnostics
@@ -463,7 +466,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 
             info!("CSS runs the analyzer");
 
-            analyze(&tree, filter, &analyzer_options, |signal| {
+            analyze(&tree, filter, &analyzer_options, Vec::new(), |signal| {
                 actions.extend(signal.actions().into_code_action_iter().map(|item| {
                     CodeAction {
                         category: item.category.clone(),
@@ -519,7 +522,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
         .workspace
         .analyzer_options::<CssLanguage>(params.biome_path, &params.document_file_source);
     loop {
-        let (action, _) = analyze(&tree, filter, &analyzer_options, |signal| {
+        let (action, _) = analyze(&tree, filter, &analyzer_options, Vec::new(), |signal| {
             let current_diagnostic = signal.diagnostic();
 
             if let Some(diagnostic) = current_diagnostic.as_ref() {

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -64,6 +64,7 @@ use biome_console::{markup, Markup, MarkupBuf};
 use biome_diagnostics::CodeSuggestion;
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
+use biome_grit_patterns::GritTargetLanguage;
 use biome_js_syntax::{TextRange, TextSize};
 use biome_text_edit::TextEdit;
 use core::str;
@@ -821,6 +822,7 @@ impl RageEntry {
 #[serde(rename_all = "camelCase")]
 pub struct ParsePatternParams {
     pub pattern: String,
+    pub default_language: GritTargetLanguage,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -25,7 +25,7 @@ use biome_diagnostics::{
 };
 use biome_formatter::Printed;
 use biome_fs::{BiomePath, ConfigName};
-use biome_grit_patterns::GritQuery;
+use biome_grit_patterns::{compile_pattern_with_options, CompilePatternOptions, GritQuery};
 use biome_js_syntax::ModuleKind;
 use biome_json_parser::{parse_json_with_cache, JsonParserOptions};
 use biome_json_syntax::JsonFileSource;
@@ -816,12 +816,9 @@ impl Workspace for WorkspaceServer {
         &self,
         params: ParsePatternParams,
     ) -> Result<ParsePatternResult, WorkspaceError> {
-        let pattern = biome_grit_patterns::compile_pattern(
-            &params.pattern,
-            None,
-            biome_grit_patterns::JsTargetLanguage.into(),
-            Vec::new(),
-        )?;
+        let options =
+            CompilePatternOptions::default().with_default_language(params.default_language);
+        let pattern = compile_pattern_with_options(&params.pattern, options)?;
 
         let pattern_id = make_search_pattern_id();
         self.patterns.insert(pattern_id.clone(), pattern);

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -451,7 +451,7 @@ macro_rules! workspace_method {
 }
 
 /// Returns a list of signature for all the methods in the [Workspace] trait
-pub fn methods() -> [WorkspaceMethod; 19] {
+pub fn methods() -> [WorkspaceMethod; 22] {
     [
         workspace_method!(file_features),
         workspace_method!(update_settings),
@@ -472,5 +472,8 @@ pub fn methods() -> [WorkspaceMethod; 19] {
         workspace_method!(format_on_type),
         workspace_method!(fix_file),
         workspace_method!(rename),
+        workspace_method!(parse_pattern),
+        workspace_method!(search_pattern),
+        workspace_method!(drop_pattern),
     ]
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3488,6 +3488,26 @@ export interface RenameResult {
 	 */
 	range: TextRange;
 }
+export interface ParsePatternParams {
+	defaultLanguage: GritTargetLanguage;
+	pattern: string;
+}
+export type GritTargetLanguage = "CSS" | "JavaScript";
+export interface ParsePatternResult {
+	patternId: PatternId;
+}
+export type PatternId = string;
+export interface SearchPatternParams {
+	path: BiomePath;
+	pattern: PatternId;
+}
+export interface SearchResults {
+	file: BiomePath;
+	matches: TextRange[];
+}
+export interface DropPatternParams {
+	pattern: PatternId;
+}
 export type Configuration = PartialConfiguration;
 export interface Workspace {
 	fileFeatures(params: SupportsFeatureParams): Promise<FileFeaturesResult>;
@@ -3515,6 +3535,9 @@ export interface Workspace {
 	formatOnType(params: FormatOnTypeParams): Promise<Printed>;
 	fixFile(params: FixFileParams): Promise<FixFileResult>;
 	rename(params: RenameParams): Promise<RenameResult>;
+	parsePattern(params: ParsePatternParams): Promise<ParsePatternResult>;
+	searchPattern(params: SearchPatternParams): Promise<SearchResults>;
+	dropPattern(params: DropPatternParams): Promise<void>;
 	destroy(): void;
 }
 export function createWorkspace(transport: Transport): Workspace {
@@ -3575,6 +3598,15 @@ export function createWorkspace(transport: Transport): Workspace {
 		},
 		rename(params) {
 			return transport.request("biome/rename", params);
+		},
+		parsePattern(params) {
+			return transport.request("biome/parse_pattern", params);
+		},
+		searchPattern(params) {
+			return transport.request("biome/search_pattern", params);
+		},
+		dropPattern(params) {
+			return transport.request("biome/drop_pattern", params);
 		},
 		destroy() {
 			transport.destroy();

--- a/xtask/bench/benches/gritql_search.rs
+++ b/xtask/bench/benches/gritql_search.rs
@@ -1,4 +1,7 @@
-use biome_grit_patterns::{compile_pattern, GritTargetFile, GritTargetLanguage, JsTargetLanguage};
+use biome_grit_patterns::{
+    compile_pattern_with_options, CompilePatternOptions, GritTargetFile, GritTargetLanguage,
+    JsTargetLanguage,
+};
 use criterion::measurement::WallTime;
 use std::collections::HashMap;
 use std::path::Path;
@@ -48,11 +51,9 @@ fn bench_gritql_search(criterion: &mut Criterion) {
 pub fn bench_search_group(group: &mut BenchmarkGroup<WallTime>, test_case: TestCase) {
     let target_language = GritTargetLanguage::JsTargetLanguage(JsTargetLanguage);
 
-    let query = compile_pattern(
+    let query = compile_pattern_with_options(
         "`getEntityNameForExtendingInterface(errorLocation)`",
-        Some(Path::new("bench.grit")),
-        target_language.clone(),
-        Vec::new(),
+        CompilePatternOptions::default().with_path(Path::new("bench.grit")),
     )
     .unwrap();
 

--- a/xtask/bench/src/language.rs
+++ b/xtask/bench/src/language.rs
@@ -212,7 +212,7 @@ impl Analyze {
                     ..AnalysisFilter::default()
                 };
                 let options = AnalyzerOptions::default();
-                biome_css_analyze::analyze(root, filter, &options, |event| {
+                biome_css_analyze::analyze(root, filter, &options, Vec::new(), |event| {
                     black_box(event.diagnostic());
                     black_box(event.actions());
                     ControlFlow::<Never>::Continue(())

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -375,7 +375,7 @@ fn assert_lint(
                     file_path: PathBuf::from(&file_path),
                     ..Default::default()
                 };
-                biome_css_analyze::analyze(&root, filter, &options, |signal| {
+                biome_css_analyze::analyze(&root, filter, &options, Vec::new(), |signal| {
                     if let Some(mut diag) = signal.diagnostic() {
                         let category = diag.category().expect("linter diagnostic has no code");
                         let severity = settings.get_current_settings().expect("project").get_severity_from_rule_code(category).expect(


### PR DESCRIPTION
## Summary

This extends plugin support to CSS files.

Also added a CLI argument so that Grit searching through CSS files works too.

Implements #4427.

## Test Plan

Tests added.