### PR TITLE
feat(useExplicitType): support explicit function argument types

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -147,6 +147,14 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@typescript-eslint/explicit-module-boundary-types" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group.use_explicit_type.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/naming-convention" => {
             if !options.include_inspired {
                 results.has_inspired_rules = true;

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3418,7 +3418,7 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_deprecated_reason:
         Option<RuleConfiguration<biome_graphql_analyze::options::UseDeprecatedReason>>,
-    #[doc = "Require explicit return types on functions and class methods."]
+    #[doc = "Require explicit argument and return types on functions and class methods."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_explicit_type: Option<RuleConfiguration<biome_js_analyze::options::UseExplicitType>>,
     #[doc = "Enforces the use of a recommended display strategy with Google Fonts."]

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
@@ -93,3 +93,15 @@ function fn() {
 
 const x = { prop: () => {} }
 const x = { bar: { prop: () => {} } }
+
+export default (a): void => {
+  return;
+}
+export function test(a: number, b) {
+  return;
+}
+export class Test {
+  method(a): void {
+    return;
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
@@ -99,6 +100,18 @@ function fn() {
 
 const x = { prop: () => {} }
 const x = { bar: { prop: () => {} } }
+
+export default (a): void => {
+  return;
+}
+export function test(a: number, b) {
+  return;
+}
+export class Test {
+  method(a): void {
+    return;
+  }
+}
 ```
 
 # Diagnostics
@@ -541,6 +554,7 @@ invalid.ts:94:19 lint/nursery/useExplicitType ━━━━━━━━━━━�
   > 94 │ const x = { prop: () => {} }
        │                   ^^^^^^^^^
     95 │ const x = { bar: { prop: () => {} } }
+    96 │ 
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
@@ -557,10 +571,88 @@ invalid.ts:95:26 lint/nursery/useExplicitType ━━━━━━━━━━━�
     94 │ const x = { prop: () => {} }
   > 95 │ const x = { bar: { prop: () => {} } }
        │                          ^^^^^^^^^
+    96 │ 
+    97 │ export default (a): void => {
   
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
   i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:97:17 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    95 │ const x = { bar: { prop: () => {} } }
+    96 │ 
+  > 97 │ export default (a): void => {
+       │                 ^
+    98 │   return;
+    99 │ }
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:100:8 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+     98 │   return;
+     99 │ }
+  > 100 │ export function test(a: number, b) {
+        │        ^^^^^^^^^^^^^
+    101 │   return;
+    102 │ }
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:100:33 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'b' should be typed.
+  
+     98 │   return;
+     99 │ }
+  > 100 │ export function test(a: number, b) {
+        │                                 ^
+    101 │   return;
+    102 │ }
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:104:10 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    102 │ }
+    103 │ export class Test {
+  > 104 │   method(a): void {
+        │          ^
+    105 │     return;
+    106 │   }
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.d.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.d.ts
@@ -46,3 +46,10 @@ declare function test(): void;
 declare var fn: () => number;
 
 declare var arrowFn: () => string;
+
+export default function test(obj: {a: string}): void {
+  return;
+}
+export function add(a: number, b: number): number {
+	return a + b;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.d.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.d.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
@@ -53,4 +54,10 @@ declare var fn: () => number;
 
 declare var arrowFn: () => string;
 
+export default function test(obj: {a: string}): void {
+  return;
+}
+export function add(a: number, b: number): number {
+	return a + b;
+}
 ```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1391,7 +1391,7 @@ export interface Nursery {
 	 */
 	useDeprecatedReason?: RuleConfiguration_for_Null;
 	/**
-	 * Require explicit return types on functions and class methods.
+	 * Require explicit argument and return types on functions and class methods.
 	 */
 	useExplicitType?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2430,7 +2430,7 @@
 					]
 				},
 				"useExplicitType": {
-					"description": "Require explicit return types on functions and class methods.",
+					"description": "Require explicit argument and return types on functions and class methods.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
related: https://github.com/biomejs/biome/issues/2017

This PR adds support for enforcing explicit type annotations on arguments in all functions and class methods. The rule is inspired by the [ explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types/) rule, but it expands coverage beyond exported functions to include all functions and methods within a class.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->


<!-- What demonstrates that your implementation is correct? -->
