### PR TITLE
docs: add typescript-eslint rule source for `useArrayLiterals`

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -158,6 +158,11 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@typescript-eslint/no-array-constructor" => {
+            let group = rules.correctness.get_or_insert_with(Default::default);
+            let rule = group.use_array_literals.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/no-dupe-class-members" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_js_analyze/src/lint/correctness/use_array_literals.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_array_literals.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
         version: "1.7.2",
         name: "useArrayLiterals",
         language: "js",
-        sources: &[RuleSource::Eslint("no-array-constructor")],
+        sources: &[RuleSource::Eslint("no-array-constructor"), RuleSource::EslintTypeScript("no-array-constructor")],
         recommended: false,
         fix_kind: FixKind::Unsafe,
     }


### PR DESCRIPTION
## Summary

Just adding this rule source: https://typescript-eslint.io/rules/no-array-constructor/

Noticed it while doing some migrating.

![CleanShot 2024-11-03 at 14 08 33@2x](https://github.com/user-attachments/assets/a4112f4e-6d49-4d30-8f26-b005078a640e)


## Test Plan

👀 
