### PR TITLE
refactor: use `biome-ignore-all` for top level suppressions

### DIFF
--- a/.changeset/new_top_level_suppression_for_the_analyzer.md
+++ b/.changeset/new_top_level_suppression_for_the_analyzer.md
@@ -13,8 +13,8 @@ In the example, we suppress the rules `lint/style/useConst` and `lint/suspicious
 ```js
 // main.js
 /**
- * biome-ignore lint/style/useConst: i like let
- * biome-ignore lint/suspicious/noDebugger: needed now
+ * biome-ignore-all lint/style/useConst: i like let
+ * biome-ignore-all lint/suspicious/noDebugger: needed now
  */
 
 let path = "/path";
@@ -26,9 +26,37 @@ In this other example, we suppress `lint/suspicious/noEmptyBlock` for a whole CS
 
 ```css
 /**
-/* biome-ignore lint/suspicious/noEmptyBlock: it's fine to have empty blocks 
+/* biome-ignore-all lint/suspicious/noEmptyBlock: it's fine to have empty blocks 
 */
 
 a {}
 span {}
+```
+
+A new diagnostic is emitted if `biome-ignore-all` suppression isn't placed at the top of the file:
+
+
+```block
+file.js:3:1 suppressions/incorrect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Top level suppressions can only be used at the beginning of the file.
+  
+    2 │ let foo = 2;
+  > 3 │ /**
+      │ ^^^
+  > 4 │ * biome-ignore-all lint/style/useConst: reason
+  > 5 │ */
+      │ ^^
+    6 │ let bar = 33;
+  
+  i Rename this to biome-ignore
+  
+    2 │ let foo = 2;
+    3 │ /**
+  > 4 │ * biome-ignore-all lint/style/useConst: reason
+      │   ^^^^^^^^^^^^^^^^
+    5 │ */
+    6 │ let bar = 33;
+  
+
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "biome_diagnostics",
  "biome_parser",
  "biome_rowan",
+ "biome_suppression",
  "enumflags2",
  "rustc-hash 2.0.0",
  "schemars",

--- a/crates/biome_analyze/Cargo.toml
+++ b/crates/biome_analyze/Cargo.toml
@@ -19,6 +19,7 @@ biome_deserialize_macros = { workspace = true, optional = true }
 biome_diagnostics        = { workspace = true }
 biome_parser             = { workspace = true }
 biome_rowan              = { workspace = true }
+biome_suppression        = { workspace = true }
 enumflags2               = { workspace = true }
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }

--- a/crates/biome_analyze/src/diagnostics.rs
+++ b/crates/biome_analyze/src/diagnostics.rs
@@ -171,15 +171,15 @@ impl AnalyzerSuppressionDiagnostic {
         }
     }
 
-    pub(crate) fn note(mut self, message: impl Into<String>, range: impl Into<TextRange>) -> Self {
-        self.advice.messages.push((message.into(), range.into()));
+    pub(crate) fn note(mut self, message: MarkupBuf, range: impl Into<TextRange>) -> Self {
+        self.advice.messages.push((message, range.into()));
         self
     }
 }
 
 #[derive(Debug, Default, Clone)]
 struct SuppressionAdvice {
-    messages: Vec<(String, TextRange)>,
+    messages: Vec<(MarkupBuf, TextRange)>,
 }
 
 impl Advices for SuppressionAdvice {

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -213,7 +213,7 @@ where
 
                     for ignore_range in &suppression.ignore_ranges {
                         diagnostic = diagnostic.note(
-                            markup! {"Rename this to "<Emphasis>"biome-ignore"</Emphasis>}
+                            markup! {"Rename this to "<Emphasis>"biome-ignore"</Emphasis>" or move it to the top of the file"}
                                 .to_owned(),
                             *ignore_range,
                         );

--- a/crates/biome_analyze/src/matcher.rs
+++ b/crates/biome_analyze/src/matcher.rs
@@ -204,7 +204,7 @@ mod tests {
         ControlFlow, MetadataRegistry, Never, Phases, QueryMatcher, RuleKey, ServiceBag,
         SignalEntry, SuppressionAction, SyntaxVisitor,
     };
-    use crate::{AnalyzerOptions, SuppressionKind};
+    use crate::{AnalyzerOptions, AnalyzerSuppression};
     use biome_diagnostics::{category, DiagnosticExt};
     use biome_diagnostics::{Diagnostic, Severity};
     use biome_rowan::{
@@ -349,14 +349,14 @@ mod tests {
             ControlFlow::Continue(())
         };
 
-        fn parse_suppression_comment<'a>(
-            comment: &'a str,
-            _token: &'_ SyntaxToken<RawLanguage>,
-        ) -> Vec<Result<SuppressionKind<'a>, Infallible>> {
+        fn parse_suppression_comment(
+            comment: &str,
+            _piece_range: TextRange,
+        ) -> Vec<Result<AnalyzerSuppression, Infallible>> {
             comment
                 .trim_start_matches("//")
                 .split(' ')
-                .map(SuppressionKind::Rule)
+                .map(AnalyzerSuppression::rule)
                 .map(Ok)
                 .collect()
         }

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -903,7 +903,7 @@ pub trait Rule: RuleMeta + Sized {
                 <Self::Group as RuleGroup>::NAME,
                 Self::METADATA.name
             );
-            let suppression_text = format!("biome-ignore {rule_category}");
+            let suppression_text = format!("biome-ignore-all {rule_category}");
             let root = ctx.root();
 
             if let Some(first_token) = root.syntax().first_token() {

--- a/crates/biome_analyze/src/suppression_action.rs
+++ b/crates/biome_analyze/src/suppression_action.rs
@@ -91,7 +91,7 @@ pub trait SuppressionAction {
 
 /// Convenient type to store useful information
 pub struct ApplySuppression<L: Language> {
-    /// If the token is following by trailing comments
+    /// If the token is followed by trailing comments
     pub token_has_trailing_comments: bool,
     /// The token to attach the suppression
     pub token_to_apply_suppression: SyntaxToken<L>,

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
@@ -10,7 +10,9 @@ snapshot_kind: text
 let foo = 2;
 /**
 * biome-ignore-all lint/style/useConst: reason
+* biome-ignore-all lint/suspicious/noDebugger: reason
 */
+debugger
 let bar = 33;
 ```
 
