### PR TITLE
refactor(aria): add abstractions for attribute lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,6 @@ name = "biome_aria"
 version = "0.5.7"
 dependencies = [
  "biome_aria_metadata",
- "rustc-hash 2.0.0",
 ]
 
 [[package]]
@@ -853,6 +852,7 @@ dependencies = [
 name = "biome_js_syntax"
 version = "0.5.7"
 dependencies = [
+ "biome_aria",
  "biome_js_factory",
  "biome_js_parser",
  "biome_rowan",

--- a/crates/biome_aria/Cargo.toml
+++ b/crates/biome_aria/Cargo.toml
@@ -14,7 +14,6 @@ version              = "0.5.7"
 
 [dependencies]
 biome_aria_metadata = { workspace = true }
-rustc-hash          = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/biome_aria/src/lib.rs
+++ b/crates/biome_aria/src/lib.rs
@@ -1,4 +1,30 @@
 pub mod roles;
 
-pub use biome_aria_metadata::{AriaAttribute, AriaValueType};
 pub use roles::AriaRoles;
+
+pub trait Element {
+    /// Name of the current element or `None` if it cannot be retrieved.
+    fn name(&self) -> Option<impl AsRef<str>>;
+
+    /// Attributes set on the current element.
+    fn attributes(&self) -> impl Iterator<Item = impl Attribute>;
+
+    /// returns the first attribute with a name that matches `matcher`.
+    fn find_attribute_by_name(&self, matcher: impl Fn(&str) -> bool) -> Option<impl Attribute> {
+        self.attributes().find_map(|attribute| {
+            if matcher(attribute.name()?.as_ref()) {
+                Some(attribute)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+pub trait Attribute {
+    /// Name of the current attribute or `None` if it cannot be retrieved.
+    fn name(&self) -> Option<impl AsRef<str>>;
+
+    /// Value of the current attribute or `None` if it cannot be retrieved.
+    fn value(&self) -> Option<impl AsRef<str>>;
+}

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -63,16 +63,10 @@ impl Rule for NoAriaHiddenOnFocusable {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let aria_roles = ctx.aria_roles();
-        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
-
         if node.is_element() {
             let aria_hidden_attr = node.find_attribute_by_name("aria-hidden")?;
             let attr_static_val = aria_hidden_attr.as_static_value()?;
             let attr_text = attr_static_val.text();
-
-            let attributes = ctx.extract_attributes(&node.attributes());
-            let attributes = ctx.convert_all_attribute_values(attributes);
 
             if attr_text == "false" {
                 return None;
@@ -111,7 +105,7 @@ impl Rule for NoAriaHiddenOnFocusable {
                 }
             }
 
-            if !aria_roles.is_not_interactive_element(element_name.text_trimmed(), attributes) {
+            if !ctx.aria_roles().is_not_interactive_element(node) {
                 return Some(());
             }
         }

--- a/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -54,40 +54,36 @@ impl Rule for NoInteractiveElementToNoninteractiveRole {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let aria_roles = ctx.aria_roles();
         if node.is_element() {
             let role_attribute = node.find_attribute_by_name("role")?;
             let role_attribute_static_value = role_attribute.as_static_value()?;
             let role_attribute_value = role_attribute_static_value.text();
             let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
+            let element_name = element_name.text_trimmed();
 
-            let attributes = ctx.extract_attributes(&node.attributes());
-            let attributes = ctx.convert_all_attribute_values(attributes);
-            if !aria_roles.is_not_interactive_element(element_name.text_trimmed(), attributes)
+            if !ctx.aria_roles().is_not_interactive_element(node)
                 && AriaRole::from_roles(role_attribute_value)
                     .is_some_and(|role| role.is_non_interactive())
             {
                 // <div> and <span> are considered neither interactive nor non-interactive, depending on the presence or absence of the role attribute.
                 // We don't report <div> and <span> here, because we cannot determine whether they are interactive or non-interactive.
                 let role_sensitive_elements = ["div", "span", "source"];
-                if role_sensitive_elements.contains(&element_name.text_trimmed()) {
+                if role_sensitive_elements.contains(&element_name) {
                     return None;
                 }
 
                 // A <svg> element can be given an "img" to make it non-interactive for a11y reasons.
-                if element_name.text_trimmed() == "svg" && role_attribute_value == "img" {
+                if element_name == "svg" && role_attribute_value == "img" {
                     return None;
                 }
 
                 // A <canvas> element can be given an "img" to make it non-interactive for a11y reasons.
-                if element_name.text_trimmed() == "canvas" && role_attribute_value == "img" {
+                if element_name == "canvas" && role_attribute_value == "img" {
                     return None;
                 }
 
                 // a tag without href is considered non-interactive
-                if element_name.text_trimmed() == "a"
-                    && node.find_attribute_by_name("href").is_none()
-                {
+                if element_name == "a" && node.find_attribute_by_name("href").is_none() {
                     return None;
                 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -7,7 +7,7 @@ use biome_console::markup;
 use biome_js_syntax::{
     jsx_ext::AnyJsxElement, AnyJsxAttributeValue, AnyNumberLikeExpression, TextRange,
 };
-use biome_rowan::{AstNode, BatchMutationExt};
+use biome_rowan::{AstNode, BatchMutationExt, TokenText};
 
 declare_lint_rule! {
     /// Enforce that `tabIndex` is not assigned to non-interactive HTML elements.
@@ -58,7 +58,7 @@ declare_lint_rule! {
 
 pub struct RuleState {
     attribute_range: TextRange,
-    element_name: String,
+    element_name: TokenText,
 }
 
 impl Rule for NoNoninteractiveTabindex {
@@ -73,23 +73,26 @@ impl Rule for NoNoninteractiveTabindex {
             return None;
         }
 
-        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
-        let aria_roles = ctx.aria_roles();
-        let attributes = ctx.extract_attributes(&node.attributes());
-        let attributes = ctx.convert_all_attribute_values(attributes);
-
-        if aria_roles.is_not_interactive_element(element_name.text_trimmed(), attributes) {
+        if ctx.aria_roles().is_not_interactive_element(node) {
             let tabindex_attribute = node.find_attribute_by_name("tabIndex")?;
             let tabindex_attribute_value = tabindex_attribute.initializer()?.value().ok()?;
             if attribute_has_negative_tabindex(&tabindex_attribute_value)? {
                 return None;
             }
 
+            let element_name = node
+                .name()
+                .ok()?
+                .as_jsx_name()?
+                .value_token()
+                .ok()?
+                .token_text_trimmed();
+
             let role_attribute = node.find_attribute_by_name("role");
             let Some(role_attribute) = role_attribute else {
                 return Some(RuleState {
                     attribute_range: tabindex_attribute.range(),
-                    element_name: element_name.text_trimmed().to_string(),
+                    element_name,
                 });
             };
 
@@ -100,19 +103,20 @@ impl Rule for NoNoninteractiveTabindex {
 
             return Some(RuleState {
                 attribute_range: tabindex_attribute.range(),
-                element_name: element_name.text_trimmed().to_string(),
+                element_name,
             });
         }
         None
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        let element_name = state.element_name.text();
         Some(
             RuleDiagnostic::new(
                 rule_category!(),
                 state.attribute_range,
                 markup! {
-                "The HTML element "<Emphasis>{{&state.element_name}}</Emphasis>" is non-interactive. Do not use "<Emphasis>"tabIndex"</Emphasis>"."
+                "The HTML element "<Emphasis>{{element_name}}</Emphasis>" is non-interactive. Do not use "<Emphasis>"tabIndex"</Emphasis>"."
 
                 },
             )

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -4,9 +4,7 @@ use biome_analyze::{
 };
 use biome_aria_metadata::AriaRole;
 use biome_console::markup;
-use biome_js_syntax::{
-    jsx_ext::AnyJsxElement, AnyJsxAttributeValue, JsxAttribute, JsxAttributeList,
-};
+use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttributeValue, JsxAttribute};
 use biome_rowan::{AstNode, BatchMutationExt};
 
 declare_lint_rule! {
@@ -55,7 +53,6 @@ declare_lint_rule! {
 pub struct RuleState {
     redundant_attribute: JsxAttribute,
     redundant_attribute_value: AnyJsxAttributeValue,
-    element_name: String,
 }
 
 impl Rule for NoRedundantRoles {
@@ -66,38 +63,30 @@ impl Rule for NoRedundantRoles {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let aria_roles = ctx.aria_roles();
-
-        let (element_name, attributes) = get_element_name_and_attributes(node)?;
-        let attribute_name_to_values = ctx.extract_attributes(&attributes);
-        let attribute_name_to_values = ctx.convert_all_attribute_values(attribute_name_to_values);
-        let attr = attribute_name_to_values?;
-        let implicit_role = aria_roles.get_implicit_role(&element_name, &attr)?;
 
         let role_attribute = node.find_attribute_by_name("role")?;
         let role_attribute_value = role_attribute.initializer()?.value().ok()?;
         let explicit_role = AriaRole::from_roles(role_attribute_value.as_static_value()?.text())?;
 
-        let is_redundant = implicit_role == explicit_role;
-        if is_redundant {
+        if ctx.aria_roles().get_implicit_role(node)? == explicit_role {
             return Some(RuleState {
                 redundant_attribute: role_attribute,
                 redundant_attribute_value: role_attribute_value,
-                element_name: element_name.to_string(),
             });
         }
         None
     }
 
-    fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
         let binding = state.redundant_attribute_value.as_static_value()?;
         let role_attribute = binding.text();
-        let element = state.element_name.to_string();
+        let element_name = ctx.query().name().ok()?.as_jsx_name()?.value_token().ok()?;
+        let element_name = element_name.text_trimmed();
         Some(RuleDiagnostic::new(
             rule_category!(),
             state.redundant_attribute_value.range(),
             markup! {
-                "Using the role attribute '"{role_attribute}"' on the '"{element}"' element is redundant, because it is implied by the semantic '"{element}"' element."
+                "Using the role attribute '"{role_attribute}"' on the '"{element_name}"' element is redundant, because it is implied by its semantic."
             },
         ))
     }
@@ -111,22 +100,5 @@ impl Rule for NoRedundantRoles {
             markup! { "Remove the "<Emphasis>"role"</Emphasis>" attribute." }.to_owned(),
             mutation,
         ))
-    }
-}
-
-fn get_element_name_and_attributes(node: &AnyJsxElement) -> Option<(String, JsxAttributeList)> {
-    match node {
-        AnyJsxElement::JsxOpeningElement(elem) => {
-            let token = elem.name().ok()?;
-            let element_name = token.as_jsx_name()?.value_token().ok()?;
-            let trimmed_element_name = element_name.text_trimmed().to_string();
-            Some((trimmed_element_name, elem.attributes()))
-        }
-        AnyJsxElement::JsxSelfClosingElement(elem) => {
-            let token = &elem.name().ok()?;
-            let element_name = token.as_jsx_name()?.value_token().ok()?;
-            let trimmed_element_name = element_name.text_trimmed().to_string();
-            Some((trimmed_element_name, elem.attributes()))
-        }
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -65,13 +65,9 @@ impl Rule for UseAriaActivedescendantWithTabindex {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let aria_roles = ctx.aria_roles();
-        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
-        let attributes = ctx.extract_attributes(&node.attributes());
-        let attributes = ctx.convert_all_attribute_values(attributes);
 
         if node.is_element()
-            && aria_roles.is_not_interactive_element(element_name.text_trimmed(), attributes)
+            && ctx.aria_roles().is_not_interactive_element(node)
             && node
                 .find_attribute_by_name("aria-activedescendant")
                 .is_some()

--- a/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -58,12 +58,7 @@ impl Rule for UseFocusableInteractive {
             return None;
         }
 
-        let element_name = node.name().ok()?.as_jsx_name()?.value_token().ok()?;
-        let aria_roles = ctx.aria_roles();
-        let attributes = ctx.extract_attributes(&node.attributes());
-        let attributes = ctx.convert_all_attribute_values(attributes);
-
-        if aria_roles.is_not_interactive_element(element_name.text_trimmed(), attributes) {
+        if ctx.aria_roles().is_not_interactive_element(node) {
             let role_attribute = node.find_attribute_by_name("role");
             if let Some(role_attribute) = role_attribute {
                 let tabindex_attribute = node.find_attribute_by_name("tabIndex");

--- a/crates/biome_js_analyze/src/services/aria.rs
+++ b/crates/biome_js_analyze/src/services/aria.rs
@@ -3,9 +3,8 @@ use biome_analyze::{
     RuleKey, ServiceBag, SyntaxVisitor,
 };
 use biome_aria::AriaRoles;
-use biome_js_syntax::{AnyJsRoot, AnyJsxAttribute, JsLanguage, JsSyntaxNode, JsxAttributeList};
+use biome_js_syntax::{AnyJsRoot, JsLanguage, JsSyntaxNode};
 use biome_rowan::AstNode;
-use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -17,72 +16,6 @@ impl AriaServices {
     pub fn aria_roles(&self) -> &AriaRoles {
         &self.roles
     }
-
-    /// Parses a [JsxAttributeList] and extracts the names and values of each [JsxAttribute],
-    /// returning them as a [FxHashMap]. Attributes with no specified value are given a value of "true".
-    /// If an attribute has multiple values, each value is stored as a separate item in the
-    /// [FxHashMap] under the same attribute name. Returns [None] if the parsing fails.
-    pub fn extract_attributes(
-        &self,
-        attribute_list: &JsxAttributeList,
-    ) -> Option<FxHashMap<String, Vec<AttributeValue>>> {
-        let mut defined_attributes: FxHashMap<String, Vec<AttributeValue>> = FxHashMap::default();
-        for attribute in attribute_list {
-            if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
-                let name = attr.name().ok()?.syntax().text_trimmed().to_string();
-                let values = if let Some(initializer) = attr.initializer() {
-                    let initializer = initializer.value().ok()?;
-                    if let Some(static_value) = initializer.as_static_value() {
-                        static_value
-                            .text()
-                            .split_ascii_whitespace()
-                            .map(|s| AttributeValue::StaticValue(s.to_string()))
-                            .collect()
-                    } else {
-                        vec![AttributeValue::DynamicValue(
-                            initializer.syntax().text_trimmed().to_string(),
-                        )]
-                    }
-                } else {
-                    vec![AttributeValue::StaticValue("true".to_string())]
-                };
-
-                defined_attributes.entry(name).or_insert(values);
-            }
-        }
-        Some(defined_attributes)
-    }
-
-    pub fn convert_all_attribute_values(
-        &self,
-        attributes: Option<FxHashMap<String, Vec<AttributeValue>>>,
-    ) -> Option<FxHashMap<String, Vec<String>>> {
-        attributes.map(|attr_map| {
-            attr_map
-                .into_iter()
-                .map(|(key, values)| {
-                    let string_values = self.convert_attribute_values(values);
-                    (key, string_values)
-                })
-                .collect()
-        })
-    }
-
-    pub fn convert_attribute_values(&self, values: Vec<AttributeValue>) -> Vec<String> {
-        values
-            .into_iter()
-            .map(|value| match value {
-                AttributeValue::StaticValue(s) => s,
-                AttributeValue::DynamicValue(s) => s,
-            })
-            .collect()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum AttributeValue {
-    StaticValue(String),
-    DynamicValue(String),
 }
 
 impl FromServices for AriaServices {
@@ -129,59 +62,5 @@ where
 
     fn unwrap_match(_: &ServiceBag, node: &Self::Input) -> Self::Output {
         N::unwrap_cast(node.clone())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::services::aria::{AriaServices, AttributeValue};
-    use biome_aria::AriaRoles;
-    use biome_js_factory::make::{
-        ident, jsx_attribute, jsx_attribute_initializer_clause, jsx_attribute_list, jsx_name,
-        jsx_string, jsx_string_literal, token,
-    };
-    use biome_js_syntax::{AnyJsxAttribute, AnyJsxAttributeName, AnyJsxAttributeValue, T};
-    use std::sync::Arc;
-
-    #[test]
-    fn test_extract_attributes() {
-        // Assume attributes of `<div class="wrapper document" role="article"></div>`
-        let attribute_list = jsx_attribute_list(vec![
-            AnyJsxAttribute::JsxAttribute(
-                jsx_attribute(AnyJsxAttributeName::JsxName(jsx_name(ident("class"))))
-                    .with_initializer(jsx_attribute_initializer_clause(
-                        token(T![=]),
-                        AnyJsxAttributeValue::JsxString(jsx_string(jsx_string_literal(
-                            "wrapper document",
-                        ))),
-                    ))
-                    .build(),
-            ),
-            AnyJsxAttribute::JsxAttribute(
-                jsx_attribute(AnyJsxAttributeName::JsxName(jsx_name(ident("role"))))
-                    .with_initializer(jsx_attribute_initializer_clause(
-                        token(T![=]),
-                        AnyJsxAttributeValue::JsxString(jsx_string(jsx_string_literal("article"))),
-                    ))
-                    .build(),
-            ),
-        ]);
-        let services = AriaServices {
-            roles: Arc::new(AriaRoles {}),
-        };
-
-        let attribute_name_to_values = services.extract_attributes(&attribute_list).unwrap();
-
-        assert_eq!(
-            attribute_name_to_values["class"],
-            vec![
-                AttributeValue::StaticValue("wrapper".to_string()),
-                AttributeValue::StaticValue("document".to_string())
-            ]
-        );
-        assert_eq!(
-            attribute_name_to_values["role"],
-            vec![AttributeValue::StaticValue("article".to_string())]
-        );
     }
 }

--- a/crates/biome_js_analyze/tests/specs/a11y/noRedundantRoles/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noRedundantRoles/invalid.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -45,7 +46,7 @@ expression: invalid.jsx
 ```
 invalid.jsx:2:16 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'article' on the 'article' element is redundant, because it is implied by the semantic 'article' element.
+  ! Using the role attribute 'article' on the 'article' element is redundant, because it is implied by its semantic.
   
     1 │ <>
   > 2 │ 	<article role="article"></article>
@@ -63,7 +64,7 @@ invalid.jsx:2:16 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:3:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'button' on the 'button' element is redundant, because it is implied by the semantic 'button' element.
+  ! Using the role attribute 'button' on the 'button' element is redundant, because it is implied by its semantic.
   
     1 │ <>
     2 │ 	<article role="article"></article>
@@ -82,7 +83,7 @@ invalid.jsx:3:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:4:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'heading' on the 'h1' element is redundant, because it is implied by the semantic 'h1' element.
+  ! Using the role attribute 'heading' on the 'h1' element is redundant, because it is implied by its semantic.
   
     2 │ 	<article role="article"></article>
     3 │ 	<button role="button"></button>
@@ -101,7 +102,7 @@ invalid.jsx:4:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:7:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'heading' on the 'h1' element is redundant, because it is implied by the semantic 'h1' element.
+  ! Using the role attribute 'heading' on the 'h1' element is redundant, because it is implied by its semantic.
   
     5 │ 		title
     6 │ 	</h1>
@@ -120,7 +121,7 @@ invalid.jsx:7:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:8:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'heading' on the 'h2' element is redundant, because it is implied by the semantic 'h2' element.
+  ! Using the role attribute 'heading' on the 'h2' element is redundant, because it is implied by its semantic.
   
      6 │ 	</h1>
      7 │ 	<h1 role="heading">title</h1>
@@ -139,7 +140,7 @@ invalid.jsx:8:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:9:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'dialog' on the 'dialog' element is redundant, because it is implied by the semantic 'dialog' element.
+  ! Using the role attribute 'dialog' on the 'dialog' element is redundant, because it is implied by its semantic.
   
      7 │ 	<h1 role="heading">title</h1>
      8 │ 	<h2 role={`heading`}></h2>
@@ -158,7 +159,7 @@ invalid.jsx:9:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:10:30 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'checkbox' on the 'input' element is redundant, because it is implied by the semantic 'input' element.
+  ! Using the role attribute 'checkbox' on the 'input' element is redundant, because it is implied by its semantic.
   
      8 │ 	<h2 role={`heading`}></h2>
      9 │ 	<dialog role="dialog"></dialog>
@@ -177,7 +178,7 @@ invalid.jsx:10:30 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:11:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'figure' on the 'figure' element is redundant, because it is implied by the semantic 'figure' element.
+  ! Using the role attribute 'figure' on the 'figure' element is redundant, because it is implied by its semantic.
   
      9 │ 	<dialog role="dialog"></dialog>
     10 │ 	<input type="checkbox" role="checkbox" />
@@ -196,7 +197,7 @@ invalid.jsx:11:15 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:12:13 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'form' on the 'form' element is redundant, because it is implied by the semantic 'form' element.
+  ! Using the role attribute 'form' on the 'form' element is redundant, because it is implied by its semantic.
   
     10 │ 	<input type="checkbox" role="checkbox" />
     11 │ 	<figure role="figure"></figure>
@@ -215,7 +216,7 @@ invalid.jsx:12:13 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:14:17 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'group' on the 'fieldset' element is redundant, because it is implied by the semantic 'fieldset' element.
+  ! Using the role attribute 'group' on the 'fieldset' element is redundant, because it is implied by its semantic.
   
     12 │ 	<form role="form"></form>
     13 │ 	{/* Needs to check the ancestors: <td role="gridcell"></td> */}
@@ -234,7 +235,7 @@ invalid.jsx:14:17 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:15:32 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'img' on the 'img' element is redundant, because it is implied by the semantic 'img' element.
+  ! Using the role attribute 'img' on the 'img' element is redundant, because it is implied by its semantic.
   
     13 │ 	{/* Needs to check the ancestors: <td role="gridcell"></td> */}
     14 │ 	<fieldset role="group"></fieldset>
@@ -253,7 +254,7 @@ invalid.jsx:15:32 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:16:19 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'presentation' on the 'img' element is redundant, because it is implied by the semantic 'img' element.
+  ! Using the role attribute 'presentation' on the 'img' element is redundant, because it is implied by its semantic.
   
     14 │ 	<fieldset role="group"></fieldset>
     15 │ 	<img src="foo" alt="bar" role="img" />
@@ -272,7 +273,7 @@ invalid.jsx:16:19 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:17:19 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'link' on the 'a' element is redundant, because it is implied by the semantic 'a' element.
+  ! Using the role attribute 'link' on the 'a' element is redundant, because it is implied by its semantic.
   
     15 │ 	<img src="foo" alt="bar" role="img" />
     16 │ 	<img alt="" role="presentation"></img>
@@ -291,7 +292,7 @@ invalid.jsx:17:19 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:18:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'list' on the 'ol' element is redundant, because it is implied by the semantic 'ol' element.
+  ! Using the role attribute 'list' on the 'ol' element is redundant, because it is implied by its semantic.
   
     16 │ 	<img alt="" role="presentation"></img>
     17 │ 	<a href="#" role="link"></a>
@@ -310,7 +311,7 @@ invalid.jsx:18:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:19:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'list' on the 'ul' element is redundant, because it is implied by the semantic 'ul' element.
+  ! Using the role attribute 'list' on the 'ul' element is redundant, because it is implied by its semantic.
   
     17 │ 	<a href="#" role="link"></a>
     18 │ 	<ol role="list"></ol>
@@ -329,7 +330,7 @@ invalid.jsx:19:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:20:27 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'combobox' on the 'select' element is redundant, because it is implied by the semantic 'select' element.
+  ! Using the role attribute 'combobox' on the 'select' element is redundant, because it is implied by its semantic.
   
     18 │ 	<ol role="list"></ol>
     19 │ 	<ul role="list"></ul>
@@ -348,7 +349,7 @@ invalid.jsx:20:27 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:21:45 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'listbox' on the 'select' element is redundant, because it is implied by the semantic 'select' element.
+  ! Using the role attribute 'listbox' on the 'select' element is redundant, because it is implied by its semantic.
   
     19 │ 	<ul role="list"></ul>
     20 │ 	<select name="name" role="combobox"></select>
@@ -367,7 +368,7 @@ invalid.jsx:21:45 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:22:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'listitem' on the 'li' element is redundant, because it is implied by the semantic 'li' element.
+  ! Using the role attribute 'listitem' on the 'li' element is redundant, because it is implied by its semantic.
   
     20 │ 	<select name="name" role="combobox"></select>
     21 │ 	<select name="name" multiple size="4" role="listbox"></select>
@@ -386,7 +387,7 @@ invalid.jsx:22:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:23:12 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'navigation' on the 'nav' element is redundant, because it is implied by the semantic 'nav' element.
+  ! Using the role attribute 'navigation' on the 'nav' element is redundant, because it is implied by its semantic.
   
     21 │ 	<select name="name" multiple size="4" role="listbox"></select>
     22 │ 	<li role="listitem"></li>
@@ -405,7 +406,7 @@ invalid.jsx:23:12 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:25:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'row' on the 'tr' element is redundant, because it is implied by the semantic 'tr' element.
+  ! Using the role attribute 'row' on the 'tr' element is redundant, because it is implied by its semantic.
   
     23 │ 	<nav role="navigation"></nav>
     24 │ 	{/* Needs to check the ancestors: <option role="option"></option> */}
@@ -424,7 +425,7 @@ invalid.jsx:25:11 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:26:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'rowgroup' on the 'tbody' element is redundant, because it is implied by the semantic 'tbody' element.
+  ! Using the role attribute 'rowgroup' on the 'tbody' element is redundant, because it is implied by its semantic.
   
     24 │ 	{/* Needs to check the ancestors: <option role="option"></option> */}
     25 │ 	<tr role="row"></tr>
@@ -443,7 +444,7 @@ invalid.jsx:26:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:27:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'rowgroup' on the 'tfoot' element is redundant, because it is implied by the semantic 'tfoot' element.
+  ! Using the role attribute 'rowgroup' on the 'tfoot' element is redundant, because it is implied by its semantic.
   
     25 │ 	<tr role="row"></tr>
     26 │ 	<tbody role="rowgroup"></tbody>
@@ -462,7 +463,7 @@ invalid.jsx:27:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:28:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'rowgroup' on the 'thead' element is redundant, because it is implied by the semantic 'thead' element.
+  ! Using the role attribute 'rowgroup' on the 'thead' element is redundant, because it is implied by its semantic.
   
     26 │ 	<tbody role="rowgroup"></tbody>
     27 │ 	<tfoot role="rowgroup"></tfoot>
@@ -481,7 +482,7 @@ invalid.jsx:28:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:30:28 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'searchbox' on the 'input' element is redundant, because it is implied by the semantic 'input' element.
+  ! Using the role attribute 'searchbox' on the 'input' element is redundant, because it is implied by its semantic.
   
     28 │ 	<thead role="rowgroup"></thead>
     29 │ 	{/* Needs to check the ancestors: <th scope="row" role="rowheader"></th> */}
@@ -500,7 +501,7 @@ invalid.jsx:30:28 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:31:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'table' on the 'table' element is redundant, because it is implied by the semantic 'table' element.
+  ! Using the role attribute 'table' on the 'table' element is redundant, because it is implied by its semantic.
   
     29 │ 	{/* Needs to check the ancestors: <th scope="row" role="rowheader"></th> */}
     30 │ 	<input type="search" role="searchbox" />
@@ -519,7 +520,7 @@ invalid.jsx:31:14 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:32:17 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'textbox' on the 'textarea' element is redundant, because it is implied by the semantic 'textarea' element.
+  ! Using the role attribute 'textbox' on the 'textarea' element is redundant, because it is implied by its semantic.
   
     30 │ 	<input type="search" role="searchbox" />
     31 │ 	<table role="table"></table>
@@ -538,7 +539,7 @@ invalid.jsx:32:17 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
 ```
 invalid.jsx:33:26 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Using the role attribute 'textbox' on the 'input' element is redundant, because it is implied by the semantic 'input' element.
+  ! Using the role attribute 'textbox' on the 'input' element is redundant, because it is implied by its semantic.
   
     31 │ 	<table role="table"></table>
     32 │ 	<textarea role="textbox"></textarea>
@@ -553,5 +554,3 @@ invalid.jsx:33:26 lint/a11y/noRedundantRoles  FIXABLE  ━━━━━━━━�
        │                      ---------------  
 
 ```
-
-

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 version              = "0.5.7"
 
 [dependencies]
+biome_aria        = { workspace = true }
 biome_rowan       = { workspace = true, features = ["serde"] }
 biome_string_case = { workspace = true }
 enumflags2        = { workspace = true }

--- a/crates/biome_js_syntax/src/static_value.rs
+++ b/crates/biome_js_syntax/src/static_value.rs
@@ -153,3 +153,9 @@ impl StaticValue {
         matches!(self, StaticValue::Null(_) | StaticValue::Undefined(_))
     }
 }
+
+impl AsRef<str> for StaticValue {
+    fn as_ref(&self) -> &str {
+        self.text()
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces an abstraction for HTML-like elements and attributes in `biome_aria`.
This allows us to use the same abstraction for HTML and JSX and avoid a dependency over `biome_rowan`/`biome_js_syntax`.

The abstraction is based on two traits (open to suggestion for naming):

- `biome_aria::Element`
- `biome_aria::Attribute`

These traits are implemented by some `biome_js_syntax` nodes (`AnyJsxElement` and `JsxAttribute`).
The trait methods returns `Option` that allows to return `None` upon buggy nodes.
This is not ideal, however I don't see a better alternative at the moment.

These traits simplify how we interact with the biome aria functions because we just need to pass regular AST nodes to them.

I plan to add a way of retrieving parent nodes or parent nodes with a role.

## Test Plan

CI must pass.
