### PR TITLE
refactor(noUnusedImports): keep orphan comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,19 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- `noUnusedImports` now keeps comments separated from the import with a blank line ([#3401](https://github.com/biomejs/biome/issues/3401)).
+
+  Here is an example:
+
+  ```diff
+    // Orphan comment
+
+  - // Header comment
+  - import {} from "mod";
+  ```
+
+  Contributed by @Conaclos
+
 #### Bug fixes
 
 - [useArrayLiterals](https://biomejs.dev/linter/rules/use-array-literals/) now reports all expressions using the `Array` constructors.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -224,21 +224,21 @@ impl Rule for NoUnusedImports {
                 if let Some(blank_line_pos) = blank_line_pos {
                     // keep all leading trivia until the last blank line.
                     leading_trivia_pieces.truncate(blank_line_pos + 1);
-                    if let Some(next_sibling) = parent.next_sibling() {
-                        let new_next_sibling = next_sibling
-                            .clone()
-                            .prepend_trivia_pieces(leading_trivia_pieces)?;
-                        mutation.replace_element_discard_trivia(
-                            next_sibling.into(),
-                            new_next_sibling.into(),
-                        );
-                    } else if let Some(prev_sibling) = parent.prev_sibling() {
+                    if let Some(prev_sibling) = parent.prev_sibling() {
                         let new_prev_sibling = prev_sibling
                             .clone()
                             .append_trivia_pieces(leading_trivia_pieces)?;
                         mutation.replace_element_discard_trivia(
                             prev_sibling.into(),
                             new_prev_sibling.into(),
+                        );
+                    } else if let Some(next_sibling) = parent.next_sibling() {
+                        let new_next_sibling = next_sibling
+                            .clone()
+                            .prepend_trivia_pieces(leading_trivia_pieces)?;
+                        mutation.replace_element_discard_trivia(
+                            next_sibling.into(),
+                            new_next_sibling.into(),
                         );
                     }
                 }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-import-namespace.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-import-namespace.ts.snap
@@ -48,10 +48,10 @@ invalid-import-namespace.ts:4:18 lint/correctness/noUnusedImports  FIXABLE  ━�
   i Safe fix: Remove the unused imports.
   
     1 1 │   import * as Ns1 from ""
-    2 2 │   export type T1 = Ns1;
-    3   │ - 
+    2   │ - export·type·T1·=·Ns1;
+      2 │ + export·type·T1·=·Ns1;
+    3 3 │   
     4   │ - import·type·*·as·Ns2·from·""
-      3 │ + 
     5 4 │   export type T2 = Ns2;
   
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-import-namespace.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-import-namespace.ts.snap
@@ -51,7 +51,8 @@ invalid-import-namespace.ts:4:18 lint/correctness/noUnusedImports  FIXABLE  ━�
     2 2 │   export type T1 = Ns1;
     3   │ - 
     4   │ - import·type·*·as·Ns2·from·""
-    5 3 │   export type T2 = Ns2;
+      3 │ + 
+    5 4 │   export type T2 = Ns2;
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
@@ -104,8 +104,9 @@ invalid-unused-react.jsx:5:8 lint/correctness/noUnusedImports  FIXABLE  ━━�
     3 3 │   import { default as X } from "react"
     4   │ - 
     5   │ - import·React·from·"x"
-    6 4 │   import * as React from "x"
-    7 5 │   import { default as React } from "x"
+      4 │ + 
+    6 5 │   import * as React from "x"
+    7 6 │   import { default as React } from "x"
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid-unused-react.jsx.snap
@@ -100,11 +100,12 @@ invalid-unused-react.jsx:5:8 lint/correctness/noUnusedImports  FIXABLE  ━━�
   
   i Safe fix: Remove the unused imports.
   
+    1 1 │   import X from "react"
     2 2 │   import * as X from "react"
-    3 3 │   import { default as X } from "react"
-    4   │ - 
+    3   │ - import·{·default·as·X·}·from·"react"
+      3 │ + import·{·default·as·X·}·from·"react"
+    4 4 │   
     5   │ - import·React·from·"x"
-      4 │ + 
     6 5 │   import * as React from "x"
     7 6 │   import { default as React } from "x"
   

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.js.snap
@@ -81,14 +81,13 @@ invalid.js:5:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   i Safe fix: Remove the unused imports.
   
      1  1 │   // Header comment
-     2  2 │   import A from "mod";
-     3    │ - 
+     2    │ - import·A·from·"mod";
+        2 │ + import·A·from·"mod";
+     3  3 │   
      4    │ - //·Header·comment
      5    │ - import·*·as·B·from·"mod";·//·Import·comment
-     6  3 │   
-        4 │ + 
+     6  4 │   
      7  5 │   // Header comment
-     8  6 │   import { C } from "mod"; // Import comment
   
 
 ```
@@ -108,15 +107,15 @@ invalid.js:8:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+     3  3 │   
      4  4 │   // Header comment
-     5  5 │   import * as B from "mod"; // Import comment
-     6    │ - 
+     5    │ - import·*·as·B·from·"mod";·//·Import·comment
+        5 │ + import·*·as·B·from·"mod";·//·Import·comment
+     6  6 │   
      7    │ - //·Header·comment
      8    │ - import·{·C·}·from·"mod";·//·Import·comment
-     9  6 │   
-        7 │ + 
+     9  7 │   
     10  8 │   // Header comment
-    11  9 │   import /*a*/ D /*b*/, /*c*/{ E }/*d*/ from "mod"; // Import comment
   
 
 ```
@@ -136,15 +135,15 @@ invalid.js:11:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+     6  6 │   
      7  7 │   // Header comment
-     8  8 │   import { C } from "mod"; // Import comment
-     9    │ - 
+     8    │ - import·{·C·}·from·"mod";·//·Import·comment
+        8 │ + import·{·C·}·from·"mod";·//·Import·comment
+     9  9 │   
     10    │ - //·Header·comment
     11    │ - import·/*a*/·D·/*b*/,·/*c*/{·E·}/*d*/·from·"mod";·//·Import·comment
-    12  9 │   
-       10 │ + 
+    12 10 │   
     13 11 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-    14 12 │   
   
 
 ```
@@ -165,14 +164,14 @@ invalid.js:13:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+     9  9 │   
     10 10 │   // Header comment
-    11 11 │   import /*a*/ D /*b*/, /*c*/{ E }/*d*/ from "mod"; // Import comment
-    12    │ - 
+    11    │ - import·/*a*/·D·/*b*/,·/*c*/{·E·}/*d*/·from·"mod";·//·Import·comment
+       11 │ + import·/*a*/·D·/*b*/,·/*c*/{·E·}/*d*/·from·"mod";·//·Import·comment
+    12 12 │   
     13    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
-    14 12 │   
-       13 │ + 
+    14 13 │   
     15 14 │   import {
-    16 15 │       // Comment
   
 
 ```
@@ -198,18 +197,18 @@ invalid.js:15:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    11 11 │   import /*a*/ D /*b*/, /*c*/{ E }/*d*/ from "mod"; // Import comment
     12 12 │   
-    13 13 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-    14    │ - 
+    13    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
+       13 │ + import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
+    14 14 │   
     15    │ - import·{
     16    │ - ····//·Comment
     17    │ - ····H,
     18    │ - ····I,
     19    │ - }·from·"mod";
-    20 14 │   
-       15 │ + 
+    20 15 │   
     21 16 │   import {/*a*/J/*b*/, /*c*/K/*d*/} from "mod";
-    22 17 │   
   
 
 ```
@@ -230,14 +229,14 @@ invalid.js:21:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    17 17 │       H,
     18 18 │       I,
-    19 19 │   } from "mod";
-    20    │ - 
+    19    │ - }·from·"mod";
+       19 │ + }·from·"mod";
+    20 20 │   
     21    │ - import·{/*a*/J/*b*/,·/*c*/K/*d*/}·from·"mod";
-    22 20 │   
-       21 │ + 
+    22 21 │   
     23 22 │   // Header comment
-    24 23 │   import { L as M, } from "mod"; // Import comment
   
 
 ```
@@ -257,15 +256,15 @@ invalid.js:24:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    19 19 │   } from "mod";
     20 20 │   
-    21 21 │   import {/*a*/J/*b*/, /*c*/K/*d*/} from "mod";
-    22    │ - 
+    21    │ - import·{/*a*/J/*b*/,·/*c*/K/*d*/}·from·"mod";
+       21 │ + import·{/*a*/J/*b*/,·/*c*/K/*d*/}·from·"mod";
+    22 22 │   
     23    │ - //·Header·comment
     24    │ - import·{·L·as·M,·}·from·"mod";·//·Import·comment
-    25 22 │   
-       23 │ + 
+    25 23 │   
     26 24 │   // See https://github.com/biomejs/biome/issues/653
-    27 25 │   import {a} from 'a'
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.js.snap
@@ -86,7 +86,9 @@ invalid.js:5:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
      4    │ - //·Header·comment
      5    │ - import·*·as·B·from·"mod";·//·Import·comment
      6  3 │   
-     7  4 │   // Header comment
+        4 │ + 
+     7  5 │   // Header comment
+     8  6 │   import { C } from "mod"; // Import comment
   
 
 ```
@@ -112,7 +114,9 @@ invalid.js:8:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━�
      7    │ - //·Header·comment
      8    │ - import·{·C·}·from·"mod";·//·Import·comment
      9  6 │   
-    10  7 │   // Header comment
+        7 │ + 
+    10  8 │   // Header comment
+    11  9 │   import /*a*/ D /*b*/, /*c*/{ E }/*d*/ from "mod"; // Import comment
   
 
 ```
@@ -138,7 +142,9 @@ invalid.js:11:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
     10    │ - //·Header·comment
     11    │ - import·/*a*/·D·/*b*/,·/*c*/{·E·}/*d*/·from·"mod";·//·Import·comment
     12  9 │   
-    13 10 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+       10 │ + 
+    13 11 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    14 12 │   
   
 
 ```
@@ -164,7 +170,9 @@ invalid.js:13:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
     12    │ - 
     13    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
     14 12 │   
-    15 13 │   import {
+       13 │ + 
+    15 14 │   import {
+    16 15 │       // Comment
   
 
 ```
@@ -199,7 +207,9 @@ invalid.js:15:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
     18    │ - ····I,
     19    │ - }·from·"mod";
     20 14 │   
-    21 15 │   import {/*a*/J/*b*/, /*c*/K/*d*/} from "mod";
+       15 │ + 
+    21 16 │   import {/*a*/J/*b*/, /*c*/K/*d*/} from "mod";
+    22 17 │   
   
 
 ```
@@ -225,7 +235,9 @@ invalid.js:21:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
     20    │ - 
     21    │ - import·{/*a*/J/*b*/,·/*c*/K/*d*/}·from·"mod";
     22 20 │   
-    23 21 │   // Header comment
+       21 │ + 
+    23 22 │   // Header comment
+    24 23 │   import { L as M, } from "mod"; // Import comment
   
 
 ```
@@ -251,7 +263,9 @@ invalid.js:24:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
     23    │ - //·Header·comment
     24    │ - import·{·L·as·M,·}·from·"mod";·//·Import·comment
     25 22 │   
-    26 23 │   // See https://github.com/biomejs/biome/issues/653
+       23 │ + 
+    26 24 │   // See https://github.com/biomejs/biome/issues/653
+    27 25 │   import {a} from 'a'
   
 
 ```
@@ -296,11 +310,13 @@ invalid.js:32:9 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    28 28 │   import {d} from 'd'
     29 29 │   import {b} from 'b'
-    30 30 │   export const bb = a + b
-    31    │ - 
+    30    │ - export·const·bb·=·a·+·b
+       30 │ + export·const·bb·=·a·+·b
+    31 31 │   
     32    │ - import·{}·from·"mod"
-    33 31 │   
+    33 32 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.jsx.snap
@@ -114,8 +114,9 @@ invalid.jsx:5:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
      3  3 │   import { default as X } from "react"
      4    │ - 
      5    │ - import·React·from·"x"
-     6  4 │   import * as React from "x"
-     7  5 │   import { default as React } from "x"
+        4 │ + 
+     6  5 │   import * as React from "x"
+     7  6 │   import { default as React } from "x"
   
 
 ```
@@ -214,8 +215,9 @@ invalid.jsx:11:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
      9    │ - 
     10    │ - //·unsupported·patterns
     11    │ - import·X,·{·default·as·React·}·from·"react"
-    12  9 │   import X, * as React from "react"
-    13 10 │   
+        9 │ + 
+    12 10 │   import X, * as React from "react"
+    13 11 │   
   
 
 ```
@@ -265,8 +267,9 @@ invalid.jsx:15:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
     13    │ - 
     14    │ - //·React·import·(no·exception)
     15    │ - import·React·from·"react"
-    16 13 │   import * as React from "react"
-    17 14 │   import { default as React } from "react"
+       13 │ + 
+    16 14 │   import * as React from "react"
+    17 15 │   import { default as React } from "react"
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.jsx.snap
@@ -110,11 +110,12 @@ invalid.jsx:5:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+     1  1 │   import X from "react"
      2  2 │   import * as X from "react"
-     3  3 │   import { default as X } from "react"
-     4    │ - 
+     3    │ - import·{·default·as·X·}·from·"react"
+        3 │ + import·{·default·as·X·}·from·"react"
+     4  4 │   
      5    │ - import·React·from·"x"
-        4 │ + 
      6  5 │   import * as React from "x"
      7  6 │   import { default as React } from "x"
   
@@ -210,12 +211,13 @@ invalid.jsx:11:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+     6  6 │   import * as React from "x"
      7  7 │   import { default as React } from "x"
-     8  8 │   import React, { useEffect } from "x"
-     9    │ - 
+     8    │ - import·React,·{·useEffect·}·from·"x"
+        8 │ + import·React,·{·useEffect·}·from·"x"
+     9  9 │   
     10    │ - //·unsupported·patterns
     11    │ - import·X,·{·default·as·React·}·from·"react"
-        9 │ + 
     12 10 │   import X, * as React from "react"
     13 11 │   
   
@@ -262,12 +264,13 @@ invalid.jsx:15:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+    10 10 │   // unsupported patterns
     11 11 │   import X, { default as React } from "react"
-    12 12 │   import X, * as React from "react"
-    13    │ - 
+    12    │ - import·X,·*·as·React·from·"react"
+       12 │ + import·X,·*·as·React·from·"react"
+    13 13 │   
     14    │ - //·React·import·(no·exception)
     15    │ - import·React·from·"react"
-       13 │ + 
     16 14 │   import * as React from "react"
     17 15 │   import { default as React } from "react"
   

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts
@@ -7,6 +7,8 @@ import type * as B from "mod"; // Import comment
 // Header comment
 import type { C } from "mod"; // Import comment
 
+// Orphan comment
+
 // Header comment
 import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
 
@@ -22,3 +24,4 @@ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
 
 // Header comment
 import type { L as M, } from "mod"; // Import comment
+

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts.snap
@@ -14,6 +14,8 @@ import type * as B from "mod"; // Import comment
 // Header comment
 import type { C } from "mod"; // Import comment
 
+// Orphan comment
+
 // Header comment
 import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
 
@@ -29,6 +31,7 @@ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
 
 // Header comment
 import type { L as M, } from "mod"; // Import comment
+
 
 ```
 
@@ -78,7 +81,9 @@ invalid.ts:5:18 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
      4    │ - //·Header·comment
      5    │ - import·type·*·as·B·from·"mod";·//·Import·comment
      6  3 │   
-     7  4 │   // Header comment
+        4 │ + 
+     7  5 │   // Header comment
+     8  6 │   import type { C } from "mod"; // Import comment
   
 
 ```
@@ -92,7 +97,7 @@ invalid.ts:8:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
    > 8 │ import type { C } from "mod"; // Import comment
        │             ^^^^^
      9 │ 
-    10 │ // Header comment
+    10 │ // Orphan comment
   
   i Unused imports might be the result of an incomplete refactoring.
   
@@ -104,33 +109,9 @@ invalid.ts:8:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
      7    │ - //·Header·comment
      8    │ - import·type·{·C·}·from·"mod";·//·Import·comment
      9  6 │   
-    10  7 │   // Header comment
-  
-
-```
-
-```
-invalid.ts:11:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! These imports are unused.
-  
-    10 │ // Header comment
-  > 11 │ import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
-       │              ^^^^^^^^^^^^^^^^^^^^^^^^
-    12 │ 
-    13 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-  
-  i Unused imports might be the result of an incomplete refactoring.
-  
-  i Safe fix: Remove the unused imports.
-  
-     7  7 │   // Header comment
-     8  8 │   import type { C } from "mod"; // Import comment
-     9    │ - 
-    10    │ - //·Header·comment
-    11    │ - import·/*a*/·D·/*b*/,·/*c*/{·type·E·}/*d*/·from·"mod";·//·Import·comment
-    12  9 │   
-    13 10 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+        7 │ + 
+    10  8 │   // Orphan comment
+    11  9 │   
   
 
 ```
@@ -140,108 +121,149 @@ invalid.ts:13:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
 
   ! These imports are unused.
   
-    11 │ import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
-    12 │ 
-  > 13 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    12 │ // Header comment
+  > 13 │ import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
+       │              ^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ 
+    15 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused imports.
+  
+     7  7 │   // Header comment
+     8  8 │   import type { C } from "mod"; // Import comment
+     9    │ - 
+    10    │ - //·Orphan·comment
+    11    │ - 
+    12    │ - //·Header·comment
+    13    │ - import·/*a*/·D·/*b*/,·/*c*/{·type·E·}/*d*/·from·"mod";·//·Import·comment
+    14  9 │   
+       10 │ + //·Orphan·comment
+       11 │ + 
+       12 │ + 
+    15 13 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    16 14 │   
+  
+
+```
+
+```
+invalid.ts:15:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These imports are unused.
+  
+    13 │ import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
+    14 │ 
+  > 15 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
        │              ^^^^^^^^^^^^^^^^^^^^^
-    14 │ 
-    15 │ import {
+    16 │ 
+    17 │ import {
   
   i Unused imports might be the result of an incomplete refactoring.
   
   i Safe fix: Remove the unused imports.
   
-    10 10 │   // Header comment
-    11 11 │   import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
-    12    │ - 
-    13    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
-    14 12 │   
-    15 13 │   import {
-  
-
-```
-
-```
-invalid.ts:15:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This import is unused.
-  
-    13 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-    14 │ 
-  > 15 │ import {
-       │        ^
-  > 16 │     // Comment
-  > 17 │     type H,
-  > 18 │     type I,
-  > 19 │ } from "mod";
-       │ ^
-    20 │ 
-    21 │ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
-  
-  i Unused imports might be the result of an incomplete refactoring.
-  
-  i Safe fix: Remove the unused imports.
-  
-    12 12 │   
-    13 13 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    12 12 │   // Header comment
+    13 13 │   import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
     14    │ - 
-    15    │ - import·{
-    16    │ - ····//·Comment
-    17    │ - ····type·H,
-    18    │ - ····type·I,
-    19    │ - }·from·"mod";
-    20 14 │   
-    21 15 │   import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
+    15    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
+    16 14 │   
+       15 │ + 
+    17 16 │   import {
+    18 17 │       // Comment
   
 
 ```
 
 ```
-invalid.ts:21:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:17:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This import is unused.
   
-    19 │ } from "mod";
-    20 │ 
-  > 21 │ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
-       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    16 │ 
+  > 17 │ import {
+       │        ^
+  > 18 │     // Comment
+  > 19 │     type H,
+  > 20 │     type I,
+  > 21 │ } from "mod";
+       │ ^
     22 │ 
-    23 │ // Header comment
+    23 │ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
   
   i Unused imports might be the result of an incomplete refactoring.
   
   i Safe fix: Remove the unused imports.
   
-    18 18 │       type I,
-    19 19 │   } from "mod";
-    20    │ - 
-    21    │ - import·{/*a*/type·J/*b*/,·/*c*/type·K/*d*/}·from·"mod";
-    22 20 │   
-    23 21 │   // Header comment
+    14 14 │   
+    15 15 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
+    16    │ - 
+    17    │ - import·{
+    18    │ - ····//·Comment
+    19    │ - ····type·H,
+    20    │ - ····type·I,
+    21    │ - }·from·"mod";
+    22 16 │   
+       17 │ + 
+    23 18 │   import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
+    24 19 │   
   
 
 ```
 
 ```
-invalid.ts:24:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:23:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This import is unused.
   
-    23 │ // Header comment
-  > 24 │ import type { L as M, } from "mod"; // Import comment
-       │             ^^^^^^^^^^^
-    25 │ 
+    21 │ } from "mod";
+    22 │ 
+  > 23 │ import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │ 
+    25 │ // Header comment
   
   i Unused imports might be the result of an incomplete refactoring.
   
   i Safe fix: Remove the unused imports.
   
-    20 20 │   
-    21 21 │   import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
+    20 20 │       type I,
+    21 21 │   } from "mod";
     22    │ - 
-    23    │ - //·Header·comment
-    24    │ - import·type·{·L·as·M,·}·from·"mod";·//·Import·comment
-    25 22 │   
+    23    │ - import·{/*a*/type·J/*b*/,·/*c*/type·K/*d*/}·from·"mod";
+    24 22 │   
+       23 │ + 
+    25 24 │   // Header comment
+    26 25 │   import type { L as M, } from "mod"; // Import comment
+  
+
+```
+
+```
+invalid.ts:26:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is unused.
+  
+    25 │ // Header comment
+  > 26 │ import type { L as M, } from "mod"; // Import comment
+       │             ^^^^^^^^^^^
+    27 │ 
+  
+  i Unused imports might be the result of an incomplete refactoring.
+  
+  i Safe fix: Remove the unused imports.
+  
+    21 21 │   } from "mod";
+    22 22 │   
+    23    │ - import·{/*a*/type·J/*b*/,·/*c*/type·K/*d*/}·from·"mod";
+       23 │ + import·{/*a*/type·J/*b*/,·/*c*/type·K/*d*/}·from·"mod";
+    24 24 │   
+    25    │ - //·Header·comment
+    26    │ - import·type·{·L·as·M,·}·from·"mod";·//·Import·comment
+    27 25 │   
+    28 26 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/invalid.ts.snap
@@ -76,14 +76,13 @@ invalid.ts:5:18 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   i Safe fix: Remove the unused imports.
   
      1  1 │   // Header comment
-     2  2 │   import type A from "mod";
-     3    │ - 
+     2    │ - import·type·A·from·"mod";
+        2 │ + import·type·A·from·"mod";
+     3  3 │   
      4    │ - //·Header·comment
      5    │ - import·type·*·as·B·from·"mod";·//·Import·comment
-     6  3 │   
-        4 │ + 
+     6  4 │   
      7  5 │   // Header comment
-     8  6 │   import type { C } from "mod"; // Import comment
   
 
 ```
@@ -103,15 +102,15 @@ invalid.ts:8:13 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+     3  3 │   
      4  4 │   // Header comment
-     5  5 │   import type * as B from "mod"; // Import comment
-     6    │ - 
+     5    │ - import·type·*·as·B·from·"mod";·//·Import·comment
+        5 │ + import·type·*·as·B·from·"mod";·//·Import·comment
+     6  6 │   
      7    │ - //·Header·comment
      8    │ - import·type·{·C·}·from·"mod";·//·Import·comment
-     9  6 │   
-        7 │ + 
+     9  7 │   
     10  8 │   // Orphan comment
-    11  9 │   
   
 
 ```
@@ -131,19 +130,19 @@ invalid.ts:13:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+     6  6 │   
      7  7 │   // Header comment
-     8  8 │   import type { C } from "mod"; // Import comment
-     9    │ - 
+     8    │ - import·type·{·C·}·from·"mod";·//·Import·comment
+        8 │ + import·type·{·C·}·from·"mod";·//·Import·comment
+        9 │ + 
+       10 │ + //·Orphan·comment
+     9 11 │   
     10    │ - //·Orphan·comment
     11    │ - 
     12    │ - //·Header·comment
     13    │ - import·/*a*/·D·/*b*/,·/*c*/{·type·E·}/*d*/·from·"mod";·//·Import·comment
-    14  9 │   
-       10 │ + //·Orphan·comment
-       11 │ + 
-       12 │ + 
+    14 12 │   
     15 13 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-    16 14 │   
   
 
 ```
@@ -164,14 +163,14 @@ invalid.ts:15:14 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━�
   
   i Safe fix: Remove the unused imports.
   
+    11 11 │   
     12 12 │   // Header comment
-    13 13 │   import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
-    14    │ - 
+    13    │ - import·/*a*/·D·/*b*/,·/*c*/{·type·E·}/*d*/·from·"mod";·//·Import·comment
+       13 │ + import·/*a*/·D·/*b*/,·/*c*/{·type·E·}/*d*/·from·"mod";·//·Import·comment
+    14 14 │   
     15    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
-    16 14 │   
-       15 │ + 
+    16 15 │   
     17 16 │   import {
-    18 17 │       // Comment
   
 
 ```
@@ -197,18 +196,18 @@ invalid.ts:17:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    13 13 │   import /*a*/ D /*b*/, /*c*/{ type E }/*d*/ from "mod"; // Import comment
     14 14 │   
-    15 15 │   import /*a*/ F /*b*/, /*c*/ * as G /*d*/ from "mod";
-    16    │ - 
+    15    │ - import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
+       15 │ + import·/*a*/·F·/*b*/,·/*c*/·*·as·G·/*d*/·from·"mod";
+    16 16 │   
     17    │ - import·{
     18    │ - ····//·Comment
     19    │ - ····type·H,
     20    │ - ····type·I,
     21    │ - }·from·"mod";
-    22 16 │   
-       17 │ + 
+    22 17 │   
     23 18 │   import {/*a*/type J/*b*/, /*c*/type K/*d*/} from "mod";
-    24 19 │   
   
 
 ```
@@ -229,14 +228,14 @@ invalid.ts:23:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━
   
   i Safe fix: Remove the unused imports.
   
+    19 19 │       type H,
     20 20 │       type I,
-    21 21 │   } from "mod";
-    22    │ - 
+    21    │ - }·from·"mod";
+       21 │ + }·from·"mod";
+    22 22 │   
     23    │ - import·{/*a*/type·J/*b*/,·/*c*/type·K/*d*/}·from·"mod";
-    24 22 │   
-       23 │ + 
+    24 23 │   
     25 24 │   // Header comment
-    26 25 │   import type { L as M, } from "mod"; // Import comment
   
 
 ```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/3401

The rule now keeps all trivia (notably comments) separated from the `import` by a blank line (aka orphan comments).

## Test Plan

I added some tests.