@@ -25,18 +27,20 @@ file.js:3:1 suppressions/incorrect ━━━━━━━━━━━━━━━
   > 3 │ /**
       │ ^^^
   > 4 │ * biome-ignore-all lint/style/useConst: reason
-  > 5 │ */
+  > 5 │ * biome-ignore-all lint/suspicious/noDebugger: reason
+  > 6 │ */
       │ ^^
-    6 │ let bar = 33;
+    7 │ debugger
+    8 │ let bar = 33;
   
-  i Rename this to biome-ignore
+  i Rename this to biome-ignore or move it to the top of the file
   
     2 │ let foo = 2;
     3 │ /**
   > 4 │ * biome-ignore-all lint/style/useConst: reason
       │   ^^^^^^^^^^^^^^^^
-    5 │ */
-    6 │ let bar = 33;
+    5 │ * biome-ignore-all lint/suspicious/noDebugger: reason
+    6 │ */
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+snapshot_kind: text
+---
+## `file.js`
+
+```js
+
+let foo = 2;
+/**
+* biome-ignore-all lint/style/useConst: reason
+*/
+let bar = 33;
+```
+
+# Emitted Messages
+
+```block
+file.js:3:1 suppressions/incorrect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Top level suppressions can only be used at the beginning of the file.
+  
+    2 │ let foo = 2;
+  > 3 │ /**
+      │ ^^^
+  > 4 │ * biome-ignore-all lint/style/useConst: reason
+  > 5 │ */
+      │ ^^
+    6 │ let bar = 33;
+  
+  i Rename this to biome-ignore
+  
+    2 │ let foo = 2;
+    3 │ /**
+  > 4 │ * biome-ignore-all lint/style/useConst: reason
+      │   ^^^^^^^^^^^^^^^^
+    5 │ */
+    6 │ let bar = 33;
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 warning.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/unused_suppression_after_top_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/unused_suppression_after_top_level.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `file.js`
 
 ```js
 /**
-* biome-ignore lint/style/useConst: reason
+* biome-ignore-all lint/style/useConst: reason
 */
 
 
