### PR TITLE
refactor(js_syntax): minor clean up

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
@@ -53,7 +53,7 @@ impl Rule for NoAccessKey {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        if node.name_value_token()?.text_trimmed() != "accessKey" {
+        if node.name_value_token().ok()?.text_trimmed() != "accessKey" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
@@ -86,11 +86,11 @@ fn find_kept_autofocus_mark(element: &AnyJsxElement) -> bool {
     // 2. inside the element with the popover attribute
 
     let is_dialog_element = match element.name_value_token() {
-        Some(syntax_token) => {
+        Ok(syntax_token) => {
             let tag_name = String::from(syntax_token.text_trimmed());
             tag_name.to_lowercase_cow() == "dialog"
         }
-        None => false,
+        Err(_) => false,
     };
 
     let has_popover_attr = element.has_truthy_attribute("popover");

--- a/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
@@ -93,7 +93,7 @@ impl Rule for NoBlankTarget {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        if node.name_value_token()?.text_trimmed() != "a"
+        if node.name_value_token().ok()?.text_trimmed() != "a"
             || node.find_attribute_by_name("href").is_none()
         {
             return None;

--- a/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -54,7 +54,7 @@ impl Rule for NoDistractingElements {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let name = element.name_value_token()?;
+        let name = element.name_value_token().ok()?;
         match name.text_trimmed() {
             "marquee" | "blink" => Some(name),
             _ => None,

--- a/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
@@ -56,7 +56,7 @@ impl Rule for NoHeaderScope {
         let element = ctx.query();
 
         if element.is_element()
-            && element.name_value_token()?.text_trimmed() != "th"
+            && element.name_value_token().ok()?.text_trimmed() != "th"
             && element.has_truthy_attribute("scope")
         {
             return Some(());

--- a/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
@@ -102,7 +102,7 @@ impl Rule for NoLabelWithoutControl {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let options = ctx.options();
-        let element_name = node.name()?.name_value_token()?;
+        let element_name = node.name()?.name_value_token().ok()?;
         let element_name = element_name.text_trimmed();
         let is_allowed_element = options.has_element_name(element_name)
             || DEFAULT_LABEL_COMPONENTS.contains(&element_name);
@@ -237,7 +237,7 @@ impl NoLabelWithoutControlOptions {
                             child_iter.skip_subtree();
                             continue;
                         };
-                        let Some(element_name) = element_name.name_value_token() else {
+                        let Ok(element_name) = element_name.name_value_token() else {
                             continue;
                         };
                         let element_name = element_name.text_trimmed();

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
@@ -57,7 +57,7 @@ impl Rule for NoRedundantAlt {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        if node.name_value_token()?.text_trimmed() != "img" {
+        if node.name_value_token().ok()?.text_trimmed() != "img" {
             return None;
         }
         let aria_hidden_attribute = node.find_attribute_by_name("aria-hidden");

--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -114,7 +114,7 @@ impl Rule for NoSvgWithoutTitle {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        if node.name_value_token()?.text_trimmed() != "svg" {
+        if node.name_value_token().ok()?.text_trimmed() != "svg" {
             return None;
         }
 
@@ -196,7 +196,7 @@ fn is_valid_attribute_value(
         .filter_map(|child| {
             let jsx_element = child.as_jsx_element()?;
             let opening_element = jsx_element.opening_element().ok()?;
-            let maybe_attribute = opening_element.find_attribute_by_name("id").ok()?;
+            let maybe_attribute = opening_element.find_attribute_by_name("id");
             let child_attribute_value = maybe_attribute?.initializer()?.value().ok()?;
             let is_valid = attribute_value.as_static_value()?.text()
                 == child_attribute_value.as_static_value()?.text();

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -87,7 +87,7 @@ impl Rule for UseAltText {
         let has_aria_label = has_valid_label(element, "aria-label");
         let has_aria_labelledby = has_valid_label(element, "aria-labelledby");
         let aria_hidden = is_aria_hidden(element);
-        match element.name_value_token()?.text_trimmed() {
+        match element.name_value_token().ok()?.text_trimmed() {
             "object" => {
                 let has_title = has_valid_label(element, "title");
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -81,7 +81,7 @@ impl Rule for UseAnchorContent {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let name = node.name().ok()?.name_value_token()?;
+        let name = node.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "a" {
             if node.has_truthy_attribute("aria-hidden") {

--- a/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
@@ -70,7 +70,7 @@ impl Rule for UseButtonType {
                 if !is_button(&name)? {
                     return None;
                 }
-                let type_attribute = element.find_attribute_by_name("type").ok()?;
+                let type_attribute = element.find_attribute_by_name("type");
                 let Some(attribute) = type_attribute else {
                     let has_spread_prop = element
                         .attributes()
@@ -92,7 +92,7 @@ impl Rule for UseButtonType {
                 if !is_button(&name)? {
                     return None;
                 }
-                let type_attribute = element.find_attribute_by_name("type").ok()?;
+                let type_attribute = element.find_attribute_by_name("type");
                 let Some(attribute) = type_attribute else {
                     let has_spread_prop = element
                         .attributes()

--- a/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
@@ -74,7 +74,7 @@ impl Rule for UseHeadingContent {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let name = node.name().ok()?.name_value_token()?;
+        let name = node.name().ok()?.name_value_token().ok()?;
 
         if HEADING_ELEMENTS.contains(&name.text_trimmed()) {
             if node.has_truthy_attribute("aria-hidden") {

--- a/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
@@ -71,7 +71,7 @@ impl Rule for UseHtmlLang {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let name = element.name().ok()?.name_value_token()?;
+        let name = element.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "html" {
             if let Some(lang_attribute) = element.find_attribute_by_name("lang") {

--- a/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
@@ -77,7 +77,7 @@ impl Rule for UseIframeTitle {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let name = element.name().ok()?.name_value_token()?;
+        let name = element.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "iframe" {
             if let Some(lang_attribute) = element.find_attribute_by_name("title") {

--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
@@ -95,10 +95,9 @@ impl Rule for UseKeyWithClickEvents {
         }
 
         let attributes = element.attributes();
-        let on_click_attribute = attributes.find_by_name("onClick").ok()?;
 
-        #[allow(clippy::question_mark)]
-        if on_click_attribute.is_none() {
+        #[expect(clippy::question_mark)]
+        if attributes.find_by_name("onClick").is_none() {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
@@ -49,8 +49,10 @@ impl Rule for UseMediaCaption {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        let has_audio_or_video =
-            matches!(node.name_value_token()?.text_trimmed(), "video" | "audio");
+        let has_audio_or_video = matches!(
+            node.name_value_token().ok()?.text_trimmed(),
+            "video" | "audio"
+        );
         let has_muted = node.find_attribute_by_name("muted").is_some();
         let has_spread_prop = node
             .attributes()
@@ -78,7 +80,7 @@ impl Rule for UseMediaCaption {
                             _ => None,
                         }?;
 
-                        let has_track = any_jsx.name_value_token()?.text_trimmed() == "track";
+                        let has_track = any_jsx.name_value_token().ok()?.text_trimmed() == "track";
                         let has_valid_kind = &any_jsx
                             .find_attribute_by_name("kind")?
                             .initializer()?

--- a/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
@@ -59,7 +59,7 @@ impl Rule for UseSemanticElements {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let role_attribute = node.find_attribute_by_name("role").ok().flatten()?;
+        let role_attribute = node.find_attribute_by_name("role")?;
         let role_value = role_attribute.as_static_value()?;
         let role_value = role_value.as_string_constant()?;
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -147,7 +147,7 @@ impl Rule for UseValidAnchor {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let name = node.name().ok()?.name_value_token()?;
+        let name = node.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "a" {
             let anchor_attribute = node.find_attribute_by_name("href");

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
@@ -208,11 +208,10 @@ impl Rule for NoVoidElementsWithChildren {
                 let name = name.as_jsx_name()?.value_token().ok()?;
                 let name = name.text_trimmed();
                 if is_void_dom_element(name) {
-                    let dangerous_prop = opening_element
-                        .find_attribute_by_name("dangerouslySetInnerHTML")
-                        .ok()?;
+                    let dangerous_prop =
+                        opening_element.find_attribute_by_name("dangerouslySetInnerHTML");
                     let has_children = !element.children().is_empty();
-                    let children_prop = opening_element.find_attribute_by_name("children").ok()?;
+                    let children_prop = opening_element.find_attribute_by_name("children");
                     if dangerous_prop.is_some() || has_children || children_prop.is_some() {
                         let cause = NoVoidElementsWithChildrenCause::Jsx {
                             children_prop,
@@ -229,10 +228,8 @@ impl Rule for NoVoidElementsWithChildren {
                 let name = name.as_jsx_name()?.value_token().ok()?;
                 let name = name.text_trimmed();
                 if is_void_dom_element(name) {
-                    let dangerous_prop = element
-                        .find_attribute_by_name("dangerouslySetInnerHTML")
-                        .ok()?;
-                    let children_prop = element.find_attribute_by_name("children").ok()?;
+                    let dangerous_prop = element.find_attribute_by_name("dangerouslySetInnerHTML");
+                    let children_prop = element.find_attribute_by_name("children");
                     if dangerous_prop.is_some() || children_prop.is_some() {
                         let cause = NoVoidElementsWithChildrenCause::Jsx {
                             children_prop,

--- a/crates/biome_js_analyze/src/lint/nursery/no_head_element.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_head_element.rs
@@ -61,7 +61,7 @@ impl Rule for NoHeadElement {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
-        let name = element.name().ok()?.name_value_token()?;
+        let name = element.name().ok()?.name_value_token().ok()?;
 
         if name.text_trimmed() == "head" {
             let is_in_app_dir = ctx

--- a/crates/biome_js_analyze/src/lint/nursery/no_img_element.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_img_element.rs
@@ -70,7 +70,7 @@ impl Rule for NoImgElement {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        if node.name().ok()?.name_value_token()?.text_trimmed() != "img"
+        if node.name().ok()?.name_value_token().ok()?.text_trimmed() != "img"
             || node.attributes().is_empty()
         {
             return None;
@@ -86,7 +86,7 @@ impl Rule for NoImgElement {
             let Some(opening_element) = parent.opening_element().ok() else {
                 return Some(());
             };
-            let name = opening_element.name().ok()?.name_value_token()?;
+            let name = opening_element.name().ok()?.name_value_token().ok()?;
 
             if name.text_trimmed() == "picture" {
                 return None;

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_display.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_display.rs
@@ -74,7 +74,7 @@ impl Rule for UseGoogleFontDisplay {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let element = ctx.query();
 
-        if element.name().ok()?.name_value_token()?.text_trimmed() != "link" {
+        if element.name().ok()?.name_value_token().ok()?.text_trimmed() != "link" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -65,7 +65,7 @@ impl Rule for UseGoogleFontPreconnect {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        if node.name().ok()?.name_value_token()?.text_trimmed() != "link" {
+        if node.name().ok()?.name_value_token().ok()?.text_trimmed() != "link" {
             return None;
         }
 
@@ -107,7 +107,7 @@ impl Rule for UseGoogleFontPreconnect {
         let mut attributes: Vec<_> = node.attributes().iter().collect();
 
         let last_attr_token = match attributes.last()? {
-            AnyJsxAttribute::JsxAttribute(a) => a.name_value_token()?,
+            AnyJsxAttribute::JsxAttribute(a) => a.name_value_token().ok()?,
             AnyJsxAttribute::JsxSpreadAttribute(a) => a.l_curly_token().ok()?,
         };
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_valid_autocomplete.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_valid_autocomplete.rs
@@ -154,7 +154,7 @@ impl Rule for UseValidAutocomplete {
         let input_components = &options.input_components;
         match ctx.query() {
             UseValidAutocompleteQuery::JsxOpeningElement(elem) => {
-                let elem_name = elem.name().ok()?.name_value_token()?;
+                let elem_name = elem.name().ok()?.name_value_token().ok()?;
                 let elem_name = elem_name.text_trimmed();
                 if !(elem_name == "input"
                     || input_components.iter().any(|x| x.as_ref() == elem_name))
@@ -162,7 +162,7 @@ impl Rule for UseValidAutocomplete {
                     return None;
                 }
                 let attributes = elem.attributes();
-                let autocomplete = attributes.find_by_name("autocomplete").ok()??;
+                let autocomplete = attributes.find_by_name("autocomplete")?;
                 let _initializer = autocomplete.initializer()?;
                 let extract_attrs = ctx.extract_attributes(&attributes)?;
                 let autocomplete_values = extract_attrs.get("autocomplete")?;
@@ -183,7 +183,7 @@ impl Rule for UseValidAutocomplete {
                 Some(autocomplete.range())
             }
             UseValidAutocompleteQuery::JsxSelfClosingElement(elem) => {
-                let elem_name = elem.name().ok()?.name_value_token()?;
+                let elem_name = elem.name().ok()?.name_value_token().ok()?;
                 let elem_name = elem_name.text_trimmed();
                 if !(elem_name == "input"
                     || input_components.iter().any(|x| x.as_ref() == elem_name))
@@ -191,7 +191,7 @@ impl Rule for UseValidAutocomplete {
                     return None;
                 }
                 let attributes = elem.attributes();
-                let autocomplete = attributes.find_by_name("autocomplete").ok()??;
+                let autocomplete = attributes.find_by_name("autocomplete")?;
                 let _initializer = autocomplete.initializer()?;
                 let extract_attrs = ctx.extract_attributes(&attributes)?;
                 let autocomplete_values = extract_attrs.get("autocomplete")?;

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
@@ -110,12 +110,10 @@ impl AnyJsCreateElement {
 
                 opening_element
                     .find_attribute_by_name("dangerouslySetInnerHTML")
-                    .ok()?
                     .map(DangerousProp::from)
             }
             AnyJsCreateElement::JsxSelfClosingElement(element) => element
                 .find_attribute_by_name("dangerouslySetInnerHTML")
-                .ok()?
                 .map(DangerousProp::from),
             AnyJsCreateElement::JsCallExpression(call_expression) => {
                 let react_create_element =
@@ -135,12 +133,10 @@ impl AnyJsCreateElement {
 
                 opening_element
                     .find_attribute_by_name("children")
-                    .ok()?
                     .map(DangerousProp::from)
             }
             AnyJsCreateElement::JsxSelfClosingElement(element) => element
                 .find_attribute_by_name("children")
-                .ok()?
                 .map(DangerousProp::from),
             AnyJsCreateElement::JsCallExpression(call_expression) => {
                 let react_create_element =

--- a/crates/biome_js_analyze/src/services/aria.rs
+++ b/crates/biome_js_analyze/src/services/aria.rs
@@ -35,7 +35,7 @@ impl AriaServices {
                     if let Some(static_value) = initializer.as_static_value() {
                         static_value
                             .text()
-                            .split_whitespace()
+                            .split_ascii_whitespace()
                             .map(|s| AttributeValue::StaticValue(s.to_string()))
                             .collect()
                     } else {

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -652,7 +652,7 @@ pub(crate) fn parse_lang_from_script_opening_tag(
                 .ok()?;
             let tag = expression.as_jsx_tag_expression()?.tag().ok()?;
             let opening_element = tag.as_jsx_element()?.opening_element().ok()?;
-            let lang_attribute = opening_element.attributes().find_by_name("lang").ok()??;
+            let lang_attribute = opening_element.attributes().find_by_name("lang")?;
             let attribute_value = lang_attribute.initializer()?.value().ok()?;
             let attribute_inner_string =
                 attribute_value.as_jsx_string()?.inner_string_text().ok()?;


### PR DESCRIPTION
## Summary

- Improve consistency of the documentation
- Use `SyntaxResult` instead of `Option` where possible.
- Remove unnecessary wrapping: use `Option<X>` instead of `SyntaxResult<Option<X>>`
- Use `split_ascii_whitespace` instead of `split_whitespace` for splitting HTML attribute values.
- Avoid some cloning and use `TokenString` instead of `String` for `get_attribute_inner_string_text`.

## Test Plan

CI must pass.
