### PR TITLE
fix(noUnknownPseudoClass): not error for pseudo class  after webkit scrollbar element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,22 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ### Bug fixes
 
 - Fix [#4121](https://github.com/biomejs/biome/issues/4326), don't ident a CSS selector when has leading comments. Contributed by @fireairforce
+
 - Fix [#4334](https://github.com/biomejs/biome/issues/4334), don't insert trailing comma on type import statement. Contributed by @fireairforce
+
 - Fix [#3229](https://github.com/biomejs/biome/issues/3229), where Biome wasn't idempotent when block comments were placed inside compound selectors. Contributed by @ematipico
+
 - Fix [#4026](https://github.com/biomejs/biome/issues/4026), don't move comments in `grid-template`. Contributed by @fireairforce
+
+- Fix [#4533](URL_ADDRESS.com/biomejs/biome/issues/4533), don't throw error when pseudeo class after a webkit scrollbar pseudeo element.
+
+  The follow code will not report:
+
+  ```css
+  ::-webkit-scrollbar-thumb:hover {}
+  ```
+
+  Contributed by @fireairforce
 
 ### JavaScript APIs
 

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
@@ -175,7 +175,7 @@ impl Rule for NoUnknownPseudoClass {
         let is_valid_class = match pseudo_type {
             PseudoClassType::PagePseudoClass => is_page_pseudo_class(lower_name),
             PseudoClassType::WebkitScrollbarPseudoClass => {
-                WEBKIT_SCROLLBAR_PSEUDO_CLASSES.contains(&lower_name)
+                WEBKIT_SCROLLBAR_PSEUDO_CLASSES.contains(&lower_name) || is_known_pseudo_class(lower_name)
             }
             PseudoClassType::Other => {
                 is_custom_selector(lower_name)

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
@@ -175,7 +175,8 @@ impl Rule for NoUnknownPseudoClass {
         let is_valid_class = match pseudo_type {
             PseudoClassType::PagePseudoClass => is_page_pseudo_class(lower_name),
             PseudoClassType::WebkitScrollbarPseudoClass => {
-                WEBKIT_SCROLLBAR_PSEUDO_CLASSES.contains(&lower_name) || is_known_pseudo_class(lower_name)
+                WEBKIT_SCROLLBAR_PSEUDO_CLASSES.contains(&lower_name)
+                    || is_known_pseudo_class(lower_name)
             }
             PseudoClassType::Other => {
                 is_custom_selector(lower_name)

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/valid.css
@@ -35,3 +35,4 @@ a:defined { }
 *:is(*) { }
 :popover-open {}
 :seeking, :stalled, :buffering, :volume-locked, :muted {}
+::-webkit-scrollbar-button:hover {}

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/valid.css.snap
@@ -41,4 +41,5 @@ a:defined { }
 *:is(*) { }
 :popover-open {}
 :seeking, :stalled, :buffering, :volume-locked, :muted {}
+::-webkit-scrollbar-button:hover {}
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #4533 

The case looks fine on `stylelint`(it has the lint rule that biome `noUnknownPseudoClass` rule from): https://stylelint.io/demo/#N4Igxg9gJgpiBcD4FoDuMBGBrAlgF2QGcwAnCAG3IwEMTk8ALAVwFsN4GIA3GEgAmAAdAHaC8kchBLw+JGFADcIvgF8Ry+CnTZ8RUhSq16zNvDwxCeAIxWB68RSky5i5SpAAaEADMc5GABy1CxwiDAAHsEADv4AdGCEhJ7gEMK+AOYIIELCfHyCIBHmwlCEBTIA2sp5+SCWAJ7+5DjCBJBpOOlEeNQltFAF1QC6Iu5e7RkAYlIs1HhZAFaEqcmwUUmIOXkFDU0teOW15HMWB57VO3iNMM2tyBOd3b1Q-YcFx+aWg8LuKkA


So i think biome need to pass the case:

```css
::-webkit-scrollbar-thumb:hover {
	color: red;
 }
```

Now it will get error like: https://biomejs.dev/playground/?lintRules=all&files.main.css=OgA6AC0AdwBlAGIAawBpAHQALQBzAGMAcgBvAGwAbABiAGEAcgAtAHQAaAB1AG0AYgA6AGgAbwB2AGUAcgAgAHsAfQAKADoAOgAtAHcAZQBiAGsAaQB0AC0AcwBjAHIAbwBsAGwAYgBhAHIALQB0AGgAdQBtAGIAOgB3AGkAbgBkAG8AdwAtAGkAbgBhAGMAdABpAHYAZQAgAHsAIAB9AAoACgA6ADoAZgBpAHIAcwB0AC0AbABpAG4AZQA6AGgAbwB2AGUAcgAgAHsAfQA%3D

I add a special judge for this case.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add test case

<!-- What demonstrates that your implementation is correct? -->