@@ -36,7 +37,7 @@ file.js:7:1 suppressions/unused ━━━━━━━━━━━━━━━━
   
   > 1 │ /**
       │ ^^^
-  > 2 │ * biome-ignore lint/style/useConst: reason
+  > 2 │ * biome-ignore-all lint/style/useConst: reason
   > 3 │ */
       │ ^^
     4 │ 

--- a/crates/biome_css_analyze/src/lib.rs
+++ b/crates/biome_css_analyze/src/lib.rs
@@ -9,11 +9,12 @@ mod utils;
 pub use crate::registry::visit_registry;
 use crate::suppression_action::CssSuppressionAction;
 use biome_analyze::{
-    AnalysisFilter, AnalyzerOptions, AnalyzerPlugin, AnalyzerSignal, ControlFlow, LanguageRoot,
-    MatchQueryParams, MetadataRegistry, RuleRegistry, SuppressionKind,
+    to_analyzer_suppressions, AnalysisFilter, AnalyzerOptions, AnalyzerPlugin, AnalyzerSignal,
+    AnalyzerSuppression, ControlFlow, LanguageRoot, MatchQueryParams, MetadataRegistry,
+    RuleRegistry,
 };
-use biome_css_syntax::{CssLanguage, CssSyntaxToken, TextSize};
-use biome_diagnostics::{category, Error};
+use biome_css_syntax::{CssLanguage, TextRange};
+use biome_diagnostics::Error;
 use biome_suppression::{parse_suppression_comment, SuppressionDiagnostic};
 use std::ops::Deref;
 use std::sync::LazyLock;
