### PR TITLE
fix(js_semantic): scope for TsDeclarationModule

### DIFF
--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -818,6 +818,7 @@ impl SemanticEventExtractor {
             }
             JS_MODULE
             | JS_SCRIPT
+            | TS_DECLARATION_MODULE
             | JS_FUNCTION_DECLARATION
             | JS_FUNCTION_EXPORT_DEFAULT_DECLARATION
             | JS_FUNCTION_EXPRESSION

--- a/crates/biome_js_semantic/src/semantic_model/builder.rs
+++ b/crates/biome_js_semantic/src/semantic_model/builder.rs
@@ -66,6 +66,7 @@ impl SemanticModelBuilder {
             // Accessible from scopes, closures
             JS_MODULE
             | JS_SCRIPT
+            | TS_DECLARATION_MODULE
             | JS_FUNCTION_DECLARATION
             | JS_FUNCTION_EXPRESSION
             | JS_ARROW_FUNCTION_EXPRESSION


### PR DESCRIPTION
## Summary

While I was testing https://github.com/biomejs/biome/pull/4579, I detected a bug introduced by https://github.com/biomejs/biome/pull/4546

As usual, we often forget to update the related methods when we push a new scope.

## Test Plan

I manually tested the change.
Unfortunately, our test infra doesn't handle `.d.ts` files