### PR TITLE
fix(analyze/js): fix bindings in bogus imports not being detected as imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noMisleadingCharacterClass](https://biomejs.dev/linter/rules/no-misleading-character-class/) no longer panics on malformed escape sequences that end with a multi-byte character ([#4587](https://github.com/biomejs/biome/issues/4587)). Contributed by @Conaclos
 
+- Fixed a panic related to bogus import statements in `useExhaustiveDependencies` ([#4568](https://github.com/biomejs/biome/issues/4568)) Contributed by @dyc3
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -597,18 +597,14 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::JsArrayBindingPatternRestElement(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternProperty(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternRest(_)
-        | AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(_) => {
-            unreachable!("The declaration should be resolved to its prent declaration")
-        }
+        | AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(_) => true,
 
         // This should be unreachable because of the test if the capture is imported
         AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)
         | AnyJsBindingDeclaration::JsNamedImportSpecifier(_)
         | AnyJsBindingDeclaration::JsBogusNamedImportSpecifier(_)
         | AnyJsBindingDeclaration::JsDefaultImportSpecifier(_)
-        | AnyJsBindingDeclaration::JsNamespaceImportSpecifier(_) => {
-            unreachable!()
-        }
+        | AnyJsBindingDeclaration::JsNamespaceImportSpecifier(_) => false,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4568.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4568.js
@@ -1,0 +1,6 @@
+import type {Point} fom '.geomet';
+import {useEffect, seRef} 'react';
+
+xpor function ueCanvasn(
+) {
+  useEffect( => {on late Point},[c

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4568.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4568.js.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue4568.js
+---
+# Input
+```jsx
+import type {Point} fom '.geomet';
+import {useEffect, seRef} 'react';
+
+xpor function ueCanvasn(
+) {
+  useEffect( => {on late Point},[c
+
+```
+
+# Diagnostics
+```
+issue4568.js:6:3 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook specifies more dependencies than necessary: c
+  
+    4 │ xpor function ueCanvasn(
+    5 │ ) {
+  > 6 │   useEffect( => {on late Point},[c
+      │   ^^^^^^^^^
+    7 │ 
+  
+  i This dependency can be removed from the list.
+  
+    4 │ xpor function ueCanvasn(
+    5 │ ) {
+  > 6 │   useEffect( => {on late Point},[c
+      │                                  ^
+    7 │ 
+  
+
+```

--- a/crates/biome_js_semantic/src/semantic_model/import.rs
+++ b/crates/biome_js_semantic/src/semantic_model/import.rs
@@ -6,8 +6,14 @@ use biome_js_syntax::{
 use biome_rowan::AstNode;
 
 pub(crate) fn is_imported(node: &JsSyntaxNode) -> bool {
-    node.ancestors()
-        .any(|x| matches!(x.kind(), JsSyntaxKind::JS_IMPORT))
+    node.ancestors().any(|x| {
+        matches!(
+            x.kind(),
+            JsSyntaxKind::JS_IMPORT
+                | JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIERS
+                | JsSyntaxKind::JS_DEFAULT_IMPORT_SPECIFIER
+        )
+    })
 }
 
 /// Marker trait that groups all "AstNode" that can be imported or


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This fix attempts to fix #4568 such that the same issue won't pop up in other lint rules.

I suppose a better fix could be to not evaluate linter rules if the file has parsing errors. Would it be better to add a `JS_BOGUS_IMPORT` instead?

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #4568

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Tested it manually against the sample in the issue.