@@ -60,44 +61,27 @@ where
     F: FnMut(&dyn AnalyzerSignal<CssLanguage>) -> ControlFlow<B> + 'a,
     B: 'a,
 {
-    fn parse_linter_suppression_comment<'a>(
-        text: &'a str,
-        token: &'_ CssSyntaxToken,
-    ) -> Vec<Result<SuppressionKind<'a>, SuppressionDiagnostic>> {
+    fn parse_linter_suppression_comment(
+        text: &str,
+        piece_range: TextRange,
+    ) -> Vec<Result<AnalyzerSuppression, SuppressionDiagnostic>> {
         let mut result = Vec::new();
 
-        for comment in parse_suppression_comment(text) {
-            let categories = match comment {
-                Ok(comment) => comment.categories,
+        for suppression in parse_suppression_comment(text) {
+            let suppression = match suppression {
+                Ok(suppression) => suppression,
                 Err(err) => {
                     result.push(Err(err));
                     continue;
                 }
             };
 
-            for (key, value) in categories {
-                if key == category!("lint") {
-                    result.push(Ok(SuppressionKind::Everything));
-                } else {
-                    let category = key.name();
-                    if let Some(rule) = category.strip_prefix("lint/") {
-                        let is_top_level = {
-                            let mut trivia = token.leading_trivia().pieces().rev();
-                            match (trivia.next(), trivia.next()) {
-                                (Some(a), Some(b)) => a.is_newline() && b.is_newline(),
-                                _ => false,
-                            }
-                        };
-                        if is_top_level && token.text_range().start() == TextSize::from(0) {
-                            result.push(Ok(SuppressionKind::TopLevel(rule)));
-                        } else if let Some(instance) = value {
-                            result.push(Ok(SuppressionKind::RuleInstance(rule, instance)));
-                        } else {
-                            result.push(Ok(SuppressionKind::Rule(rule)));
-                        }
-                    }
-                }
-            }
+            let analyzer_suppressions: Vec<_> = to_analyzer_suppressions(suppression, piece_range)
+                .into_iter()
+                .map(Ok)
+                .collect();
+
+            result.extend(analyzer_suppressions)
         }
 
         result

--- a/crates/biome_css_analyze/tests/suppression/suspicious/noDuplicateFontNames/noDuplicateFontNames.css.snap
+++ b/crates/biome_css_analyze/tests/suppression/suspicious/noDuplicateFontNames/noDuplicateFontNames.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: noDuplicateFontNames.css
+snapshot_kind: text
 ---
 # Input
 ```css
@@ -35,7 +36,7 @@ noDuplicateFontNames.css:1:56 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
@@ -67,7 +68,7 @@ noDuplicateFontNames.css:2:44 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
@@ -101,7 +102,7 @@ noDuplicateFontNames.css:3:35 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
@@ -135,7 +136,7 @@ noDuplicateFontNames.css:4:27 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
@@ -167,7 +168,7 @@ noDuplicateFontNames.css:5:39 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }
@@ -197,7 +198,7 @@ noDuplicateFontNames.css:6:75 lint/suspicious/noDuplicateFontNames  FIXABLE  ━
   
   i Safe fix: Suppress rule lint/suspicious/noDuplicateFontNames for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDuplicateFontNames:·<explanation>·*/
       2 │ + 
     1 3 │   a { font-family: "Lucida Grande", 'Arial', sans-serif, sans-serif; }
     2 4 │   a { font-family: 'Arial', "Lucida Grande", Arial, sans-serif; }

--- a/crates/biome_css_analyze/tests/suppression/suspicious/noEmptyBlock/noEmptyBlock.css.snap
+++ b/crates/biome_css_analyze/tests/suppression/suspicious/noEmptyBlock/noEmptyBlock.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: noEmptyBlock.css
+snapshot_kind: text
 ---
 # Input
 ```css
@@ -87,7 +88,7 @@ noEmptyBlock.css:2:3 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -122,7 +123,7 @@ noEmptyBlock.css:3:3 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -160,7 +161,7 @@ noEmptyBlock.css:4:3 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -193,7 +194,7 @@ noEmptyBlock.css:8:4 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -225,7 +226,7 @@ noEmptyBlock.css:9:4 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -261,7 +262,7 @@ noEmptyBlock.css:10:4 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -293,7 +294,7 @@ noEmptyBlock.css:15:14 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -329,7 +330,7 @@ noEmptyBlock.css:16:14 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -361,7 +362,7 @@ noEmptyBlock.css:19:18 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -393,7 +394,7 @@ noEmptyBlock.css:22:30 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -426,7 +427,7 @@ noEmptyBlock.css:23:12 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -458,7 +459,7 @@ noEmptyBlock.css:26:20 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -495,7 +496,7 @@ noEmptyBlock.css:28:10 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -533,7 +534,7 @@ noEmptyBlock.css:38:13 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -565,7 +566,7 @@ noEmptyBlock.css:44:7 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━�
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -599,7 +600,7 @@ noEmptyBlock.css:45:14 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -631,7 +632,7 @@ noEmptyBlock.css:50:28 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }
@@ -668,7 +669,7 @@ noEmptyBlock.css:52:16 lint/suspicious/noEmptyBlock  FIXABLE  ━━━━━━
   i Safe fix: Suppress rule lint/suspicious/noEmptyBlock for the whole file.
   
      1    │ - /*·CssDeclarationOrRuleBlock·*/
-        1 │ + /**·biome-ignore·lint/suspicious/noEmptyBlock:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noEmptyBlock:·<explanation>·*/
         2 │ + 
      2  3 │   a {}
      3  4 │   a { }

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -382,7 +382,7 @@ define_categories! {
     "suppressions/unknownGroup",
     "suppressions/unknownRule",
     "suppressions/unused",
-    "suppressions/deprecatedSuppressionComment",
+    "suppressions/incorrect",
 
     // Used in tests and examples
     "args/fileNotFound",

--- a/crates/biome_graphql_analyze/tests/suppression/nursery/noDuplicatedFields/noDuplicatedFields.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/suppression/nursery/noDuplicatedFields/noDuplicatedFields.graphql.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_graphql_analyze/tests/spec_tests.rs
 expression: noDuplicatedFields.graphql
+snapshot_kind: text
 ---
 # Input
 ```graphql
@@ -58,7 +59,7 @@ noDuplicatedFields.graphql:1:36 lint/nursery/noDuplicatedFields  FIXABLE  ━━
   
   i Safe fix: Suppress rule lint/nursery/noDuplicatedFields for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/noDuplicatedFields:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/noDuplicatedFields:·<explanation>
         2 │ + 
      1  3 │   query test($v: String, $t: String, $v: String) {
      2  4 │     id
@@ -91,7 +92,7 @@ noDuplicatedFields.graphql:6:48 lint/nursery/noDuplicatedFields  FIXABLE  ━━
   
   i Safe fix: Suppress rule lint/nursery/noDuplicatedFields for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/noDuplicatedFields:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/noDuplicatedFields:·<explanation>
         2 │ + 
      1  3 │   query test($v: String, $t: String, $v: String) {
      2  4 │     id
@@ -125,7 +126,7 @@ noDuplicatedFields.graphql:16:5 lint/nursery/noDuplicatedFields  FIXABLE  ━━
   
   i Safe fix: Suppress rule lint/nursery/noDuplicatedFields for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/noDuplicatedFields:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/noDuplicatedFields:·<explanation>
         2 │ + 
      1  3 │   query test($v: String, $t: String, $v: String) {
      2  4 │     id

--- a/crates/biome_graphql_analyze/tests/suppression/nursery/useDeprecatedReason/useDeprecatedReason.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/suppression/nursery/useDeprecatedReason/useDeprecatedReason.graphql.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_graphql_analyze/tests/spec_tests.rs
 expression: useDeprecatedReason.graphql
+snapshot_kind: text
 ---
 # Input
 ```graphql
@@ -52,7 +53,7 @@ useDeprecatedReason.graphql:2:10 lint/nursery/useDeprecatedReason  FIXABLE  ━�
   
   i Safe fix: Suppress rule lint/nursery/useDeprecatedReason for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/useDeprecatedReason:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/useDeprecatedReason:·<explanation>
         2 │ + 
      1  3 │   query {
      2  4 │     member @deprecated {
@@ -85,7 +86,7 @@ useDeprecatedReason.graphql:8:10 lint/nursery/useDeprecatedReason  FIXABLE  ━�
   
   i Safe fix: Suppress rule lint/nursery/useDeprecatedReason for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/useDeprecatedReason:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/useDeprecatedReason:·<explanation>
         2 │ + 
      1  3 │   query {
      2  4 │     member @deprecated {
@@ -119,7 +120,7 @@ useDeprecatedReason.graphql:13:3 lint/nursery/useDeprecatedReason  FIXABLE  ━�
   
   i Safe fix: Suppress rule lint/nursery/useDeprecatedReason for the whole file.
   
-        1 │ + #·biome-ignore·lint/nursery/useDeprecatedReason:·<explanation>
+        1 │ + #·biome-ignore-all·lint/nursery/useDeprecatedReason:·<explanation>
         2 │ + 
      1  3 │   query {
      2  4 │     member @deprecated {

--- a/crates/biome_js_analyze/tests/suppression/a11y/useKeyWithClickEvents/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/a11y/useKeyWithClickEvents/invalid.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -36,7 +37,7 @@ invalid.jsx:2:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━�
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
   
-      1 │ + /**·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
       2 │ + 
     1 3 │   <>
     2 4 │       <div onClick={() => {}} />

--- a/crates/biome_js_analyze/tests/suppression/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
+++ b/crates/biome_js_analyze/tests/suppression/correctness/noUndeclaredVariables/noUndeclaredVariables.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noUndeclaredVariables.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
@@ -36,7 +37,7 @@ noUndeclaredVariables.ts:1:50 lint/correctness/noUndeclaredVariables  FIXABLE  �
   
   i Safe fix: Suppress rule lint/correctness/noUndeclaredVariables for the whole file.
   
-      1 │ + /**·biome-ignore·lint/correctness/noUndeclaredVariables:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/correctness/noUndeclaredVariables:·<explanation>·*/
       2 │ + 
     1 3 │   export type Invalid<S extends number> = `Hello ${T}`
     2 4 │   
@@ -69,7 +70,7 @@ noUndeclaredVariables.ts:5:7 lint/correctness/noUndeclaredVariables  FIXABLE  �
   
   i Safe fix: Suppress rule lint/correctness/noUndeclaredVariables for the whole file.
   
-      1 │ + /**·biome-ignore·lint/correctness/noUndeclaredVariables:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/correctness/noUndeclaredVariables:·<explanation>·*/
       2 │ + 
     1 3 │   export type Invalid<S extends number> = `Hello ${T}`
     2 4 │   

--- a/crates/biome_js_analyze/tests/suppression/correctness/noUnusedVariables/simple.js.snap
+++ b/crates/biome_js_analyze/tests/suppression/correctness/noUnusedVariables/simple.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: simple.js
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -25,7 +26,7 @@ simple.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━
   
   i Safe fix: Suppress rule lint/correctness/noUnusedVariables for the whole file.
   
-      1 │ + /**·biome-ignore·lint/correctness/noUnusedVariables:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/correctness/noUnusedVariables:·<explanation>·*/
       2 │ + 
     1 3 │   let c = !a || !b;
   

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noArrayIndexKey/noArrayIndexKey.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noArrayIndexKey/noArrayIndexKey.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noArrayIndexKey.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -154,7 +155,7 @@ noArrayIndexKey.jsx:4:18 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -199,7 +200,7 @@ noArrayIndexKey.jsx:7:18 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -244,7 +245,7 @@ noArrayIndexKey.jsx:10:31 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -288,7 +289,7 @@ noArrayIndexKey.jsx:14:18 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -333,7 +334,7 @@ noArrayIndexKey.jsx:17:18 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -378,7 +379,7 @@ noArrayIndexKey.jsx:20:31 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -423,7 +424,7 @@ noArrayIndexKey.jsx:23:62 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -467,7 +468,7 @@ noArrayIndexKey.jsx:28:35 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -511,7 +512,7 @@ noArrayIndexKey.jsx:32:42 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -555,7 +556,7 @@ noArrayIndexKey.jsx:36:29 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -599,7 +600,7 @@ noArrayIndexKey.jsx:40:36 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -643,7 +644,7 @@ noArrayIndexKey.jsx:44:41 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -687,7 +688,7 @@ noArrayIndexKey.jsx:50:37 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -730,7 +731,7 @@ noArrayIndexKey.jsx:54:63 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -774,7 +775,7 @@ noArrayIndexKey.jsx:57:25 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -818,7 +819,7 @@ noArrayIndexKey.jsx:61:25 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -861,7 +862,7 @@ noArrayIndexKey.jsx:65:54 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -904,7 +905,7 @@ noArrayIndexKey.jsx:69:64 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -947,7 +948,7 @@ noArrayIndexKey.jsx:72:67 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -990,7 +991,7 @@ noArrayIndexKey.jsx:74:67 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1033,7 +1034,7 @@ noArrayIndexKey.jsx:77:50 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1076,7 +1077,7 @@ noArrayIndexKey.jsx:81:58 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1121,7 +1122,7 @@ noArrayIndexKey.jsx:83:55 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1166,7 +1167,7 @@ noArrayIndexKey.jsx:90:50 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1211,7 +1212,7 @@ noArrayIndexKey.jsx:98:50 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   
@@ -1256,7 +1257,7 @@ noArrayIndexKey.jsx:107:62 lint/suspicious/noArrayIndexKey  FIXABLE  ━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noArrayIndexKey for the whole file.
   
-          1 │ + /**·biome-ignore·lint/suspicious/noArrayIndexKey:·<explanation>·*/
+          1 │ + /**·biome-ignore-all·lint/suspicious/noArrayIndexKey:·<explanation>·*/
           2 │ + 
       1   3 │   import { Children, cloneElement } from "react";
       2   4 │   

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noAssignInExpressions/noAssignInExpressions.ts.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noAssignInExpressions/noAssignInExpressions.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noAssignInExpressions.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
@@ -41,7 +42,7 @@ noAssignInExpressions.ts:3:10 lint/suspicious/noAssignInExpressions  FIXABLE  �
   
   i Safe fix: Suppress rule lint/suspicious/noAssignInExpressions for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noAssignInExpressions:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noAssignInExpressions:·<explanation>·*/
       2 │ + 
     1 3 │   export function foo() {
     2 4 │   	let x: number;

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.js.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noDoubleEquals.js
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -63,7 +64,7 @@ noDoubleEquals.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-        1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
         2 │ + 
      1  3 │   const foo = `
      2  4 │   text
@@ -102,7 +103,7 @@ noDoubleEquals.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-        1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
         2 │ + 
      1  3 │   const foo = `
      2  4 │   text
@@ -143,7 +144,7 @@ noDoubleEquals.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-        1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
         2 │ + 
      1  3 │   const foo = `
      2  4 │   text
@@ -184,7 +185,7 @@ noDoubleEquals.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-        1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
         2 │ + 
      1  3 │   const foo = `
      2  4 │   text
@@ -225,7 +226,7 @@ noDoubleEquals.js:19:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-        1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+        1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
         2 │ + 
      1  3 │   const foo = `
      2  4 │   text

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noDoubleEquals.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -49,7 +50,7 @@ noDoubleEquals.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noDoubleEquals:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noDoubleEquals:·<explanation>·*/
       2 │ + 
     1 3 │   let a = <button
     2 4 │       className="SomeManyClasses"

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noExplicitAny/noExplicitAny.ts.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noExplicitAny/noExplicitAny.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noExplicitAny.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
@@ -31,7 +32,7 @@ noExplicitAny.ts:1:27 lint/suspicious/noExplicitAny  FIXABLE  ━━━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noExplicitAny for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noExplicitAny:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noExplicitAny:·<explanation>·*/
       2 │ + 
     1 3 │   export function test(arg: any) {
     2 4 │     const a: any = arg;
@@ -63,7 +64,7 @@ noExplicitAny.ts:2:12 lint/suspicious/noExplicitAny  FIXABLE  ━━━━━━
   
   i Safe fix: Suppress rule lint/suspicious/noExplicitAny for the whole file.
   
-      1 │ + /**·biome-ignore·lint/suspicious/noExplicitAny:·<explanation>·*/
+      1 │ + /**·biome-ignore-all·lint/suspicious/noExplicitAny:·<explanation>·*/
       2 │ + 
     1 3 │   export function test(arg: any) {
     2 4 │     const a: any = arg;

--- a/crates/biome_json_analyze/src/lib.rs
+++ b/crates/biome_json_analyze/src/lib.rs
@@ -9,11 +9,11 @@ pub mod utils;
 pub use crate::registry::visit_registry;
 use crate::suppression_action::JsonSuppressionAction;
 use biome_analyze::{
-    AnalysisFilter, AnalyzerOptions, AnalyzerSignal, ControlFlow, LanguageRoot, MatchQueryParams,
-    MetadataRegistry, RuleAction, RuleRegistry, SuppressionKind,
+    to_analyzer_suppressions, AnalysisFilter, AnalyzerOptions, AnalyzerSignal, AnalyzerSuppression,
+    ControlFlow, LanguageRoot, MatchQueryParams, MetadataRegistry, RuleAction, RuleRegistry,
 };
-use biome_diagnostics::{category, Error};
-use biome_json_syntax::{JsonFileSource, JsonLanguage, JsonSyntaxToken, TextSize};
+use biome_diagnostics::Error;
+use biome_json_syntax::{JsonFileSource, JsonLanguage, TextRange};
 use biome_suppression::{parse_suppression_comment, SuppressionDiagnostic};
 use std::ops::Deref;
 use std::sync::LazyLock;
@@ -62,44 +62,27 @@ where
     F: FnMut(&dyn AnalyzerSignal<JsonLanguage>) -> ControlFlow<B> + 'a,
     B: 'a,
 {
-    fn parse_linter_suppression_comment<'a>(
-        text: &'a str,
-        token: &'_ JsonSyntaxToken,
-    ) -> Vec<Result<SuppressionKind<'a>, SuppressionDiagnostic>> {
+    fn parse_linter_suppression_comment(
+        text: &str,
+        piece_range: TextRange,
+    ) -> Vec<Result<AnalyzerSuppression, SuppressionDiagnostic>> {
         let mut result = Vec::new();
 
-        for comment in parse_suppression_comment(text) {
-            let categories = match comment {
-                Ok(comment) => comment.categories,
+        for suppression in parse_suppression_comment(text) {
+            let suppression = match suppression {
+                Ok(suppression) => suppression,
                 Err(err) => {
                     result.push(Err(err));
                     continue;
                 }
             };
 
-            for (key, value) in categories {
-                if key == category!("lint") {
-                    result.push(Ok(SuppressionKind::Everything));
-                } else {
-                    let category = key.name();
-                    if let Some(rule) = category.strip_prefix("lint/") {
-                        let is_top_level = {
-                            let mut trivia = token.leading_trivia().pieces().rev();
-                            match (trivia.next(), trivia.next()) {
-                                (Some(a), Some(b)) => a.is_newline() && b.is_newline(),
-                                _ => false,
-                            }
-                        };
-                        if is_top_level && token.text_range().start() == TextSize::from(0) {
-                            result.push(Ok(SuppressionKind::TopLevel(rule)));
-                        } else if let Some(instance) = value {
-                            result.push(Ok(SuppressionKind::RuleInstance(rule, instance)));
-                        } else {
-                            result.push(Ok(SuppressionKind::Rule(rule)));
-                        }
-                    }
-                }
-            }
+            let analyzer_suppressions: Vec<_> = to_analyzer_suppressions(suppression, piece_range)
+                .into_iter()
+                .map(Ok)
+                .collect();
+
+            result.extend(analyzer_suppressions)
         }
 
         result

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3279,7 +3279,7 @@ export type Category =
 	| "suppressions/unknownGroup"
 	| "suppressions/unknownRule"
 	| "suppressions/unused"
-	| "suppressions/deprecatedSuppressionComment"
+	| "suppressions/incorrect"
 	| "args/fileNotFound"
 	| "flags/invalid"
 	| "semanticTests";


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #4305 

As requested by @arendjr , this PR uses the `biome-ignore-all` for a top-level suppression.

I also took the liberty to provide a very good diagnostic in case the `biome-ignore-all`, and because of that I had to add more information returned by the function that parses the suppression comments.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the snapshots, the tests and the changeset

<!-- What demonstrates that your implementation is correct? -->
