### PR TITLE
fix(migrate-eslint): load non-conventional shared config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - `biome migrate eslint` now correctly resolves scoped package named `eslint-config` with a path.
   Contributed by @Conaclos
 
+- `biome migrate eslint` now correctly handles shared ESLint configuration that don't follow the ESLint naming convention ([#4528](https://github.com/biomejs/biome/issues/4528)).
+
+  ESLint recommends that a package that exports a shared configuration be prefixed with `eslint-config-` or simply named `eslint-config`.
+  This is only a recommendation.
+  Packages that export shared configurations can have arbitrary names.
+  Biome is now able to load any package.
+
+  Contributed by @Conaclos
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_cli/src/execute/migrate/eslint.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint.rs
@@ -308,10 +308,17 @@ fn load_eslint_extends_config(
         } else {
             EslintPackage::Config.resolve_name(name)
         };
+        // Try to load `module_name` or else try to load diretcly `name`.
         let node::Resolution {
             content,
             resolved_path,
-        } = node::load_config(&module_name)?;
+        } = node::load_config(&module_name).or_else(|err| {
+            if module_name != name {
+                node::load_config(name)
+            } else {
+                Err(err)
+            }
+        })?;
         let deserialized = deserialize_from_json_str::<eslint_eslint::LegacyConfigData>(
             &content,
             JsonParserOptions::default(),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1983,7 +1983,7 @@ export interface Suspicious {
 	 */
 	useNumberToFixedDigitsArgument?: RuleFixConfiguration_for_Null;
 	/**
-	 * This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions
+	 * This rule checks that the result of a `typeof' expression is compared to a valid value.
 	 */
 	useValidTypeof?: RuleFixConfiguration_for_Null;
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -4247,7 +4247,7 @@
 					]
 				},
 				"useValidTypeof": {
-					"description": "This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions",
+					"description": "This rule checks that the result of a `typeof' expression is compared to a valid value.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleFixConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
Fix https://github.com/biomejs/biome/issues/4528

ESLint recommends that a package that exports a shared configuration be prefixed with `eslint-config-` or simply named `eslint-config`.
This is only a recommendation.
Packages that export shared configurations can have arbitrary names.
Biome is now able to load any package.
