### PR TITLE
refactor(analyzer): use rule name for quick fix

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Let's say we want to create a new **lint** rule called `useMyRuleName`, follow t
        fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<JsRuleAction> {
          let mut mutation = ctx.root().mutation();
          Some(JsRuleAction::new(
-           ActionCategory::QuickFix,
+           ctx.action_category(ctx.category(), ctx.group()),
            ctx.metadata().applicability(),
            markup! { "<MESSAGE>" }.to_owned(),
            mutation,
@@ -120,7 +120,7 @@ Let's say we want to create a new **lint** rule called `useMyRuleName`, follow t
    }
    ```
    When returning a code action, you must pass the `category` and the `applicability` fields.
-   `category` must be `ActionCategory::QuickFix`.
+   `category` must be `ctx.action_category(ctx.category(), ctx.group())`.
    `applicability` is derived from the metadata [`fix_kind`](#code-action).
    In other words, the code transformation should always result in code that doesn't change the behavior of the logic.
    In the case of `noVar`, it is not always safe to turn `var` to `const` or `let`.
@@ -509,7 +509,7 @@ impl Rule for ExampleRule {
       let mut mutation = ctx.root().begin();
 
       Some(JsRuleAction::new(
-        ActionCategory::QuickFix,
+        ctx.action_category(ctx.category(), ctx.group()),
         ctx.metadata().applicability(),
         markup! { "Remove the '"{name.text_trimmed()}"' element." }.to_owned(),
         mutation,

--- a/crates/biome_analyze/src/categories.rs
+++ b/crates/biome_analyze/src/categories.rs
@@ -37,7 +37,7 @@ pub enum ActionCategory {
     /// Base kind for quickfix actions: 'quickfix'.
     ///
     /// This action provides a fix to the diagnostic emitted by the same signal
-    QuickFix,
+    QuickFix(Cow<'static, str>),
     /// Base kind for refactoring actions: 'refactor'.
     ///
     /// This action provides an optional refactor opportunity
@@ -57,10 +57,10 @@ impl ActionCategory {
     /// ## Examples
     ///
     /// ```
+    /// use std::borrow::Cow;
     /// use biome_analyze::{ActionCategory, RefactorKind};
     ///
-    /// assert!(ActionCategory::QuickFix.matches("quickfix"));
-    /// assert!(!ActionCategory::QuickFix.matches("refactor"));
+    /// assert!(ActionCategory::QuickFix(Cow::from("quickfix")).matches("quickfix"));
     ///
     /// assert!(ActionCategory::Refactor(RefactorKind::None).matches("refactor"));
     /// assert!(!ActionCategory::Refactor(RefactorKind::None).matches("refactor.extract"));
@@ -75,7 +75,13 @@ impl ActionCategory {
     /// Returns the representation of this [ActionCategory] as a `CodeActionKind` string
     pub fn to_str(&self) -> Cow<'static, str> {
         match self {
-            ActionCategory::QuickFix => Cow::Borrowed("quickfix.biome"),
+            ActionCategory::QuickFix(tag) => {
+                if tag.is_empty() {
+                    Cow::Borrowed("quickfix.biome")
+                } else {
+                    Cow::Owned(format!("quickfix.biome.{tag}"))
+                }
+            }
 
             ActionCategory::Refactor(RefactorKind::None) => Cow::Borrowed("refactor.biome"),
             ActionCategory::Refactor(RefactorKind::Extract) => {

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -1,6 +1,6 @@
 use crate::options::{JsxRuntime, PreferredQuote};
-use crate::RuleMetadata;
 use crate::{registry::RuleRoot, FromServices, Queryable, Rule, RuleKey, ServiceBag};
+use crate::{GroupCategory, RuleCategory, RuleGroup, RuleMetadata};
 use biome_diagnostics::{Error, Result};
 use std::ops::Deref;
 use std::path::Path;
@@ -51,6 +51,16 @@ where
 
     pub fn query(&self) -> &RuleQueryResult<R> {
         self.query_result
+    }
+
+    /// Returns the group that belongs to the current rule
+    pub fn group(&self) -> &'static str {
+        <R::Group as RuleGroup>::NAME
+    }
+
+    /// Returns the category that belongs to the current rule
+    pub fn category(&self) -> RuleCategory {
+        <<R::Group as RuleGroup>::Category as GroupCategory>::CATEGORY
     }
 
     /// Returns a clone of the AST root

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::fmt::{Debug, Display, Formatter};
@@ -677,7 +678,7 @@ fn create_suppression_comment_action<L: Language>(
     Some(AnalyzerAction {
         mutation,
         applicability: Applicability::MaybeIncorrect,
-        category: ActionCategory::QuickFix,
+        category: ActionCategory::QuickFix(Cow::Borrowed("")),
         message: markup! {
             "Use // biome-ignore instead"
         }
@@ -766,7 +767,7 @@ fn update_suppression<L: Language>(
 
     Some(AnalyzerAction {
         rule_name: None,
-        category: ActionCategory::QuickFix,
+        category: ActionCategory::QuickFix(Cow::Borrowed("")),
         applicability: Applicability::Always,
         message: markup! {
             "Rewrite suppression to use the newer syntax"

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1,7 +1,9 @@
 use crate::categories::{ActionCategory, RuleCategory};
 use crate::context::RuleContext;
 use crate::registry::{RegistryVisitor, RuleLanguage, RuleSuppressions};
-use crate::{Phase, Phases, Queryable, SuppressionAction, SuppressionCommentEmitterPayload};
+use crate::{
+    Phase, Phases, Queryable, SourceActionKind, SuppressionAction, SuppressionCommentEmitterPayload,
+};
 use biome_console::fmt::Display;
 use biome_console::{markup, MarkupBuf};
 use biome_diagnostics::advice::CodeSuggestionAdvice;
@@ -12,6 +14,7 @@ use biome_diagnostics::{
     Visit,
 };
 use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Language, TextRange};
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 
@@ -365,6 +368,18 @@ impl RuleMetadata {
         self.fix_kind
             .try_into()
             .expect("Fix kind is not set in the rule metadata")
+    }
+
+    pub fn action_category(&self, category: RuleCategory, group: &'static str) -> ActionCategory {
+        match category {
+            RuleCategory::Lint => {
+                ActionCategory::QuickFix(Cow::Owned(format!("{}.{}", group, self.name)))
+            }
+            RuleCategory::Action => {
+                ActionCategory::Source(SourceActionKind::Other(Cow::Borrowed(self.name)))
+            }
+            RuleCategory::Syntax | RuleCategory::Transformation => unimplemented!(""),
+        }
     }
 }
 

--- a/crates/biome_graphql_analyze/src/lint/nursery/use_named_operation.rs
+++ b/crates/biome_graphql_analyze/src/lint/nursery/use_named_operation.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_graphql_factory::make;
@@ -86,7 +86,7 @@ impl Rule for UseNamedOperation {
         mutation.replace_node(node, new_node);
 
         Some(GraphqlRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Rename this "{operation_type}" to "{suggested_name}"."

--- a/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxAttribute, JsxAttributeList};
@@ -100,7 +99,7 @@ impl Rule for NoAccessKey {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(node.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"accessKey"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttributeValue, AnyNumberLikeExpression};
@@ -141,7 +140,7 @@ impl Rule for NoAriaHiddenOnFocusable {
         let aria_hidden_attr = node.find_attribute_by_name("aria-hidden")?;
         mutation.remove_node(aria_hidden_attr);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the aria-hidden attribute from the element." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -146,7 +145,7 @@ impl Rule for NoAriaUnsupportedElements {
         mutation.remove_node(attribute);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>""{removed_attribute}""</Emphasis>" attribute." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxAttribute};
@@ -100,7 +99,7 @@ impl Rule for NoAutofocus {
         }
         mutation.remove_node(attr.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"autoFocus"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
 use biome_js_factory::make::{
@@ -193,7 +191,7 @@ impl Rule for NoBlankTarget {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             message,
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::*;
@@ -83,7 +81,7 @@ impl Rule for NoDistractingElements {
         mutation.remove_node(element.clone());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the '"{name.text_trimmed()}"' element." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -96,7 +94,7 @@ impl Rule for NoHeaderScope {
         mutation.remove_node(scope_node);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"scope"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
@@ -123,7 +122,7 @@ impl Rule for NoInteractiveElementToNoninteractiveRole {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(role_attribute);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"role"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -1,7 +1,7 @@
 use crate::services::aria::Aria;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
@@ -116,7 +116,7 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(role_attribute);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"role"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_aria::AriaRoles;
 use biome_console::markup;
@@ -130,7 +129,7 @@ impl Rule for NoNoninteractiveTabindex {
 
         mutation.remove_node(tabindex_attribute);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"tabIndex"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -194,7 +194,7 @@ impl Rule for NoPositiveTabindex {
         };
 
         Some(JsRuleAction::new(
-            biome_analyze::ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace the "<Emphasis>"tableIndex"</Emphasis>" prop value with 0." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_aria::{roles::AriaRoleDefinition, AriaRoles};
 use biome_console::markup;
@@ -107,7 +106,7 @@ impl Rule for NoRedundantRoles {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(state.redundant_attribute.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the "<Emphasis>"role"</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxElement;
@@ -144,7 +142,7 @@ impl Rule for UseAnchorContent {
             mutation.remove_node(aria_hidden);
 
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                  markup! { "Remove the "<Emphasis>"aria-hidden"</Emphasis>" attribute to allow the anchor element and its content visible to assistive technologies." }.to_owned(),
                 mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{
@@ -125,7 +124,7 @@ impl Rule for UseAriaActivedescendantWithTabindex {
         mutation.replace_node(old_attribute_list, jsx_attribute_list(new_attribute_list));
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Add the tabIndex attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -1,7 +1,7 @@
 use crate::services::aria::Aria;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxAttribute;
@@ -94,7 +94,7 @@ impl Rule for UseValidAriaProps {
         mutation.remove_node(attribute.clone());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
 
                 markup! { "Remove the invalid "<Emphasis>"aria-*"</Emphasis>" attribute.

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -1,7 +1,6 @@
 use crate::{services::aria::Aria, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
@@ -142,7 +141,7 @@ impl Rule for UseValidAriaRole {
         let role_attribute = node.find_attribute_by_name("role")?;
         mutation.remove_node(role_attribute);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
 
                 markup! { "Remove the invalid "<Emphasis>"role"</Emphasis>" attribute.\n Check the list of all "<Hyperlink href="https://www.w3.org/TR/wai-aria/#role_definitions">"valid"</Hyperlink>" role attributes." }

--- a/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -176,7 +176,7 @@ impl Rule for NoBannedTypes {
         let suggested_type = banned_type.as_js_syntax_kind()?.to_string()?;
         mutation.replace_node(reference_identifier.clone()?, banned_type.fix_with()?);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use '"{suggested_type}"' instead" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -183,7 +182,7 @@ impl Rule for NoExtraBooleanCast {
         mutation.replace_node(node.clone(), node_to_replace.clone());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { {message} }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{JsRegexLiteralExpression, JsSyntaxKind, JsSyntaxToken, TextRange, TextSize};
@@ -176,7 +175,7 @@ impl Rule for NoMultipleSpacesInRegularExpressionLiterals {
         let mut mutation = ctx.root().begin();
         mutation.replace_token(token, next_trimmed_token);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use a quantifier instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -171,7 +170,7 @@ impl Rule for NoThisInStatic {
         let mut mutation = ctx.root().begin();
         mutation.replace_node(expr, suggested_class_name.into());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use the class name instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -154,7 +153,7 @@ impl Rule for NoUselessCatch {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup!("Remove the "<Emphasis>{note}</Emphasis>" clause.").to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -214,7 +213,7 @@ impl Rule for NoUselessConstructor {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(constructor.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the unnecessary constructor." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{AnyJsModuleItem, JsExport, JsModuleItemList, JsSyntaxToken};
@@ -103,7 +102,7 @@ impl Rule for NoUselessEmptyExport {
         let mut mutation = ctx.root().begin();
         mutation.remove_node(ctx.query().clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove this useless empty export." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::services::semantic::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make::{
     js_string_literal_expression, jsx_expression_child, jsx_string, jsx_string_literal,
@@ -397,7 +397,7 @@ impl Rule for NoUselessFragments {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the Fragment" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsStatement, JsLabeledStatement, JsSyntaxKind};
 
@@ -110,7 +108,7 @@ impl Rule for NoUselessLabel {
         mutation.remove_token(label_token);
         mutation.replace_token_discard_trivia(stmt_token, new_stmt_token);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
              markup! {"Remove the unnecessary "<Emphasis>"label"</Emphasis>".\nYou can achieve the same result without the label."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -130,7 +129,7 @@ impl Rule for NoUselessLoneBlockStatements {
         mutation.replace_node_discard_trivia(stmts_list, new_stmts_list);
 
         return Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove redundant block." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -159,7 +157,7 @@ impl Rule for NoUselessRename {
             }
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the renaming." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{
@@ -163,7 +162,7 @@ impl Rule for NoUselessStringConcat {
         };
 
         fix_result.and(Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the useless concatenation" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{AnyJsSwitchClause, JsCaseClause, JsDefaultClause};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, Direction};
@@ -155,7 +153,7 @@ impl Rule for NoUselessSwitchCase {
             mutation.remove_node(useless_case);
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Remove the useless "<Emphasis>"case"</Emphasis>"."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -206,7 +205,7 @@ impl Rule for NoUselessTernary {
 
         mutation.replace_element(node.clone().into(), new_node.into());
         return Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the conditional expression with" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
@@ -2,8 +2,8 @@ use crate::{
     services::control_flow::AnyJsControlFlowRoot, services::semantic::Semantic, JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -176,7 +176,7 @@ impl Rule for NoUselessThisAlias {
             mutation.remove_token(deleted_comma?);
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use "<Emphasis>"this"</Emphasis>" instead of an alias."

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 
 use biome_js_factory::make;
@@ -152,7 +150,7 @@ impl Rule for NoUselessTypeConstraint {
             mutation.remove_node(node.clone());
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the constraint." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::js_variable_declarator_list;
@@ -192,7 +191,7 @@ impl Rule for NoUselessUndefinedInitialization {
         mutation.replace_node_discard_trivia(assignment_statement, new_node);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove undefined initialization." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -1,8 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, AddVisitor, FixKind, Phases,
-    QueryMatch, Queryable, Rule, RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor,
-    VisitorContext,
+    context::RuleContext, declare_lint_rule, AddVisitor, FixKind, Phases, QueryMatch, Queryable,
+    Rule, RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -189,7 +188,7 @@ impl Rule for UseArrowFunction {
             arrow_function,
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use an "<Emphasis>"arrow function"</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -133,7 +132,7 @@ impl Rule for UseDateNow {
         mutation.replace_node_discard_trivia::<AnyJsExpression>(node.clone(), new_call_expr.into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Replace with "<Emphasis>"Date.now()"</Emphasis>"."

--- a/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make::{ident, js_name};
 use biome_js_syntax::{AnyJsExpression, AnyJsMemberExpression, AnyJsName, JsCallExpression};
@@ -122,7 +120,7 @@ impl Rule for UseFlatMap {
         mutation.replace_node(node.clone(), flat_map_call);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Replace the chain with "<Emphasis>".flatMap()"</Emphasis>"."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -178,7 +177,7 @@ impl Rule for UseLiteralKeys {
             }
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use a literal key instead."

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -1,7 +1,5 @@
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -201,7 +199,7 @@ impl Rule for UseOptionalChain {
                 let mut mutation = ctx.root().begin();
                 mutation.replace_node(AnyJsExpression::from(logical.clone()), replacement);
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Change to an optional chain." }.to_owned(),
                     mutation,
@@ -249,7 +247,7 @@ impl Rule for UseOptionalChain {
                 let mut mutation = ctx.root().begin();
                 mutation.replace_node(prev_member, new_member);
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Change to an optional chain." }.to_owned(),
                     mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::js_regex_literal_expression;
@@ -127,7 +126,7 @@ impl Rule for UseRegexLiterals {
         mutation.replace_node(prev, next);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                "Use a "<Emphasis>"literal notation"</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -353,7 +351,7 @@ impl Rule for UseSimpleNumberKeys {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             message,
             mutation,

--- a/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simplified_logic_expression.rs
@@ -1,7 +1,5 @@
 use crate::JsRuleAction;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -154,7 +152,7 @@ impl Rule for UseSimplifiedLogicExpression {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { ""{message}"" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
@@ -1,7 +1,7 @@
 use crate::services::semantic::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make::{self};
 use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
@@ -106,7 +106,7 @@ impl Rule for NoConstAssign {
             let let_token = make::token(JsSyntaxKind::LET_KW);
             mutation.replace_token(const_token, let_token);
             return Some(JsRuleAction::new(
-                            ActionCategory::QuickFix,
+                            ctx.metadata().action_category(ctx.category(), ctx.group()),
                             ctx.metadata().applicability(),
                              markup! { "Replace "<Emphasis>"const"</Emphasis>" with "<Emphasis>"let"</Emphasis>" if you assign it to a new value." }
                                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
@@ -1,8 +1,7 @@
 use std::{cmp::Ordering, str::FromStr};
 
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
@@ -108,7 +107,7 @@ impl Rule for NoConstantMathMinMaxClamp {
         mutation.replace_node(state.1.clone(), state.0.clone());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Swap "<Emphasis>{state.0.text()}</Emphasis>" with "<Emphasis>{state.1.text()}</Emphasis>"."}
             .to_owned(),

--- a/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{ident, js_call_argument_list, js_call_arguments, js_name, token};
@@ -172,7 +171,7 @@ impl Rule for NoFlatMapIdentity {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Replace unnecessary "<Emphasis>"flatMap"</Emphasis>" call to "<Emphasis>"flat"</Emphasis>" instead."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -139,7 +138,7 @@ impl Rule for NoInvalidBuiltinInstantiation {
                 mutation
                     .replace_node::<AnyJsExpression>(node.clone().into(), call_expression.into());
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Remove "<Emphasis>"new"</Emphasis>" keyword." }.to_owned(),
                     mutation,
@@ -151,7 +150,7 @@ impl Rule for NoInvalidBuiltinInstantiation {
                 mutation
                     .replace_node::<AnyJsExpression>(node.clone().into(), new_expression.into());
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Add "<Emphasis>"new"</Emphasis>" keyword." }.to_owned(),
                     mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_new_builtin.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_new_builtin.rs
@@ -1,7 +1,5 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -95,7 +93,7 @@ impl Rule for NoInvalidNewBuiltin {
             call_expression.into(),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove "<Emphasis>"new"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_new_symbol.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_new_symbol.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -75,7 +74,7 @@ impl Rule for NoNewSymbol {
             call_expression.into(),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove "<Emphasis>"new"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -216,7 +215,7 @@ impl Rule for NoNonoctalDecimalEscape {
         mutation.replace_token(prev_token, next_token);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
              match kind {
 				FixSuggestionKind::Refactor => {

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::*;
@@ -111,7 +109,7 @@ impl Rule for NoStringCaseMismatch {
             ),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Use "<Emphasis>{state.expected_case.description()}</Emphasis>" string value."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -138,7 +136,7 @@ impl Rule for NoSwitchDeclarations {
         mutation.replace_token_discard_trivia(colon_token, new_colon_token);
         mutation.replace_node_discard_trivia(consequent, new_consequent);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Wrap the "<Emphasis>"declaration"</Emphasis>" in a block." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_unnecessary_continue.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unnecessary_continue.rs
@@ -1,6 +1,4 @@
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{JsContinueStatement, JsLabeledStatement, JsSyntaxKind, JsSyntaxNode};
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -107,7 +105,7 @@ impl Rule for NoUnnecessaryContinue {
         let mut mutation = ctx.root().begin();
         mutation.remove_statement(node.clone().into());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Delete the unnecessary continue statement" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_function_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_function_parameters.rs
@@ -1,6 +1,4 @@
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::{
@@ -180,7 +178,7 @@ impl Rule for NoUnusedFunctionParameters {
                 mutation.rename_node_declaration(model, binding, &new_name);
 
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "If this is intentional, prepend "<Emphasis>{name_trimmed}</Emphasis>" with an underscore." }
                     .to_owned(),

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -4,8 +4,8 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, options::JsxRuntime, ActionCategory, FixKind, Rule,
-    RuleDiagnostic, RuleSource,
+    context::RuleContext, declare_lint_rule, options::JsxRuntime, FixKind, Rule, RuleDiagnostic,
+    RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -160,7 +160,7 @@ impl Rule for NoUnusedImports {
             }
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the unused import." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
@@ -1,7 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{
-    declare_lint_rule, ActionCategory, AddVisitor, FixKind, Phases, QueryMatch, Queryable, Rule,
-    RuleDiagnostic, RuleSource, ServiceBag, Visitor, VisitorContext,
+    declare_lint_rule, AddVisitor, FixKind, Phases, QueryMatch, Queryable, Rule, RuleDiagnostic,
+    RuleSource, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -196,7 +196,7 @@ impl Rule for NoUnusedLabels {
         let mut mutation = ctx.root().begin();
         mutation.replace_node(unused_label.clone().into(), body);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Remove the unused "<Emphasis>"label"</Emphasis>"."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -107,7 +106,7 @@ impl Rule for NoUnusedPrivateClassMembers {
         mutation.remove_node(state.clone());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove unused declaration." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -1,9 +1,7 @@
 use crate::JsRuleAction;
 use crate::{services::semantic::Semantic, utils::rename::RenameSymbolExtensions};
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::binding_ext::{
@@ -444,7 +442,7 @@ impl Rule for NoUnusedVariables {
                 mutation.rename_node_declaration(model, binding, &new_name);
 
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "If this is intentional, prepend "<Emphasis>{name_trimmed}</Emphasis>" with an underscore." }
                     .to_owned(),

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
@@ -2,7 +2,7 @@ use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::services::semantic::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
 use biome_js_factory::make::{jsx_attribute_list, jsx_self_closing_element};
 use biome_js_syntax::{
@@ -393,7 +393,7 @@ impl Rule for NoVoidElementsWithChildren {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             state.action_message(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/use_array_literals.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_array_literals.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -148,7 +147,7 @@ impl Rule for UseArrayLiterals {
         };
         mutation.replace_node::<AnyJsExpression>(node.clone().into(), new_node.into());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use an array literal." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -2,9 +2,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, Path};
 
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
 use biome_js_factory::make;
@@ -190,7 +188,7 @@ impl Rule for UseImportExtensions {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Add potential import extension "<Emphasis>"."{extension}</Emphasis>"."

--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
@@ -182,7 +182,7 @@ impl Rule for UseIsNan {
                 );
 
                 return Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! {
                         "Use "<Emphasis>"Number.isNaN()"</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
@@ -1,9 +1,7 @@
 use crate::JsRuleAction;
 use ::serde::{Deserialize, Serialize};
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_deserialize::{
     Deserializable, DeserializableType, DeserializableValue, DeserializationDiagnostic,
@@ -105,7 +103,7 @@ impl Rule for NoRestrictedTypes {
         mutation.replace_element(prev_token.into(), new_token.into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use '"{suggested_type}"' instead" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/no_substr.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_substr.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -105,7 +104,7 @@ impl Rule for NoSubstr {
         mutation.replace_element(node.member()?.into(), replaced_function.into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>".slice()"</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{JsRegexLiteralExpression, JsSyntaxKind, JsSyntaxToken};
@@ -287,7 +286,7 @@ impl Rule for NoUselessEscapeInRegex {
         let mut mutation = ctx.root().begin();
         mutation.replace_token(value_token, new_regex);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Unescape the character." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{self, js_function_body};
@@ -298,7 +297,7 @@ impl Rule for NoUselessUndefined {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the undefined."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::{markup, MarkupBuf};
 use biome_js_factory::make::{self};
@@ -184,7 +184,7 @@ impl Rule for UseAtIndex {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>".at()"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_collapsed_if.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_collapsed_if.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -193,7 +192,7 @@ impl Rule for UseCollapsedIf {
         mutation.replace_node(parent_consequent, child_consequent);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use collapsed "<Emphasis>"if"</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -296,7 +296,7 @@ impl Rule for UseConsistentCurlyBraces {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { {msg} }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -133,7 +133,7 @@ impl Rule for UseGoogleFontPreconnect {
         mutation.replace_node(node.attributes(), make::jsx_attribute_list(attributes));
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Add the "<Emphasis>"rel=\"preconnect\""</Emphasis>" attribute." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -7,9 +7,7 @@ mod sort;
 mod sort_config;
 mod tailwind_preset;
 
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make::{
     js_literal_member_name, js_string_literal, js_string_literal_expression,
@@ -233,7 +231,7 @@ impl Rule for UseSortedClasses {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Sort the classes."

--- a/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, options::PreferredQuote, ActionCategory, Ast, FixKind,
-    Rule, RuleDiagnostic,
+    context::RuleContext, declare_lint_rule, options::PreferredQuote, Ast, FixKind, Rule,
+    RuleDiagnostic,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -102,7 +102,7 @@ impl Rule for UseStrictMode {
         let new_node = node.clone().with_directives(directives);
         mutation.replace_node(node, new_node);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup!("Insert a top level"<Emphasis>"\"use strict\" "</Emphasis>".").to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/nursery/use_trim_start_end.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_trim_start_end.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{self};
@@ -217,7 +216,7 @@ impl Rule for UseTrimStartEnd {
         mutation.replace_node(callee, call_expression);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace "<Emphasis>{state.member_name}</Emphasis>" with "<Emphasis>{replaced_member_name}</Emphasis>"." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/performance/no_delete.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_delete.rs
@@ -1,6 +1,4 @@
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -136,7 +134,7 @@ impl Rule for NoDelete {
             )),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use an "<Emphasis>"undefined"</Emphasis>" assignment instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_implicit_boolean.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_implicit_boolean.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -127,7 +127,7 @@ impl Rule for NoImplicitBoolean {
         mutation.replace_node(n.clone(), next_attr);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Add explicit `true` literal for this attribute" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsExpression, AnyTsPropertyAnnotation, AnyTsVariableAnnotation, JsFormalParameter,
@@ -198,7 +196,7 @@ impl Rule for NoInferrableTypes {
         mutation.replace_token_discard_trivia(next_token, new_next_token);
         mutation.remove_node(annotation.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the type annotation." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_negation_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_negation_else.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -121,7 +120,7 @@ impl Rule for NoNegationElse {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Invert the condition and the blocks." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -154,7 +153,7 @@ impl Rule for NoNonNullAssertion {
                 };
 
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                      markup! { "Replace with optional chain operator "<Emphasis>"?."</Emphasis>" This operator includes runtime checks, so it is safer than the compile-only non-null assertion operator" }
                         .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
@@ -1,7 +1,5 @@
 use crate::{services::semantic::Semantic, utils::batch::JsBatchMutation, JsRuleAction};
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make::{js_literal_member_name, js_property_object_member};
 use biome_js_semantic::{Reference, ReferencesExtensions};
@@ -191,7 +189,7 @@ impl Rule for NoShoutyConstants {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use the constant value directly" }.to_owned(),
             batch,

--- a/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
@@ -1,6 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -105,7 +105,7 @@ impl Rule for NoUnusedTemplateLiteral {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace with string literal" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -177,7 +177,7 @@ impl Rule for NoUselessElse {
             let mut mutation = ctx.root().begin();
             mutation.replace_node_discard_trivia(stmts_list, new_stmts_list);
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                 markup! { "Omit the "<Emphasis>"else"</Emphasis>" clause." }.to_owned(),
                 mutation,

--- a/crates/biome_js_analyze/src/lint/style/no_var.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_var.rs
@@ -2,8 +2,7 @@ use crate::{
     services::control_flow::AnyJsControlFlowRoot, services::semantic::Semantic, JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -118,7 +117,7 @@ impl Rule for NoVar {
             make::token(replacing_token_kind),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use '"<Emphasis>{replacing_token_kind.to_string()?}</Emphasis>"' instead." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
@@ -1,7 +1,6 @@
 use crate::{utils::is_node_equal, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -183,7 +182,7 @@ impl Rule for NoYodaExpression {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             Applicability::Always,
             markup! { "Flip the operators of the expression." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -190,7 +189,7 @@ impl Rule for UseAsConstAssertion {
             }
         };
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace with "<Emphasis>"as const"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -284,7 +282,7 @@ impl Rule for UseBlockStatements {
             },
         };
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Wrap the statement with a `JsBlockStatement`" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_collapsed_else_if.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_collapsed_else_if.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{AnyJsStatement, JsBlockStatement, JsElseClause, JsIfStatement};
@@ -157,7 +156,7 @@ impl Rule for UseCollapsedElseIf {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use collapsed "<Emphasis>"else if"</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_array_type.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::{markup, Markup, MarkupBuf};
 use biome_deserialize_macros::Deserializable;
@@ -181,7 +180,7 @@ impl Rule for UseConsistentArrayType {
                 mutation.replace_node(AnyTsType::TsReferenceType(ty.clone()), state.clone());
                 if let Some(kind) = get_array_kind_by_reference(ty) {
                     return Some(JsRuleAction::new(
-                        ActionCategory::QuickFix,
+                        ctx.metadata().action_category(ctx.category(), ctx.group()),
                         ctx.metadata().applicability(),
                         get_action_message(kind),
                         mutation,
@@ -196,7 +195,7 @@ impl Rule for UseConsistentArrayType {
 
                 if let Some(kind) = get_array_kind_by_any_type(&ty) {
                     return Some(JsRuleAction::new(
-                        ActionCategory::QuickFix,
+                        ctx.metadata().action_category(ctx.category(), ctx.group()),
                         ctx.metadata().applicability(),
                         get_action_message(kind),
                         mutation,
@@ -210,7 +209,7 @@ impl Rule for UseConsistentArrayType {
             {
                 mutation.replace_node(AnyTsType::TsArrayType(ty.clone()), state.clone());
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     get_action_message(TsArrayKind::Shorthand),
                     mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_consistent_builtin_instantiation.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_consistent_builtin_instantiation.rs
@@ -3,8 +3,7 @@ use crate::{
     services::semantic::Semantic, JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -137,7 +136,7 @@ impl Rule for UseConsistentBuiltinInstantiation {
                 mutation
                     .replace_node::<AnyJsExpression>(node.clone().into(), call_expression.into());
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Remove "<Emphasis>"new"</Emphasis>" keyword." }.to_owned(),
                     mutation,
@@ -149,7 +148,7 @@ impl Rule for UseConsistentBuiltinInstantiation {
                 mutation
                     .replace_node::<AnyJsExpression>(node.clone().into(), new_expression.into());
                 Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Add "<Emphasis>"new"</Emphasis>" keyword." }.to_owned(),
                     mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_const.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_const.rs
@@ -3,8 +3,7 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 
@@ -148,7 +147,7 @@ impl Rule for UseConst {
                 make::token(JsSyntaxKind::CONST_KW),
             );
             Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                 markup! { "Use "<Emphasis>"const"</Emphasis>" instead." }.to_owned(),
                 batch,

--- a/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{JsFormalParameter, JsInitializerClause, JsSyntaxToken, TsPropertyParameter};
 use biome_rowan::{declare_node_union, AstNode, BatchMutationExt, Direction};
@@ -162,7 +160,7 @@ impl Rule for UseDefaultParameterLast {
             mutation.remove_node(initializer);
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Turn the parameter into a "<Emphasis>"required parameter"</Emphasis>"."}
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsExpression, AnyJsLiteralExpression, JsSyntaxKind, TsEnumDeclaration};
@@ -194,7 +192,7 @@ impl Rule for UseEnumInitializers {
 
         if has_mutations {
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                 markup! { "Initialize all enum members." }.to_owned(),
                 mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_explicit_length_check.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -289,7 +288,7 @@ impl Rule for UseExplicitLengthCheck {
         };
         let member_name = state.member_name.text();
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
              markup! { "Replace "<Emphasis>"."{member_name}</Emphasis>" with "<Emphasis>"."{member_name}" "{code}</Emphasis> }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
@@ -1,7 +1,7 @@
 use crate::services::semantic::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::{make, syntax::T};
 use biome_js_syntax::{
@@ -161,7 +161,7 @@ impl Rule for UseExponentiationOperator {
             .append_trivia_pieces(node.syntax().last_trailing_trivia()?.pieces())?;
         mutation.replace_node_discard_trivia(AnyJsExpression::from(node.clone()), new_node);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use the '**' operator instead of 'Math.pow'." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -1,7 +1,7 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -289,7 +289,7 @@ impl Rule for UseExportType {
                     }
                 }
                 JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Use "<Emphasis>"export type"</Emphasis>"." }.to_owned(),
                     mutation,
@@ -312,7 +312,7 @@ impl Rule for UseExportType {
                     );
                 }
                 JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
                     mutation,
@@ -323,7 +323,7 @@ impl Rule for UseExportType {
                     mutation.remove_token(type_token.clone());
                 }
                 JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
                         .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_fragment_syntax.rs
@@ -2,7 +2,7 @@ use crate::react::{jsx_member_name_is_react_fragment, jsx_reference_identifier_i
 use crate::services::semantic::Semantic;
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make::{
     jsx_child_list, jsx_closing_fragment, jsx_fragment, jsx_opening_fragment,
@@ -90,7 +90,7 @@ impl Rule for UseFragmentSyntax {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             (markup! { "Replace "<Emphasis>"<Fragment>"</Emphasis>" with the fragment syntax" })
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -4,8 +4,8 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, options::JsxRuntime, ActionCategory, FixKind, Rule,
-    RuleDiagnostic, RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, options::JsxRuntime, FixKind, Rule, RuleDiagnostic,
+    RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -560,7 +560,7 @@ impl Rule for UseImportType {
                     mutation.replace_node(specifier.clone(), new_specifier);
                 }
                 return Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Add inline "<Emphasis>"type"</Emphasis>" keywords." }.to_owned(),
                     mutation,
@@ -571,7 +571,7 @@ impl Rule for UseImportType {
                     mutation.remove_token(type_token.clone());
                 }
                 return Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                     markup! { "Remove useless inline "<Emphasis>"type"</Emphasis>" keywords." }
                         .to_owned(),
@@ -580,7 +580,7 @@ impl Rule for UseImportType {
             }
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>"import type"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -9,8 +9,8 @@ use crate::{
     JsRuleAction,
 };
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_deserialize::{DeserializableValidator, DeserializationDiagnostic};
@@ -843,7 +843,7 @@ impl Rule for UseNamingConvention {
             let renamed = mutation.rename_any_renamable_node(model, &renamable, &new_name[..]);
             if renamed {
                 return Some(JsRuleAction::new(
-                    ActionCategory::QuickFix,
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
                      markup! { "Rename this symbol in "<Emphasis>{preferred_case.to_string()}</Emphasis>"." }.to_owned(),
                     mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_node_assert_strict.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_node_assert_strict.rs
@@ -1,7 +1,5 @@
 use crate::JsRuleAction;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::BatchMutationExt;
@@ -77,7 +75,7 @@ impl Rule for UseNodeAssertStrict {
         let mut mutation = ctx.root().begin();
         mutation.replace_token(module_name.clone(), new_module_name);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace with "<Emphasis>"node:assert/strict"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
@@ -110,7 +109,7 @@ impl Rule for UseNodejsImportProtocol {
         let mut mutation = ctx.root().begin();
         mutation.replace_token(module_name.clone(), new_module_name);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Add the "<Emphasis>"node:"</Emphasis>" protocol." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -237,7 +236,7 @@ impl Rule for UseNumberNamespace {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use "<Emphasis>"Number."{equivalent_property}</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
@@ -1,7 +1,7 @@
 use crate::services::semantic::Semantic;
 use crate::{ast_utils, JsRuleAction};
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic, RuleSource};
+use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
@@ -102,7 +102,7 @@ impl Rule for UseNumericLiterals {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use the computed "{call.radix.description()}" literal instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
@@ -177,7 +176,7 @@ impl Rule for UseSelfClosingElements {
             AnyJsxTag::JsxSelfClosingElement(self_closing_element),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use a SelfClosingElement instead" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_array_type.rs
@@ -1,6 +1,4 @@
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -125,7 +123,7 @@ impl Rule for UseShorthandArrayType {
                 }
             };
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                 message,
                 mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -151,7 +150,7 @@ impl Rule for UseShorthandAssign {
         mutation.replace_node(node.clone(), shorthand_node);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>""{shorthand_operator.to_string()?}""</Emphasis>" instead." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_factory::make::ts_type_alias_declaration;
@@ -153,7 +151,7 @@ impl Rule for UseShorthandFunctionType {
                 AnyJsDeclarationClause::from(type_alias_declaration),
             );
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                  markup! { "Alias a function type instead of using an interface with a call signature." }.to_owned(),
                 mutation,
@@ -195,7 +193,7 @@ impl Rule for UseShorthandFunctionType {
 
             mutation.replace_node(AnyTsType::from(ts_object_type), new_function_type);
             return Some(JsRuleAction::new(
-                ActionCategory::QuickFix,
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
                 ctx.metadata().applicability(),
                 markup! { "Use a function type instead of an object type with a call signature." }
                     .to_owned(),

--- a/crates/biome_js_analyze/src/lint/style/use_single_case_statement.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_single_case_statement.rs
@@ -1,6 +1,4 @@
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsStatement, AnyJsSwitchClause, TriviaPieceKind, T};
@@ -96,7 +94,7 @@ impl Rule for UseSingleCaseStatement {
         mutation.replace_token_discard_trivia(colon_token, new_colon_token);
         mutation.replace_node_discard_trivia(consequent, new_consequent);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Wrap the statements in a block." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -203,7 +202,7 @@ impl Rule for UseSingleVarDeclarator {
         mutation.replace_element(prev_parent.into(), next_parent.into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Break out into multiple declarations" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_template.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_template.rs
@@ -1,7 +1,5 @@
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::AnyJsTemplateElement;
@@ -98,7 +96,7 @@ impl Rule for UseTemplate {
             AnyJsExpression::JsTemplateExpression(template),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use a "<Emphasis>"template literal"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_throw_new_error.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_throw_new_error.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -119,7 +118,7 @@ impl Rule for UseThrowNewError {
         mutation.replace_node::<AnyJsExpression>(node.clone().into(), new_expression.into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Add "<Emphasis>"new"</Emphasis>" keyword." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/style/use_while.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_while.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -98,7 +97,7 @@ impl Rule for UseWhile {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use a "<Emphasis>"while"</Emphasis>" loop." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
@@ -1,8 +1,7 @@
 use std::cmp::Ordering;
 
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -108,7 +107,7 @@ impl Rule for NoApproximativeNumericConstant {
             AnyJsExpression::from(new_node),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>"Math."{ constant_name }</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -162,7 +161,7 @@ impl Rule for NoCommentText {
         let mut mutation = ctx.root().begin();
         mutation.replace_node(AnyJsxChild::from(node.clone()), new_jsx_text);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Wrap the comments with braces" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -124,7 +123,7 @@ impl Rule for NoCompareNegZero {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace -0 with 0" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -107,7 +106,7 @@ impl Rule for NoConfusingVoidType {
             AnyTsType::from(make::ts_undefined_type(make::token(T![undefined]))),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             Applicability::MaybeIncorrect,
             markup! { "Use "<Emphasis>"undefined"</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
@@ -107,7 +106,7 @@ impl Rule for NoConsole {
             }
         }
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove "<Emphasis>"console"</Emphasis>"." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console_log.rs
@@ -1,7 +1,5 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{
     global_identifier, AnyJsMemberExpression, JsCallExpression, JsExpressionStatement,
@@ -97,7 +95,7 @@ impl Rule for NoConsoleLog {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove console.log" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_const_enum.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_const_enum.rs
@@ -1,5 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::TsEnumDeclaration;
 use biome_rowan::{chain_trivia_pieces, trim_leading_trivia_pieces, AstNode, BatchMutationExt};
@@ -81,7 +81,7 @@ impl Rule for NoConstEnum {
         mutation.remove_token(const_token);
         mutation.replace_token_discard_trivia(enum_token, new_enum_token);
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
              markup! {
                 "Turn the "<Emphasis>"const enum"</Emphasis>" into a regular "<Emphasis>"enum"</Emphasis>"."

--- a/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::JsDebuggerStatement;
@@ -65,7 +64,7 @@ impl Rule for NoDebugger {
         mutation.remove_statement(node.clone().into());
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove debugger statement" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
@@ -1,7 +1,5 @@
 use biome_analyze::RuleSource;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
 use biome_js_factory::make;
@@ -143,7 +141,7 @@ impl Rule for NoDoubleEquals {
         mutation.replace_token(op.clone(), make::token(suggestion));
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             // SAFETY: `suggestion` can only be JsSyntaxKind::EQ3 or JsSyntaxKind::NEQ2,
             // the implementation of `to_string` for these two variants always returns Some

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -309,7 +309,7 @@ impl Rule for NoDuplicateObjectKeys {
         let mut batch = ctx.root().begin();
         batch.remove_js_object_member(member_definition.node());
         Some(JsRuleAction::new(
-            biome_analyze::ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             // The property initialization could contain side effects
             ctx.metadata().applicability(),
             markup!("Remove this " {member_definition.to_string()}).to_owned(),

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
@@ -1,8 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-    RuleSourceKind,
+    declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::{
@@ -102,7 +101,7 @@ impl Rule for NoEmptyInterface {
             AnyJsDeclarationClause::from(new_node),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use a type alias instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
@@ -1,7 +1,5 @@
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsExpression, JsSyntaxKind, TsNonNullAssertionAssignment,
@@ -141,7 +139,7 @@ impl Rule for NoExtraNonNullAssertion {
         mutation.remove_token(excl_token);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove extra non-null assertion." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -144,7 +144,7 @@ impl Rule for NoFocusedTests {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove focus from test." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
@@ -1,7 +1,5 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{global_identifier, AnyJsExpression, T};
@@ -112,7 +110,7 @@ impl Rule for NoGlobalIsFinite {
         };
         mutation.replace_node(old, new.into());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use "<Emphasis>"Number.isFinite"</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
@@ -1,7 +1,5 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_factory::make;
 use biome_js_syntax::{global_identifier, AnyJsExpression, T};
@@ -113,7 +111,7 @@ impl Rule for NoGlobalIsNan {
         };
         mutation.replace_node(old, new.into());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use "<Emphasis>"Number.isNaN"</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -185,7 +184,7 @@ impl Rule for NoMisleadingCharacterClass {
                     let mut mutation = ctx.root().begin();
                     mutation.replace_token(prev_token, next_token);
                     Some(JsRuleAction::new(
-                        ActionCategory::QuickFix,
+                        ctx.metadata().action_category(ctx.category(), ctx.group()),
                         ctx.metadata().applicability(),
                         markup! { "Add unicode "<Emphasis>"u"</Emphasis>" flag to regex" }
                             .to_owned(),
@@ -202,7 +201,7 @@ impl Rule for NoMisleadingCharacterClass {
                             let mut mutation = ctx.root().begin();
                             mutation.replace_node(prev_node, suggest);
                             Some(JsRuleAction::new(
-                                ActionCategory::QuickFix,
+                                ctx.metadata().action_category(ctx.category(), ctx.group()),
                                 ctx.metadata().applicability(),
                                 markup! { "Add unicode "<Emphasis>"u"</Emphasis>" flag to regex" }
                                     .to_owned(),
@@ -222,7 +221,7 @@ impl Rule for NoMisleadingCharacterClass {
                             let mut mutation = ctx.root().begin();
                             mutation.replace_node(prev_node, suggest);
                             Some(JsRuleAction::new(
-                                ActionCategory::QuickFix,
+                                ctx.metadata().action_category(ctx.category(), ctx.group()),
                                 ctx.metadata().applicability(),
                                 markup! { "Add unicode "<Emphasis>"u"</Emphasis>" flag to regex" }
                                     .to_owned(),

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_syntax::{
@@ -140,7 +139,7 @@ impl Rule for NoMisrefactoredShorthandAssign {
         mutation.replace_node(node.clone(), replacement_node);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use "<Emphasis>""{replacement_text}""</Emphasis>" instead." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make::{self};
@@ -191,7 +190,7 @@ impl Rule for NoPrototypeBuiltins {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Use 'Object.hasOwn()' instead." },
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_react_specific_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_react_specific_props.rs
@@ -1,8 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{
-    declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
-};
+use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_js_factory::make::{jsx_ident, jsx_name};
 use biome_js_syntax::{AnyJsxAttributeName, JsxAttribute};
@@ -89,7 +87,7 @@ impl Rule for NoReactSpecificProps {
         mutation.replace_node(original_name_node, new_name_node);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 {format!("Replace this attribute name with {replacement:?}")}

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
@@ -1,7 +1,5 @@
 use crate::JsRuleAction;
-use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-};
+use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_js_syntax::{
     AnyJsClass, JsDirective, JsDirectiveList, JsFileSource, JsFunctionBody, JsModule, JsScript,
@@ -196,7 +194,7 @@ impl Rule for NoRedundantUseStrict {
         // which is intended
         mutation.remove_node(node.clone());
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Remove the redundant "<Emphasis>"use strict"</Emphasis>" directive." }
                 .to_owned(),

--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource, RuleSourceKind,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
+    RuleSourceKind,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -115,7 +115,7 @@ impl Rule for NoSkippedTests {
         };
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Enable the test." }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -98,7 +97,7 @@ markup! {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Replace hole with undefined" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
@@ -1,7 +1,6 @@
 use crate::JsRuleAction;
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -126,7 +125,7 @@ impl Rule for NoUnsafeNegation {
         }
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Wrap the expression with a parenthesis" }.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
@@ -1,7 +1,6 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -103,7 +102,7 @@ impl Rule for UseIsArray {
             call.into(),
         );
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {
                 "Use "<Emphasis>"Array.isArray()"</Emphasis>" instead."

--- a/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -78,7 +77,7 @@ impl Rule for UseNamespaceKeyword {
         let mut mutation = ctx.root().begin();
         mutation.replace_token_transfer_trivia(module_token.clone(), make::token(T![namespace]));
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! {"Use "<Emphasis>"namespace"</Emphasis>" instead."}.to_owned(),
             mutation,

--- a/crates/biome_js_analyze/src/lint/suspicious/use_number_to_fixed_digits_argument.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_number_to_fixed_digits_argument.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
@@ -114,7 +113,7 @@ impl Rule for UseNumberToFixedDigitsArgument {
         mutation.replace_node::<JsCallArgumentList>(previous_args, new_args);
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             Applicability::MaybeIncorrect,
             markup! {
                 "Add explicit digits argument to "<Emphasis>"toFixed"</Emphasis>" method."

--- a/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
@@ -1,6 +1,5 @@
 use biome_analyze::{
-    context::RuleContext, declare_lint_rule, ActionCategory, Ast, FixKind, Rule, RuleDiagnostic,
-    RuleSource,
+    context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
 use biome_js_factory::make;
@@ -239,7 +238,7 @@ impl Rule for UseValidTypeof {
         );
 
         Some(JsRuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             markup! { "Compare the result of `typeof` with a valid type name" }.to_owned(),
             mutation,

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -68,7 +68,7 @@ pub(crate) fn code_actions(
             let kind = kind.as_str();
             if FIX_ALL_CATEGORY.matches(kind) {
                 has_fix_all = true;
-            } else if ActionCategory::QuickFix.to_str() == kind {
+            } else if "quickfix.biome" == kind {
                 // The action is a on-save quick-fixes
                 has_quick_fix = true;
             }

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -922,7 +922,9 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
         title: String::from("Replace -0 with 0"),
-        kind: Some(lsp::CodeActionKind::new("quickfix.biome")),
+        kind: Some(lsp::CodeActionKind::new(
+            "quickfix.biome.suspicious.noCompareNegZero",
+        )),
         diagnostics: Some(vec![fixable_diagnostic(0)?]),
         edit: Some(lsp::WorkspaceEdit {
             changes: Some(changes),
@@ -1097,7 +1099,9 @@ async fn pull_biome_quick_fixes() -> Result<()> {
                 },
                 context: lsp::CodeActionContext {
                     diagnostics: vec![fixable_diagnostic(0)?],
-                    only: Some(vec![lsp::CodeActionKind::new("quickfix.biome")]),
+                    only: Some(vec![lsp::CodeActionKind::new(
+                        "quickfix.biome.suspicious.noCompareNegZero",
+                    )]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
@@ -1131,7 +1135,9 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 
     let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
         title: String::from("Replace -0 with 0"),
-        kind: Some(lsp::CodeActionKind::new("quickfix.biome")),
+        kind: Some(lsp::CodeActionKind::new(
+            "quickfix.biome.suspicious.noCompareNegZero",
+        )),
         diagnostics: Some(vec![fixable_diagnostic(0)?]),
         edit: Some(lsp::WorkspaceEdit {
             changes: Some(changes),
@@ -1246,7 +1252,9 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 
     let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
         title: String::from("Use ==="),
-        kind: Some(lsp::CodeActionKind::new("quickfix.biome")),
+        kind: Some(lsp::CodeActionKind::new(
+            "quickfix.biome.suspicious.noDoubleEquals",
+        )),
         diagnostics: Some(vec![unsafe_fixable.clone()]),
         edit: Some(lsp::WorkspaceEdit {
             changes: Some(changes),
@@ -1726,17 +1734,8 @@ if(a === -0) {}
 #[tokio::test]
 async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
-    let (stream, sink) = client.split();
-    let mut server = Server::new(service);
-
-    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
-    let reader = tokio::spawn(client_handler(stream, sink, sender));
-
-    server.initialize().await?;
-    server.initialized().await?;
-
-    let incorrect_config = r#"{
+    let mut fs = MemoryFileSystem::default();
+    let config = r#"{
     "$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
     "organizeImports": { "enabled": false },
     "linter": {
@@ -1761,10 +1760,22 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
         }
     ]
 }"#;
-    server
-        .open_named_document(incorrect_config, url!("biome.json"), "json")
-        .await?;
 
+    fs.insert(url!("biome.json").to_file_path().unwrap(), config);
+    let (service, client) = factory
+        .create_with_fs(None, DynRef::Owned(Box::new(fs)))
+        .into_inner();
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, _) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+    server
+        .open_named_document(config, url!("biome.json"), "json")
+        .await?;
     server
         .open_named_document(
             r#"enum X {

--- a/crates/biome_migrate/src/analyzers/indent_size.rs
+++ b/crates/biome_migrate/src/analyzers/indent_size.rs
@@ -7,6 +7,7 @@ use biome_json_analyze::utils::matches_path;
 use biome_json_factory::make::{ident, json_member_name};
 use biome_json_syntax::JsonMemberName;
 use biome_rowan::{AstNode, BatchMutationExt};
+use std::borrow::Cow;
 
 declare_migration! {
     pub(crate) IndentSize {
@@ -54,7 +55,7 @@ impl Rule for IndentSize {
         mutation.replace_node(node.clone(), new_node);
 
         Some(RuleAction::new(
-            ActionCategory::QuickFix,
+            ActionCategory::Other(Cow::Borrowed("migrate")),
             Applicability::Always,
             markup! {
                 "Use the property "<Emphasis>"formatter.indentWidth"</Emphasis>" instead."

--- a/crates/biome_migrate/src/analyzers/nursery_rules.rs
+++ b/crates/biome_migrate/src/analyzers/nursery_rules.rs
@@ -1,6 +1,6 @@
 use crate::{declare_migration, MigrationAction};
 use biome_analyze::context::RuleContext;
-use biome_analyze::{ActionCategory, Ast, FixKind, Rule, RuleDiagnostic};
+use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_diagnostics::category;
 use biome_json_factory::make::{
@@ -374,7 +374,7 @@ impl Rule for NurseryRules {
         };
 
         Some(MigrationAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
             if rule_already_exists {
                 markup! {

--- a/crates/biome_migrate/src/analyzers/schema.rs
+++ b/crates/biome_migrate/src/analyzers/schema.rs
@@ -1,7 +1,7 @@
 use crate::version_services::Version;
 use crate::{declare_migration, MigrationAction};
 use biome_analyze::context::RuleContext;
-use biome_analyze::{ActionCategory, Rule, RuleAction, RuleDiagnostic};
+use biome_analyze::{Rule, RuleAction, RuleDiagnostic};
 use biome_console::markup;
 use biome_diagnostics::{category, Applicability};
 use biome_json_factory::make::{ident, json_string_value};
@@ -70,7 +70,7 @@ impl Rule for Schema {
         mutation.replace_node(member_value.clone(), new_node);
 
         Some(RuleAction::new(
-            ActionCategory::QuickFix,
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
             Applicability::Always,
             markup! {
                 "Update the URL."

--- a/crates/biome_migrate/src/analyzers/trailing_comma.rs
+++ b/crates/biome_migrate/src/analyzers/trailing_comma.rs
@@ -7,6 +7,7 @@ use biome_json_analyze::utils::matches_path;
 use biome_json_factory::make::{ident, json_member_name};
 use biome_json_syntax::JsonMemberName;
 use biome_rowan::{AstNode, BatchMutationExt};
+use std::borrow::Cow;
 
 declare_migration! {
     pub(crate) TrailingComma {
@@ -54,7 +55,7 @@ impl Rule for TrailingComma {
         mutation.replace_node(node.clone(), new_node);
 
         Some(RuleAction::new(
-            ActionCategory::QuickFix,
+            ActionCategory::Other(Cow::Borrowed("migrate")),
             Applicability::Always,
             markup! {
                 "Use the property "<Emphasis>"javascript.formatter.trailingCommas"</Emphasis>" instead."

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3374,7 +3374,7 @@ export interface CodeAction {
 [CodeActionKind]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind 
 	 */
 export type ActionCategory =
-	| "QuickFix"
+	| { QuickFix: string }
 	| { Refactor: RefactorKind }
 	| { Source: SourceActionKind }
 	| { Other: string };


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR is the start of a refactor I have been doing in order to add a new feature in Biome via LSP. 

The feature I am developing is meant for `next`, but this feature is harmless and it should be merged in `main` so all new rules are in line with the new way of creating action categories. Doing on `next` would increase the maintenance debt.

This PR changes how the `ActionCategory` of rules is computed. Until now, all rules had `quickfix.biome` as action category, which was fine, With this PR, now all rules will have a personalised action category e.g. `quickfix.biome.suspicious.noDebugger`. This will allow LSP users to decide which code actions to filter. 

Eventually, users will be able to decide which quick fixes to apply, but that will be for another PR.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The current tests should pass

<!-- What demonstrates that your implementation is correct? -->
