### PR TITLE
fix(biome_js_analyze): use consistent code action markup for noAria*/useAria*

### DIFF
--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -142,7 +142,7 @@ impl Rule for NoAriaHiddenOnFocusable {
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-            markup! { "Remove the aria-hidden attribute from the element." }.to_owned(),
+            markup! { "Remove the "<Emphasis>"aria-hidden"</Emphasis>" attribute from the element." }.to_owned(),
             mutation,
         ))
     }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -126,7 +126,7 @@ impl Rule for UseAriaActivedescendantWithTabindex {
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-            markup! { "Add the tabIndex attribute." }.to_owned(),
+            markup! { "Add the "<Emphasis>"tabIndex"</Emphasis>" attribute." }.to_owned(),
             mutation,
         ))
     }


### PR DESCRIPTION
## Summary

Align the code action message formatting of `useAriaActiveDescendantWithTabIndex` and `noAriaHiddenOnFocusable` with the other code actions by adding `<Emphasis></Emphasis>` tags.

## Test Plan

No modifications to unit tests necessary.