### PR TITLE
feat(noUndeclaredVariables): add checkTypes option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,48 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) now provides the `checkTypes` option ([#3998](https://github.com/biomejs/biome/issues/3998)).
+
+  `noUndeclaredVariables` is inspired by the [no-undef ESLint rule](https://eslint.org/docs/latest/rules/no-undef). It reports all references that are not bound to any declarations within a module.
+  Node.js, JavaScript and TypeScript globals are ignored.
+  Bioem provides the `javascript.globals` option to list additional globals that should be ignored by the rule.
+
+  In TypeScript projects, developers often use global declaration files to declare global types.
+  Biome is currently unable to detect these global types.
+  This creates many false positives for `noUndeclaredVariables`.
+
+  TypeScript is better suited to perform this kind of check.
+  As proof of this, TypeScript ESLint doesn't provide any rule that extends the `no-undef` ESLint rule.
+
+  This is why we introduce today a new option `checkTypes` which, when it is set to `false`, ignores undeclared type references.
+  Given the following configuration...
+
+  ```json
+  {
+      "linter": {
+          "rules": {
+              "correctness": {
+                  "noUndeclaredVariables": {
+                      "level": "error",
+                      "options": { "checkTypes": false }
+                  }
+              }
+          }
+      }
+  }
+  ```
+
+  ... `UndeclaredType` is not reported by the rule.
+
+  ```ts
+  export default function(): UndeclaredType {}
+  ```
+
+  We plan to turn off the option by default in Biome 2.0
+  Also, this will bring the Biome rule closer to the [no-undef ESLint rule](https://eslint.org/docs/latest/rules/no-undef).
+
+  Contributed by @Conaclos
+
 #### Enhancements
 
 - `useExportType` and `useImportType` now ignore TypeScript declaration files ([#4416](https://github.com/biomejs/biome/pull/4416)). Contributed by @Conaclos

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::SemanticServices;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{
     AnyJsFunction, JsFileSource, Language, TextRange, TsAsExpression, TsReferenceType,
 };
@@ -12,6 +13,19 @@ declare_lint_rule! {
     /// Prevents the usage of variables that haven't been declared inside the document.
     ///
     /// If you need to allow-list some global bindings, you can use the [`javascript.globals`](/reference/configuration/#javascriptglobals) configuration.
+    ///
+    /// ## Options (Since v2.0.0)
+    ///
+    /// The rule provides a `checkTypes` option that make the rule checks undeclared types.
+    /// The option defaults to `true`.
+    ///
+    /// ```json
+    /// {
+    ///     "options": {
+    ///         "checkTypes": true
+    ///     }
+    /// }
+    /// ```
     ///
     /// ## Examples
     ///
@@ -43,7 +57,7 @@ impl Rule for NoUndeclaredVariables {
     type Query = SemanticServices;
     type State = (TextRange, Box<str>);
     type Signals = Box<[Self::State]>;
-    type Options = ();
+    type Options = UndeclaredVariablesOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         ctx.query()
@@ -87,6 +101,10 @@ impl Rule for NoUndeclaredVariables {
                     return None;
                 }
 
+                if !ctx.options().check_types && identifier.is_only_type() {
+                    return None;
+                }
+
                 let span = token.text_trimmed_range();
                 let text = text.to_string().into_boxed_str();
                 Some((span, text))
@@ -105,6 +123,19 @@ impl Rule for NoUndeclaredVariables {
         ).note(markup! {
             "By default, Biome recognizes browser and Node.js globals.\nYou can ignore more globals using the "<Hyperlink href="https://biomejs.dev/reference/configuration/#javascriptglobals">"javascript.globals"</Hyperlink>" configuration."
         }))
+    }
+}
+
+#[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(default, rename_all = "camelCase")]
+pub struct UndeclaredVariablesOptions {
+    /// Check undeclared types.
+    check_types: bool,
+}
+impl Default for UndeclaredVariablesOptions {
+    fn default() -> Self {
+        Self { check_types: true }
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.options.json
@@ -1,0 +1,14 @@
+{
+    "linter": {
+        "rules": {
+            "correctness": {
+                "noUndeclaredVariables": {
+                    "level": "error",
+                    "options": {
+                        "checkTypes": false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.ts
@@ -1,0 +1,3 @@
+export function f(): UndeclaredType {}
+
+export const X = UndeclaredVariable;

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/ignore-types.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignore-types.ts
+snapshot_kind: text
+---
+# Input
+```ts
+export function f(): UndeclaredType {}
+
+export const X = UndeclaredVariable;
+```
+
+# Diagnostics
+```
+ignore-types.ts:3:18 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The UndeclaredVariable variable is undeclared.
+  
+    1 │ export function f(): UndeclaredType {}
+    2 │ 
+  > 3 │ export const X = UndeclaredVariable;
+      │                  ^^^^^^^^^^^^^^^^^^
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1112,7 +1112,7 @@ export interface Correctness {
 	/**
 	 * Prevents the usage of variables that haven't been declared inside the document.
 	 */
-	noUndeclaredVariables?: RuleConfiguration_for_Null;
+	noUndeclaredVariables?: RuleConfiguration_for_UndeclaredVariablesOptions;
 	/**
 	 * Disallow unknown CSS value functions.
 	 */
@@ -2061,6 +2061,9 @@ export type RuleConfiguration_for_ComplexityOptions =
 export type RuleConfiguration_for_NoUndeclaredDependenciesOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoUndeclaredDependenciesOptions;
+export type RuleConfiguration_for_UndeclaredVariablesOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_UndeclaredVariablesOptions;
 export type RuleConfiguration_for_UseExhaustiveDependenciesOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_UseExhaustiveDependenciesOptions;
@@ -2215,6 +2218,16 @@ export interface RuleWithOptions_for_NoUndeclaredDependenciesOptions {
 	 * Rule's options
 	 */
 	options: NoUndeclaredDependenciesOptions;
+}
+export interface RuleWithOptions_for_UndeclaredVariablesOptions {
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: UndeclaredVariablesOptions;
 }
 export interface RuleWithOptions_for_UseExhaustiveDependenciesOptions {
 	/**
@@ -2475,6 +2488,12 @@ export interface NoUndeclaredDependenciesOptions {
 	 * If set to `false`, then the rule will show an error when `peerDependencies` are imported. Defaults to `true`.
 	 */
 	peerDependencies?: DependencyAvailability;
+}
+export interface UndeclaredVariablesOptions {
+	/**
+	 * Check undeclared types.
+	 */
+	checkTypes?: boolean;
 }
 /**
  * Options for the rule `useExhaustiveDependencies`

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -917,7 +917,7 @@
 				"noUndeclaredVariables": {
 					"description": "Prevents the usage of variables that haven't been declared inside the document.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/UndeclaredVariablesConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -3098,6 +3098,21 @@
 			},
 			"additionalProperties": false
 		},
+		"RuleWithUndeclaredVariablesOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/UndeclaredVariablesOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
 		"RuleWithUseComponentExportOnlyModulesOptions": {
 			"type": "object",
 			"required": ["level"],
@@ -4267,6 +4282,22 @@
 					"enum": ["all"]
 				}
 			]
+		},
+		"UndeclaredVariablesConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithUndeclaredVariablesOptions" }
+			]
+		},
+		"UndeclaredVariablesOptions": {
+			"type": "object",
+			"properties": {
+				"checkTypes": {
+					"description": "Check undeclared types.",
+					"default": true,
+					"type": "boolean"
+				}
+			}
 		},
 		"UseComponentExportOnlyModulesConfiguration": {
 			"anyOf": [


### PR DESCRIPTION
## Summary

See [this thread](https://github.com/biomejs/biome/issues/3998#issuecomment-2361821503) for some context.

Add a new `checkTypes` option for `noUndeclaredVariables`.

The option is turned on by default. I plan to turn it off in Biome 2.0.
This will bring `noUndeclaredVariables` closer to `no-undef` (So we will set the rule as a source instead of an inspiration).
This also eliminates many false positives.
TypeScript is better suited to perform this kind of check.
We could consider in Biome 2.0 to turn on the rule by default because `checkTypes` set to false will reduce significantly the number of false positives.

I chose to name the option `checkTypes` instead of `ignoreTypes` because I plan to make it false by default.

## Test Plan

I added a test.
