### PR TITLE
fix(grit): linting inside workspace

### DIFF
--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -160,7 +160,6 @@ impl DocumentFileSource {
         if let Ok(file_source) = HtmlFileSource::try_from_extension(extension) {
             return Ok(file_source.into());
         }
-
         if let Ok(file_source) = GritFileSource::try_from_extension(extension) {
             return Ok(file_source.into());
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Grit was failing in the playground because we don't expose the `lint` method, which is charge of pulling diagnostics, even from the parser.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I locally tested by compiling the WASM module. It works now

![Screenshot 2024-11-06 at 11 02 25](https://github.com/user-attachments/assets/74d733c8-9adc-4bea-89ca-4c092e3f4744)


<!-- What demonstrates that your implementation is correct? -->
