### PR TITLE
refactor: drop `DynRef` and move `fs` into `Workspace`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ version = "1.9.4"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
+ "biome_fs",
  "biome_js_factory",
  "biome_js_formatter",
  "biome_rowan",

--- a/crates/biome_cli/src/changed.rs
+++ b/crates/biome_cli/src/changed.rs
@@ -1,11 +1,10 @@
 use crate::CliDiagnostic;
 use biome_configuration::PartialConfiguration;
 use biome_fs::FileSystem;
-use biome_service::DynRef;
 use std::ffi::OsString;
 
 pub(crate) fn get_changed_files(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     configuration: &PartialConfiguration,
     since: Option<&str>,
 ) -> Result<Vec<OsString>, CliDiagnostic> {
@@ -28,9 +27,7 @@ pub(crate) fn get_changed_files(
     Ok(filtered_changed_files)
 }
 
-pub(crate) fn get_staged_files(
-    fs: &DynRef<'_, dyn FileSystem>,
-) -> Result<Vec<OsString>, CliDiagnostic> {
+pub(crate) fn get_staged_files(fs: &dyn FileSystem) -> Result<Vec<OsString>, CliDiagnostic> {
     let staged_files = fs.get_staged_files()?;
 
     let filtered_staged_files = staged_files.iter().map(OsString::from).collect::<Vec<_>>();

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -10,7 +10,7 @@ use biome_configuration::{
 use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
-use biome_service::{configuration::LoadedConfiguration, DynRef, Workspace, WorkspaceError};
+use biome_service::{configuration::LoadedConfiguration, Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct CheckCommandPayload {
@@ -44,7 +44,7 @@ impl CommandRunner for CheckCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         let editorconfig_search_path = loaded_configuration.directory_path.clone();
@@ -105,7 +105,7 @@ impl CommandRunner for CheckCommandPayload {
 
     fn get_files_to_process(
         &self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         let paths = get_files_to_process_with_cli_options(

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -9,7 +9,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
-use biome_service::{DynRef, Workspace, WorkspaceError};
+use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct CiCommandPayload {
@@ -38,7 +38,7 @@ impl CommandRunner for CiCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         let LoadedConfiguration {
@@ -100,7 +100,7 @@ impl CommandRunner for CiCommandPayload {
 
     fn get_files_to_process(
         &self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         if self.changed {

--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -4,6 +4,7 @@ use crate::{
     CliDiagnostic, CliSession,
 };
 use biome_console::{markup, ConsoleExt};
+use biome_fs::OsFileSystem;
 use biome_lsp::ServerFactory;
 use biome_service::{workspace::WorkspaceClient, TransportError, WorkspaceError};
 use std::{env, fs, path::PathBuf};
@@ -50,7 +51,7 @@ pub(crate) fn stop(session: CliSession) -> Result<(), CliDiagnostic> {
     let rt = Runtime::new()?;
 
     if let Some(transport) = open_transport(rt)? {
-        let client = WorkspaceClient::new(transport)?;
+        let client = WorkspaceClient::new(transport, Box::new(OsFileSystem::default()))?;
         match client.shutdown() {
             // The `ChannelClosed` error is expected since the server can
             // shutdown before sending a response

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -11,7 +11,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
-use biome_service::{DynRef, Workspace, WorkspaceError};
+use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct FormatCommandPayload {
@@ -46,7 +46,7 @@ impl CommandRunner for FormatCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         let LoadedConfiguration {
@@ -106,7 +106,7 @@ impl CommandRunner for FormatCommandPayload {
 
     fn get_files_to_process(
         &self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         let paths = get_files_to_process_with_cli_options(

--- a/crates/biome_cli/src/commands/init.rs
+++ b/crates/biome_cli/src/commands/init.rs
@@ -4,8 +4,8 @@ use biome_console::{markup, ConsoleExt};
 use biome_fs::ConfigName;
 use biome_service::configuration::create_config;
 
-pub(crate) fn init(mut session: CliSession, emit_jsonc: bool) -> Result<(), CliDiagnostic> {
-    let fs = &mut session.app.fs;
+pub(crate) fn init(session: CliSession, emit_jsonc: bool) -> Result<(), CliDiagnostic> {
+    let fs = session.app.workspace.fs();
     create_config(fs, PartialConfiguration::init(), emit_jsonc)?;
     let file_created = if emit_jsonc {
         ConfigName::biome_jsonc()

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -15,7 +15,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
-use biome_service::{DynRef, Workspace, WorkspaceError};
+use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct LintCommandPayload {
@@ -46,7 +46,7 @@ impl CommandRunner for LintCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        _fs: &DynRef<'_, dyn FileSystem>,
+        _fs: &dyn FileSystem,
         _console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         let LoadedConfiguration {
@@ -100,7 +100,7 @@ impl CommandRunner for LintCommandPayload {
 
     fn get_files_to_process(
         &self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         let paths = get_files_to_process_with_cli_options(

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -9,7 +9,7 @@ use biome_configuration::PartialConfiguration;
 use biome_console::{markup, Console, ConsoleExt};
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
-use biome_service::{DynRef, Workspace, WorkspaceError};
+use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -27,7 +27,7 @@ impl CommandRunner for MigrateCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        _fs: &DynRef<'_, dyn FileSystem>,
+        _fs: &dyn FileSystem,
         _console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         self.configuration_file_path = loaded_configuration.file_path;
@@ -37,7 +37,7 @@ impl CommandRunner for MigrateCommandPayload {
 
     fn get_files_to_process(
         &self,
-        _fs: &DynRef<'_, dyn FileSystem>,
+        _fs: &dyn FileSystem,
         _configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         Ok(vec![])

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -10,7 +10,7 @@ use biome_fs::FileSystem;
 use biome_grit_patterns::GritTargetLanguage;
 use biome_service::configuration::LoadedConfiguration;
 use biome_service::workspace::ParsePatternParams;
-use biome_service::{DynRef, Workspace, WorkspaceError};
+use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
 pub(crate) struct SearchCommandPayload {
@@ -28,7 +28,7 @@ impl CommandRunner for SearchCommandPayload {
     fn merge_configuration(
         &mut self,
         loaded_configuration: LoadedConfiguration,
-        _fs: &DynRef<'_, dyn FileSystem>,
+        _fs: &dyn FileSystem,
         _console: &mut dyn Console,
     ) -> Result<PartialConfiguration, WorkspaceError> {
         let LoadedConfiguration {
@@ -44,7 +44,7 @@ impl CommandRunner for SearchCommandPayload {
 
     fn get_files_to_process(
         &self,
-        _fs: &DynRef<'_, dyn FileSystem>,
+        _fs: &dyn FileSystem,
         _configuration: &PartialConfiguration,
     ) -> Result<Vec<OsString>, CliDiagnostic> {
         Ok(self.paths.clone())

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -49,9 +49,9 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
         sub_command,
     } = migrate_payload;
     let mut cache = NodeCache::default();
-    let fs = &session.app.fs;
     let console = session.app.console;
     let workspace = session.app.workspace;
+    let fs = workspace.fs();
 
     let open_options = if write {
         OpenOptions::default().read(true).write(true)

--- a/crates/biome_cli/src/execute/migrate/eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint.rs
@@ -4,7 +4,6 @@ use biome_deserialize::Merge;
 use biome_diagnostics::{DiagnosticExt, PrintDiagnostic};
 use biome_fs::{FileSystem, OpenOptions};
 use biome_json_parser::JsonParserOptions;
-use biome_service::DynRef;
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -75,7 +74,7 @@ pub(crate) const IGNORE_FILE: &str = ".eslintignore";
 ///
 /// The `extends` field is recursively resolved.
 pub(crate) fn read_eslint_config(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     console: &mut dyn Console,
 ) -> Result<Config, CliDiagnostic> {
     for config_path_str in FLAT_CONFIG_FILES {
@@ -151,7 +150,7 @@ fn load_flat_config_data(
 /// Load an ESlint legacy config
 /// See https://eslint.org/docs/latest/use/configure/configuration-files
 fn load_legacy_config_data(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     path: &Path,
     console: &mut dyn Console,
 ) -> Result<eslint_eslint::LegacyConfigData, CliDiagnostic> {

--- a/crates/biome_cli/src/execute/migrate/ignorefile.rs
+++ b/crates/biome_cli/src/execute/migrate/ignorefile.rs
@@ -1,12 +1,11 @@
 use std::{io, path::Path};
 
 use biome_fs::{FileSystem, OpenOptions};
-use biome_service::DynRef;
 
 /// Read an ignore file that follows gitignore pattern syntax,
 /// and turn them into a list of UNIX glob patterns.
 pub(crate) fn read_ignore_file(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     ignore_filename: &str,
 ) -> io::Result<IgnorePatterns> {
     let mut file = fs.open_with_options(

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -11,7 +11,6 @@ use biome_formatter::{
 use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingCommas};
 use biome_json_parser::JsonParserOptions;
-use biome_service::DynRef;
 use std::{ffi::OsStr, path::Path};
 
 use super::{eslint_eslint::ShorthandVec, node};
@@ -380,7 +379,7 @@ pub(crate) const IGNORE_FILE: &str = ".prettierignore";
 
 /// This function is in charge of reading prettier files, deserialize its contents
 pub(crate) fn read_config_file(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     console: &mut dyn Console,
 ) -> Result<Config, CliDiagnostic> {
     // We don't report an error if Prettier config is not embedded in `PACKAGE_JSON`.
@@ -405,7 +404,7 @@ pub(crate) fn read_config_file(
 }
 
 fn load_config(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     path: &Path,
     console: &mut dyn Console,
 ) -> Result<PrettierConfiguration, CliDiagnostic> {

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -25,7 +25,6 @@ use biome_grit_patterns::GritTargetLanguage;
 use biome_service::workspace::{
     FeatureName, FeaturesBuilder, FixFileMode, FormatFileParams, OpenFileParams, PatternId,
 };
-use std::borrow::Borrow;
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
@@ -569,7 +568,7 @@ pub fn execute_mode(
                 };
                 reporter.write(&mut GitLabReporterVisitor::new(
                     console,
-                    session.app.fs.borrow().working_directory(),
+                    session.app.workspace.fs().working_directory(),
                 ))?;
             }
             ReportMode::Junit => {

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -81,8 +81,8 @@ pub(crate) fn traverse(
     let matches = AtomicUsize::new(0);
     let skipped = AtomicUsize::new(0);
 
-    let fs = &*session.app.fs;
     let workspace = &*session.app.workspace;
+    let fs = workspace.fs();
 
     let max_diagnostics = execution.get_max_diagnostics();
     let remaining_diagnostics = AtomicU32::new(max_diagnostics);

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -7,8 +7,7 @@
 //! execute the traversal of directory and files, based on the command that were passed.
 
 use biome_console::{ColorMode, Console};
-use biome_fs::OsFileSystem;
-use biome_service::{App, DynRef, Workspace, WorkspaceRef};
+use biome_service::{App, Workspace, WorkspaceRef};
 use commands::search::SearchCommandPayload;
 use std::env;
 
@@ -55,11 +54,7 @@ impl<'app> CliSession<'app> {
         console: &'app mut dyn Console,
     ) -> Result<Self, CliDiagnostic> {
         Ok(Self {
-            app: App::new(
-                DynRef::Owned(Box::<OsFileSystem>::default()),
-                console,
-                WorkspaceRef::Borrowed(workspace),
-            ),
+            app: App::new(console, WorkspaceRef::Borrowed(workspace)),
         })
     }
 

--- a/crates/biome_cli/tests/cases/assists.rs
+++ b/crates/biome_cli/tests/cases/assists.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -33,10 +32,10 @@ fn assist_emit_diagnostic() {
         r#"{ "zod": true, "lorem": "ipsum", "foo": "bar" }"#.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -77,10 +76,10 @@ fn assist_writes() {
         r#"{ "zod": true, "lorem": "ipsum", "foo": "bar" }"#.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--write", file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", "--write", file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/biome_json_support.rs
+++ b/crates/biome_cli/tests/cases/biome_json_support.rs
@@ -3,7 +3,6 @@ use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayloa
 use crate::{run_cli, UNFORMATTED};
 use biome_console::BufferConsole;
 use biome_fs::{FileSystemExt, MemoryFileSystem};
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
 
@@ -30,19 +29,19 @@ fn formatter_biome_json() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), CUSTOM_CONFIGURATION_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--line-width"),
-                ("10"),
-                ("--indent-style"),
-                ("space"),
-                ("--indent-width"),
-                ("8"),
-                ("--write"),
+                "format",
+                "--line-width",
+                "10",
+                "--indent-style",
+                "space",
+                "--indent-width",
+                "8",
+                "--write",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -85,17 +84,10 @@ fn linter_biome_json() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["lint", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -141,17 +133,10 @@ fn check_biome_json() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -193,10 +178,10 @@ fn ci_biome_json() {
 
     fs.insert(input_file.into(), "  statement(  )  ".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), input_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", input_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -237,11 +222,7 @@ fn biome_json_is_not_ignored() {
 
     fs.insert(input_file.into(), "  statement(  )  ".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("ci"), "./"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["ci", "./"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -274,8 +255,8 @@ fn always_disable_trailing_commas_biome_json() {
 "#;
     fs.insert(file_path.into(), config);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--write", "."].as_slice()),
     );

--- a/crates/biome_cli/tests/cases/config_extends.rs
+++ b/crates/biome_cli/tests/cases/config_extends.rs
@@ -3,7 +3,6 @@ use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_formatter::LineWidth;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -28,10 +27,10 @@ fn extends_config_ok_formatter_no_linter() {
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -76,10 +75,10 @@ fn extends_config_ok_linter_not_formatter() {
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -114,10 +113,10 @@ fn extends_should_raise_an_error_for_unresolved_configuration() {
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -152,12 +151,12 @@ fn extends_should_raise_an_error_for_unresolved_configuration_and_show_verbose()
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--verbose",
                 test_file.as_os_str().to_str().unwrap(),
             ]
@@ -197,12 +196,12 @@ fn extends_resolves_when_using_config_path() {
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--config-path=config/",
                 test_file.as_os_str().to_str().unwrap(),
             ]
@@ -244,17 +243,10 @@ fn applies_extended_values_in_current_config() {
         r#"debugger; const a = ["lorem", "ipsum"]; "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--write",
-                test_file.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -288,17 +280,10 @@ fn respects_unaffected_values_from_extended_config() {
         r#"debugger; const a = ["lorem", "ipsum"]; "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--write",
-                test_file.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -335,17 +320,10 @@ fn allows_reverting_fields_in_extended_config_to_default() {
         r#"debugger; const a = ["lorem", "ipsum"]; "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--write",
-                test_file.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -390,8 +368,8 @@ fn extends_config_merge_overrides() {
     let test_file = Path::new("test.js");
     fs.insert(test_file.into(), "debugger; const a = 0;");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );

--- a/crates/biome_cli/tests/cases/config_path.rs
+++ b/crates/biome_cli/tests/cases/config_path.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -36,10 +35,10 @@ fn set_config_path_to_directory() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), ("--config-path=config"), ("src")].as_slice()),
+        Args::from(["check", "--config-path=config", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -83,10 +82,10 @@ fn set_config_path_to_file() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), ("--config-path=config/a.jsonc"), ("src")].as_slice()),
+        Args::from(["check", "--config-path=config/a.jsonc", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/cts_files.rs
+++ b/crates/biome_cli/tests/cases/cts_files.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -17,10 +16,10 @@ fn should_allow_using_export_statements() {
         r#"export default { cjs: true };"#.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -2,7 +2,6 @@ use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use crate::{run_cli, UNFORMATTED};
 use biome_console::{BufferConsole, LogLevel};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
 
@@ -35,13 +34,13 @@ fn logs_the_appropriate_messages_according_to_set_diagnostics_level() {
     let test = Path::new("test.js");
     fs.insert(test.into(), TEST_CONTENTS.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--diagnostic-level=error"),
+                "lint",
+                "--diagnostic-level=error",
                 test.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -82,10 +81,10 @@ fn max_diagnostics_no_verbose() {
     let file_path = PathBuf::from("src/file.js".to_string());
     fs.insert(file_path, UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), ("--max-diagnostics"), ("10"), ("src")].as_slice()),
+        Args::from(["ci", "--max-diagnostics", "10", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -116,10 +115,10 @@ fn max_diagnostics_verbose() {
     let file_path = PathBuf::from("src/file.js".to_string());
     fs.insert(file_path, UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), ("--max-diagnostics=10"), "--verbose", ("src")].as_slice()),
+        Args::from(["ci", "--max-diagnostics=10", "--verbose", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -168,10 +167,10 @@ import { FC, memo, useCallback } from "react";
 "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), ("--diagnostic-level=error"), ("src")].as_slice()),
+        Args::from(["check", "--diagnostic-level=error", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -211,14 +210,14 @@ fn max_diagnostics_are_lifted() {
         "debugger;".repeat(u8::MAX as usize * 2).as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--max-diagnostics"),
-                ("none"),
+                "ci",
+                "--max-diagnostics",
+                "none",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -25,14 +24,14 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
-                ("--use-editorconfig=true"),
+                "format",
+                "--write",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -81,17 +80,10 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                ("--write"),
-                test_file.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -125,13 +117,13 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--use-editorconfig=true"),
+                "check",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -180,10 +172,10 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -231,14 +223,14 @@ indent_style = tab
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
-                ("--use-editorconfig=true"),
+                "format",
+                "--write",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -275,14 +267,14 @@ max_line_length = 90
     fs.insert(test_file.into(), r#"console.log("really long string that should break if the line width is <=90, but not at 100");
 "#);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--line-width=100"),
-                ("--use-editorconfig=true"),
+                "check",
+                "--line-width=100",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -336,13 +328,13 @@ indent_style = space
     "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--use-editorconfig=true"),
+                "check",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
                 test_file2.as_os_str().to_str().unwrap(),
             ]
@@ -380,13 +372,13 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--use-editorconfig=true"),
+                "ci",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -435,10 +427,10 @@ max_line_length = 300
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), test_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", test_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -472,14 +464,14 @@ insert_final_newline = false
 "#;
     fs.insert(test_file.into(), contents);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
-                ("--use-editorconfig=true"),
+                "format",
+                "--write",
+                "--use-editorconfig=true",
                 test_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),

--- a/crates/biome_cli/tests/cases/graphql.rs
+++ b/crates/biome_cli/tests/cases/graphql.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -29,10 +28,10 @@ fn format_graphql_files() {
     let file_path = Path::new("file.graphql");
     fs.insert(file_path.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -56,17 +55,10 @@ fn format_and_write_graphql_files() {
     let file_path = Path::new("file.graphql");
     fs.insert(file_path.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--write",
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -90,12 +82,12 @@ fn lint_single_rule() {
     let file_path = Path::new("file.graphql");
     fs.insert(file_path.into(), MISSING_REASON.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--only=nursery/useDeprecatedReason",
                 file_path.as_os_str().to_str().unwrap(),
             ]

--- a/crates/biome_cli/tests/cases/handle_astro_files.rs
+++ b/crates/biome_cli/tests/cases/handle_astro_files.rs
@@ -4,7 +4,6 @@ use crate::snap_test::{
 };
 use biome_console::{markup, BufferConsole};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -105,10 +104,10 @@ fn format_astro_files() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), ASTRO_FILE_UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -132,8 +131,8 @@ fn format_astro_files_write() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), ASTRO_FILE_UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -166,8 +165,8 @@ fn format_empty_astro_files_write() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), "<div></div>".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -203,10 +202,10 @@ fn format_astro_carriage_return_line_feed_files() {
         ASTRO_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -237,10 +236,10 @@ fn lint_astro_files() {
         ASTRO_FILE_DEBUGGER_BEFORE.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -265,12 +264,12 @@ fn lint_and_fix_astro_files() {
         ASTRO_FILE_DEBUGGER_BEFORE.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 astro_file_path.as_os_str().to_str().unwrap(),
@@ -300,12 +299,12 @@ fn sorts_imports_check() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), ASTRO_FILE_IMPORTS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 astro_file_path.as_os_str().to_str().unwrap(),
@@ -335,12 +334,12 @@ fn sorts_imports_write() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), ASTRO_FILE_IMPORTS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 "--write",
@@ -371,10 +370,10 @@ fn does_not_throw_parse_error_for_return() {
     let astro_file_path = Path::new("file.astro");
     fs.insert(astro_file_path.into(), ASTRO_RETURN.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -390,13 +389,13 @@ fn does_not_throw_parse_error_for_return() {
 
 #[test]
 fn format_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(ASTRO_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -425,13 +424,13 @@ fn format_stdin_successfully() {
 
 #[test]
 fn format_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(ASTRO_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--write", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -460,15 +459,15 @@ fn format_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(ASTRO_FILE_USELESS_RENAME_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -497,15 +496,15 @@ fn lint_stdin_successfully() {
 
 #[test]
 fn lint_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(ASTRO_FILE_USELESS_RENAME_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -534,15 +533,15 @@ fn lint_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(ASTRO_FILE_DEBUGGER_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -580,13 +579,13 @@ fn lint_stdin_write_unsafe_successfully() {
 
 #[test]
 fn check_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(ASTRO_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -615,13 +614,13 @@ fn check_stdin_successfully() {
 
 #[test]
 fn check_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(ASTRO_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--write", "--stdin-file-path", "file.astro"].as_slice()),
     );
@@ -650,13 +649,13 @@ fn check_stdin_write_successfully() {
 
 #[test]
 fn check_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(ASTRO_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -703,10 +702,10 @@ fn astro_global_object() {
         ASTRO_FILE_ASTRO_GLOBAL_OBJECT.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", astro_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/handle_css_files.rs
+++ b/crates/biome_cli/tests/cases/handle_css_files.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -15,10 +14,10 @@ fn should_not_format_files_by_default() {
     let css_file = Path::new("input.css");
     fs.insert(css_file.into(), css_file_content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), css_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", css_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     // no files processed error
@@ -42,8 +41,8 @@ fn should_format_files_by_when_opt_in() {
     let css_file = Path::new("input.css");
     fs.insert(css_file.into(), css_file_content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -76,8 +75,8 @@ fn should_format_write_files_by_when_opt_in() {
     let css_file = Path::new("input.css");
     fs.insert(css_file.into(), css_file_content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -120,8 +119,8 @@ fn should_not_lint_files_by_default() {
     let css_file = Path::new("input.css");
     fs.insert(css_file.into(), css_file_content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", css_file.as_os_str().to_str().unwrap()].as_slice()),
     );
@@ -157,8 +156,8 @@ fn should_lint_files_by_when_enabled() {
     let css_file = Path::new("input.css");
     fs.insert(css_file.into(), css_file_content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -4,7 +4,6 @@ use crate::snap_test::{
 };
 use biome_console::{markup, BufferConsole};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -87,12 +86,12 @@ fn sorts_imports_check() {
         SVELTE_FILE_IMPORTS_BEFORE.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 svelte_file_path.as_os_str().to_str().unwrap(),
@@ -125,12 +124,12 @@ fn sorts_imports_write() {
         SVELTE_FILE_IMPORTS_BEFORE.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 "--write",
@@ -164,10 +163,10 @@ fn format_svelte_ts_context_module_files() {
         SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -198,8 +197,8 @@ fn format_svelte_ts_context_module_files_write() {
         SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -239,10 +238,10 @@ fn format_svelte_carriage_return_line_feed_files() {
         SVELTE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", svelte_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -264,15 +263,15 @@ fn format_svelte_carriage_return_line_feed_files() {
 
 #[test]
 fn format_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -301,15 +300,15 @@ fn format_stdin_successfully() {
 
 #[test]
 fn format_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_CONTEXT_MODULE_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--write", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -338,15 +337,15 @@ fn format_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_LINT_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -375,15 +374,15 @@ fn lint_stdin_successfully() {
 
 #[test]
 fn lint_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_LINT_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -412,15 +411,15 @@ fn lint_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_LINT_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -458,15 +457,15 @@ fn lint_stdin_write_unsafe_successfully() {
 
 #[test]
 fn check_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -495,15 +494,15 @@ fn check_stdin_successfully() {
 
 #[test]
 fn check_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--write", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -532,15 +531,15 @@ fn check_stdin_write_successfully() {
 
 #[test]
 fn check_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push(SVELTE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -4,7 +4,6 @@ use crate::snap_test::{
 };
 use biome_console::{markup, BufferConsole};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -152,10 +151,10 @@ fn format_vue_implicit_js_files() {
         VUE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -182,8 +181,8 @@ fn format_vue_implicit_js_files_write() {
         VUE_IMPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -219,10 +218,10 @@ fn format_vue_explicit_js_files() {
         VUE_EXPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -249,8 +248,8 @@ fn format_vue_explicit_js_files_write() {
         VUE_EXPLICIT_JS_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -283,8 +282,8 @@ fn format_empty_vue_js_files_write() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), "<template></template>".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -317,10 +316,10 @@ fn format_vue_ts_files() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_TS_FILE_UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -344,8 +343,8 @@ fn format_vue_ts_files_write() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_TS_FILE_UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -378,8 +377,8 @@ fn format_empty_vue_ts_files_write() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), "<template></template>".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -415,10 +414,10 @@ fn format_vue_carriage_return_line_feed_files() {
         VUE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -449,10 +448,10 @@ fn format_vue_generic_component_files() {
         VUE_GENERIC_COMPONENT_FILE_UNFORMATTED.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -476,10 +475,10 @@ fn lint_vue_js_files() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_JS_FILE_NOT_LINTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -501,10 +500,10 @@ fn lint_vue_ts_files() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_TS_FILE_NOT_LINTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -526,12 +525,12 @@ fn sorts_imports_check() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_FILE_IMPORTS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 vue_file_path.as_os_str().to_str().unwrap(),
@@ -561,12 +560,12 @@ fn sorts_imports_write() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_FILE_IMPORTS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 "--write",
@@ -591,13 +590,13 @@ fn sorts_imports_write() {
 
 #[test]
 fn format_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--stdin-file-path", "file.vue"].as_slice()),
     );
@@ -626,13 +625,13 @@ fn format_stdin_successfully() {
 
 #[test]
 fn format_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_UNFORMATTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", "--write", "--stdin-file-path", "file.vue"].as_slice()),
     );
@@ -661,13 +660,13 @@ fn format_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_NOT_LINTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -696,13 +695,13 @@ fn lint_stdin_successfully() {
 
 #[test]
 fn lint_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_NOT_LINTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--stdin-file-path", "file.svelte"].as_slice()),
     );
@@ -731,13 +730,13 @@ fn lint_stdin_write_successfully() {
 
 #[test]
 fn lint_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_NOT_LINTED.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -775,13 +774,13 @@ fn lint_stdin_write_unsafe_successfully() {
 
 #[test]
 fn check_stdin_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--stdin-file-path", "file.vue"].as_slice()),
     );
@@ -810,13 +809,13 @@ fn check_stdin_successfully() {
 
 #[test]
 fn check_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--write", "--stdin-file-path", "file.vue"].as_slice()),
     );
@@ -845,13 +844,13 @@ fn check_stdin_write_successfully() {
 
 #[test]
 fn check_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(VUE_TS_FILE_CHECK_BEFORE.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -895,10 +894,10 @@ fn vue_compiler_macros_as_globals() {
     let vue_file_path = Path::new("file.vue");
     fs.insert(vue_file_path.into(), VUE_TS_FILE_SETUP_GLOBALS.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", vue_file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/included_files.rs
+++ b/crates/biome_cli/tests/cases/included_files.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -37,13 +36,13 @@ fn does_handle_only_included_files() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -86,13 +85,13 @@ fn does_not_handle_included_files_if_overridden_by_ignore() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -135,13 +134,13 @@ fn does_not_handle_included_files_if_overridden_by_ignore_formatter() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -184,13 +183,13 @@ fn does_not_handle_included_files_if_overridden_by_ignore_linter() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--write"),
+                "lint",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -235,13 +234,13 @@ fn does_not_handle_included_files_if_overridden_by_organize_imports() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNORGANIZED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
+                "check",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]

--- a/crates/biome_cli/tests/cases/overrides_formatter.rs
+++ b/crates/biome_cli/tests/cases/overrides_formatter.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -53,13 +52,13 @@ fn does_handle_included_file_and_disable_formatter() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -102,13 +101,13 @@ fn does_include_file_with_different_formatting() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -154,13 +153,13 @@ fn does_include_file_with_different_formatting_and_all_of_them() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -206,13 +205,13 @@ fn does_include_file_with_different_overrides() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -276,13 +275,13 @@ fn complex_enable_disable_overrides() {
     let unformatted = Path::new("dirty.js");
     fs.insert(unformatted.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 formatted.as_os_str().to_str().unwrap(),
                 unformatted.as_os_str().to_str().unwrap(),
             ]
@@ -328,13 +327,13 @@ fn does_include_file_with_different_languages() {
     let test_css = Path::new("test.css");
     fs.insert(test_css.into(), CSS_UNFORMATTED_QUOTES.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
                 test_css.as_os_str().to_str().unwrap(),
@@ -399,13 +398,13 @@ fn does_include_file_with_different_languages_and_files() {
     let css_file = Path::new("test4.css");
     fs.insert(css_file.into(), UNFORMATTED_CSS.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
                 json_file.as_os_str().to_str().unwrap(),
@@ -455,13 +454,13 @@ fn does_not_change_formatting_settings() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -507,13 +506,13 @@ fn does_not_change_formatting_language_settings() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -559,13 +558,13 @@ fn does_not_change_formatting_language_settings_2() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
-                ("--write"),
+                "format",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -610,8 +609,8 @@ fn does_not_conceal_previous_overrides() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -656,8 +655,8 @@ fn takes_last_formatter_enabled_into_account() {
     let test = Path::new("test.js");
     fs.insert(test.into(), UNFORMATTED_LINE_WIDTH.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["format", test.as_os_str().to_str().unwrap()].as_slice()),
     );
@@ -708,8 +707,8 @@ fn does_not_override_well_known_special_files_when_config_override_is_present() 
 }"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -780,8 +779,8 @@ fn allow_trailing_commas_on_well_known_files() {
 }"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -836,8 +835,8 @@ fn disallow_comments_on_well_known_files() {
 }"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", tsconfig.as_os_str().to_str().unwrap()].as_slice()),
     );

--- a/crates/biome_cli/tests/cases/overrides_linter.rs
+++ b/crates/biome_cli/tests/cases/overrides_linter.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -39,13 +38,13 @@ fn does_handle_included_file_and_disable_linter() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--write"),
+                "lint",
+                "--write",
                 test.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -90,12 +89,12 @@ fn does_include_file_with_different_rules() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 test.as_os_str().to_str().unwrap(),
@@ -165,12 +164,12 @@ fn does_include_file_with_different_linting_and_applies_all_of_them() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 test.as_os_str().to_str().unwrap(),
@@ -240,12 +239,12 @@ fn does_include_file_with_different_overrides() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), SIMPLE_NUMBERS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 test.as_os_str().to_str().unwrap(),
@@ -303,12 +302,12 @@ fn does_override_the_rules() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 test.as_os_str().to_str().unwrap(),
@@ -362,12 +361,12 @@ fn does_not_change_linting_settings() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--write",
                 "--unsafe",
                 test.as_os_str().to_str().unwrap(),
@@ -424,8 +423,8 @@ fn does_override_recommended() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--unsafe", "."].as_slice()),
     );
@@ -480,8 +479,8 @@ fn does_override_groupe_recommended() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--unsafe", "."].as_slice()),
     );
@@ -534,8 +533,8 @@ fn does_preserve_group_recommended_when_override_global_recommened() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--unsafe", "."].as_slice()),
     );
@@ -588,8 +587,8 @@ fn does_preserve_individually_diabled_rules_in_overrides() {
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["lint", "--write", "--unsafe", "."].as_slice()),
     );
@@ -656,11 +655,7 @@ fn does_merge_all_overrides() {
     let test3 = Path::new("test3.js");
     fs.insert(test3.into(), DEBUGGER_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from(["lint", "."].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["lint", "."].as_slice()));
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_cli_snapshot(SnapshotPayload::new(
@@ -702,11 +697,7 @@ fn does_not_conceal_overrides_globals() {
     let test = Path::new("test.js");
     fs.insert(test.into(), "export { GLOBAL_VAR };".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from(["lint", "."].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["lint", "."].as_slice()));
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -748,11 +739,7 @@ fn takes_last_linter_enabled_into_account() {
     let test = Path::new("test.js");
     fs.insert(test.into(), "export { GLOBAL_VAR };".as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from(["lint", "."].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["lint", "."].as_slice()));
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/cases/overrides_organize_imports.rs
+++ b/crates/biome_cli/tests/cases/overrides_organize_imports.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -35,13 +34,13 @@ fn does_handle_included_file_and_disable_organize_imports() {
     let test2 = Path::new("special/test2.js");
     fs.insert(test2.into(), UNORGANIZED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
+                "check",
+                "--write",
                 "--formatter-enabled=false",
                 "--linter-enabled=false",
                 test.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/cases/protected_files.rs
+++ b/crates/biome_cli/tests/cases/protected_files.rs
@@ -2,21 +2,20 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, markup_to_string, SnapshotPayload};
 use biome_console::{markup, BufferConsole};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
 #[test]
 fn not_process_file_from_stdin_format() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(r#"{ "name": "test" }"#.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), ("--stdin-file-path=package-lock.json")].as_slice()),
+        Args::from(["format", "--stdin-file-path=package-lock.json"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -32,15 +31,15 @@ fn not_process_file_from_stdin_format() {
 
 #[test]
 fn not_process_file_from_stdin_lint() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(r#"{ "name": "test" }"#.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), ("--stdin-file-path=package.json")].as_slice()),
+        Args::from(["lint", "--stdin-file-path=package.json"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -56,22 +55,15 @@ fn not_process_file_from_stdin_lint() {
 
 #[test]
 fn not_process_file_from_stdin_verbose_format() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(r#"{ "name": "test" }"#.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--verbose",
-                ("--stdin-file-path=package-lock.json"),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--verbose", "--stdin-file-path=package-lock.json"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -87,22 +79,15 @@ fn not_process_file_from_stdin_verbose_format() {
 
 #[test]
 fn not_process_file_from_stdin_verbose_lint() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(r#"{ "name": "test" }"#.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("format"),
-                "--verbose",
-                ("--stdin-file-path=package-lock.json"),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--verbose", "--stdin-file-path=package-lock.json"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -124,10 +109,10 @@ fn not_process_file_from_cli() {
     let file_path = Path::new("package-lock.json");
     fs.insert(file_path.into(), r#"{ "name": "test" }"#.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["format", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -149,12 +134,12 @@ fn not_process_file_from_cli_verbose() {
     let file_path = Path::new("package-lock.json");
     fs.insert(file_path.into(), r#"{ "name": "test" }"#.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--verbose",
                 file_path.as_os_str().to_str().unwrap(),
             ]
@@ -190,12 +175,12 @@ fn not_process_ignored_file_from_cli_verbose() {
         r#"{ "files": { "ignore": ["package.json"] } }"#.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--verbose",
                 file_path.as_os_str().to_str().unwrap(),
             ]
@@ -231,12 +216,12 @@ fn not_process_file_linter_disabled_from_cli_verbose() {
         r#"{ "linter": { "enabled": false } }"#.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--verbose",
                 file_path.as_os_str().to_str().unwrap(),
             ]
@@ -257,16 +242,16 @@ fn not_process_file_linter_disabled_from_cli_verbose() {
 
 #[test]
 fn should_return_the_content_of_protected_files_via_stdin() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
     console
         .in_buffer
         .push(r#"{ "name": "something" }"#.to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("format"), ("--stdin-file-path"), ("package-lock.json")].as_slice()),
+        Args::from(["format", "--stdin-file-path", "package-lock.json"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/reporter_github.rs
+++ b/crates/biome_cli/tests/cases/reporter_github.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -37,12 +36,12 @@ fn reports_diagnostics_github_check_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--reporter=github",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -73,12 +72,12 @@ fn reports_diagnostics_github_ci_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 "--reporter=github",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -109,12 +108,12 @@ fn reports_diagnostics_github_lint_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--reporter=github",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -145,12 +144,12 @@ fn reports_diagnostics_github_format_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--reporter=github",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/cases/reporter_gitlab.rs
+++ b/crates/biome_cli/tests/cases/reporter_gitlab.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -57,12 +56,12 @@ fn reports_diagnostics_gitlab_check_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--reporter=gitlab",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -94,12 +93,12 @@ fn reports_diagnostics_gitlab_ci_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 "--reporter=gitlab",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -131,12 +130,12 @@ fn reports_diagnostics_gitlab_lint_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--reporter=gitlab",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -168,12 +167,12 @@ fn reports_diagnostics_gitlab_format_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--reporter=gitlab",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/cases/reporter_junit.rs
+++ b/crates/biome_cli/tests/cases/reporter_junit.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -37,12 +36,12 @@ fn reports_diagnostics_junit_check_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--reporter=junit",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -73,12 +72,12 @@ fn reports_diagnostics_junit_ci_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 "--reporter=junit",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -109,12 +108,12 @@ fn reports_diagnostics_junit_lint_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--reporter=junit",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
@@ -145,12 +144,12 @@ fn reports_diagnostics_junit_format_command() {
     let file_path2 = Path::new("index.ts");
     fs.insert(file_path2.into(), MAIN_2.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--reporter=junit",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/cases/reporter_summary.rs
+++ b/crates/biome_cli/tests/cases/reporter_summary.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -70,12 +69,12 @@ fn reports_diagnostics_summary_check_command() {
     let file_path3 = Path::new("index.css");
     fs.insert(file_path3.into(), MAIN_3.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--reporter=summary",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -111,12 +110,12 @@ fn reports_diagnostics_summary_ci_command() {
     let file_path3 = Path::new("index.css");
     fs.insert(file_path3.into(), MAIN_3.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 "--reporter=summary",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -152,12 +151,12 @@ fn reports_diagnostics_summary_lint_command() {
     let file_path3 = Path::new("index.css");
     fs.insert(file_path3.into(), MAIN_3.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
+                "lint",
                 "--reporter=summary",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -193,12 +192,12 @@ fn reports_diagnostics_summary_format_command() {
     let file_path3 = Path::new("index.css");
     fs.insert(file_path3.into(), MAIN_3.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 "--reporter=summary",
                 "--max-diagnostics=200",
                 file_path1.as_os_str().to_str().unwrap(),

--- a/crates/biome_cli/tests/cases/suppressions.rs
+++ b/crates/biome_cli/tests/cases/suppressions.rs
@@ -2,7 +2,6 @@ use crate::snap_test::SnapshotPayload;
 use crate::{assert_cli_snapshot, run_cli, FORMATTED};
 use biome_console::BufferConsole;
 use biome_fs::{FileSystemExt, MemoryFileSystem};
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -21,13 +20,13 @@ fn ok() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), FORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (_, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
+                "lint",
+                "--suppress",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -45,14 +44,14 @@ fn err_when_both_write_and_suppress_are_passed() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), FORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--write"),
-                ("--suppress"),
+                "lint",
+                "--write",
+                "--suppress",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -77,13 +76,13 @@ fn suppress_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), SUPPRESS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
+                "lint",
+                "--suppress",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -120,13 +119,13 @@ fn suppress_multiple_ok() {
         [SUPPRESS_BEFORE, SUPPRESS_BEFORE].join("\n").as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
+                "lint",
+                "--suppress",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -160,14 +159,14 @@ fn suppress_only_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), SUPPRESS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
-                ("--only=lint/suspicious/noCompareNegZero"),
+                "lint",
+                "--suppress",
+                "--only=lint/suspicious/noCompareNegZero",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -201,14 +200,14 @@ fn suppress_skip_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), SUPPRESS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
-                ("--skip=lint/suspicious/noCompareNegZero"),
+                "lint",
+                "--suppress",
+                "--skip=lint/suspicious/noCompareNegZero",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -242,17 +241,10 @@ fn err_when_only_reason() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), SUPPRESS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("lint"),
-                ("--reason"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["lint", "--reason", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -282,14 +274,14 @@ fn custom_explanation_with_reason() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), SUPPRESS_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("lint"),
-                ("--suppress"),
-                ("--reason=We love Biome"),
+                "lint",
+                "--suppress",
+                "--reason=We love Biome",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -335,10 +327,10 @@ let foo = 2;
 let bar = 33;",
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lint"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["lint", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/cases/unknown_files.rs
+++ b/crates/biome_cli/tests/cases/unknown_files.rs
@@ -2,7 +2,6 @@ use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use crate::{run_cli, UNFORMATTED};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -17,12 +16,12 @@ fn should_print_a_diagnostic_unknown_file() {
     let file_path2 = Path::new("format.js");
     fs.insert(file_path2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]
@@ -58,12 +57,12 @@ fn should_not_print_a_diagnostic_unknown_file_because_ignored() {
     let file_path2 = Path::new("format.js");
     fs.insert(file_path2.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("format"),
+                "format",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -15,10 +15,11 @@ use crate::configs::{
     CONFIG_LINTER_UPGRADE_DIAGNOSTIC, CONFIG_RECOMMENDED_GROUP,
 };
 use crate::snap_test::{assert_file_contents, markup_to_string, SnapshotPayload};
-use crate::{assert_cli_snapshot, run_cli, FORMATTED, LINT_ERROR, PARSE_ERROR};
+use crate::{
+    assert_cli_snapshot, run_cli, run_cli_with_dyn_fs, FORMATTED, LINT_ERROR, PARSE_ERROR,
+};
 use biome_console::{markup, BufferConsole, LogLevel, MarkupBuf};
 use biome_fs::{ErrorEntry, FileSystemExt, MemoryFileSystem, OsFileSystem};
-use biome_service::DynRef;
 
 const ERRORS: &str = r#"
 for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);for(;true;);
@@ -58,14 +59,10 @@ const NURSERY_UNSTABLE: &str = r#"if(a = b) {}"#;
 
 #[test]
 fn check_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("check"), "--help"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["check", "--help"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -86,10 +83,10 @@ fn ok() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), FORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (_, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -103,10 +100,10 @@ fn ok_read_only() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), FORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (_, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -120,10 +117,10 @@ fn parse_error() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), PARSE_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -144,10 +141,10 @@ fn lint_error() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -168,10 +165,10 @@ fn maximum_diagnostics() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), ERRORS.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -213,17 +210,10 @@ fn apply_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -253,17 +243,10 @@ fn apply_noop() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_AFTER.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -285,14 +268,14 @@ fn apply_suggested_error() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--unsafe"),
-                ("--write"),
+                "check",
+                "--unsafe",
+                "--write",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -318,12 +301,12 @@ fn apply_suggested() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
@@ -374,12 +357,12 @@ function f() {\n\targuments;\n}
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), source.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 test1.as_os_str().to_str().unwrap(),
@@ -414,17 +397,10 @@ fn no_lint_if_linter_is_disabled_when_run_apply() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), CONFIG_LINTER_DISABLED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -457,17 +433,10 @@ fn no_lint_if_linter_is_disabled_when_run_apply_biome_jsonc() {
     let config_path = Path::new("biome.jsonc");
     fs.insert(config_path.into(), CONFIG_LINTER_DISABLED_JSONC.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -500,10 +469,10 @@ fn no_lint_if_linter_is_disabled() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), CONFIG_LINTER_DISABLED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -536,17 +505,10 @@ fn should_disable_a_rule() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), CONFIG_LINTER_SUPPRESSED_RULE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -582,17 +544,10 @@ fn should_disable_a_rule_group() {
         CONFIG_LINTER_SUPPRESSED_GROUP.as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -627,10 +582,10 @@ fn downgrade_severity() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), NO_DEBUGGER.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -671,10 +626,10 @@ fn upgrade_severity() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), UPGRADE_SEVERITY_CODE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -716,17 +671,10 @@ fn no_lint_when_file_is_ignored() {
     let file_path = Path::new("test.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -774,13 +722,13 @@ fn no_lint_if_files_are_listed_in_ignore_option() {
     let file_path_test2 = Path::new("test2.js");
     fs.insert(file_path_test2.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
+                "check",
+                "--write",
                 file_path_test1.as_os_str().to_str().unwrap(),
                 file_path_test2.as_os_str().to_str().unwrap(),
             ]
@@ -841,10 +789,10 @@ fn fs_error_dereferenced_symlink() {
         ));
     }
 
-    let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+    let result = run_cli_with_dyn_fs(
+        Box::new(OsFileSystem::new(root_path.clone())),
         &mut console,
-        Args::from([("check"), root_path.display().to_string().as_str()].as_slice()),
+        Args::from(["check", &root_path.display().to_string()].as_slice()),
     );
 
     remove_dir_all(root_path).unwrap();
@@ -885,10 +833,10 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
         check_windows_symlink!(symlink_dir(subdir1_path, subdir2_path.join("symlink2")));
     }
 
-    let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+    let result = run_cli_with_dyn_fs(
+        Box::new(OsFileSystem::new(root_path.clone())),
         &mut console,
-        Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
+        Args::from(["check", &root_path.display().to_string()].as_slice()),
     );
 
     remove_dir_all(root_path).unwrap();
@@ -931,10 +879,10 @@ fn fs_error_infinite_symlink_expansion_to_files() {
         check_windows_symlink!(symlink_dir(&symlink1_path, &symlink2_path));
     }
 
-    let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+    let result = run_cli_with_dyn_fs(
+        Box::new(OsFileSystem::new(root_path.clone())),
         &mut console,
-        Args::from([("check"), (root_path.display().to_string().as_str())].as_slice()),
+        Args::from(["check", &root_path.display().to_string()].as_slice()),
     );
 
     remove_dir_all(root_path).unwrap();
@@ -968,17 +916,10 @@ fn fs_error_read_only() {
     let file_path = Path::new("test.js");
     fs.insert(file_path.into(), *b"content");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1002,11 +943,7 @@ fn fs_error_unknown() {
 
     fs.insert_error(PathBuf::from("prefix/ci.js"), ErrorEntry::UnknownFileType);
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("check"), ("prefix")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["check", "prefix"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -1111,17 +1048,17 @@ fn fs_files_ignore_symlink() {
         file.write_all(APPLY_SUGGESTED_BEFORE.as_bytes()).unwrap();
     }
 
-    let result = run_cli(
-        DynRef::Owned(Box::new(OsFileSystem::new(root_path.clone()))),
+    let result = run_cli_with_dyn_fs(
+        Box::new(OsFileSystem::new(root_path.clone())),
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--config-path"),
-                (root_path.display().to_string().as_str()),
+                "check",
+                "--config-path",
+                &root_path.display().to_string(),
                 "--write",
                 "--unsafe",
-                (src_path.display().to_string().as_str()),
+                &src_path.display().to_string(),
             ]
             .as_slice(),
         ),
@@ -1148,10 +1085,10 @@ fn file_too_large() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), "statement();\n".repeat(80660).as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1178,10 +1115,10 @@ fn file_too_large_config_limit() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1203,13 +1140,13 @@ fn file_too_large_cli_limit() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--files-max-size=16"),
+                "check",
+                "--files-max-size=16",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -1235,13 +1172,13 @@ fn files_max_size_parse_error() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--files-max-size=-1"),
+                "check",
+                "--files-max-size=-1",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -1270,11 +1207,7 @@ fn max_diagnostics_default() {
         fs.insert(file_path, LINT_ERROR.as_bytes());
     }
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("check"), ("src")].as_slice()),
-    );
+    let (_, result) = run_cli(fs, &mut console, Args::from(["check", "src"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -1314,14 +1247,14 @@ fn max_diagnostics() {
         fs.insert(file_path, LINT_ERROR.as_bytes());
     }
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (_, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--max-diagnostics"),
-                ("10"),
+                "check",
+                "--max-diagnostics",
+                "10",
                 Path::new("src").as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -1358,14 +1291,10 @@ fn max_diagnostics() {
 
 #[test]
 fn no_supported_file_found() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("check"), "."].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["check", "."].as_slice()));
 
     eprintln!("{:?}", console.out_buffer);
 
@@ -1385,13 +1314,13 @@ fn print_verbose() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--verbose"),
+                "check",
+                "--verbose",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -1417,13 +1346,13 @@ fn print_verbose_write() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--verbose"),
+                "check",
+                "--verbose",
                 "--write",
                 file_path.as_os_str().to_str().unwrap(),
             ]
@@ -1450,10 +1379,10 @@ fn unsupported_file() {
     let file_path = Path::new("check.txt");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -1474,12 +1403,12 @@ fn unsupported_file_verbose() {
     let file_path = Path::new("check.txt");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--verbose",
                 file_path.as_os_str().to_str().unwrap(),
             ]
@@ -1505,10 +1434,10 @@ fn suppression_syntax_error() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), *b"// biome-ignore(:\n");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1533,10 +1462,10 @@ fn config_recommended_group() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), NEW_SYMBOL.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
     assert!(result.is_err(), "run_cli returned {result:?}");
     assert_cli_snapshot(SnapshotPayload::new(
@@ -1556,10 +1485,10 @@ fn nursery_unstable() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), NURSERY_UNSTABLE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1591,8 +1520,8 @@ import * as something from "../something";
 "#;
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
@@ -1621,10 +1550,10 @@ import * as something from "../something";
 "#;
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1654,17 +1583,10 @@ import * as something from "../something";
 "#;
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -1696,12 +1618,12 @@ import * as something from "../something";
 "#;
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
@@ -1738,16 +1660,16 @@ import * as something from "../something";
 
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
-                ("--formatter-enabled=false"),
-                ("--linter-enabled=false"),
-                ("--organize-imports-enabled=true"),
+                "check",
+                "--write",
+                "--formatter-enabled=false",
+                "--linter-enabled=false",
+                "--organize-imports-enabled=true",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -1784,10 +1706,10 @@ fn all_rules() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), rome_json.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1832,10 +1754,10 @@ fn top_level_all_down_level_not_all() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), rome_json.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1880,10 +1802,10 @@ fn top_level_not_all_down_level_all() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), rome_json.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1917,10 +1839,10 @@ fn ignore_configured_globals() {
     let config_path = Path::new("biome.json");
     fs.insert(config_path.into(), rome_json.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -1968,12 +1890,12 @@ file2.js
     let ignore_file = Path::new(".gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]
@@ -2018,16 +1940,16 @@ ignored/**
     let ignore_file = Path::new("./.gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--vcs-enabled=true"),
-                ("--vcs-client-kind=git"),
-                ("--vcs-use-ignore-file=true"),
-                ("--vcs-root=."),
+                "check",
+                "--vcs-enabled=true",
+                "--vcs-client-kind=git",
+                "--vcs-use-ignore-file=true",
+                "--vcs-root=.",
                 "--write",
                 "--unsafe",
                 file_path1.as_os_str().to_str().unwrap(),
@@ -2087,12 +2009,12 @@ fn ignore_vcs_os_independent_parse() {
     let ignore_file = Path::new(".gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
                 file_path3.as_os_str().to_str().unwrap(),
@@ -2138,16 +2060,16 @@ file2.js
     let ignore_file = Path::new("./.gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--vcs-enabled=true"),
-                ("--vcs-client-kind=git"),
-                ("--vcs-use-ignore-file=true"),
-                ("--vcs-root=."),
+                "check",
+                "--vcs-enabled=true",
+                "--vcs-client-kind=git",
+                "--vcs-use-ignore-file=true",
+                "--vcs-root=.",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]
@@ -2168,17 +2090,17 @@ file2.js
 
 #[test]
 fn check_stdin_write_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console
         .in_buffer
         .push("import {a as a} from 'mod'; function f() {return{a}} class Foo {}".to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--write", ("--stdin-file-path"), ("mock.js")].as_slice()),
+        Args::from(["check", "--write", "--stdin-file-path", "mock.js"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -2208,7 +2130,7 @@ fn check_stdin_write_successfully() {
 
 #[test]
 fn check_stdin_write_unsafe_successfully() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(
@@ -2216,17 +2138,17 @@ fn check_stdin_write_unsafe_successfully() {
             .to_string(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--organize-imports-enabled=true",
                 "--write",
                 "--unsafe",
-                ("--stdin-file-path"),
-                ("mock.js"),
+                "--stdin-file-path",
+                "mock.js",
             ]
             .as_slice(),
         ),
@@ -2259,7 +2181,7 @@ fn check_stdin_write_unsafe_successfully() {
 
 #[test]
 fn check_stdin_write_unsafe_only_organize_imports() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push(
@@ -2267,19 +2189,19 @@ fn check_stdin_write_unsafe_only_organize_imports() {
             .to_string(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--organize-imports-enabled=true",
                 "--linter-enabled=false",
                 "--formatter-enabled=false",
                 "--write",
                 "--unsafe",
-                ("--stdin-file-path"),
-                ("mock.js"),
+                "--stdin-file-path",
+                "mock.js",
             ]
             .as_slice(),
         ),
@@ -2312,22 +2234,22 @@ fn check_stdin_write_unsafe_only_organize_imports() {
 
 #[test]
 fn check_stdin_returns_text_if_content_is_not_changed() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push("console.log(\"\");\n".to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--organize-imports-enabled=true",
                 "--write",
                 "--unsafe",
-                ("--stdin-file-path"),
-                ("mock.js"),
+                "--stdin-file-path",
+                "mock.js",
             ]
             .as_slice(),
         ),
@@ -2357,20 +2279,20 @@ fn check_stdin_returns_text_if_content_is_not_changed() {
 
 #[test]
 fn check_stdin_returns_content_when_not_write() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     console.in_buffer.push("let b = 2;".to_string());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--organize-imports-enabled=true",
-                ("--stdin-file-path"),
-                ("mock.js"),
+                "--stdin-file-path",
+                "mock.js",
             ]
             .as_slice(),
         ),
@@ -2425,10 +2347,10 @@ fn should_apply_correct_file_source() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -2488,10 +2410,10 @@ fn should_not_enable_all_recommended_rules() {
 		"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -2537,10 +2459,10 @@ array.map((sentence) => sentence.split(" ")).flat();
 		"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -2565,12 +2487,12 @@ fn apply_bogus_argument() {
         "function _13_1_3_fun(arguments) { }".as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 file_path.as_os_str().to_str().unwrap(),
                 "--write",
                 "--unsafe",
@@ -2601,12 +2523,12 @@ fn ignores_unknown_file() {
     let file_path2 = Path::new("test.js");
     fs.insert(file_path2.into(), *b"console.log('bar');\n");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
                 "--files-ignore-unknown=true",
@@ -2650,10 +2572,10 @@ fn check_json_files() {
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path1.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path1.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -2670,12 +2592,12 @@ fn check_json_files() {
 #[test]
 fn doesnt_error_if_no_files_were_processed() {
     let mut console = BufferConsole::default();
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--no-errors-on-unmatched", ("file.js")].as_slice()),
+        Args::from(["check", "--no-errors-on-unmatched", "file.js"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -2721,12 +2643,12 @@ A = 0;
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
@@ -2778,12 +2700,12 @@ A = 0;
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 "--error-on-warnings",
@@ -2817,12 +2739,12 @@ fn use_literal_keys_should_emit_correct_ast_issue_266() {
 		"#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
@@ -2874,10 +2796,10 @@ fn should_show_formatter_diagnostics_for_files_ignored_by_linter() {
         "#,
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -2899,12 +2821,12 @@ fn print_json() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 "--reporter=json",
@@ -2933,12 +2855,12 @@ fn print_json_pretty() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
+                "check",
                 "--write",
                 "--unsafe",
                 "--reporter=json-pretty",
@@ -2967,11 +2889,7 @@ fn lint_error_without_file_paths() {
     let file_path = Path::new("check.js");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
-    let result: Result<(), biome_cli::CliDiagnostic> = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("check"), ""].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["check", ""].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -2990,17 +2908,10 @@ fn fix_ok() {
     let mut console = BufferConsole::default();
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--fix"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--fix", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -3026,14 +2937,14 @@ fn fix_unsafe_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--fix"),
-                ("--unsafe"),
+                "check",
+                "--fix",
+                "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -3066,17 +2977,10 @@ fn fix_noop() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_AFTER.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--fix"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--fix", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -3096,14 +3000,14 @@ fn fix_suggested_error() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--fix"),
-                ("--write"),
+                "check",
+                "--fix",
+                "--write",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -3140,14 +3044,14 @@ function f() {\n\targuments;\n}
     fs.insert(test1.into(), source.as_bytes());
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), source.as_bytes());
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--fix"),
-                ("--unsafe"),
+                "check",
+                "--fix",
+                "--unsafe",
                 test1.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -3174,17 +3078,10 @@ fn write_ok() {
     let mut console = BufferConsole::default();
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -3210,14 +3107,14 @@ fn write_unsafe_ok() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
-                ("--unsafe"),
+                "check",
+                "--write",
+                "--unsafe",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -3250,17 +3147,10 @@ fn write_noop() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), FIX_AFTER.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("check"),
-                ("--write"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["check", "--write", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -3280,14 +3170,14 @@ fn write_suggested_error() {
     let file_path = Path::new("fix.js");
     fs.insert(file_path.into(), APPLY_SUGGESTED_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
-                ("--write"),
+                "check",
+                "--write",
+                "--write",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -3324,14 +3214,14 @@ function f() {\n\targuments;\n}
     fs.insert(test1.into(), source.as_bytes());
     let test2 = Path::new("test2.js");
     fs.insert(test2.into(), source.as_bytes());
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("check"),
-                ("--write"),
-                ("--unsafe"),
+                "check",
+                "--write",
+                "--unsafe",
                 test1.as_os_str().to_str().unwrap(),
                 test2.as_os_str().to_str().unwrap(),
             ]
@@ -3361,10 +3251,10 @@ fn should_error_if_unstaged_files_only_with_staged_flag() {
         Path::new("file1.js").into(),
         r#"console.log('file1');"#.as_bytes(),
     );
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--staged"].as_slice()),
+        Args::from(["check", "--staged"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -3386,10 +3276,10 @@ fn should_error_if_unchanged_files_only_with_changed_flag() {
         Path::new("file1.js").into(),
         r#"console.log('file1');"#.as_bytes(),
     );
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--changed", "--since=main"].as_slice()),
+        Args::from(["check", "--changed", "--since=main"].as_slice()),
     );
     assert!(result.is_err(), "run_cli returned {result:?}");
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/commands/ci.rs
+++ b/crates/biome_cli/tests/commands/ci.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use biome_console::{BufferConsole, MarkupBuf};
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
 
@@ -33,14 +32,10 @@ const CI_CONFIGURATION: &str = r#"
 
 #[test]
 fn ci_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("ci"), "--help"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["ci", "--help"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -61,10 +56,10 @@ fn ok() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), FORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -92,10 +87,10 @@ fn formatting_error() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -117,10 +112,10 @@ fn ci_parse_error() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), PARSE_ERROR.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -141,10 +136,10 @@ fn ci_lint_error() {
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -172,10 +167,10 @@ fn ci_does_not_run_formatter() {
 
     fs.insert(input_file.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), input_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", input_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -205,10 +200,10 @@ fn ci_does_not_run_formatter_biome_jsonc() {
 
     fs.insert(input_file.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), input_file.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", input_file.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -232,13 +227,13 @@ fn ci_does_not_run_formatter_via_cli() {
     let input_file = Path::new("file.js");
     fs.insert(input_file.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--formatter-enabled=false"),
+                "ci",
+                "--formatter-enabled=false",
                 input_file.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -271,10 +266,10 @@ fn ci_does_not_run_linter() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), CUSTOM_FORMAT_BEFORE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -298,13 +293,13 @@ fn ci_does_not_run_linter_via_cli() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), UNFORMATTED_AND_INCORRECT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--linter-enabled=false"),
+                "ci",
+                "--linter-enabled=false",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -336,13 +331,13 @@ import * as something from "../something";
 "#;
     fs.insert(file_path.into(), content.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--organize-imports-enabled=false"),
+                "ci",
+                "--organize-imports-enabled=false",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -373,15 +368,15 @@ fn ci_errors_for_all_disabled_checks() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), UNFORMATTED_AND_INCORRECT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--linter-enabled=false"),
-                ("--formatter-enabled=false"),
-                ("--organize-imports-enabled=false"),
+                "ci",
+                "--linter-enabled=false",
+                "--formatter-enabled=false",
+                "--organize-imports-enabled=false",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -409,10 +404,10 @@ fn file_too_large() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), "statement();\n".repeat(80660).as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -439,10 +434,10 @@ fn file_too_large_config_limit() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -464,13 +459,13 @@ fn file_too_large_cli_limit() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--files-max-size=16"),
+                "ci",
+                "--files-max-size=16",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -496,13 +491,13 @@ fn files_max_size_parse_error() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), "statement1();\nstatement2();");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--files-max-size=-1"),
+                "ci",
+                "--files-max-size=-1",
                 file_path.as_os_str().to_str().unwrap(),
             ]
             .as_slice(),
@@ -531,10 +526,10 @@ fn ci_runs_linter_not_formatter_issue_3495() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), INCORRECT_CODE.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -558,11 +553,7 @@ fn max_diagnostics_default() {
         fs.insert(file_path, UNFORMATTED.as_bytes());
     }
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("ci"), ("src")].as_slice()),
-    );
+    let (mut fs, result) = run_cli(fs, &mut console, Args::from(["ci", "src"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -614,10 +605,10 @@ fn max_diagnostics() {
         fs.insert(file_path, UNFORMATTED.as_bytes());
     }
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (mut fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), ("--max-diagnostics"), ("10"), ("src")].as_slice()),
+        Args::from(["ci", "--max-diagnostics", "10", "src"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -667,17 +658,10 @@ fn print_verbose() {
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from(
-            [
-                ("ci"),
-                ("--verbose"),
-                file_path.as_os_str().to_str().unwrap(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["ci", "--verbose", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -730,10 +714,10 @@ something( )
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), input.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), file_path.as_os_str().to_str().unwrap()].as_slice()),
+        Args::from(["ci", file_path.as_os_str().to_str().unwrap()].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -783,12 +767,12 @@ file2.js
     let ignore_file = Path::new(".gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]
@@ -832,16 +816,16 @@ file2.js
     let ignore_file = Path::new("./.gitignore");
     fs.insert(ignore_file.into(), git_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
-                ("--vcs-enabled=true"),
-                ("--vcs-client-kind=git"),
-                ("--vcs-use-ignore-file=true"),
-                ("--vcs-root=."),
+                "ci",
+                "--vcs-enabled=true",
+                "--vcs-client-kind=git",
+                "--vcs-use-ignore-file=true",
+                "--vcs-root=.",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
             ]
@@ -871,12 +855,12 @@ fn ignores_unknown_file() {
     let file_path2 = Path::new("test.js");
     fs.insert(file_path2.into(), *b"console.log('bar');\n");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
                 "--files-ignore-unknown=true",
@@ -924,12 +908,12 @@ fn correctly_handles_ignored_and_not_ignored_files() {
     let file_path3 = Path::new("/globally-ignored/test.js");
     fs.insert(file_path3.into(), UNFORMATTED_AND_INCORRECT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
-                ("ci"),
+                "ci",
                 file_path1.as_os_str().to_str().unwrap(),
                 file_path2.as_os_str().to_str().unwrap(),
                 file_path3.as_os_str().to_str().unwrap(),
@@ -950,12 +934,12 @@ fn correctly_handles_ignored_and_not_ignored_files() {
 #[test]
 fn doesnt_error_if_no_files_were_processed() {
     let mut console = BufferConsole::default();
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("ci"), "--no-errors-on-unmatched", ("file.js")].as_slice()),
+        Args::from(["ci", "--no-errors-on-unmatched", "file.js"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -1002,8 +986,8 @@ A = 0;
         .as_bytes(),
     );
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -1034,11 +1018,7 @@ fn does_formatting_error_without_file_paths() {
     let file_path = Path::new("ci.js");
     fs.insert(file_path.into(), UNFORMATTED.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("ci"), ""].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["ci", ""].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -1060,10 +1040,10 @@ fn should_error_if_unchanged_files_only_with_changed_flag() {
         Path::new("file1.js").into(),
         r#"console.log('file1');"#.as_bytes(),
     );
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("check"), "--changed", "--since=main"].as_slice()),
+        Args::from(["check", "--changed", "--since=main"].as_slice()),
     );
     assert!(result.is_err(), "run_cli returned {result:?}");
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/commands/explain.rs
+++ b/crates/biome_cli/tests/commands/explain.rs
@@ -4,17 +4,16 @@ use crate::snap_test::SnapshotPayload;
 use crate::{assert_cli_snapshot, run_cli};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 
 #[test]
 fn explain_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("explain"), "--help"].as_slice()),
+        Args::from(["explain", "--help"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -30,13 +29,13 @@ fn explain_help() {
 
 #[test]
 fn explain_valid_rule() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("explain"), "noBlankTarget"].as_slice()),
+        Args::from(["explain", "noBlankTarget"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -52,13 +51,13 @@ fn explain_valid_rule() {
 
 #[test]
 fn explain_not_found() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("explain"), "dontExists"].as_slice()),
+        Args::from(["explain", "dontExists"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -74,13 +73,13 @@ fn explain_not_found() {
 
 #[test]
 fn explain_logs() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("explain"), "daemon-logs"].as_slice()),
+        Args::from(["explain", "daemon-logs"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/commands/init.rs
+++ b/crates/biome_cli/tests/commands/init.rs
@@ -2,20 +2,15 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
 #[test]
 fn init_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init"), "--help"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init", "--help"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -30,14 +25,10 @@ fn init_help() {
 
 #[test]
 fn creates_config_file() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init"].as_slice()));
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_cli_snapshot(SnapshotPayload::new(
@@ -51,14 +42,10 @@ fn creates_config_file() {
 
 #[test]
 fn creates_config_jsonc_file() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init"), "--jsonc"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init", "--jsonc"].as_slice()));
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_cli_snapshot(SnapshotPayload::new(
@@ -78,11 +65,7 @@ fn creates_config_file_when_biome_installed_via_package_manager() {
     let file_path = Path::new("./node_modules/@biomejs/biome/configuration_schema.json");
     fs.insert(file_path.into(), *b"{}");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init"].as_slice()));
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -101,11 +84,7 @@ fn does_not_create_config_file_if_json_exists() {
     let file_path = Path::new("biome.json");
     fs.insert(file_path.into(), *b"{}");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -126,11 +105,7 @@ fn does_not_create_config_file_if_jsonc_exists() {
     let file_path = Path::new("biome.jsonc");
     fs.insert(file_path.into(), *b"{}");
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("init")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["init"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 

--- a/crates/biome_cli/tests/commands/lsp_proxy.rs
+++ b/crates/biome_cli/tests/commands/lsp_proxy.rs
@@ -2,18 +2,17 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 
 #[test]
 fn lsp_proxy_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("lsp-proxy"), "--help"].as_slice()),
+        Args::from(["lsp-proxy", "--help"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/commands/migrate.rs
+++ b/crates/biome_cli/tests/commands/migrate.rs
@@ -2,19 +2,18 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, assert_file_contents, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
 #[test]
 fn migrate_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "--help"].as_slice()),
+        Args::from(["migrate", "--help"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -38,11 +37,7 @@ fn migrate_config_up_to_date() {
     let configuration_path = Path::new("biome.json");
     fs.insert(configuration_path.into(), configuration.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("migrate")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["migrate"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -59,14 +54,10 @@ fn migrate_config_up_to_date() {
 
 #[test]
 fn missing_configuration_file() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("migrate")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["migrate"].as_slice()));
 
     assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -88,10 +79,10 @@ fn should_emit_incompatible_arguments_error() {
     let configuration_path = Path::new("biome.json");
     fs.insert(configuration_path.into(), configuration.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "--write", "--fix"].as_slice()),
+        Args::from(["migrate", "--write", "--fix"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -43,8 +42,8 @@ fn migrate_eslintrcjson() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -96,8 +95,8 @@ fn migrate_eslintrc() {
     fs.insert(Path::new(".eslintrc").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -149,8 +148,8 @@ fn migrate_eslintrcjson_write() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint", "--write"].as_slice()),
     );
@@ -202,8 +201,8 @@ fn migrate_eslintrcjson_fix() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint", "--fix"].as_slice()),
     );
@@ -228,8 +227,8 @@ fn migrate_eslintrcjson_override_existing_config() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -254,8 +253,8 @@ fn migrate_eslintrcjson_exclude_inspired() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -280,8 +279,8 @@ fn migrate_eslintrcjson_include_inspired() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint", "--include-inspired"].as_slice()),
     );
@@ -381,8 +380,8 @@ fn migrate_eslintrcjson_rule_options() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint", "--include-inspired"].as_slice()),
     );
@@ -407,8 +406,8 @@ fn migrate_eslintrcjson_empty() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -431,8 +430,8 @@ fn migrate_eslintrcjson_missing_biomejson() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -457,8 +456,8 @@ fn migrate_eslintrcyaml_unsupported() {
     fs.insert(Path::new(".eslintrc.yaml").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -492,8 +491,8 @@ fn migrate_eslint_config_packagejson() {
     fs.insert(Path::new("package.json").into(), packagejson.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -521,8 +520,8 @@ fn migrate_no_eslint_config_packagejson() {
     fs.insert(Path::new("package.json").into(), packagejson.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -555,8 +554,8 @@ test/main.js
     fs.insert(Path::new(".eslintignore").into(), eslintignore.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -586,8 +585,8 @@ fn migrate_eslintignore_and_ignore_patterns() {
     fs.insert(Path::new(".eslintignore").into(), eslintignore.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -617,8 +616,8 @@ a/**
     fs.insert(Path::new(".eslintignore").into(), eslintignore.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -650,8 +649,8 @@ fn migrate_eslintrcjson_extended_rules() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );
@@ -689,8 +688,8 @@ fn migrate_merge_with_overrides() {
     fs.insert(Path::new(".eslintrc.json").into(), eslintrc.as_bytes());
 
     let mut console = BufferConsole::default();
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(["migrate", "eslint"].as_slice()),
     );

--- a/crates/biome_cli/tests/commands/migrate_prettier.rs
+++ b/crates/biome_cli/tests/commands/migrate_prettier.rs
@@ -2,7 +2,6 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -20,10 +19,10 @@ fn prettier_migrate() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -51,10 +50,10 @@ fn prettier_migrate_end_of_line() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -93,10 +92,10 @@ generated/*.spec.js
     let prettier_ignore_path = Path::new(".prettierignore");
     fs.insert(prettier_ignore_path.into(), prettier_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -124,10 +123,10 @@ fn prettier_migrate_jsonc() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -151,10 +150,10 @@ fn prettier_migrate_no_file() {
     let configuration_path = Path::new("biome.json");
     fs.insert(configuration_path.into(), configuration.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -182,10 +181,10 @@ fn prettier_migrate_yml_file() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
@@ -213,10 +212,10 @@ fn prettier_migrate_write() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+        Args::from(["migrate", "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -244,10 +243,10 @@ fn prettier_migrate_fix() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--fix"].as_slice()),
+        Args::from(["migrate", "prettier", "--fix"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -275,10 +274,10 @@ fn prettierjson_migrate_write() {
     let prettier_path = Path::new(".prettierrc.json");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+        Args::from(["migrate", "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -310,10 +309,10 @@ fn prettier_migrate_write_packagejson() {
     let prettier_path = Path::new("package.json");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+        Args::from(["migrate", "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -352,10 +351,10 @@ generated/*.spec.js
     let prettier_ignore_path = Path::new(".prettierignore");
     fs.insert(prettier_ignore_path.into(), prettier_ignore.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+        Args::from(["migrate", "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -383,10 +382,10 @@ fn prettier_migrate_write_biome_jsonc() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier", "--write"].as_slice()),
+        Args::from(["migrate", "prettier", "--write"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -425,10 +424,10 @@ fn prettier_migrate_overrides() {
     let prettier_path = Path::new(".prettierrc");
     fs.insert(prettier_path.into(), prettier.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
-        Args::from([("migrate"), "prettier"].as_slice()),
+        Args::from(["migrate", "prettier"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -2,8 +2,7 @@ use crate::run_cli;
 use crate::snap_test::{assert_cli_snapshot, CliSnapshot, SnapshotPayload};
 use biome_cli::CliDiagnostic;
 use biome_console::{BufferConsole, Console};
-use biome_fs::{FileSystem, MemoryFileSystem};
-use biome_service::DynRef;
+use biome_fs::MemoryFileSystem;
 use bpaf::Args;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard};
@@ -11,14 +10,10 @@ use std::{env, fs};
 
 #[test]
 fn rage_help() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("rage"), "--help"].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["rage", "--help"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -33,14 +28,10 @@ fn rage_help() {
 
 #[test]
 fn ok() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("rage")].as_slice()),
-    );
+    let (fs, result) = run_rage(fs, &mut console, Args::from(["rage"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -66,11 +57,7 @@ fn with_configuration() {
 }"#,
     );
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("rage")].as_slice()),
-    );
+    let (fs, result) = run_rage(fs, &mut console, Args::from(["rage"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -97,11 +84,7 @@ fn with_jsonc_configuration() {
 }"#,
     );
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("rage")].as_slice()),
-    );
+    let (fs, result) = run_rage(fs, &mut console, Args::from(["rage"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -127,11 +110,7 @@ fn with_malformed_configuration() {
 }"#,
     );
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("rage")].as_slice()),
-    );
+    let (fs, result) = run_rage(fs, &mut console, Args::from(["rage"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -146,10 +125,10 @@ fn with_malformed_configuration() {
 
 #[test]
 fn with_server_logs() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = {
+    let (fs, result) = {
         let log_dir = TestLogDir::new("biome-test-logs");
         fs::create_dir_all(&log_dir.path).expect("Failed to create test log directory");
 
@@ -195,9 +174,9 @@ Not most recent log file
         .expect("Failed to write configuration file");
 
         run_cli(
-            DynRef::Borrowed(&mut fs),
+            fs,
             &mut console,
-            Args::from([("rage"), "--daemon-logs"].as_slice()),
+            Args::from(["rage", "--daemon-logs"].as_slice()),
         )
     };
 
@@ -262,10 +241,10 @@ fn with_formatter_configuration() {
 }"#,
     );
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_rage(
+        fs,
         &mut console,
-        Args::from([("rage"), "--formatter"].as_slice()),
+        Args::from(["rage", "--formatter"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -310,10 +289,10 @@ fn with_linter_configuration() {
 }"#,
     );
 
-    let result = run_rage(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_rage(
+        fs,
         &mut console,
-        Args::from([("rage"), "--linter"].as_slice()),
+        Args::from(["rage", "--linter"].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -328,11 +307,11 @@ fn with_linter_configuration() {
 }
 
 /// Runs the `rage` command mocking out the log directory.
-fn run_rage<'app>(
-    fs: DynRef<'app, dyn FileSystem>,
-    console: &'app mut dyn Console,
+fn run_rage(
+    fs: MemoryFileSystem,
+    console: &mut dyn Console,
     args: Args,
-) -> Result<(), CliDiagnostic> {
+) -> (MemoryFileSystem, Result<(), CliDiagnostic>) {
     let _test_dir = TestLogDir::new("biome-rage-test");
     run_cli(fs, console, args)
 }

--- a/crates/biome_cli/tests/commands/search.rs
+++ b/crates/biome_cli/tests/commands/search.rs
@@ -1,6 +1,5 @@
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 use std::path::Path;
 
@@ -27,8 +26,8 @@ fn search_css_pattern() {
     let file_path = Path::new("file.css");
     fs.insert(file_path.into(), CSS_FILE_CONTENT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -60,8 +59,8 @@ fn search_css_pattern_shorthand() {
     let file_path = Path::new("file.css");
     fs.insert(file_path.into(), CSS_FILE_CONTENT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [
@@ -93,8 +92,8 @@ fn search_js_pattern() {
     let file_path = Path::new("file.js");
     fs.insert(file_path.into(), JS_FILE_CONTENT.as_bytes());
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
+    let (fs, result) = run_cli(
+        fs,
         &mut console,
         Args::from(
             [

--- a/crates/biome_cli/tests/commands/version.rs
+++ b/crates/biome_cli/tests/commands/version.rs
@@ -2,19 +2,14 @@ use crate::snap_test::SnapshotPayload;
 use crate::{assert_cli_snapshot, run_cli};
 use biome_console::BufferConsole;
 use biome_fs::MemoryFileSystem;
-use biome_service::DynRef;
 use bpaf::Args;
 
 #[test]
 fn ok() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("--version")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["--version"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
@@ -29,14 +24,10 @@ fn ok() {
 
 #[test]
 fn full() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
-    let result = run_cli(
-        DynRef::Borrowed(&mut fs),
-        &mut console,
-        Args::from([("version")].as_slice()),
-    );
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["version"].as_slice()));
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 

--- a/crates/biome_cli/tests/main.rs
+++ b/crates/biome_cli/tests/main.rs
@@ -10,7 +10,7 @@ use snap_test::assert_cli_snapshot;
 use biome_cli::{biome_command, CliDiagnostic, CliSession};
 use biome_console::{markup, BufferConsole, Console, ConsoleExt};
 use biome_fs::{FileSystem, MemoryFileSystem};
-use biome_service::{App, DynRef};
+use biome_service::App;
 use bpaf::ParseFailure;
 
 const UNFORMATTED: &str = "  statement(  )  ";
@@ -32,12 +32,12 @@ mod help {
     #[test]
     fn unknown_command() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (_, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("unknown"), ("--help")].as_slice()),
+            Args::from(["unknown", "--help"].as_slice()),
         );
 
         assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -51,25 +51,21 @@ mod main {
     #[test]
     fn unknown_command() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
-            &mut console,
-            Args::from([("unknown")].as_slice()),
-        );
+        let (_, result) = run_cli(fs, &mut console, Args::from(["unknown"].as_slice()));
         assert!(result.is_err(), "run_cli returned {result:?}");
     }
 
     #[test]
     fn unexpected_argument() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (_, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("format"), ("--unknown"), ("file.js")].as_slice()),
+            Args::from(["format", "--unknown", "file.js"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -78,13 +74,9 @@ mod main {
     #[test]
     fn empty_arguments() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
-            &mut console,
-            Args::from([("format")].as_slice()),
-        );
+        let (_, result) = run_cli(fs, &mut console, Args::from(["format"].as_slice()));
 
         assert!(result.is_err(), "run_cli returned {result:?}");
     }
@@ -92,12 +84,12 @@ mod main {
     #[test]
     fn missing_argument() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (_, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("format"), ("--write")].as_slice()),
+            Args::from(["format", "--write"].as_slice()),
         );
         assert!(result.is_err(), "run_cli returned {result:?}");
     }
@@ -105,12 +97,12 @@ mod main {
     #[test]
     fn incorrect_value() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (_, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("check"), ("--max-diagnostics=foo")].as_slice()),
+            Args::from(["check", "--max-diagnostics=foo"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -119,12 +111,12 @@ mod main {
     #[test]
     fn overflow_value() {
         let mut console = BufferConsole::default();
-        let mut fs = MemoryFileSystem::default();
+        let fs = MemoryFileSystem::default();
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (_, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("check"), ("--max-diagnostics=500")].as_slice()),
+            Args::from(["check", "--max-diagnostics=500"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -132,7 +124,7 @@ mod main {
     //
     // #[test]
     // fn no_colors() {
-    //     let mut args = Args::from([("--colors=off")]);
+    //     let mut args = Args::from(["--colors=off"]);
     //     let result = color_from_arguments(&mut args);
     //
     //     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -140,7 +132,7 @@ mod main {
     //
     // #[test]
     // fn force_colors() {
-    //     let mut args = Args::from([("--colors=force")]);
+    //     let mut args = Args::from(["--colors=force"]);
     //     let result = color_from_arguments(&mut args);
     //
     //     assert!(result.is_ok(), "run_cli returned {result:?}");
@@ -148,7 +140,7 @@ mod main {
     //
     // #[test]
     // fn invalid_colors() {
-    //     let mut args = Args::from([("--colors=other")]);
+    //     let mut args = Args::from(["--colors=other"]);
     //     let result = color_from_arguments(&mut args);
     //     assert!(result.is_err(), "run_cli returned {result:?}");
     // }
@@ -163,7 +155,6 @@ mod configuration {
     use crate::snap_test::SnapshotPayload;
     use biome_console::BufferConsole;
     use biome_fs::MemoryFileSystem;
-    use biome_service::DynRef;
     use bpaf::Args;
     use std::path::Path;
 
@@ -174,10 +165,10 @@ mod configuration {
         let file_path = Path::new("biome.json");
         fs.insert(file_path.into(), CONFIG_ALL_FIELDS.as_bytes());
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (fs, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("format"), ("file.js")].as_slice()),
+            Args::from(["format", "file.js"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -199,10 +190,10 @@ mod configuration {
         let file_path = Path::new("biome.json");
         fs.insert(file_path.into(), CONFIG_BAD_LINE_WIDTH.as_bytes());
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (fs, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("format"), ("file.js")].as_slice()),
+            Args::from(["format", "file.js"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -224,10 +215,10 @@ mod configuration {
         let file_path = Path::new("biome.json");
         fs.insert(file_path.into(), CONFIG_LINTER_WRONG_RULE.as_bytes());
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (fs, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("check"), ("file.js")].as_slice()),
+            Args::from(["check", "file.js"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -249,10 +240,10 @@ mod configuration {
         let file_path = Path::new("biome.json");
         fs.insert(file_path.into(), CONFIG_INCORRECT_GLOBALS.as_bytes());
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
+        let (fs, result) = run_cli(
+            fs,
             &mut console,
-            Args::from([("check"), ("file.js")].as_slice()),
+            Args::from(["check", "file.js"].as_slice()),
         );
 
         assert!(result.is_err(), "run_cli returned {result:?}");
@@ -277,11 +268,7 @@ mod configuration {
         );
         fs.insert(Path::new("file.js").into(), UNFORMATTED.as_bytes());
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
-            &mut console,
-            Args::from(&["check", "file.js"]),
-        );
+        let (_, result) = run_cli(fs, &mut console, Args::from(&["check", "file.js"]));
 
         assert!(result.is_err(), "run_cli returned {result:?}");
     }
@@ -324,11 +311,7 @@ mod configuration {
                 .as_bytes(),
         );
 
-        let result = run_cli(
-            DynRef::Borrowed(&mut fs),
-            &mut console,
-            Args::from(&["lint", "tests/test.js"]),
-        );
+        let (fs, result) = run_cli(fs, &mut console, Args::from(&["lint", "tests/test.js"]));
 
         assert!(result.is_err(), "run_cli returned {result:?}");
 
@@ -344,9 +327,28 @@ mod configuration {
 
 /// Create an [App] instance using the provided [FileSystem] and [Console]
 /// instance, and using an in-process "remote" instance of the workspace
-pub(crate) fn run_cli<'app>(
-    fs: DynRef<'app, dyn FileSystem>,
-    console: &'app mut dyn Console,
+pub(crate) fn run_cli(
+    fs: MemoryFileSystem,
+    console: &mut dyn Console,
+    args: bpaf::Args,
+) -> (MemoryFileSystem, Result<(), CliDiagnostic>) {
+    let files = fs.files.clone();
+
+    let result = run_cli_with_dyn_fs(Box::new(fs), console, args);
+
+    // This is a little bit of a workaround to allow us to easily create
+    // a snapshot of the files even though the original file system was
+    // consumed by the workspace.
+    let fs = MemoryFileSystem::from_files(files);
+
+    (fs, result)
+}
+
+/// Create an [App] instance using the provided [FileSystem] and [Console]
+/// instance, and using an in-process "remote" instance of the workspace
+pub(crate) fn run_cli_with_dyn_fs(
+    fs: Box<dyn FileSystem>,
+    console: &mut dyn Console,
     args: bpaf::Args,
 ) -> Result<(), CliDiagnostic> {
     use biome_cli::SocketTransport;
@@ -369,8 +371,8 @@ pub(crate) fn run_cli<'app>(
     let (client_read, client_write) = split(client);
     let transport = SocketTransport::open(runtime, client_read, client_write);
 
-    let workspace = workspace::client(transport).unwrap();
-    let app = App::new(fs, console, WorkspaceRef::Owned(workspace));
+    let workspace = workspace::client(transport, fs).unwrap();
+    let app = App::new(console, WorkspaceRef::Owned(workspace));
 
     let mut session = CliSession { app };
     let command = biome_command().run_inner(args);

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -339,18 +339,16 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
             }
         }
 
-        let files: Vec<_> = fs
-            .files()
+        cli_snapshot.files = fs
+            .files
+            .read()
+            .iter()
             .map(|(file, entry)| {
                 let content = entry.lock();
                 let content = std::str::from_utf8(content.as_slice()).unwrap();
                 (file.to_str().unwrap().to_string(), String::from(content))
             })
             .collect();
-
-        for (file, content) in files {
-            cli_snapshot.files.insert(file, content);
-        }
 
         let in_buffer = &console.in_buffer;
         for (index, message) in in_buffer.iter().enumerate() {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -9,7 +9,7 @@ use biome_configuration::ConfigurationPathHint;
 use biome_console::markup;
 use biome_deserialize::Merge;
 use biome_diagnostics::{DiagnosticExt, Error, PrintDescription};
-use biome_fs::{BiomePath, FileSystem};
+use biome_fs::BiomePath;
 use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use biome_service::configuration::{
     load_configuration, load_editorconfig, LoadedConfiguration, PartialConfigurationExt,
@@ -21,7 +21,7 @@ use biome_service::workspace::{
 };
 use biome_service::workspace::{RageEntry, RageParams, RageResult, UpdateSettingsParams};
 use biome_service::Workspace;
-use biome_service::{DynRef, WorkspaceError};
+use biome_service::WorkspaceError;
 use futures::stream::futures_unordered::FuturesUnordered;
 use futures::StreamExt;
 use rustc_hash::FxHashMap;
@@ -73,9 +73,6 @@ pub(crate) struct Session {
     /// A flag to notify a message to the user when the configuration is broken, and the LSP attempts
     /// to update the diagnostics
     notified_broken_configuration: AtomicBool,
-
-    /// File system to read files inside the workspace
-    pub(crate) fs: DynRef<'static, dyn FileSystem>,
 
     documents: RwLock<FxHashMap<lsp_types::Url, Document>>,
 
@@ -165,7 +162,6 @@ impl Session {
         client: tower_lsp::Client,
         workspace: Arc<dyn Workspace>,
         cancellation: Arc<Notify>,
-        fs: DynRef<'static, dyn FileSystem>,
     ) -> Self {
         let documents = Default::default();
         let config = RwLock::new(ExtensionSettings::new());
@@ -177,7 +173,6 @@ impl Session {
             configuration_status: AtomicU8::new(ConfigurationStatus::Missing as u8),
             documents,
             extension_settings: config,
-            fs,
             cancellation,
             config_path: None,
             manifest_path: None,
@@ -489,7 +484,7 @@ impl Session {
         &self,
         base_path: ConfigurationPathHint,
     ) -> ConfigurationStatus {
-        match load_configuration(&self.fs, base_path.clone()) {
+        match load_configuration(self.workspace.fs(), base_path.clone()) {
             Ok(loaded_configuration) => {
                 if loaded_configuration.has_errors() {
                     error!("Couldn't load the configuration file, reasons:");
@@ -507,7 +502,7 @@ impl Session {
                     info!("Configuration loaded successfully from disk.");
                     info!("Update workspace settings.");
 
-                    let fs = &self.fs;
+                    let fs = self.workspace.fs();
                     let should_use_editorconfig =
                         fs_configuration.use_editorconfig().unwrap_or_default();
                     let mut configuration = if should_use_editorconfig {
@@ -607,7 +602,8 @@ impl Session {
             .map(PathBuf::from)
             .or(self.base_path());
         if let Some(base_path) = base_path {
-            let result = self.fs.auto_search(&base_path, &["package.json"], false);
+            let fs = self.workspace.fs();
+            let result = fs.auto_search(&base_path, &["package.json"], false);
             match result {
                 Ok(result) => {
                     if let Some(result) = result {

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -8,7 +8,6 @@ use biome_lsp::ServerFactory;
 use biome_lsp::WorkspaceSettings;
 use biome_service::workspace::GetSyntaxTreeResult;
 use biome_service::workspace::{GetFileContentParams, GetSyntaxTreeParams};
-use biome_service::DynRef;
 use futures::channel::mpsc::{channel, Sender};
 use futures::Sink;
 use futures::SinkExt;
@@ -1491,9 +1490,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
     }"#;
 
     fs.insert(url!("biome.json").to_file_path().unwrap(), config);
-    let (service, client) = factory
-        .create_with_fs(None, DynRef::Owned(Box::new(fs)))
-        .into_inner();
+    let (service, client) = factory.create_with_fs(None, Box::new(fs)).into_inner();
 
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
@@ -1857,9 +1854,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
 }"#;
 
     fs.insert(url!("biome.json").to_file_path().unwrap(), config);
-    let (service, client) = factory
-        .create_with_fs(None, DynRef::Owned(Box::new(fs)))
-        .into_inner();
+    let (service, client) = factory.create_with_fs(None, Box::new(fs)).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2335,9 +2330,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
     }"#;
 
     fs.insert(url!("biome.json").to_file_path().unwrap(), config);
-    let (service, client) = factory
-        .create_with_fs(None, DynRef::Owned(Box::new(fs)))
-        .into_inner();
+    let (service, client) = factory.create_with_fs(None, Box::new(fs)).into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -1,6 +1,6 @@
 use crate::matcher::Pattern;
 use crate::settings::Settings;
-use crate::{DynRef, WorkspaceError};
+use crate::WorkspaceError;
 use biome_analyze::AnalyzerRules;
 use biome_configuration::diagnostics::{CantLoadExtendFile, EditorConfigDiagnostic};
 use biome_configuration::{push_to_analyzer_assists, VERSION};
@@ -101,7 +101,7 @@ impl FusedIterator for ConfigurationDiagnosticsIter<'_> {}
 impl LoadedConfiguration {
     fn try_from_payload(
         value: Option<ConfigurationPayload>,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
     ) -> Result<Self, WorkspaceError> {
         let Some(value) = value else {
             return Ok(LoadedConfiguration::default());
@@ -142,7 +142,7 @@ impl LoadedConfiguration {
 
 /// Load the partial configuration for this session of the CLI.
 pub fn load_configuration(
-    fs: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     config_path: ConfigurationPathHint,
 ) -> Result<LoadedConfiguration, WorkspaceError> {
     let config = load_config(fs, config_path)?;
@@ -156,7 +156,7 @@ type LoadConfig = Result<Option<ConfigurationPayload>, WorkspaceError>;
 
 /// Load the configuration from the file system.
 ///
-/// The configuration file will be read from the `file_system`. A [path hint](ConfigurationPathHint) should be provided.
+/// The configuration file will be read from the `fs`. A [path hint](ConfigurationPathHint) should be provided.
 ///
 /// - If the path hint is a path to a file that is provided by the user, the function will try to load that file or error.
 ///     The name doesn't have to be `biome.json` or `biome.jsonc`. And if it doesn't end with `.json`, Biome will try to
@@ -168,10 +168,7 @@ type LoadConfig = Result<Option<ConfigurationPayload>, WorkspaceError>;
 /// - Otherwise, the function will try to traverse upwards the file system until it finds a `biome.json` or `biome.jsonc`
 ///     file, or there aren't directories anymore. In this case, the function will not error but return an `Ok(None)`, which
 ///     means Biome will use the default configuration.
-fn load_config(
-    file_system: &DynRef<'_, dyn FileSystem>,
-    base_path: ConfigurationPathHint,
-) -> LoadConfig {
+fn load_config(fs: &dyn FileSystem, base_path: ConfigurationPathHint) -> LoadConfig {
     // This path is used for configuration resolution from external packages.
     let external_resolution_base_path = match base_path {
         // Path hint from LSP is always the workspace root
@@ -180,7 +177,7 @@ fn load_config(
         ConfigurationPathHint::FromWorkspace(ref path) => path.clone(),
         // Path hint from user means the command is invoked from the CLI
         // So we use the working directory (CWD) as the resolution base path
-        ConfigurationPathHint::FromUser(_) | ConfigurationPathHint::None => file_system
+        ConfigurationPathHint::FromUser(_) | ConfigurationPathHint::None => fs
             .working_directory()
             .map_or(PathBuf::new(), |working_directory| working_directory),
     };
@@ -188,8 +185,8 @@ fn load_config(
     // If the configuration path hint is from user and is a file path,
     // we'll load it directly
     if let ConfigurationPathHint::FromUser(ref config_file_path) = base_path {
-        if file_system.path_is_file(config_file_path) {
-            let content = file_system.read_file_from_path(config_file_path)?;
+        if fs.path_is_file(config_file_path) {
+            let content = fs.read_file_from_path(config_file_path)?;
             let parser_options = match config_file_path.extension().map(OsStr::as_encoded_bytes) {
                 Some(b"json") => JsonParserOptions::default(),
                 _ => JsonParserOptions::default()
@@ -213,11 +210,11 @@ fn load_config(
         ConfigurationPathHint::FromLsp(path) => path,
         ConfigurationPathHint::FromUser(path) => path,
         ConfigurationPathHint::FromWorkspace(path) => path,
-        ConfigurationPathHint::None => file_system.working_directory().unwrap_or_default(),
+        ConfigurationPathHint::None => fs.working_directory().unwrap_or_default(),
     };
 
     // We first search for `biome.json` or `biome.jsonc` files
-    if let Some(auto_search_result) = file_system.auto_search(
+    if let Some(auto_search_result) = fs.auto_search(
         &configuration_directory,
         ConfigName::file_names().as_slice(),
         should_error,
@@ -245,13 +242,13 @@ fn load_config(
 }
 
 pub fn load_editorconfig(
-    file_system: &DynRef<'_, dyn FileSystem>,
+    fs: &dyn FileSystem,
     workspace_root: PathBuf,
 ) -> Result<(Option<PartialConfiguration>, Vec<EditorConfigDiagnostic>), WorkspaceError> {
     // How .editorconfig is supposed to be resolved: https://editorconfig.org/#file-location
     // We currently don't support the `root` property, so we just search for the file like we do for biome.json
     if let Some(auto_search_result) =
-        match file_system.auto_search(&workspace_root, [".editorconfig"].as_slice(), false) {
+        match fs.auto_search(&workspace_root, [".editorconfig"].as_slice(), false) {
             Ok(result) => result,
             Err(error) => return Err(WorkspaceError::from(error)),
         }
@@ -295,7 +292,7 @@ pub fn load_editorconfig(
 /// - the configuration file already exists
 /// - the program doesn't have the write rights
 pub fn create_config(
-    fs: &mut DynRef<dyn FileSystem>,
+    fs: &dyn FileSystem,
     mut configuration: PartialConfiguration,
     emit_jsonc: bool,
 ) -> Result<(), WorkspaceError> {
@@ -368,7 +365,7 @@ pub fn to_analyzer_rules(settings: &Settings, path: &Path) -> AnalyzerRules {
 pub trait PartialConfigurationExt {
     fn apply_extends(
         &mut self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         file_path: &Path,
         external_resolution_base_path: &Path,
         diagnostics: &mut Vec<Error>,
@@ -376,7 +373,7 @@ pub trait PartialConfigurationExt {
 
     fn deserialize_extends(
         &mut self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         relative_resolution_base_path: &Path,
         external_resolution_base_path: &Path,
     ) -> Result<Vec<Deserialized<PartialConfiguration>>, WorkspaceError>;
@@ -385,7 +382,7 @@ pub trait PartialConfigurationExt {
 
     fn retrieve_gitignore_matches(
         &self,
-        file_system: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         vcs_base_path: Option<&Path>,
     ) -> Result<(Option<PathBuf>, Vec<String>), WorkspaceError>;
 }
@@ -399,7 +396,7 @@ impl PartialConfigurationExt for PartialConfiguration {
     /// If a configuration can't be resolved from the file system, the operation will fail.
     fn apply_extends(
         &mut self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         file_path: &Path,
         external_resolution_base_path: &Path,
         diagnostics: &mut Vec<Error>,
@@ -441,7 +438,7 @@ impl PartialConfigurationExt for PartialConfiguration {
     /// It attempts to deserialize all the configuration files that were specified in the `extends` property
     fn deserialize_extends(
         &mut self,
-        fs: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         relative_resolution_base_path: &Path,
         external_resolution_base_path: &Path,
     ) -> Result<Vec<Deserialized<PartialConfiguration>>, WorkspaceError> {
@@ -529,7 +526,7 @@ impl PartialConfigurationExt for PartialConfiguration {
     /// A tuple with VCS root folder and the contents of the `.gitignore` file
     fn retrieve_gitignore_matches(
         &self,
-        file_system: &DynRef<'_, dyn FileSystem>,
+        fs: &dyn FileSystem,
         vcs_base_path: Option<&Path>,
     ) -> Result<(Option<PathBuf>, Vec<String>), WorkspaceError> {
         let Some(vcs) = &self.vcs else {
@@ -544,7 +541,7 @@ impl PartialConfigurationExt for PartialConfiguration {
             };
             if let Some(client_kind) = &vcs.client_kind {
                 if !vcs.ignore_file_disabled() {
-                    let result = file_system
+                    let result = fs
                         .auto_search(&vcs_base_path, &[client_kind.ignore_file()], false)
                         .map_err(WorkspaceError::from)?;
 

--- a/crates/biome_service/tests/workspace.rs
+++ b/crates/biome_service/tests/workspace.rs
@@ -2,15 +2,16 @@
 mod test {
     use biome_analyze::RuleCategories;
     use biome_configuration::analyzer::{RuleGroup, RuleSelector};
-    use biome_fs::BiomePath;
+    use biome_fs::{BiomePath, MemoryFileSystem};
     use biome_js_syntax::{JsFileSource, TextSize};
     use biome_service::file_handlers::DocumentFileSource;
     use biome_service::workspace::{
         server, FileGuard, OpenFileParams, RegisterProjectFolderParams,
     };
     use biome_service::Workspace;
+
     fn create_server() -> Box<dyn Workspace> {
-        let workspace = server();
+        let workspace = server(Box::new(MemoryFileSystem::default()));
         workspace
             .register_project_folder(RegisterProjectFolderParams {
                 set_as_current_workspace: true,

--- a/crates/biome_wasm/Cargo.toml
+++ b/crates/biome_wasm/Cargo.toml
@@ -22,6 +22,7 @@ experimental-html = ["biome_service/experimental-html"]
 [dependencies]
 biome_console      = { workspace = true }
 biome_diagnostics  = { workspace = true }
+biome_fs           = { workspace = true }
 biome_service      = { workspace = true }
 js-sys             = "0.3.72"
 serde              = { workspace = true }

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -1,6 +1,7 @@
 use js_sys::Error;
 use wasm_bindgen::prelude::*;
 
+use biome_fs::MemoryFileSystem;
 use biome_service::workspace::{
     self, ChangeFileParams, CloseFileParams, FixFileParams, FormatFileParams, FormatOnTypeParams,
     FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams, GetFormatterIRParams,
@@ -32,7 +33,10 @@ impl Workspace {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Workspace {
         Workspace {
-            inner: workspace::server(),
+            // Q: We can't use a real filesystem here, but is the memory
+            // filesystem the right choice? It might be, since I guess it
+            // will allow us to inject plugins if we wanted to.
+            inner: workspace::server(Box::new(MemoryFileSystem::default())),
         }
     }
 


### PR DESCRIPTION
## Summary

The reason `DynRef` existed was primarily because of tests: It allowed for dynamic ownership which was used to let the `Session` own the `fs` under normal execution, which in tests the test owned the `fs` for snapshot purposes. With this PR, the `Workspace` has become the owner of the `fs`, while everywhere else we use references. To resolve the situation in the tests, I've wrapped the `files` of the `MemoryFileSystem` in an `Arc`, which allows me to reconstruct the `MemoryFileSystem` for the snapshot, even though the original instance was consumed during the test run.

The reason I wanted to place the `fs` into `Workspace` is so that we can start doing I/O from inside the workspace server, which this solution also allows for.

## Test Plan

CI should remain green.
