### PR TITLE
docs(linter): include advice on the singleton pattern with `noConstructorReturn`

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
@@ -43,6 +43,15 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
+    /// ## Using this rule in combination with the singleton pattern
+    ///
+    /// Some people implement the singleton pattern in JavaScript by returning
+    /// an existing instance from the constructor, which would conflict with
+    /// this rule.
+    ///
+    /// Instead, we advise to follow one of the suggestions described in this
+    /// blog post: https://arendjr.nl/blog/2024/11/singletons-in-javascript/
+    ///
     pub NoConstructorReturn {
         version: "1.0.0",
         name: "noConstructorReturn",


### PR DESCRIPTION
## Summary

As [suggested](https://github.com/biomejs/biome/issues/4453#issuecomment-2466454739) by @Conaclos, I'm adding a link to my blog post for advice on how to use the singleton pattern with the `noConstructorReturn` rule.

## Test Plan

CI should remain green.
