### PR TITLE
fix: allow trailing commas on `biome.jsonc`

### DIFF
--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3,6 +3,7 @@
 	"title": "Configuration",
 	"description": "The configuration that is contained inside the file `biome.json`",
 	"type": "object",
+	"allowTrailingCommas": true,
 	"properties": {
 		"$schema": {
 			"description": "A field for the [JSON schema](https://json-schema.org/) specification",


### PR DESCRIPTION
## Summary

vscode reports trailing commas as error in `biome.jsonc`

## Test Plan

try to use this file on vscode:
```jsonc
// biome.jsonc
{
  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
  "json": {
    "formatter": {
      "trailingCommas": "all",
    },
  },
}
```
adding `"allowTrailingCommas": true` to `configuration_schema.json` fix it