### PR TITLE
fix(css): reformat issue in comments between compound selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#4121](https://github.com/biomejs/biome/issues/4326), don't ident a CSS selector when has leading comments. Contributed by @fireairforce
 - Fix [#4334](https://github.com/biomejs/biome/issues/4334), don't insert trailing comma on type import statement. Contributed by @fireairforce
-
+- Fix [#3229](https://github.com/biomejs/biome/issues/3229), where Biome wasn't idempotent when block comments were placed inside compound selectors. Contributed by @ematipico
 ### JavaScript APIs
 
 ### Linter
@@ -130,7 +130,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   Also, this will bring the Biome rule closer to the [no-undef ESLint rule](https://eslint.org/docs/latest/rules/no-undef).
 
   Contributed by @Conaclos
-  
+
 - Add [noGlobalDirnameFilename](https://biomejs.dev/linter/rules/no-global-dirname-filename/). Contributed by @unvalley
 
 #### Enhancements

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
-use biome_css_syntax::{AnyCssDeclarationName, CssFunction, CssIdentifier, CssLanguage, TextLen};
+use biome_css_syntax::{
+    AnyCssDeclarationName, CssComplexSelector, CssFunction, CssIdentifier, CssLanguage, TextLen,
+};
 use biome_diagnostics::category;
 use biome_formatter::comments::{
     is_doc_comment, CommentKind, CommentPlacement, CommentStyle, CommentTextPosition, Comments,
@@ -89,15 +91,15 @@ impl CommentStyle for CssCommentStyle {
         comment: DecoratedComment<Self::Language>,
     ) -> CommentPlacement<Self::Language> {
         match comment.text_position() {
-            CommentTextPosition::EndOfLine => {
-                handle_function_comment(comment).or_else(handle_declaration_name_comment)
-            }
-            CommentTextPosition::OwnLine => {
-                handle_function_comment(comment).or_else(handle_declaration_name_comment)
-            }
-            CommentTextPosition::SameLine => {
-                handle_function_comment(comment).or_else(handle_declaration_name_comment)
-            }
+            CommentTextPosition::EndOfLine => handle_function_comment(comment)
+                .or_else(handle_declaration_name_comment)
+                .or_else(handle_complex_selector_comment),
+            CommentTextPosition::OwnLine => handle_function_comment(comment)
+                .or_else(handle_declaration_name_comment)
+                .or_else(handle_complex_selector_comment),
+            CommentTextPosition::SameLine => handle_function_comment(comment)
+                .or_else(handle_declaration_name_comment)
+                .or_else(handle_complex_selector_comment),
         }
     }
 }
@@ -129,4 +131,15 @@ fn handle_function_comment(
     } else {
         CommentPlacement::Default(comment)
     }
+}
+
+fn handle_complex_selector_comment(
+    comment: DecoratedComment<CssLanguage>,
+) -> CommentPlacement<CssLanguage> {
+    if let Some(complex) = CssComplexSelector::cast_ref(comment.enclosing_node()) {
+        if let Ok(right) = complex.right() {
+            return CommentPlacement::leading(right.into_syntax(), comment);
+        }
+    }
+    CommentPlacement::Default(comment)
 }

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -12,8 +12,12 @@ mod language {
 #[test]
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
-    let src = r#"
-@charset "UTF-8";
+    let src = r#"foo
+  /* a comment */
+
+  .aRule {
+  color: red;
+}
 "#;
     let parse = parse_css(src, CssParserOptions::default());
     println!("{parse:#?}");

--- a/crates/biome_css_formatter/tests/specs/css/issue_3229.css
+++ b/crates/biome_css_formatter/tests/specs/css/issue_3229.css
@@ -1,0 +1,39 @@
+foo /* a comment */
+.aRule {
+	color: red;
+}
+
+foo /* a comment */
+
+.aRule {
+	color: red;
+}
+
+foo
+
+
+	/* a comment */
+
+.aRule {
+	color: red;
+}
+
+/* input */
+foo
+
+	/* a comment */
+
+.aRule {
+	color: red
+}
+
+
+
+
+/* first format */
+foo
+	/* a comment */
+
+.aRule {
+	color: red;
+}

--- a/crates/biome_css_formatter/tests/specs/css/issue_3229.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/issue_3229.css.snap
@@ -1,0 +1,100 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/issue_3229.css
+snapshot_kind: text
+---
+# Input
+
+```css
+foo /* a comment */
+.aRule {
+	color: red;
+}
+
+foo /* a comment */
+
+.aRule {
+	color: red;
+}
+
+foo
+
+
+	/* a comment */
+
+.aRule {
+	color: red;
+}
+
+/* input */
+foo
+
+	/* a comment */
+
+.aRule {
+	color: red
+}
+
+
+
+
+/* first format */
+foo
+	/* a comment */
+
+.aRule {
+	color: red;
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+foo /* a comment */ .aRule {
+	color: red;
+}
+
+foo
+	/* a comment */
+
+	.aRule {
+	color: red;
+}
+
+foo
+	/* a comment */
+
+	.aRule {
+	color: red;
+}
+
+/* input */
+foo
+	/* a comment */
+
+	.aRule {
+	color: red;
+}
+
+/* first format */
+foo
+	/* a comment */
+
+	.aRule {
+	color: red;
+}
+```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/atrule/supports.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/atrule/supports.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/atrule/supports.css
+snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_css_formatter/tests/specs/prettier/css/bom/bom.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/bom/bom.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/bom/bom.css
+snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/custom-properties.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/custom-properties.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/comments/custom-properties.css
+snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/comments/selectors.css
+snapshot_kind: text
 ---
 # Input
 
@@ -231,8 +232,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  
 -/* comment 29 */
 -.element /* comment 30 */ > /* comment 31 */ .element /* comment 32 */ {
-+/* comment 29 */ .element /* comment 30 */
-+  > /* comment 31 */ .element /* comment 32 */ {
++/* comment 29 */ .element
++  > /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
  }
  /* comment 33 */
  .element
@@ -249,8 +250,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  
 -/* comment 37 */
 -.element /* comment 38 */ + /* comment 39 */ .element /* comment 40 */ {
-+/* comment 37 */ .element /* comment 38 */
-+  + /* comment 39 */ .element /* comment 40 */ {
++/* comment 37 */ .element
++  + /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
  }
  /* comment 41 */
  .element
@@ -267,8 +268,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
  
 -/* comment 45 */
 -.element /* comment 46 */ ~ /* comment 47 */ .element /* comment 48 */ {
-+/* comment 45 */ .element /* comment 46 */
-+  ~ /* comment 47 */ .element /* comment 48 */ {
++/* comment 45 */ .element
++  ~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
  }
  /* comment 49 */
  .element
@@ -442,8 +443,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 -/* comment 167 */
 -article /* comment 168 */ :--heading /* comment 169 */ + /* comment 170 */ p /* comment 171 */ {
 +/* comment 167 */ article
-+  /* comment 168 */ :--heading /* comment 169 */
-+  + /* comment 170 */ p /* comment 171 */ {
++  /* comment 168 */ :--heading
++  + /* comment 169 */ /* comment 170 */ p /* comment 171 */ {
  }
  
 -/* comment 172 */
@@ -534,8 +535,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 {
 }
 
-/* comment 29 */ .element /* comment 30 */
-  > /* comment 31 */ .element /* comment 32 */ {
+/* comment 29 */ .element
+  > /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
 }
 /* comment 33 */
 .element
@@ -545,8 +546,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 {
 }
 
-/* comment 37 */ .element /* comment 38 */
-  + /* comment 39 */ .element /* comment 40 */ {
+/* comment 37 */ .element
+  + /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
 }
 /* comment 41 */
 .element
@@ -556,8 +557,8 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 {
 }
 
-/* comment 45 */ .element /* comment 46 */
-  ~ /* comment 47 */ .element /* comment 48 */ {
+/* comment 45 */ .element
+  ~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
 }
 /* comment 49 */
 .element
@@ -679,8 +680,8 @@ input:not(
 } /* comment 166 */
 
 /* comment 167 */ article
-  /* comment 168 */ :--heading /* comment 169 */
-  + /* comment 170 */ p /* comment 171 */ {
+  /* comment 168 */ :--heading
+  + /* comment 169 */ /* comment 170 */ p /* comment 171 */ {
 }
 
 /* comment 172 */ .foo

--- a/crates/biome_css_formatter/tests/specs/prettier/css/front-matter/custom-parser.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/front-matter/custom-parser.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/front-matter/custom-parser.css
+snapshot_kind: text
 ---
 # Input
 
@@ -21,7 +22,7 @@ description: Description
 ```diff
 --- Prettier
 +++ Biome
-@@ -1,8 +1,6 @@
+@@ -1,8 +1,7 @@
  ---mycustomparser
 -title: Title
 -description: Description
@@ -31,7 +32,8 @@ description: Description
 -.something {
 +  title:Title
 +  description:Description
-+  --- /* comment */
++  ---
++  /* comment */
 +  .something {
  }
 ```
@@ -42,7 +44,8 @@ description: Description
 ---mycustomparser
   title:Title
   description:Description
-  --- /* comment */
+  ---
+  /* comment */
   .something {
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/prettier/css/front-matter/empty.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/front-matter/empty.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/front-matter/empty.css
+snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_css_formatter/tests/specs/prettier/css/yaml/comment_after.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/yaml/comment_after.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/yaml/comment_after.css
+snapshot_kind: text
 ---
 # Input
 

--- a/crates/biome_formatter_test/src/check_reformat.rs
+++ b/crates/biome_formatter_test/src/check_reformat.rs
@@ -28,7 +28,6 @@ where
         root: &'a SyntaxNode<L::ServiceLanguage>,
         text: &'a str,
         file_name: &'a str,
-
         language: &'a L,
         format_language: L::FormatLanguage,
     ) -> Self {
@@ -36,7 +35,6 @@ where
             root,
             text,
             file_name,
-
             language,
             format_language,
         }
@@ -67,7 +65,7 @@ where
             )
         }
 
-        let formatted = match self
+        let re_formatted = match self
             .language
             .format_node(self.format_language.clone(), &re_parse.syntax())
         {
@@ -77,15 +75,15 @@ where
             }
         };
 
-        let printed = formatted.print().unwrap();
+        let re_printed = re_formatted.print().unwrap();
 
-        if self.text != printed.as_code() {
+        if self.text != re_printed.as_code() {
             let input_format_element = self
                 .language
                 .format_node(self.format_language.clone(), self.root)
                 .unwrap();
-            let pretty_input_ir = format!("{}", formatted.into_document());
-            let pretty_reformat_ir = format!("{}", input_format_element.into_document());
+            let pretty_reformat_ir = format!("{}", re_formatted.into_document());
+            let pretty_input_ir = format!("{}", input_format_element.into_document());
 
             // Print a diff of the Formatter IR emitted for the input and the output
             let diff = similar_asserts::SimpleDiff::from_str(
@@ -94,10 +92,18 @@ where
                 "input",
                 "output",
             );
-
             println!("{diff}");
 
-            similar_asserts::assert_eq!(self.text, printed.as_code());
+            similar_asserts::assert_eq!(
+                re_printed.as_code(),
+                self.text,
+                "left is the re-formatted"
+            );
+            similar_asserts::assert_eq!(
+                pretty_reformat_ir,
+                pretty_input_ir,
+                "left is the re-formatted"
+            );
         }
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/3229

The issue was caused by comments that belonged to `left` and `combinator` of a `CssCompoundSelector`. 

To make the reformatting happy, I decided to place the comments of the node to be a trailing comment of `right`.

The end result is way better than Prettier. Prettier [isn't able to remove the empty lines inside comments](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAdK7NQPQCoAEAllAA4CuM+u2WWAZhBFvvnvgIb6QC23Cl1WhmHoWAOnYAlMgBs4+YKJZcIMiACck+dXAAmSgL5CsbYuQE0oDJhhhtOPPrCqXMMCdLkK3kNZu16ANzoBiAANCAQJDCE0ADOyKDs6uoQAO4ACskICSjsMmnsAJ4JEQBG6uxgANZwMADK7HwAMsRwyHT5cXDllTV19SRVxADmyDDqZD0g3dyE45PTcAAeJHDqhE4w+QAq61DJhHC5nTLdEXGjcgCKZBDwHV3TAFZxy-VXcLf37Uin5yAAI53eAZVIkXIgdhxAC0UDgej04RAE3YhBkowAwhBeOxkFCZDJkZcoCM5ABBGATQhlChwDLrVrwx5naYACxg3BkAHU2YR4HEhmA4PUcvzCAA3flFfFgOKlEASqYASSgun49TAG2i5LV9RgRTkLIBJFS3W5lRI+NNx3WEvaEWI3XUMDB7BG3DxfyeESG6mdsvlyNNxBg3MIuhgbOQAA4AAwRHTAwg6N0er3-abbMrhyPRpAAJgiZG6O3YZROPpAcG4ZT06t0zXYpLI7rgADENJ6qaN8ewKBAQAYDEA), while Biome can, as shown in the test snapshot.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added few test cases similar to the one reported (and the one reported)

<!-- What demonstrates that your implementation is correct? -->
