### PR TITLE
fix(noUndeclaredVariables): bind read in ambient context to import type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,19 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- [noUndeclaredVariables](https://biomejs.dev/linter/rules/no-undeclared-variables/) is now able to bind read of value to a type-only import in ambient contexts ([#4526](https://github.com/biomejs/biome/issues/4526)).
+
+  In the following code, `A` is now correctly bound to the type-only import.
+  Previously, `A` was reported as an undeclared variable.
+
+  ```ts
+  import type { A } from "mod";
+
+  declare class B extends A {}
+  ```
+
+  Contributed by @Conaclos
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.d.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.d.ts
@@ -1,0 +1,3 @@
+import type { TransformStream as TransformWebStream } from "node:stream/web";
+
+export class TextLineStream extends TransformWebStream<string, string> {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.d.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.d.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validAmbientRead.d.ts
+snapshot_kind: text
+---
+# Input
+```ts
+import type { TransformStream as TransformWebStream } from "node:stream/web";
+
+export class TextLineStream extends TransformWebStream<string, string> {}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.ts
@@ -1,0 +1,3 @@
+import type { TransformStream as TransformWebStream } from "node:stream/web";
+
+export declare class TextLineStream extends TransformWebStream<string, string> {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/validAmbientRead.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validAmbientRead.ts
+snapshot_kind: text
+---
+# Input
+```ts
+import type { TransformStream as TransformWebStream } from "node:stream/web";
+
+export declare class TextLineStream extends TransformWebStream<string, string> {}
+
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/4526

The semantic model now tracks if the traversed node is in an ambient context not.
The scope registers if it is in ambient context to properly restore the information once we leave a scope.

When we are in an ambient context we emit `AmbientRead` instead of `Read`.
This allows us to bind ambient read to type-only imports.

## Test Plan

I added some tests.
