### PR TITLE
feat(noRestrictedImports): add import_names and allow_import_names settings

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -357,8 +357,11 @@ impl ImportRestrictionStatus {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct CustomRestrictedImportOptions {
+    /// The message to display when this module is imported.
     message: String,
+    /// Names of the exported members that should not be used.
     import_names: Box<[Box<str>]>,
+    /// Names of the exported members that allowed to be not be used.
     allow_import_names: Box<[Box<str>]>,
 }
 
@@ -419,7 +422,9 @@ impl CustomRestrictedImportOptions {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum CustomRestrictedImport {
+    /// The message to display when this module is imported.
     Plain(String),
+    /// Additional options to configure the message and allowed/disallowed import names.
     WithOptions(CustomRestrictedImportOptions),
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -225,7 +225,7 @@ declare_lint_rule! {
     /// - **Named import:** `"someIdentifier"` (`import { someIdentifier } from 'named-import'`)
     /// - **Default import:** `"default"` (`import defaultExport from 'default-import'`)
     /// - **Namespace import:** `"*"` (`import * as alias1 from 'namespace-import'`)
-    /// - **Sideeffect/Bare import:** `""` (`import "sideeffect-import"`)
+    /// - **Side effect/Bare import:** `""` (`import "sideeffect-import"`)
     ///
     /// **Only one of `importNames` and `allowImportNames` must be specified.**
     ///
@@ -310,7 +310,7 @@ declare_lint_rule! {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct RestrictedImportsOptions {
-    /// A list of names that should trigger the rule
+    /// A list of import paths that should trigger the rule
     #[serde(skip_serializing_if = "FxHashMap::is_empty")]
     paths: FxHashMap<Box<str>, CustomRestrictedImport>,
 }
@@ -631,8 +631,8 @@ impl<'a> RestrictedImportVisitor<'a> {
         let clause = module_source_node.syntax().parent()?;
         match clause.kind() {
             JsSyntaxKind::JS_IMPORT_BARE_CLAUSE => {
-                let sideeffect_import: JsImportBareClause = clause.cast()?;
-                self.visit_sideeffect_import(sideeffect_import)
+                let side_effect_import: JsImportBareClause = clause.cast()?;
+                self.visit_side_effect_import(side_effect_import)
             }
             JsSyntaxKind::JS_IMPORT_COMBINED_CLAUSE => {
                 let import_combined_clause: JsImportCombinedClause = clause.cast()?;
@@ -749,8 +749,8 @@ impl<'a> RestrictedImportVisitor<'a> {
     }
 
     /// Checks whether this bare import of the form `import from 'source'` is allowed.
-    fn visit_sideeffect_import(&mut self, sideeffect_import: JsImportBareClause) -> Option<()> {
-        let source_token = sideeffect_import
+    fn visit_side_effect_import(&mut self, bare_import: JsImportBareClause) -> Option<()> {
+        let source_token = bare_import
             .source()
             .ok()?
             .as_js_module_source()?
@@ -972,7 +972,7 @@ impl Rule for NoRestrictedImports {
             AnyJsImportLike::JsImportCallExpression(import_call) => {
                 // TODO: We have to parse the context of the import() call to determine
                 // which exports are being used/whether this should be considered a
-                // namespace import, a sideeffect import (the two of which may
+                // namespace import, a side-effect import (the two of which may
                 // be difficult to distinguish) or a collection of named imports.
                 if !restricted_import.has_import_name_patterns() {
                     // All imports disallowed, add diagnostic to the import source

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -791,7 +791,7 @@ impl<'a> RestrictedImportVisitor<'a> {
     /// Checks whether this import of the form `const local_name = import(...)` is allowed.
     fn visit_namespace_binding(&mut self, namespace_import: &JsIdentifierBinding) -> Option<()> {
         return self
-            .visit_special_import_node(&namespace_import.syntax(), Self::NAMESPACE_IMPORT_ALIAS);
+            .visit_special_import_node(namespace_import.syntax(), Self::NAMESPACE_IMPORT_ALIAS);
     }
 
     /// Checks whether this import of the form `{ imported_name }` is allowed.

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -693,10 +693,8 @@ impl<'a> RestrictedImportVisitor<'a> {
 
     fn visit_named_imports(&mut self, named_imports: &JsNamedImportSpecifiers) -> Option<()> {
         let import_specifiers = named_imports.specifiers();
-        for import_specifier_maybe in import_specifiers.iter() {
-            if let Ok(import_specifier) = import_specifier_maybe {
-                self.visit_named_or_shorthand_import(&import_specifier);
-            }
+        for import_specifier in import_specifiers.iter().flatten() {
+            self.visit_named_or_shorthand_import(&import_specifier);
         }
         Some(())
     }
@@ -705,20 +703,16 @@ impl<'a> RestrictedImportVisitor<'a> {
         &mut self,
         named_reexports: &JsExportNamedFromSpecifierList,
     ) -> Option<()> {
-        for export_specifier_maybe in named_reexports.iter() {
-            if let Ok(export_specifier) = export_specifier_maybe {
-                self.visit_named_or_shorthand_reexport(&export_specifier);
-            }
+        for export_specifier in named_reexports.iter().flatten() {
+            self.visit_named_or_shorthand_reexport(&export_specifier);
         }
         Some(())
     }
 
     fn visit_named_bindings(&mut self, named_imports: &JsObjectBindingPattern) -> Option<()> {
         let import_bindings = named_imports.properties();
-        for import_binding_maybe in import_bindings.iter() {
-            if let Ok(import_binding) = import_binding_maybe {
-                self.visit_named_or_shorthand_binding(&import_binding);
-            }
+        for import_binding in import_bindings.iter().flatten() {
+            self.visit_named_or_shorthand_binding(&import_binding);
         }
         Some(())
     }
@@ -867,7 +861,7 @@ impl<'a> RestrictedImportVisitor<'a> {
         //       If the imported name uses e.g. Unicode escape sequences, this may cause
         //       problems because restricted_import.(allow_)import_names contains decoded
         //       strings, while inner_string_text(name_token) returns encoded strings.
-        self.visit_special_import_token(&name_token, inner_string_text(&name_token).text())
+        self.visit_special_import_token(name_token, inner_string_text(name_token).text())
     }
 
     /// Checks whether the import specified by `name_or_alias` is allowed.

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -361,8 +361,8 @@ impl ImportRestrictionStatus {
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct CustomRestrictedImportOptions {
     /// The message to display when this module is imported.
-    #[serde(skip_serializing_if = "String::is_empty")]
-    message: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    message: Box<str>,
 
     /// Names of the exported members that should not be used.
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
@@ -408,7 +408,7 @@ impl CustomRestrictedImportOptions {
         reason: ImportRestrictionCause,
     ) -> String {
         if !self.message.is_empty() {
-            self.message.clone()
+            self.message.to_string()
         } else {
             match reason {
                 ImportRestrictionCause::ImportSource => {
@@ -430,8 +430,8 @@ impl CustomRestrictedImportOptions {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum CustomRestrictedImport {
-    /// The message to display when this module is imported.pattern
-    Plain(String),
+    /// The message to display when this module is imported.
+    Plain(Box<str>),
     /// Additional options to configure the message and allowed/disallowed import names.
     WithOptions(CustomRestrictedImportOptions),
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -190,7 +190,11 @@ impl CustomRestrictedImportOptions {
                     format!("Do not import '{import_source}'.")
                 }
                 ImportRestrictionCause::ImportNames | ImportRestrictionCause::AllowImportNames => {
-                    format!("Do not import '{imported_name}' from '{import_source}'.")
+                    if imported_name == RestrictedImportVisitor::BARE_IMPORT_ALIAS {
+                        format!("Do not import '{import_source}' through a side-effect import.")
+                    } else {
+                        format!("Do not import '{imported_name}' from '{import_source}'.")
+                    }
                 }
             }
         }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -193,7 +193,10 @@ declare_lint_rule! {
     /// ```
     ///
     /// ```js,expect_diagnostic,use_options
-    /// import * from 'services-deprecated';
+    /// import * as namespaceAlias from 'services-deprecated';
+    /// ```
+    ///
+    /// ```js,expect_diagnostic,use_options
     /// import { export1 } from 'constants';
     /// ```
     ///

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -313,7 +313,7 @@ declare_lint_rule! {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct RestrictedImportsOptions {
-    /// A list of import paths that should trigger the rule
+    /// A list of import paths that should trigger the rule.
     #[serde(skip_serializing_if = "FxHashMap::is_empty")]
     paths: FxHashMap<Box<str>, CustomRestrictedImport>,
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -361,10 +361,15 @@ impl ImportRestrictionStatus {
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct CustomRestrictedImportOptions {
     /// The message to display when this module is imported.
+    #[serde(skip_serializing_if = "String::is_empty")]
     message: String,
+
     /// Names of the exported members that should not be used.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
     import_names: Box<[Box<str>]>,
+
     /// Names of the exported members that allowed to be not be used.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
     allow_import_names: Box<[Box<str>]>,
 }
 
@@ -425,7 +430,7 @@ impl CustomRestrictedImportOptions {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum CustomRestrictedImport {
-    /// The message to display when this module is imported.
+    /// The message to display when this module is imported.pattern
     Plain(String),
     /// Additional options to configure the message and allowed/disallowed import names.
     WithOptions(CustomRestrictedImportOptions),

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -16,7 +16,7 @@ use biome_js_syntax::{
     JsObjectBindingPatternShorthandProperty, JsShorthandNamedImportSpecifier,
     JsStaticMemberExpression, JsSyntaxKind, JsVariableDeclarator,
 };
-use biome_rowan::{AstNode, SyntaxNode, SyntaxNodeCast, SyntaxToken, TextRange};
+use biome_rowan::{AstNode, AstSeparatedList, SyntaxNode, SyntaxNodeCast, SyntaxToken, TextRange};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -556,7 +556,7 @@ impl<'a> RestrictedImportVisitor<'a> {
                     .arguments()
                     .ok()?
                     .args()
-                    .into_iter()
+                    .iter()
                     .next()?
                     .ok()?
                     .as_any_js_expression()?
@@ -575,7 +575,7 @@ impl<'a> RestrictedImportVisitor<'a> {
                             AnyJsArrowFunctionParameters::JsParameters(parameters) => Some(
                                 parameters
                                     .items()
-                                    .into_iter()
+                                    .iter()
                                     .next()?
                                     .ok()?
                                     .as_any_js_formal_parameter()?
@@ -591,7 +591,7 @@ impl<'a> RestrictedImportVisitor<'a> {
                             .parameters()
                             .ok()?
                             .items()
-                            .into_iter()
+                            .iter()
                             .next()?
                             .ok()?
                             .as_any_js_formal_parameter()?
@@ -688,7 +688,7 @@ impl<'a> RestrictedImportVisitor<'a> {
 
     fn visit_named_imports(&mut self, named_imports: JsNamedImportSpecifiers) -> Option<()> {
         let import_specifiers = named_imports.specifiers();
-        for import_specifier_maybe in import_specifiers.into_iter() {
+        for import_specifier_maybe in import_specifiers.iter() {
             if let Some(import_specifier) = import_specifier_maybe.ok() {
                 self.visit_named_or_shorthand_import(import_specifier);
             }
@@ -700,7 +700,7 @@ impl<'a> RestrictedImportVisitor<'a> {
         &mut self,
         named_reexports: JsExportNamedFromSpecifierList,
     ) -> Option<()> {
-        for export_specifier_maybe in named_reexports.into_iter() {
+        for export_specifier_maybe in named_reexports.iter() {
             if let Some(export_specifier) = export_specifier_maybe.ok() {
                 self.visit_named_or_shorthand_reexport(export_specifier);
             }
@@ -710,7 +710,7 @@ impl<'a> RestrictedImportVisitor<'a> {
 
     fn visit_named_bindings(&mut self, named_imports: JsObjectBindingPattern) -> Option<()> {
         let import_bindings = named_imports.properties();
-        for import_binding_maybe in import_bindings.into_iter() {
+        for import_binding_maybe in import_bindings.iter() {
             if let Some(import_binding) = import_binding_maybe.ok() {
                 self.visit_named_or_shorthand_binding(import_binding);
             }

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -68,7 +68,7 @@ declare_lint_rule! {
     ///
     /// All of the following import syntaxes are supported:
     ///
-    /// ### Static `import` declaration
+    /// ### Static `import` (and re-`export`) declarations
     ///
     /// Normal static [ESM `import` declarations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) are supported:
     ///
@@ -82,6 +82,9 @@ declare_lint_rule! {
     /// import defaultExport from "default-import";
     /// import defaultExport, * as alias5 from "default+namespace-import";
     /// import defaultExport, { export1 /* … */ } from "default+named-import";
+    ///
+    /// export * from "namespace-import";
+    /// export { export1, export2 as alias2, "string-name" as alias3, default as defaultExport /* … */ } from "named-import";
     /// ```
     ///
     /// The TypeScript-specific [type-only imports](https://www.typescriptlang.org/docs/handbook/modules/reference.html#type-only-imports-and-exports) are also supported:

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -622,9 +622,9 @@ impl<'a> RestrictedImportVisitor<'a> {
             let variable_declarator = current.cast::<JsVariableDeclarator>()?;
 
             // #1: const **{ ... }** = (await (import("")))
-            return Some(variable_declarator.id().ok()?);
+            variable_declarator.id().ok()
         } else {
-            return None;
+            None
         }
     }
 
@@ -694,7 +694,7 @@ impl<'a> RestrictedImportVisitor<'a> {
     fn visit_named_imports(&mut self, named_imports: &JsNamedImportSpecifiers) -> Option<()> {
         let import_specifiers = named_imports.specifiers();
         for import_specifier_maybe in import_specifiers.iter() {
-            if let Some(import_specifier) = import_specifier_maybe.ok() {
+            if let Ok(import_specifier) = import_specifier_maybe {
                 self.visit_named_or_shorthand_import(&import_specifier);
             }
         }
@@ -706,7 +706,7 @@ impl<'a> RestrictedImportVisitor<'a> {
         named_reexports: &JsExportNamedFromSpecifierList,
     ) -> Option<()> {
         for export_specifier_maybe in named_reexports.iter() {
-            if let Some(export_specifier) = export_specifier_maybe.ok() {
+            if let Ok(export_specifier) = export_specifier_maybe {
                 self.visit_named_or_shorthand_reexport(&export_specifier);
             }
         }
@@ -716,7 +716,7 @@ impl<'a> RestrictedImportVisitor<'a> {
     fn visit_named_bindings(&mut self, named_imports: &JsObjectBindingPattern) -> Option<()> {
         let import_bindings = named_imports.properties();
         for import_binding_maybe in import_bindings.iter() {
-            if let Some(import_binding) = import_binding_maybe.ok() {
+            if let Ok(import_binding) = import_binding_maybe {
                 self.visit_named_or_shorthand_binding(&import_binding);
             }
         }
@@ -891,7 +891,7 @@ impl<'a> RestrictedImportVisitor<'a> {
             import_source: self.import_source.to_string(),
             allowed_import_names: self.restricted_import.allow_import_names.clone(),
         });
-        return Some(());
+        Some(())
     }
 
     /// Checks whether the import specified by `name_or_alias` is allowed.
@@ -915,7 +915,7 @@ impl<'a> RestrictedImportVisitor<'a> {
             import_source: self.import_source.to_string(),
             allowed_import_names: self.restricted_import.allow_import_names.clone(),
         });
-        return Some(());
+        Some(())
     }
 }
 
@@ -1038,7 +1038,7 @@ impl Rule for NoRestrictedImports {
             let mut sorted = state.allowed_import_names.to_vec();
             sorted.sort();
             let allowed_import_names = sorted.into_iter().map(|name| {
-                if &**&name == RestrictedImportVisitor::BARE_IMPORT_ALIAS {
+                if &*name == RestrictedImportVisitor::BARE_IMPORT_ALIAS {
                     "Side-effect only import".into()
                 } else {
                     name

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -143,6 +143,8 @@ declare_lint_rule! {
     ///
     /// ## Options
     ///
+    /// Use the options to specify the import paths and/or specific import names within them that you want to restrict in your source code.
+    ///
     /// ```json,options
     /// {
     ///     "options": {
@@ -164,35 +166,39 @@ declare_lint_rule! {
     ///
     /// ### `paths`
     ///
-    /// Specifies the import paths that are either wholly or partially restricted.
+    /// An object that lists the import paths that are either wholly or partially restricted.
     ///
-    /// ### `paths.<import>`
+    /// The keys of the object are the import paths to restrict, and the values can be:
+    /// - A string with a custom message to show in the diagnostic when any
+    /// - An object with additional options, as explained [below](#pathsimportimportnames).
     ///
-    /// The message be shown when this import is used and/or additional options that configure which import names are restricted.
-    ///
-    /// Can be either a `"message string"` or an object with one or more of the following properties:
-    ///
-    /// ### `paths.<import>.message`
-    ///
-    /// Specifies the message to be shown when the restricted import is used.
+    /// In the example below, we restrict the two paths `services-deprecated` and `constants`, with two particular messages.
+    /// Importing `services-deprecated` will emit the message `Use services instead.`.
+    /// Importing `constants` will emit the message `This file will be deleted soon.`:
     ///
     /// ```json,options
     /// {
     ///     "options": {
     ///         "paths": {
-    ///             "import-foo": {
-    ///                 "message": "Please use import-bar instead."
-    ///             }
+    ///             "services-deprecated": {
+    ///                 "message": "Use services instead."
+    ///             },
+    ///	            "constants": "This file will be deleted soon."
     ///         }
     ///     }
     /// }
     /// ```
     ///
     /// ```js,expect_diagnostic,use_options
-    /// import { export1 } from 'import-foo';
+    /// import * from 'services-deprecated';
+    /// import { export1 } from 'constants';
     /// ```
     ///
-    /// A default message will be generated if `message` is empty or not specified.
+    /// ### `paths.<import>.message`
+    ///
+    /// Specifies the message to be shown when the restricted import is used.
+    ///
+    /// A default message will be generated if `message` is empty or not specified:
     ///
     /// ```json,options
     /// {

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -1,11 +1,14 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
-use biome_deserialize_macros::Deserializable;
+use biome_deserialize::{
+    Deserializable, DeserializableType, DeserializableValue, DeserializationDiagnostic,
+};
 use biome_js_syntax::{inner_string_text, AnyJsImportLike};
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
 
 declare_lint_rule! {
     /// Disallow specified modules when loaded by import or require.
@@ -14,10 +17,20 @@ declare_lint_rule! {
     ///
     /// ```json,options
     /// {
-    ///     "options": {
-    ///         "paths": {
-    ///             "lodash": "Using lodash is not encouraged",
-    ///             "underscore": "Using underscore is not encouraged"
+    ///     "noRestrictedImports": {
+    ///         "options": {
+    ///             "paths": {
+    ///                 "lodash": "Using lodash is not encouraged",
+    ///                 "underscore": "Using underscore is not encouraged",
+    ///                 "import-foo": {
+    ///                     "importNames": ["Bar"],
+    ///                     "message": "Please use Bar from /import-bar/baz/ instead."
+    ///                 },
+    ///                 "import-bar": {
+    ///                   "allowImportNames": ["Bar"],
+    ///                   "message": "Please use only Bar from import-bar."
+    ///                 }
+    ///             }
     ///         }
     ///     }
     /// }
@@ -60,13 +73,100 @@ declare_lint_rule! {
 }
 
 /// Options for the rule `noRestrictedImports`.
-#[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    biome_deserialize_macros::Deserializable,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct RestrictedImportsOptions {
     /// A list of names that should trigger the rule
     #[serde(skip_serializing_if = "FxHashMap::is_empty")]
-    paths: FxHashMap<Box<str>, Box<str>>,
+    paths: FxHashMap<Box<str>, CustomRestrictedImport>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Deserialize,
+    biome_deserialize_macros::Deserializable,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct CustomRestrictedImportOptions {
+    message: String,
+    import_names: Box<[Box<str>]>,
+    allow_import_names: Box<[Box<str>]>,
+}
+
+impl CustomRestrictedImportOptions {
+    pub fn has_import_name_patterns(&self) -> bool {
+        !self.import_names.is_empty() || !self.allow_import_names.is_empty()
+    }
+
+    pub fn is_import_allowed(&self, imported_name: &str) -> bool {
+        if !self.allow_import_names.is_empty() {
+            // Deny all imports except for the names specified in allow_import_names
+            self.allow_import_names
+                .iter()
+                .any(|name| Borrow::<str>::borrow(name) == imported_name)
+        } else if !self.import_names.is_empty() {
+            // Allow all imports except for the names specified in import_names
+            self.import_names
+                .iter()
+                .all(|name| Borrow::<str>::borrow(name) != imported_name)
+        } else {
+            // Deny all imports from this module
+            false
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum CustomRestrictedImport {
+    Plain(String),
+    WithOptions(CustomRestrictedImportOptions),
+}
+
+impl From<CustomRestrictedImport> for CustomRestrictedImportOptions {
+    fn from(options: CustomRestrictedImport) -> Self {
+        match options {
+            CustomRestrictedImport::Plain(message) => CustomRestrictedImportOptions {
+                message,
+                import_names: [].into(),
+                allow_import_names: [].into(),
+            },
+            CustomRestrictedImport::WithOptions(options) => options,
+        }
+    }
+}
+
+impl Deserializable for CustomRestrictedImport {
+    fn deserialize(
+        value: &impl DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        if value.visitable_type()? == DeserializableType::Str {
+            biome_deserialize::Deserializable::deserialize(value, name, diagnostics)
+                .map(Self::Plain)
+        } else {
+            biome_deserialize::Deserializable::deserialize(value, name, diagnostics)
+                .map(Self::WithOptions)
+        }
+    }
 }
 
 impl Rule for NoRestrictedImports {
@@ -86,7 +186,10 @@ impl Rule for NoRestrictedImports {
         ctx.options()
             .paths
             .get(inner_text.text())
-            .map(|message| (module_name.text_trimmed_range(), message.to_string()))
+            .map(|restricted_import| {
+                let restricted_import_options: CustomRestrictedImportOptions = restricted_import.clone().into();
+                (module_name.text_trimmed_range(), restricted_import_options.message.to_string())
+            })
     }
 
     fn diagnostic(_ctx: &RuleContext<Self>, (span, text): &Self::State) -> Option<RuleDiagnostic> {

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
@@ -6,6 +6,7 @@ import 'namespace-allowed';
 import 'default-allowed';
 import 'default-and-member-allowed';
 
+export * from 'namespace-forbidden';
 import * as n1 from 'namespace-forbidden';
 const n2 = await import('namespace-forbidden');
 const n2b = ((await (import('namespace-forbidden'))));
@@ -19,6 +20,7 @@ import('namespace-forbidden').then(function (n6) { });
 ((import('namespace-forbidden'))).then(((function (n8) { })));
 
 import d0 from 'default-forbidden';
+export { default as d1 } from 'default-forbidden';
 import { default as d1 } from 'default-forbidden';
 const { "default": d2 } = await import('default-forbidden');
 const { default: d3 } = await import('default-forbidden');
@@ -27,6 +29,7 @@ const { allowed2, default: d5 } = await import('default-forbidden');
 const { allowed3, default: d6 } = import('default-forbidden');
 const { "allowed4": a1, "default": d7 } = import('default-forbidden');
 
+export { allowed5, forbidden1 } from 'member-forbidden';
 import { allowed5, forbidden1 } from 'member-forbidden';
 const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
 import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -39,6 +42,7 @@ const { allowed1 } = require('default-forbidden');
 const { allowed2 } = require('namespace-allowed');
 const { allowed3 } = require('member-allowed');
 
+export * from 'default-allowed';
 import * as n1 from 'default-allowed';
 const n2 = await import('default-allowed');
 const n2b = ((await (import('default-allowed'))));
@@ -51,6 +55,7 @@ import('default-allowed').then(function (n6) { });
 ((import('default-allowed'))).then((((n7) => { })));
 ((import('default-allowed'))).then(((function (n8) { })));
 
+export * from 'member-allowed';
 import * as n1 from 'member-allowed';
 const n2 = await import('member-allowed');
 const n2b = ((await (import('member-allowed'))));
@@ -63,6 +68,7 @@ import('member-allowed').then(function (n6) { });
 ((import('member-allowed'))).then((((n7) => { })));
 ((import('member-allowed'))).then(((function (n8) { })));
 
+export * from 'bare-allowed';
 import * as n1 from 'bare-allowed';
 const n2 = await import('bare-allowed');
 const n2b = ((await (import('bare-allowed'))));
@@ -76,6 +82,7 @@ import('bare-allowed').then(function (n6) { });
 ((import('bare-allowed'))).then(((function (n8) { })));
 
 import d0 from 'namespace-allowed';
+export { default as d1 } from 'namespace-allowed';
 import { default as d1 } from 'namespace-allowed';
 const { "default": d2 } = await import('namespace-allowed');
 const { default: d3 } = await import('namespace-allowed');
@@ -85,6 +92,7 @@ const { forbidden3, default: d6 } = import('namespace-allowed');
 const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
 
 import d0 from 'member-allowed';
+export { default as d1 } from 'member-allowed';
 import { default as d1 } from 'member-allowed';
 const { "default": d2 } = await import('member-allowed');
 const { default: d3 } = await import('member-allowed');
@@ -94,24 +102,29 @@ const { forbidden3, default: d6 } = import('member-allowed');
 const { "forbidden4": f4, "default": d7 } = import('member-allowed');
 
 import d0 from 'bare-allowed';
+export { default as d1 } from 'bare-allowed';
 import { default as d1 } from 'bare-allowed';
 const { "default": d2 } = await import('bare-allowed');
 const { default: d3 } = await import('bare-allowed');
+export { default as d4, forbidden1 } from 'bare-allowed';
 import { default as d4, forbidden1 } from 'bare-allowed';
 const { forbidden2, default: d5 } = await import('bare-allowed');
 const { forbidden3, default: d6 } = import('bare-allowed');
 const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
 
+export { forbidden1 } from 'default-allowed';
 import { forbidden1 } from 'default-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
 import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
 import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
 
+export { forbidden1 } from 'namespace-allowed';
 import { forbidden1 } from 'namespace-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
 import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
 import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
 
+export { forbidden1 } from 'bare-allowed';
 import { forbidden1 } from 'bare-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
 import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js
@@ -1,2 +1,118 @@
 import eslint from 'eslint';
 const l = require('lodash');
+
+import 'bare-forbidden';
+import 'namespace-allowed';
+import 'default-allowed';
+import 'default-and-member-allowed';
+
+import * as n1 from 'namespace-forbidden';
+const n2 = await import('namespace-forbidden');
+const n2b = ((await (import('namespace-forbidden'))));
+const n3 = import('namespace-forbidden');
+const n3b = (import('namespace-forbidden'));
+import('namespace-forbidden').then(n4 => { });
+import('namespace-forbidden').then((n5) => { });
+import('namespace-forbidden').then(function (n6) { });
+((import('namespace-forbidden'))).then(((n6 => { })));
+((import('namespace-forbidden'))).then((((n7) => { })));
+((import('namespace-forbidden'))).then(((function (n8) { })));
+
+import d0 from 'default-forbidden';
+import { default as d1 } from 'default-forbidden';
+const { "default": d2 } = await import('default-forbidden');
+const { default: d3 } = await import('default-forbidden');
+import { default as d4, allowed1 } from 'default-forbidden';
+const { allowed2, default: d5 } = await import('default-forbidden');
+const { allowed3, default: d6 } = import('default-forbidden');
+const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+
+import { allowed5, forbidden1 } from 'member-forbidden';
+const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+// require() returns the default import, not a namespace object,
+// so this import corresponds to default.allowed1 (and not namespace.allowed1)
+// and is therefore *NOT* allowed.
+const { allowed1 } = require('default-forbidden');
+const { allowed2 } = require('namespace-allowed');
+const { allowed3 } = require('member-allowed');
+
+import * as n1 from 'default-allowed';
+const n2 = await import('default-allowed');
+const n2b = ((await (import('default-allowed'))));
+const n3 = import('default-allowed');
+const n3b = (import('default-allowed'));
+import('default-allowed').then(n4 => { });
+import('default-allowed').then((n5) => { });
+import('default-allowed').then(function (n6) { });
+((import('default-allowed'))).then(((n6 => { })));
+((import('default-allowed'))).then((((n7) => { })));
+((import('default-allowed'))).then(((function (n8) { })));
+
+import * as n1 from 'member-allowed';
+const n2 = await import('member-allowed');
+const n2b = ((await (import('member-allowed'))));
+const n3 = import('member-allowed');
+const n3b = (import('member-allowed'));
+import('member-allowed').then(n4 => { });
+import('member-allowed').then((n5) => { });
+import('member-allowed').then(function (n6) { });
+((import('member-allowed'))).then(((n6 => { })));
+((import('member-allowed'))).then((((n7) => { })));
+((import('member-allowed'))).then(((function (n8) { })));
+
+import * as n1 from 'bare-allowed';
+const n2 = await import('bare-allowed');
+const n2b = ((await (import('bare-allowed'))));
+const n3 = import('bare-allowed');
+const n3b = (import('bare-allowed'));
+import('bare-allowed').then(n4 => { });
+import('bare-allowed').then((n5) => { });
+import('bare-allowed').then(function (n6) { });
+((import('bare-allowed'))).then(((n6 => { })));
+((import('bare-allowed'))).then((((n7) => { })));
+((import('bare-allowed'))).then(((function (n8) { })));
+
+import d0 from 'namespace-allowed';
+import { default as d1 } from 'namespace-allowed';
+const { "default": d2 } = await import('namespace-allowed');
+const { default: d3 } = await import('namespace-allowed');
+import { default as d4, forbidden1 } from 'namespace-allowed';
+const { forbidden2, default: d5 } = await import('namespace-allowed');
+const { forbidden3, default: d6 } = import('namespace-allowed');
+const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+
+import d0 from 'member-allowed';
+import { default as d1 } from 'member-allowed';
+const { "default": d2 } = await import('member-allowed');
+const { default: d3 } = await import('member-allowed');
+import { default as d4, forbidden1 } from 'member-allowed';
+const { forbidden2, default: d5 } = await import('member-allowed');
+const { forbidden3, default: d6 } = import('member-allowed');
+const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+
+import d0 from 'bare-allowed';
+import { default as d1 } from 'bare-allowed';
+const { "default": d2 } = await import('bare-allowed');
+const { default: d3 } = await import('bare-allowed');
+import { default as d4, forbidden1 } from 'bare-allowed';
+const { forbidden2, default: d5 } = await import('bare-allowed');
+const { forbidden3, default: d6 } = import('bare-allowed');
+const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+
+import { forbidden1 } from 'default-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+import { forbidden1 } from 'namespace-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+import { forbidden1 } from 'bare-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -13,6 +13,7 @@ import 'namespace-allowed';
 import 'default-allowed';
 import 'default-and-member-allowed';
 
+export * from 'namespace-forbidden';
 import * as n1 from 'namespace-forbidden';
 const n2 = await import('namespace-forbidden');
 const n2b = ((await (import('namespace-forbidden'))));
@@ -26,6 +27,7 @@ import('namespace-forbidden').then(function (n6) { });
 ((import('namespace-forbidden'))).then(((function (n8) { })));
 
 import d0 from 'default-forbidden';
+export { default as d1 } from 'default-forbidden';
 import { default as d1 } from 'default-forbidden';
 const { "default": d2 } = await import('default-forbidden');
 const { default: d3 } = await import('default-forbidden');
@@ -34,6 +36,7 @@ const { allowed2, default: d5 } = await import('default-forbidden');
 const { allowed3, default: d6 } = import('default-forbidden');
 const { "allowed4": a1, "default": d7 } = import('default-forbidden');
 
+export { allowed5, forbidden1 } from 'member-forbidden';
 import { allowed5, forbidden1 } from 'member-forbidden';
 const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
 import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -46,6 +49,7 @@ const { allowed1 } = require('default-forbidden');
 const { allowed2 } = require('namespace-allowed');
 const { allowed3 } = require('member-allowed');
 
+export * from 'default-allowed';
 import * as n1 from 'default-allowed';
 const n2 = await import('default-allowed');
 const n2b = ((await (import('default-allowed'))));
@@ -58,6 +62,7 @@ import('default-allowed').then(function (n6) { });
 ((import('default-allowed'))).then((((n7) => { })));
 ((import('default-allowed'))).then(((function (n8) { })));
 
+export * from 'member-allowed';
 import * as n1 from 'member-allowed';
 const n2 = await import('member-allowed');
 const n2b = ((await (import('member-allowed'))));
@@ -70,6 +75,7 @@ import('member-allowed').then(function (n6) { });
 ((import('member-allowed'))).then((((n7) => { })));
 ((import('member-allowed'))).then(((function (n8) { })));
 
+export * from 'bare-allowed';
 import * as n1 from 'bare-allowed';
 const n2 = await import('bare-allowed');
 const n2b = ((await (import('bare-allowed'))));
@@ -83,6 +89,7 @@ import('bare-allowed').then(function (n6) { });
 ((import('bare-allowed'))).then(((function (n8) { })));
 
 import d0 from 'namespace-allowed';
+export { default as d1 } from 'namespace-allowed';
 import { default as d1 } from 'namespace-allowed';
 const { "default": d2 } = await import('namespace-allowed');
 const { default: d3 } = await import('namespace-allowed');
@@ -92,6 +99,7 @@ const { forbidden3, default: d6 } = import('namespace-allowed');
 const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
 
 import d0 from 'member-allowed';
+export { default as d1 } from 'member-allowed';
 import { default as d1 } from 'member-allowed';
 const { "default": d2 } = await import('member-allowed');
 const { default: d3 } = await import('member-allowed');
@@ -101,24 +109,29 @@ const { forbidden3, default: d6 } = import('member-allowed');
 const { "forbidden4": f4, "default": d7 } = import('member-allowed');
 
 import d0 from 'bare-allowed';
+export { default as d1 } from 'bare-allowed';
 import { default as d1 } from 'bare-allowed';
 const { "default": d2 } = await import('bare-allowed');
 const { default: d3 } = await import('bare-allowed');
+export { default as d4, forbidden1 } from 'bare-allowed';
 import { default as d4, forbidden1 } from 'bare-allowed';
 const { forbidden2, default: d5 } = await import('bare-allowed');
 const { forbidden3, default: d6 } = import('bare-allowed');
 const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
 
+export { forbidden1 } from 'default-allowed';
 import { forbidden1 } from 'default-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
 import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
 import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
 
+export { forbidden1 } from 'namespace-allowed';
 import { forbidden1 } from 'namespace-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
 import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
 import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
 
+export { forbidden1 } from 'bare-allowed';
 import { forbidden1 } from 'bare-allowed';
 const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
 import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -213,24 +226,24 @@ invalid.js:9:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
   
      7 │ import 'default-and-member-allowed';
      8 │ 
-   > 9 │ import * as n1 from 'namespace-forbidden';
+   > 9 │ export * from 'namespace-forbidden';
        │        ^
-    10 │ const n2 = await import('namespace-forbidden');
-    11 │ const n2b = ((await (import('namespace-forbidden'))));
+    10 │ import * as n1 from 'namespace-forbidden';
+    11 │ const n2 = await import('namespace-forbidden');
   
 
 ```
 
 ```
-invalid.js:10:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:10:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-     9 │ import * as n1 from 'namespace-forbidden';
-  > 10 │ const n2 = await import('namespace-forbidden');
-       │       ^^
-    11 │ const n2b = ((await (import('namespace-forbidden'))));
-    12 │ const n3 = import('namespace-forbidden');
+     9 │ export * from 'namespace-forbidden';
+  > 10 │ import * as n1 from 'namespace-forbidden';
+       │        ^
+    11 │ const n2 = await import('namespace-forbidden');
+    12 │ const n2b = ((await (import('namespace-forbidden'))));
   
 
 ```
@@ -240,12 +253,12 @@ invalid.js:11:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-     9 │ import * as n1 from 'namespace-forbidden';
-    10 │ const n2 = await import('namespace-forbidden');
-  > 11 │ const n2b = ((await (import('namespace-forbidden'))));
-       │       ^^^
-    12 │ const n3 = import('namespace-forbidden');
-    13 │ const n3b = (import('namespace-forbidden'));
+     9 │ export * from 'namespace-forbidden';
+    10 │ import * as n1 from 'namespace-forbidden';
+  > 11 │ const n2 = await import('namespace-forbidden');
+       │       ^^
+    12 │ const n2b = ((await (import('namespace-forbidden'))));
+    13 │ const n3 = import('namespace-forbidden');
   
 
 ```
@@ -255,12 +268,12 @@ invalid.js:12:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    10 │ const n2 = await import('namespace-forbidden');
-    11 │ const n2b = ((await (import('namespace-forbidden'))));
-  > 12 │ const n3 = import('namespace-forbidden');
-       │       ^^
-    13 │ const n3b = (import('namespace-forbidden'));
-    14 │ import('namespace-forbidden').then(n4 => { });
+    10 │ import * as n1 from 'namespace-forbidden';
+    11 │ const n2 = await import('namespace-forbidden');
+  > 12 │ const n2b = ((await (import('namespace-forbidden'))));
+       │       ^^^
+    13 │ const n3 = import('namespace-forbidden');
+    14 │ const n3b = (import('namespace-forbidden'));
   
 
 ```
@@ -270,428 +283,475 @@ invalid.js:13:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    11 │ const n2b = ((await (import('namespace-forbidden'))));
-    12 │ const n3 = import('namespace-forbidden');
-  > 13 │ const n3b = (import('namespace-forbidden'));
+    11 │ const n2 = await import('namespace-forbidden');
+    12 │ const n2b = ((await (import('namespace-forbidden'))));
+  > 13 │ const n3 = import('namespace-forbidden');
+       │       ^^
+    14 │ const n3b = (import('namespace-forbidden'));
+    15 │ import('namespace-forbidden').then(n4 => { });
+  
+
+```
+
+```
+invalid.js:14:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'namespace-forbidden'.
+  
+    12 │ const n2b = ((await (import('namespace-forbidden'))));
+    13 │ const n3 = import('namespace-forbidden');
+  > 14 │ const n3b = (import('namespace-forbidden'));
        │       ^^^
-    14 │ import('namespace-forbidden').then(n4 => { });
-    15 │ import('namespace-forbidden').then((n5) => { });
+    15 │ import('namespace-forbidden').then(n4 => { });
+    16 │ import('namespace-forbidden').then((n5) => { });
   
 
 ```
 
 ```
-invalid.js:14:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:15:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    12 │ const n3 = import('namespace-forbidden');
-    13 │ const n3b = (import('namespace-forbidden'));
-  > 14 │ import('namespace-forbidden').then(n4 => { });
+    13 │ const n3 = import('namespace-forbidden');
+    14 │ const n3b = (import('namespace-forbidden'));
+  > 15 │ import('namespace-forbidden').then(n4 => { });
        │                                    ^^
-    15 │ import('namespace-forbidden').then((n5) => { });
-    16 │ import('namespace-forbidden').then(function (n6) { });
+    16 │ import('namespace-forbidden').then((n5) => { });
+    17 │ import('namespace-forbidden').then(function (n6) { });
   
 
 ```
 
 ```
-invalid.js:15:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:16:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    13 │ const n3b = (import('namespace-forbidden'));
-    14 │ import('namespace-forbidden').then(n4 => { });
-  > 15 │ import('namespace-forbidden').then((n5) => { });
+    14 │ const n3b = (import('namespace-forbidden'));
+    15 │ import('namespace-forbidden').then(n4 => { });
+  > 16 │ import('namespace-forbidden').then((n5) => { });
        │                                     ^^
-    16 │ import('namespace-forbidden').then(function (n6) { });
-    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    17 │ import('namespace-forbidden').then(function (n6) { });
+    18 │ ((import('namespace-forbidden'))).then(((n6 => { })));
   
 
 ```
 
 ```
-invalid.js:16:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:17:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    14 │ import('namespace-forbidden').then(n4 => { });
-    15 │ import('namespace-forbidden').then((n5) => { });
-  > 16 │ import('namespace-forbidden').then(function (n6) { });
+    15 │ import('namespace-forbidden').then(n4 => { });
+    16 │ import('namespace-forbidden').then((n5) => { });
+  > 17 │ import('namespace-forbidden').then(function (n6) { });
        │                                              ^^
-    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
-    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+    18 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    19 │ ((import('namespace-forbidden'))).then((((n7) => { })));
   
 
 ```
 
 ```
-invalid.js:17:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:18:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    15 │ import('namespace-forbidden').then((n5) => { });
-    16 │ import('namespace-forbidden').then(function (n6) { });
-  > 17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    16 │ import('namespace-forbidden').then((n5) => { });
+    17 │ import('namespace-forbidden').then(function (n6) { });
+  > 18 │ ((import('namespace-forbidden'))).then(((n6 => { })));
        │                                          ^^
-    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
-    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    19 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+    20 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
   
 
 ```
 
 ```
-invalid.js:18:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:19:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    16 │ import('namespace-forbidden').then(function (n6) { });
-    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
-  > 18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+    17 │ import('namespace-forbidden').then(function (n6) { });
+    18 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+  > 19 │ ((import('namespace-forbidden'))).then((((n7) => { })));
        │                                           ^^
-    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
-    20 │ 
+    20 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    21 │ 
   
 
 ```
 
 ```
-invalid.js:19:52 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:20:52 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'namespace-forbidden'.
   
-    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
-    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
-  > 19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    18 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    19 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+  > 20 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
        │                                                    ^^
-    20 │ 
-    21 │ import d0 from 'default-forbidden';
+    21 │ 
+    22 │ import d0 from 'default-forbidden';
   
 
 ```
 
 ```
-invalid.js:21:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:22:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
-    20 │ 
-  > 21 │ import d0 from 'default-forbidden';
+    20 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    21 │ 
+  > 22 │ import d0 from 'default-forbidden';
        │        ^^
-    22 │ import { default as d1 } from 'default-forbidden';
-    23 │ const { "default": d2 } = await import('default-forbidden');
+    23 │ export { default as d1 } from 'default-forbidden';
+    24 │ import { default as d1 } from 'default-forbidden';
   
 
 ```
 
 ```
-invalid.js:22:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:23:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    21 │ import d0 from 'default-forbidden';
-  > 22 │ import { default as d1 } from 'default-forbidden';
+    22 │ import d0 from 'default-forbidden';
+  > 23 │ export { default as d1 } from 'default-forbidden';
        │          ^^^^^^^
-    23 │ const { "default": d2 } = await import('default-forbidden');
-    24 │ const { default: d3 } = await import('default-forbidden');
+    24 │ import { default as d1 } from 'default-forbidden';
+    25 │ const { "default": d2 } = await import('default-forbidden');
   
 
 ```
 
 ```
-invalid.js:23:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:24:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    21 │ import d0 from 'default-forbidden';
-    22 │ import { default as d1 } from 'default-forbidden';
-  > 23 │ const { "default": d2 } = await import('default-forbidden');
+    22 │ import d0 from 'default-forbidden';
+    23 │ export { default as d1 } from 'default-forbidden';
+  > 24 │ import { default as d1 } from 'default-forbidden';
+       │          ^^^^^^^
+    25 │ const { "default": d2 } = await import('default-forbidden');
+    26 │ const { default: d3 } = await import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:25:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'default-forbidden'.
+  
+    23 │ export { default as d1 } from 'default-forbidden';
+    24 │ import { default as d1 } from 'default-forbidden';
+  > 25 │ const { "default": d2 } = await import('default-forbidden');
        │         ^^^^^^^^^
-    24 │ const { default: d3 } = await import('default-forbidden');
-    25 │ import { default as d4, allowed1 } from 'default-forbidden';
+    26 │ const { default: d3 } = await import('default-forbidden');
+    27 │ import { default as d4, allowed1 } from 'default-forbidden';
   
 
 ```
 
 ```
-invalid.js:24:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:26:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    22 │ import { default as d1 } from 'default-forbidden';
-    23 │ const { "default": d2 } = await import('default-forbidden');
-  > 24 │ const { default: d3 } = await import('default-forbidden');
+    24 │ import { default as d1 } from 'default-forbidden';
+    25 │ const { "default": d2 } = await import('default-forbidden');
+  > 26 │ const { default: d3 } = await import('default-forbidden');
        │         ^^^^^^^
-    25 │ import { default as d4, allowed1 } from 'default-forbidden';
-    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    27 │ import { default as d4, allowed1 } from 'default-forbidden';
+    28 │ const { allowed2, default: d5 } = await import('default-forbidden');
   
 
 ```
 
 ```
-invalid.js:25:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:27:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    23 │ const { "default": d2 } = await import('default-forbidden');
-    24 │ const { default: d3 } = await import('default-forbidden');
-  > 25 │ import { default as d4, allowed1 } from 'default-forbidden';
+    25 │ const { "default": d2 } = await import('default-forbidden');
+    26 │ const { default: d3 } = await import('default-forbidden');
+  > 27 │ import { default as d4, allowed1 } from 'default-forbidden';
        │          ^^^^^^^
-    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
-    27 │ const { allowed3, default: d6 } = import('default-forbidden');
+    28 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    29 │ const { allowed3, default: d6 } = import('default-forbidden');
   
 
 ```
 
 ```
-invalid.js:26:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:28:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    24 │ const { default: d3 } = await import('default-forbidden');
-    25 │ import { default as d4, allowed1 } from 'default-forbidden';
-  > 26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    26 │ const { default: d3 } = await import('default-forbidden');
+    27 │ import { default as d4, allowed1 } from 'default-forbidden';
+  > 28 │ const { allowed2, default: d5 } = await import('default-forbidden');
        │                   ^^^^^^^
-    27 │ const { allowed3, default: d6 } = import('default-forbidden');
-    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    29 │ const { allowed3, default: d6 } = import('default-forbidden');
+    30 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
   
 
 ```
 
 ```
-invalid.js:27:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:29:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    25 │ import { default as d4, allowed1 } from 'default-forbidden';
-    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
-  > 27 │ const { allowed3, default: d6 } = import('default-forbidden');
+    27 │ import { default as d4, allowed1 } from 'default-forbidden';
+    28 │ const { allowed2, default: d5 } = await import('default-forbidden');
+  > 29 │ const { allowed3, default: d6 } = import('default-forbidden');
        │                   ^^^^^^^
-    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
-    29 │ 
+    30 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    31 │ 
   
 
 ```
 
 ```
-invalid.js:28:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:30:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'default-forbidden'.
   
-    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
-    27 │ const { allowed3, default: d6 } = import('default-forbidden');
-  > 28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    28 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    29 │ const { allowed3, default: d6 } = import('default-forbidden');
+  > 30 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
        │                         ^^^^^^^^^
-    29 │ 
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    31 │ 
+    32 │ export { allowed5, forbidden1 } from 'member-forbidden';
   
 
 ```
 
 ```
-invalid.js:30:20 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:32:20 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden1' from 'member-forbidden'.
   
-    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
-    29 │ 
-  > 30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    30 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    31 │ 
+  > 32 │ export { allowed5, forbidden1 } from 'member-forbidden';
        │                    ^^^^^^^^^^
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
   
 
 ```
 
 ```
-invalid.js:31:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:33:20 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'member-forbidden'.
+  
+    32 │ export { allowed5, forbidden1 } from 'member-forbidden';
+  > 33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+       │                    ^^^^^^^^^^
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+
+```
+
+```
+invalid.js:34:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ export { allowed5, forbidden1 } from 'member-forbidden';
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
        │                   ^^^^^^^^^^
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
 
 ```
 
 ```
-invalid.js:31:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ export { allowed5, forbidden1 } from 'member-forbidden';
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
        │                               ^^^^^^^^^^
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
 
 ```
 
 ```
-invalid.js:31:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:34:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ export { allowed5, forbidden1 } from 'member-forbidden';
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
        │                                               ^^^^^^^^^^^^
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
 
 ```
 
 ```
-invalid.js:32:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:35:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
        │                                              ^^^^^^^^^^
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    34 │ 
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    37 │ 
   
 
 ```
 
 ```
-invalid.js:32:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:35:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
        │                                                          ^^^^^^^^^^
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    34 │ 
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    37 │ 
   
 
 ```
 
 ```
-invalid.js:32:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:35:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'member-forbidden'.
   
-    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
        │                                                                          ^^^^^^^^^^^^
-    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    34 │ 
+    36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    37 │ 
   
 
 ```
 
 ```
-invalid.js:33:55 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:36:55 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'member-forbidden'.
   
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
        │                                                       ^^^^^^^^^^
-    34 │ 
-    35 │ // require() returns the default import, not a namespace object,
+    37 │ 
+    38 │ // require() returns the default import, not a namespace object,
   
 
 ```
 
 ```
-invalid.js:33:67 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:36:67 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'member-forbidden'.
   
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
        │                                                                   ^^^^^^^^^^
-    34 │ 
-    35 │ // require() returns the default import, not a namespace object,
+    37 │ 
+    38 │ // require() returns the default import, not a namespace object,
   
 
 ```
 
 ```
-invalid.js:33:83 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:36:83 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'member-forbidden'.
   
-    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
-    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    35 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 36 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
        │                                                                                   ^^^^^^^^^^^^
-    34 │ 
-    35 │ // require() returns the default import, not a namespace object,
+    37 │ 
+    38 │ // require() returns the default import, not a namespace object,
   
 
 ```
 
 ```
-invalid.js:38:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:41:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default-forbidden'.
   
-    36 │ // so this import corresponds to default.allowed1 (and not namespace.allowed1)
-    37 │ // and is therefore *NOT* allowed.
-  > 38 │ const { allowed1 } = require('default-forbidden');
+    39 │ // so this import corresponds to default.allowed1 (and not namespace.allowed1)
+    40 │ // and is therefore *NOT* allowed.
+  > 41 │ const { allowed1 } = require('default-forbidden');
        │                              ^^^^^^^^^^^^^^^^^^^
-    39 │ const { allowed2 } = require('namespace-allowed');
-    40 │ const { allowed3 } = require('member-allowed');
+    42 │ const { allowed2 } = require('namespace-allowed');
+    43 │ const { allowed3 } = require('member-allowed');
   
 
 ```
 
 ```
-invalid.js:39:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:42:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'namespace-allowed'.
   
-    37 │ // and is therefore *NOT* allowed.
-    38 │ const { allowed1 } = require('default-forbidden');
-  > 39 │ const { allowed2 } = require('namespace-allowed');
+    40 │ // and is therefore *NOT* allowed.
+    41 │ const { allowed1 } = require('default-forbidden');
+  > 42 │ const { allowed2 } = require('namespace-allowed');
        │                              ^^^^^^^^^^^^^^^^^^^
-    40 │ const { allowed3 } = require('member-allowed');
-    41 │ 
+    43 │ const { allowed3 } = require('member-allowed');
+    44 │ 
   
 
 ```
 
 ```
-invalid.js:40:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:43:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'member-allowed'.
   
-    38 │ const { allowed1 } = require('default-forbidden');
-    39 │ const { allowed2 } = require('namespace-allowed');
-  > 40 │ const { allowed3 } = require('member-allowed');
+    41 │ const { allowed1 } = require('default-forbidden');
+    42 │ const { allowed2 } = require('namespace-allowed');
+  > 43 │ const { allowed3 } = require('member-allowed');
        │                              ^^^^^^^^^^^^^^^^
-    41 │ 
-    42 │ import * as n1 from 'default-allowed';
+    44 │ 
+    45 │ export * from 'default-allowed';
   
 
 ```
 
 ```
-invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:45:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    40 │ const { allowed3 } = require('member-allowed');
-    41 │ 
-  > 42 │ import * as n1 from 'default-allowed';
+    43 │ const { allowed3 } = require('member-allowed');
+    44 │ 
+  > 45 │ export * from 'default-allowed';
        │        ^
-    43 │ const n2 = await import('default-allowed');
-    44 │ const n2b = ((await (import('default-allowed'))));
+    46 │ import * as n1 from 'default-allowed';
+    47 │ const n2 = await import('default-allowed');
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -701,15 +761,34 @@ invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:46:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    42 │ import * as n1 from 'default-allowed';
-  > 43 │ const n2 = await import('default-allowed');
+    45 │ export * from 'default-allowed';
+  > 46 │ import * as n1 from 'default-allowed';
+       │        ^
+    47 │ const n2 = await import('default-allowed');
+    48 │ const n2b = ((await (import('default-allowed'))));
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:47:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'default-allowed'.
+  
+    45 │ export * from 'default-allowed';
+    46 │ import * as n1 from 'default-allowed';
+  > 47 │ const n2 = await import('default-allowed');
        │       ^^
-    44 │ const n2b = ((await (import('default-allowed'))));
-    45 │ const n3 = import('default-allowed');
+    48 │ const n2b = ((await (import('default-allowed'))));
+    49 │ const n3 = import('default-allowed');
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -719,16 +798,16 @@ invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:48:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    42 │ import * as n1 from 'default-allowed';
-    43 │ const n2 = await import('default-allowed');
-  > 44 │ const n2b = ((await (import('default-allowed'))));
+    46 │ import * as n1 from 'default-allowed';
+    47 │ const n2 = await import('default-allowed');
+  > 48 │ const n2b = ((await (import('default-allowed'))));
        │       ^^^
-    45 │ const n3 = import('default-allowed');
-    46 │ const n3b = (import('default-allowed'));
+    49 │ const n3 = import('default-allowed');
+    50 │ const n3b = (import('default-allowed'));
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -738,16 +817,16 @@ invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:49:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    43 │ const n2 = await import('default-allowed');
-    44 │ const n2b = ((await (import('default-allowed'))));
-  > 45 │ const n3 = import('default-allowed');
+    47 │ const n2 = await import('default-allowed');
+    48 │ const n2b = ((await (import('default-allowed'))));
+  > 49 │ const n3 = import('default-allowed');
        │       ^^
-    46 │ const n3b = (import('default-allowed'));
-    47 │ import('default-allowed').then(n4 => { });
+    50 │ const n3b = (import('default-allowed'));
+    51 │ import('default-allowed').then(n4 => { });
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -757,16 +836,16 @@ invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:50:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    44 │ const n2b = ((await (import('default-allowed'))));
-    45 │ const n3 = import('default-allowed');
-  > 46 │ const n3b = (import('default-allowed'));
+    48 │ const n2b = ((await (import('default-allowed'))));
+    49 │ const n3 = import('default-allowed');
+  > 50 │ const n3b = (import('default-allowed'));
        │       ^^^
-    47 │ import('default-allowed').then(n4 => { });
-    48 │ import('default-allowed').then((n5) => { });
+    51 │ import('default-allowed').then(n4 => { });
+    52 │ import('default-allowed').then((n5) => { });
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -776,16 +855,16 @@ invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:51:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    45 │ const n3 = import('default-allowed');
-    46 │ const n3b = (import('default-allowed'));
-  > 47 │ import('default-allowed').then(n4 => { });
+    49 │ const n3 = import('default-allowed');
+    50 │ const n3b = (import('default-allowed'));
+  > 51 │ import('default-allowed').then(n4 => { });
        │                                ^^
-    48 │ import('default-allowed').then((n5) => { });
-    49 │ import('default-allowed').then(function (n6) { });
+    52 │ import('default-allowed').then((n5) => { });
+    53 │ import('default-allowed').then(function (n6) { });
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -795,16 +874,16 @@ invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:52:33 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    46 │ const n3b = (import('default-allowed'));
-    47 │ import('default-allowed').then(n4 => { });
-  > 48 │ import('default-allowed').then((n5) => { });
+    50 │ const n3b = (import('default-allowed'));
+    51 │ import('default-allowed').then(n4 => { });
+  > 52 │ import('default-allowed').then((n5) => { });
        │                                 ^^
-    49 │ import('default-allowed').then(function (n6) { });
-    50 │ ((import('default-allowed'))).then(((n6 => { })));
+    53 │ import('default-allowed').then(function (n6) { });
+    54 │ ((import('default-allowed'))).then(((n6 => { })));
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -814,16 +893,16 @@ invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:53:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    47 │ import('default-allowed').then(n4 => { });
-    48 │ import('default-allowed').then((n5) => { });
-  > 49 │ import('default-allowed').then(function (n6) { });
+    51 │ import('default-allowed').then(n4 => { });
+    52 │ import('default-allowed').then((n5) => { });
+  > 53 │ import('default-allowed').then(function (n6) { });
        │                                          ^^
-    50 │ ((import('default-allowed'))).then(((n6 => { })));
-    51 │ ((import('default-allowed'))).then((((n7) => { })));
+    54 │ ((import('default-allowed'))).then(((n6 => { })));
+    55 │ ((import('default-allowed'))).then((((n7) => { })));
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -833,16 +912,16 @@ invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:54:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    48 │ import('default-allowed').then((n5) => { });
-    49 │ import('default-allowed').then(function (n6) { });
-  > 50 │ ((import('default-allowed'))).then(((n6 => { })));
+    52 │ import('default-allowed').then((n5) => { });
+    53 │ import('default-allowed').then(function (n6) { });
+  > 54 │ ((import('default-allowed'))).then(((n6 => { })));
        │                                      ^^
-    51 │ ((import('default-allowed'))).then((((n7) => { })));
-    52 │ ((import('default-allowed'))).then(((function (n8) { })));
+    55 │ ((import('default-allowed'))).then((((n7) => { })));
+    56 │ ((import('default-allowed'))).then(((function (n8) { })));
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -852,16 +931,16 @@ invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:55:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    49 │ import('default-allowed').then(function (n6) { });
-    50 │ ((import('default-allowed'))).then(((n6 => { })));
-  > 51 │ ((import('default-allowed'))).then((((n7) => { })));
+    53 │ import('default-allowed').then(function (n6) { });
+    54 │ ((import('default-allowed'))).then(((n6 => { })));
+  > 55 │ ((import('default-allowed'))).then((((n7) => { })));
        │                                       ^^
-    52 │ ((import('default-allowed'))).then(((function (n8) { })));
-    53 │ 
+    56 │ ((import('default-allowed'))).then(((function (n8) { })));
+    57 │ 
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -871,16 +950,16 @@ invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:56:48 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'default-allowed'.
   
-    50 │ ((import('default-allowed'))).then(((n6 => { })));
-    51 │ ((import('default-allowed'))).then((((n7) => { })));
-  > 52 │ ((import('default-allowed'))).then(((function (n8) { })));
+    54 │ ((import('default-allowed'))).then(((n6 => { })));
+    55 │ ((import('default-allowed'))).then((((n7) => { })));
+  > 56 │ ((import('default-allowed'))).then(((function (n8) { })));
        │                                                ^^
-    53 │ 
-    54 │ import * as n1 from 'member-allowed';
+    57 │ 
+    58 │ export * from 'member-allowed';
   
   i Only the following imports from 'default-allowed' are allowed:
   
@@ -890,16 +969,16 @@ invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:58:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    52 │ ((import('default-allowed'))).then(((function (n8) { })));
-    53 │ 
-  > 54 │ import * as n1 from 'member-allowed';
+    56 │ ((import('default-allowed'))).then(((function (n8) { })));
+    57 │ 
+  > 58 │ export * from 'member-allowed';
        │        ^
-    55 │ const n2 = await import('member-allowed');
-    56 │ const n2b = ((await (import('member-allowed'))));
+    59 │ import * as n1 from 'member-allowed';
+    60 │ const n2 = await import('member-allowed');
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -917,15 +996,42 @@ invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:59:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    54 │ import * as n1 from 'member-allowed';
-  > 55 │ const n2 = await import('member-allowed');
+    58 │ export * from 'member-allowed';
+  > 59 │ import * as n1 from 'member-allowed';
+       │        ^
+    60 │ const n2 = await import('member-allowed');
+    61 │ const n2b = ((await (import('member-allowed'))));
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:60:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'member-allowed'.
+  
+    58 │ export * from 'member-allowed';
+    59 │ import * as n1 from 'member-allowed';
+  > 60 │ const n2 = await import('member-allowed');
        │       ^^
-    56 │ const n2b = ((await (import('member-allowed'))));
-    57 │ const n3 = import('member-allowed');
+    61 │ const n2b = ((await (import('member-allowed'))));
+    62 │ const n3 = import('member-allowed');
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -943,16 +1049,16 @@ invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:61:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    54 │ import * as n1 from 'member-allowed';
-    55 │ const n2 = await import('member-allowed');
-  > 56 │ const n2b = ((await (import('member-allowed'))));
+    59 │ import * as n1 from 'member-allowed';
+    60 │ const n2 = await import('member-allowed');
+  > 61 │ const n2b = ((await (import('member-allowed'))));
        │       ^^^
-    57 │ const n3 = import('member-allowed');
-    58 │ const n3b = (import('member-allowed'));
+    62 │ const n3 = import('member-allowed');
+    63 │ const n3b = (import('member-allowed'));
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -970,16 +1076,16 @@ invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:62:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    55 │ const n2 = await import('member-allowed');
-    56 │ const n2b = ((await (import('member-allowed'))));
-  > 57 │ const n3 = import('member-allowed');
+    60 │ const n2 = await import('member-allowed');
+    61 │ const n2b = ((await (import('member-allowed'))));
+  > 62 │ const n3 = import('member-allowed');
        │       ^^
-    58 │ const n3b = (import('member-allowed'));
-    59 │ import('member-allowed').then(n4 => { });
+    63 │ const n3b = (import('member-allowed'));
+    64 │ import('member-allowed').then(n4 => { });
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -997,16 +1103,16 @@ invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:63:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    56 │ const n2b = ((await (import('member-allowed'))));
-    57 │ const n3 = import('member-allowed');
-  > 58 │ const n3b = (import('member-allowed'));
+    61 │ const n2b = ((await (import('member-allowed'))));
+    62 │ const n3 = import('member-allowed');
+  > 63 │ const n3b = (import('member-allowed'));
        │       ^^^
-    59 │ import('member-allowed').then(n4 => { });
-    60 │ import('member-allowed').then((n5) => { });
+    64 │ import('member-allowed').then(n4 => { });
+    65 │ import('member-allowed').then((n5) => { });
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1024,16 +1130,16 @@ invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:64:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    57 │ const n3 = import('member-allowed');
-    58 │ const n3b = (import('member-allowed'));
-  > 59 │ import('member-allowed').then(n4 => { });
+    62 │ const n3 = import('member-allowed');
+    63 │ const n3b = (import('member-allowed'));
+  > 64 │ import('member-allowed').then(n4 => { });
        │                               ^^
-    60 │ import('member-allowed').then((n5) => { });
-    61 │ import('member-allowed').then(function (n6) { });
+    65 │ import('member-allowed').then((n5) => { });
+    66 │ import('member-allowed').then(function (n6) { });
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1051,16 +1157,16 @@ invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:65:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    58 │ const n3b = (import('member-allowed'));
-    59 │ import('member-allowed').then(n4 => { });
-  > 60 │ import('member-allowed').then((n5) => { });
+    63 │ const n3b = (import('member-allowed'));
+    64 │ import('member-allowed').then(n4 => { });
+  > 65 │ import('member-allowed').then((n5) => { });
        │                                ^^
-    61 │ import('member-allowed').then(function (n6) { });
-    62 │ ((import('member-allowed'))).then(((n6 => { })));
+    66 │ import('member-allowed').then(function (n6) { });
+    67 │ ((import('member-allowed'))).then(((n6 => { })));
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1078,16 +1184,16 @@ invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:66:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    59 │ import('member-allowed').then(n4 => { });
-    60 │ import('member-allowed').then((n5) => { });
-  > 61 │ import('member-allowed').then(function (n6) { });
+    64 │ import('member-allowed').then(n4 => { });
+    65 │ import('member-allowed').then((n5) => { });
+  > 66 │ import('member-allowed').then(function (n6) { });
        │                                         ^^
-    62 │ ((import('member-allowed'))).then(((n6 => { })));
-    63 │ ((import('member-allowed'))).then((((n7) => { })));
+    67 │ ((import('member-allowed'))).then(((n6 => { })));
+    68 │ ((import('member-allowed'))).then((((n7) => { })));
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1105,16 +1211,16 @@ invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:67:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    60 │ import('member-allowed').then((n5) => { });
-    61 │ import('member-allowed').then(function (n6) { });
-  > 62 │ ((import('member-allowed'))).then(((n6 => { })));
+    65 │ import('member-allowed').then((n5) => { });
+    66 │ import('member-allowed').then(function (n6) { });
+  > 67 │ ((import('member-allowed'))).then(((n6 => { })));
        │                                     ^^
-    63 │ ((import('member-allowed'))).then((((n7) => { })));
-    64 │ ((import('member-allowed'))).then(((function (n8) { })));
+    68 │ ((import('member-allowed'))).then((((n7) => { })));
+    69 │ ((import('member-allowed'))).then(((function (n8) { })));
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1132,16 +1238,16 @@ invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:68:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    61 │ import('member-allowed').then(function (n6) { });
-    62 │ ((import('member-allowed'))).then(((n6 => { })));
-  > 63 │ ((import('member-allowed'))).then((((n7) => { })));
+    66 │ import('member-allowed').then(function (n6) { });
+    67 │ ((import('member-allowed'))).then(((n6 => { })));
+  > 68 │ ((import('member-allowed'))).then((((n7) => { })));
        │                                      ^^
-    64 │ ((import('member-allowed'))).then(((function (n8) { })));
-    65 │ 
+    69 │ ((import('member-allowed'))).then(((function (n8) { })));
+    70 │ 
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1159,16 +1265,16 @@ invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:69:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'member-allowed'.
   
-    62 │ ((import('member-allowed'))).then(((n6 => { })));
-    63 │ ((import('member-allowed'))).then((((n7) => { })));
-  > 64 │ ((import('member-allowed'))).then(((function (n8) { })));
+    67 │ ((import('member-allowed'))).then(((n6 => { })));
+    68 │ ((import('member-allowed'))).then((((n7) => { })));
+  > 69 │ ((import('member-allowed'))).then(((function (n8) { })));
        │                                               ^^
-    65 │ 
-    66 │ import * as n1 from 'bare-allowed';
+    70 │ 
+    71 │ export * from 'bare-allowed';
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1186,16 +1292,16 @@ invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:71:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    64 │ ((import('member-allowed'))).then(((function (n8) { })));
-    65 │ 
-  > 66 │ import * as n1 from 'bare-allowed';
+    69 │ ((import('member-allowed'))).then(((function (n8) { })));
+    70 │ 
+  > 71 │ export * from 'bare-allowed';
        │        ^
-    67 │ const n2 = await import('bare-allowed');
-    68 │ const n2b = ((await (import('bare-allowed'))));
+    72 │ import * as n1 from 'bare-allowed';
+    73 │ const n2 = await import('bare-allowed');
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1205,15 +1311,34 @@ invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:72:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    66 │ import * as n1 from 'bare-allowed';
-  > 67 │ const n2 = await import('bare-allowed');
+    71 │ export * from 'bare-allowed';
+  > 72 │ import * as n1 from 'bare-allowed';
+       │        ^
+    73 │ const n2 = await import('bare-allowed');
+    74 │ const n2b = ((await (import('bare-allowed'))));
+  
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
+  
+
+```
+
+```
+invalid.js:73:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'bare-allowed'.
+  
+    71 │ export * from 'bare-allowed';
+    72 │ import * as n1 from 'bare-allowed';
+  > 73 │ const n2 = await import('bare-allowed');
        │       ^^
-    68 │ const n2b = ((await (import('bare-allowed'))));
-    69 │ const n3 = import('bare-allowed');
+    74 │ const n2b = ((await (import('bare-allowed'))));
+    75 │ const n3 = import('bare-allowed');
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1223,16 +1348,16 @@ invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:74:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    66 │ import * as n1 from 'bare-allowed';
-    67 │ const n2 = await import('bare-allowed');
-  > 68 │ const n2b = ((await (import('bare-allowed'))));
+    72 │ import * as n1 from 'bare-allowed';
+    73 │ const n2 = await import('bare-allowed');
+  > 74 │ const n2b = ((await (import('bare-allowed'))));
        │       ^^^
-    69 │ const n3 = import('bare-allowed');
-    70 │ const n3b = (import('bare-allowed'));
+    75 │ const n3 = import('bare-allowed');
+    76 │ const n3b = (import('bare-allowed'));
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1242,16 +1367,16 @@ invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:75:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    67 │ const n2 = await import('bare-allowed');
-    68 │ const n2b = ((await (import('bare-allowed'))));
-  > 69 │ const n3 = import('bare-allowed');
+    73 │ const n2 = await import('bare-allowed');
+    74 │ const n2b = ((await (import('bare-allowed'))));
+  > 75 │ const n3 = import('bare-allowed');
        │       ^^
-    70 │ const n3b = (import('bare-allowed'));
-    71 │ import('bare-allowed').then(n4 => { });
+    76 │ const n3b = (import('bare-allowed'));
+    77 │ import('bare-allowed').then(n4 => { });
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1261,16 +1386,16 @@ invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:76:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    68 │ const n2b = ((await (import('bare-allowed'))));
-    69 │ const n3 = import('bare-allowed');
-  > 70 │ const n3b = (import('bare-allowed'));
+    74 │ const n2b = ((await (import('bare-allowed'))));
+    75 │ const n3 = import('bare-allowed');
+  > 76 │ const n3b = (import('bare-allowed'));
        │       ^^^
-    71 │ import('bare-allowed').then(n4 => { });
-    72 │ import('bare-allowed').then((n5) => { });
+    77 │ import('bare-allowed').then(n4 => { });
+    78 │ import('bare-allowed').then((n5) => { });
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1280,16 +1405,16 @@ invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:77:29 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    69 │ const n3 = import('bare-allowed');
-    70 │ const n3b = (import('bare-allowed'));
-  > 71 │ import('bare-allowed').then(n4 => { });
+    75 │ const n3 = import('bare-allowed');
+    76 │ const n3b = (import('bare-allowed'));
+  > 77 │ import('bare-allowed').then(n4 => { });
        │                             ^^
-    72 │ import('bare-allowed').then((n5) => { });
-    73 │ import('bare-allowed').then(function (n6) { });
+    78 │ import('bare-allowed').then((n5) => { });
+    79 │ import('bare-allowed').then(function (n6) { });
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1299,16 +1424,16 @@ invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:78:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    70 │ const n3b = (import('bare-allowed'));
-    71 │ import('bare-allowed').then(n4 => { });
-  > 72 │ import('bare-allowed').then((n5) => { });
+    76 │ const n3b = (import('bare-allowed'));
+    77 │ import('bare-allowed').then(n4 => { });
+  > 78 │ import('bare-allowed').then((n5) => { });
        │                              ^^
-    73 │ import('bare-allowed').then(function (n6) { });
-    74 │ ((import('bare-allowed'))).then(((n6 => { })));
+    79 │ import('bare-allowed').then(function (n6) { });
+    80 │ ((import('bare-allowed'))).then(((n6 => { })));
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1318,16 +1443,16 @@ invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:79:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    71 │ import('bare-allowed').then(n4 => { });
-    72 │ import('bare-allowed').then((n5) => { });
-  > 73 │ import('bare-allowed').then(function (n6) { });
+    77 │ import('bare-allowed').then(n4 => { });
+    78 │ import('bare-allowed').then((n5) => { });
+  > 79 │ import('bare-allowed').then(function (n6) { });
        │                                       ^^
-    74 │ ((import('bare-allowed'))).then(((n6 => { })));
-    75 │ ((import('bare-allowed'))).then((((n7) => { })));
+    80 │ ((import('bare-allowed'))).then(((n6 => { })));
+    81 │ ((import('bare-allowed'))).then((((n7) => { })));
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1337,16 +1462,16 @@ invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:80:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    72 │ import('bare-allowed').then((n5) => { });
-    73 │ import('bare-allowed').then(function (n6) { });
-  > 74 │ ((import('bare-allowed'))).then(((n6 => { })));
+    78 │ import('bare-allowed').then((n5) => { });
+    79 │ import('bare-allowed').then(function (n6) { });
+  > 80 │ ((import('bare-allowed'))).then(((n6 => { })));
        │                                   ^^
-    75 │ ((import('bare-allowed'))).then((((n7) => { })));
-    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    81 │ ((import('bare-allowed'))).then((((n7) => { })));
+    82 │ ((import('bare-allowed'))).then(((function (n8) { })));
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1356,16 +1481,16 @@ invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:81:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    73 │ import('bare-allowed').then(function (n6) { });
-    74 │ ((import('bare-allowed'))).then(((n6 => { })));
-  > 75 │ ((import('bare-allowed'))).then((((n7) => { })));
+    79 │ import('bare-allowed').then(function (n6) { });
+    80 │ ((import('bare-allowed'))).then(((n6 => { })));
+  > 81 │ ((import('bare-allowed'))).then((((n7) => { })));
        │                                    ^^
-    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
-    77 │ 
+    82 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    83 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1375,16 +1500,16 @@ invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:82:45 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import '*' from 'bare-allowed'.
   
-    74 │ ((import('bare-allowed'))).then(((n6 => { })));
-    75 │ ((import('bare-allowed'))).then((((n7) => { })));
-  > 76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    80 │ ((import('bare-allowed'))).then(((n6 => { })));
+    81 │ ((import('bare-allowed'))).then((((n7) => { })));
+  > 82 │ ((import('bare-allowed'))).then(((function (n8) { })));
        │                                             ^^
-    77 │ 
-    78 │ import d0 from 'namespace-allowed';
+    83 │ 
+    84 │ import d0 from 'namespace-allowed';
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -1394,16 +1519,16 @@ invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:84:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'namespace-allowed'.
   
-    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
-    77 │ 
-  > 78 │ import d0 from 'namespace-allowed';
+    82 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    83 │ 
+  > 84 │ import d0 from 'namespace-allowed';
        │        ^^
-    79 │ import { default as d1 } from 'namespace-allowed';
-    80 │ const { "default": d2 } = await import('namespace-allowed');
+    85 │ export { default as d1 } from 'namespace-allowed';
+    86 │ import { default as d1 } from 'namespace-allowed';
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
@@ -1413,15 +1538,15 @@ invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:85:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'namespace-allowed'.
   
-    78 │ import d0 from 'namespace-allowed';
-  > 79 │ import { default as d1 } from 'namespace-allowed';
+    84 │ import d0 from 'namespace-allowed';
+  > 85 │ export { default as d1 } from 'namespace-allowed';
        │          ^^^^^^^
-    80 │ const { "default": d2 } = await import('namespace-allowed');
-    81 │ const { default: d3 } = await import('namespace-allowed');
+    86 │ import { default as d1 } from 'namespace-allowed';
+    87 │ const { "default": d2 } = await import('namespace-allowed');
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
@@ -1431,16 +1556,35 @@ invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:86:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'namespace-allowed'.
   
-    78 │ import d0 from 'namespace-allowed';
-    79 │ import { default as d1 } from 'namespace-allowed';
-  > 80 │ const { "default": d2 } = await import('namespace-allowed');
+    84 │ import d0 from 'namespace-allowed';
+    85 │ export { default as d1 } from 'namespace-allowed';
+  > 86 │ import { default as d1 } from 'namespace-allowed';
+       │          ^^^^^^^
+    87 │ const { "default": d2 } = await import('namespace-allowed');
+    88 │ const { default: d3 } = await import('namespace-allowed');
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:87:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    85 │ export { default as d1 } from 'namespace-allowed';
+    86 │ import { default as d1 } from 'namespace-allowed';
+  > 87 │ const { "default": d2 } = await import('namespace-allowed');
        │         ^^^^^^^^^
-    81 │ const { default: d3 } = await import('namespace-allowed');
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    88 │ const { default: d3 } = await import('namespace-allowed');
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
@@ -1450,16 +1594,16 @@ invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:88:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'namespace-allowed'.
   
-    79 │ import { default as d1 } from 'namespace-allowed';
-    80 │ const { "default": d2 } = await import('namespace-allowed');
-  > 81 │ const { default: d3 } = await import('namespace-allowed');
+    86 │ import { default as d1 } from 'namespace-allowed';
+    87 │ const { "default": d2 } = await import('namespace-allowed');
+  > 88 │ const { default: d3 } = await import('namespace-allowed');
        │         ^^^^^^^
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
@@ -1469,16 +1613,16 @@ invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 
 ```
-invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:89:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'namespace-allowed'.
   
-    80 │ const { "default": d2 } = await import('namespace-allowed');
-    81 │ const { default: d3 } = await import('namespace-allowed');
-  > 82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    87 │ const { "default": d2 } = await import('namespace-allowed');
+    88 │ const { default: d3 } = await import('namespace-allowed');
+  > 89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
        │          ^^^^^^^
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
@@ -1488,214 +1632,20 @@ invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:82:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:89:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden1' from 'namespace-allowed'.
   
-    80 │ const { "default": d2 } = await import('namespace-allowed');
-    81 │ const { default: d3 } = await import('namespace-allowed');
-  > 82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    87 │ const { "default": d2 } = await import('namespace-allowed');
+    88 │ const { default: d3 } = await import('namespace-allowed');
+  > 89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
        │                         ^^^^^^^^^^
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
   i Only the following imports from 'namespace-allowed' are allowed:
   
   - *
-  
-
-```
-
-```
-invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden2' from 'namespace-allowed'.
-  
-    81 │ const { default: d3 } = await import('namespace-allowed');
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
-  > 83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-       │         ^^^^^^^^^^
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:83:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'namespace-allowed'.
-  
-    81 │ const { default: d3 } = await import('namespace-allowed');
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
-  > 83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-       │                     ^^^^^^^
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:84:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden3' from 'namespace-allowed'.
-  
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-  > 84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-       │         ^^^^^^^^^^
-    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-    86 │ 
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:84:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'namespace-allowed'.
-  
-    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-  > 84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-       │                     ^^^^^^^
-    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-    86 │ 
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:85:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'namespace-allowed'.
-  
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-  > 85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-       │         ^^^^^^^^^^^^
-    86 │ 
-    87 │ import d0 from 'member-allowed';
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:85:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'namespace-allowed'.
-  
-    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
-    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
-  > 85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-       │                           ^^^^^^^^^
-    86 │ 
-    87 │ import d0 from 'member-allowed';
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:87:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'member-allowed'.
-  
-    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
-    86 │ 
-  > 87 │ import d0 from 'member-allowed';
-       │        ^^
-    88 │ import { default as d1 } from 'member-allowed';
-    89 │ const { "default": d2 } = await import('member-allowed');
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:88:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'member-allowed'.
-  
-    87 │ import d0 from 'member-allowed';
-  > 88 │ import { default as d1 } from 'member-allowed';
-       │          ^^^^^^^
-    89 │ const { "default": d2 } = await import('member-allowed');
-    90 │ const { default: d3 } = await import('member-allowed');
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'member-allowed'.
-  
-    87 │ import d0 from 'member-allowed';
-    88 │ import { default as d1 } from 'member-allowed';
-  > 89 │ const { "default": d2 } = await import('member-allowed');
-       │         ^^^^^^^^^
-    90 │ const { default: d3 } = await import('member-allowed');
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
   
 
 ```
@@ -1703,80 +1653,75 @@ invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:90:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'member-allowed'.
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
   
-    88 │ import { default as d1 } from 'member-allowed';
-    89 │ const { "default": d2 } = await import('member-allowed');
-  > 90 │ const { default: d3 } = await import('member-allowed');
-       │         ^^^^^^^
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    88 │ const { default: d3 } = await import('namespace-allowed');
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+  > 90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+       │         ^^^^^^^^^^
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed:
+  i Only the following imports from 'namespace-allowed' are allowed:
   
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
+  - *
   
 
 ```
 
 ```
-invalid.js:91:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:90:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'member-allowed'.
+  ! Do not import 'default' from 'namespace-allowed'.
   
-    89 │ const { "default": d2 } = await import('member-allowed');
-    90 │ const { default: d3 } = await import('member-allowed');
-  > 91 │ import { default as d4, forbidden1 } from 'member-allowed';
-       │          ^^^^^^^
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+    88 │ const { default: d3 } = await import('namespace-allowed');
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+  > 90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+       │                     ^^^^^^^
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed:
+  i Only the following imports from 'namespace-allowed' are allowed:
   
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
+  - *
   
 
 ```
 
 ```
-invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:91:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden1' from 'member-allowed'.
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
   
-    89 │ const { "default": d2 } = await import('member-allowed');
-    90 │ const { default: d3 } = await import('member-allowed');
-  > 91 │ import { default as d4, forbidden1 } from 'member-allowed';
-       │                         ^^^^^^^^^^
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+  > 91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+       │         ^^^^^^^^^^
+    92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    93 │ 
   
-  i Only the following imports from 'member-allowed' are allowed:
+  i Only the following imports from 'namespace-allowed' are allowed:
   
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
+  - *
+  
+
+```
+
+```
+invalid.js:91:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    89 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+  > 91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+       │                     ^^^^^^^
+    92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    93 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1784,149 +1729,52 @@ invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'member-allowed'.
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
   
-    90 │ const { default: d3 } = await import('member-allowed');
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-  > 92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-       │         ^^^^^^^^^^
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
-    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:92:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'member-allowed'.
-  
-    90 │ const { default: d3 } = await import('member-allowed');
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-  > 92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-       │                     ^^^^^^^
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
-    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:93:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden3' from 'member-allowed'.
-  
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-  > 93 │ const { forbidden3, default: d6 } = import('member-allowed');
-       │         ^^^^^^^^^^
-    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-    95 │ 
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:93:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'member-allowed'.
-  
-    91 │ import { default as d4, forbidden1 } from 'member-allowed';
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-  > 93 │ const { forbidden3, default: d6 } = import('member-allowed');
-       │                     ^^^^^^^
-    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-    95 │ 
-  
-  i Only the following imports from 'member-allowed' are allowed:
-  
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
-  
-
-```
-
-```
-invalid.js:94:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'member-allowed'.
-  
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
-  > 94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  > 92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
        │         ^^^^^^^^^^^^
-    95 │ 
-    96 │ import d0 from 'bare-allowed';
+    93 │ 
+    94 │ import d0 from 'member-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed:
+  i Only the following imports from 'namespace-allowed' are allowed:
   
-  - allowed1
-  - allowed2
-  - allowed3
-  - allowed4
-  - allowed5
-  - allowed6
-  - allowed7
-  - allowed8
-  - allowed9
+  - *
   
 
 ```
 
 ```
-invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:92:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    90 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    91 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  > 92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+       │                           ^^^^^^^^^
+    93 │ 
+    94 │ import d0 from 'member-allowed';
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:94:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'member-allowed'.
   
-    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
-    93 │ const { forbidden3, default: d6 } = import('member-allowed');
-  > 94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-       │                           ^^^^^^^^^
-    95 │ 
-    96 │ import d0 from 'bare-allowed';
+    92 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    93 │ 
+  > 94 │ import d0 from 'member-allowed';
+       │        ^^
+    95 │ export { default as d1 } from 'member-allowed';
+    96 │ import { default as d1 } from 'member-allowed';
   
   i Only the following imports from 'member-allowed' are allowed:
   
@@ -1944,38 +1792,81 @@ invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:96:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:95:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'bare-allowed'.
+  ! Do not import 'default' from 'member-allowed'.
   
-    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
-    95 │ 
-  > 96 │ import d0 from 'bare-allowed';
-       │        ^^
-    97 │ import { default as d1 } from 'bare-allowed';
-    98 │ const { "default": d2 } = await import('bare-allowed');
-  
-  i Only the following imports from 'bare-allowed' are allowed:
-  
-  - Side-effect only import
-  
-
-```
-
-```
-invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'bare-allowed'.
-  
-    96 │ import d0 from 'bare-allowed';
-  > 97 │ import { default as d1 } from 'bare-allowed';
+    94 │ import d0 from 'member-allowed';
+  > 95 │ export { default as d1 } from 'member-allowed';
        │          ^^^^^^^
-    98 │ const { "default": d2 } = await import('bare-allowed');
-    99 │ const { default: d3 } = await import('bare-allowed');
+    96 │ import { default as d1 } from 'member-allowed';
+    97 │ const { "default": d2 } = await import('member-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:96:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    94 │ import d0 from 'member-allowed';
+    95 │ export { default as d1 } from 'member-allowed';
+  > 96 │ import { default as d1 } from 'member-allowed';
+       │          ^^^^^^^
+    97 │ const { "default": d2 } = await import('member-allowed');
+    98 │ const { default: d3 } = await import('member-allowed');
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:97:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    95 │ export { default as d1 } from 'member-allowed';
+    96 │ import { default as d1 } from 'member-allowed';
+  > 97 │ const { "default": d2 } = await import('member-allowed');
+       │         ^^^^^^^^^
+    98 │ const { default: d3 } = await import('member-allowed');
+    99 │ import { default as d4, forbidden1 } from 'member-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1983,75 +1874,134 @@ invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:98:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'bare-allowed'.
+  ! Do not import 'default' from 'member-allowed'.
   
-     96 │ import d0 from 'bare-allowed';
-     97 │ import { default as d1 } from 'bare-allowed';
-   > 98 │ const { "default": d2 } = await import('bare-allowed');
-        │         ^^^^^^^^^
-     99 │ const { default: d3 } = await import('bare-allowed');
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-  
-  i Only the following imports from 'bare-allowed' are allowed:
-  
-  - Side-effect only import
-  
-
-```
-
-```
-invalid.js:99:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'bare-allowed'.
-  
-     97 │ import { default as d1 } from 'bare-allowed';
-     98 │ const { "default": d2 } = await import('bare-allowed');
-   > 99 │ const { default: d3 } = await import('bare-allowed');
+     96 │ import { default as d1 } from 'member-allowed';
+     97 │ const { "default": d2 } = await import('member-allowed');
+   > 98 │ const { default: d3 } = await import('member-allowed');
         │         ^^^^^^^
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+     99 │ import { default as d4, forbidden1 } from 'member-allowed';
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
 
 ```
-invalid.js:100:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:99:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'bare-allowed'.
+  ! Do not import 'default' from 'member-allowed'.
   
-     98 │ const { "default": d2 } = await import('bare-allowed');
-     99 │ const { default: d3 } = await import('bare-allowed');
-  > 100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+     97 │ const { "default": d2 } = await import('member-allowed');
+     98 │ const { default: d3 } = await import('member-allowed');
+   > 99 │ import { default as d4, forbidden1 } from 'member-allowed';
         │          ^^^^^^^
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
 
 ```
-invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:99:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden1' from 'bare-allowed'.
+  ! Do not import 'forbidden1' from 'member-allowed'.
   
-     98 │ const { "default": d2 } = await import('bare-allowed');
-     99 │ const { default: d3 } = await import('bare-allowed');
-  > 100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+     97 │ const { "default": d2 } = await import('member-allowed');
+     98 │ const { default: d3 } = await import('member-allowed');
+   > 99 │ import { default as d4, forbidden1 } from 'member-allowed';
         │                         ^^^^^^^^^^
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:100:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'member-allowed'.
+  
+     98 │ const { default: d3 } = await import('member-allowed');
+     99 │ import { default as d4, forbidden1 } from 'member-allowed';
+  > 100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+        │         ^^^^^^^^^^
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
+    102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:100:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+     98 │ const { default: d3 } = await import('member-allowed');
+     99 │ import { default as d4, forbidden1 } from 'member-allowed';
+  > 100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+        │                     ^^^^^^^
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
+    102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -2059,18 +2009,26 @@ invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'bare-allowed'.
+  ! Do not import 'forbidden3' from 'member-allowed'.
   
-     99 │ const { default: d3 } = await import('bare-allowed');
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-  > 101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+     99 │ import { default as d4, forbidden1 } from 'member-allowed';
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+  > 101 │ const { forbidden3, default: d6 } = import('member-allowed');
         │         ^^^^^^^^^^
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    103 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -2078,18 +2036,26 @@ invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'default' from 'bare-allowed'.
+  ! Do not import 'default' from 'member-allowed'.
   
-     99 │ const { default: d3 } = await import('bare-allowed');
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-  > 101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+     99 │ import { default as d4, forbidden1 } from 'member-allowed';
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+  > 101 │ const { forbidden3, default: d6 } = import('member-allowed');
         │                     ^^^^^^^
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    103 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -2097,71 +2063,68 @@ invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:102:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden3' from 'bare-allowed'.
+  ! Do not import 'forbidden4' from 'member-allowed'.
   
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-  > 102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-        │         ^^^^^^^^^^
-    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
-    104 │ 
-  
-  i Only the following imports from 'bare-allowed' are allowed:
-  
-  - Side-effect only import
-  
-
-```
-
-```
-invalid.js:102:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'default' from 'bare-allowed'.
-  
-    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-  > 102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-        │                     ^^^^^^^
-    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
-    104 │ 
-  
-  i Only the following imports from 'bare-allowed' are allowed:
-  
-  - Side-effect only import
-  
-
-```
-
-```
-invalid.js:103:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'bare-allowed'.
-  
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-  > 103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
+  > 102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
         │         ^^^^^^^^^^^^
-    104 │ 
-    105 │ import { forbidden1 } from 'default-allowed';
+    103 │ 
+    104 │ import d0 from 'bare-allowed';
   
-  i Only the following imports from 'bare-allowed' are allowed:
+  i Only the following imports from 'member-allowed' are allowed:
   
-  - Side-effect only import
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
 
 ```
-invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:102:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    100 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    101 │ const { forbidden3, default: d6 } = import('member-allowed');
+  > 102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+        │                           ^^^^^^^^^
+    103 │ 
+    104 │ import d0 from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
+  
+
+```
+
+```
+invalid.js:104:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'default' from 'bare-allowed'.
   
-    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
-    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
-  > 103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
-        │                           ^^^^^^^^^
-    104 │ 
-    105 │ import { forbidden1 } from 'default-allowed';
+    102 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    103 │ 
+  > 104 │ import d0 from 'bare-allowed';
+        │        ^^
+    105 │ export { default as d1 } from 'bare-allowed';
+    106 │ import { default as d1 } from 'bare-allowed';
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2173,186 +2136,112 @@ invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:105:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden1' from 'default-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
-    104 │ 
-  > 105 │ import { forbidden1 } from 'default-allowed';
-        │          ^^^^^^^^^^
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    104 │ import d0 from 'bare-allowed';
+  > 105 │ export { default as d1 } from 'bare-allowed';
+        │          ^^^^^^^
+    106 │ import { default as d1 } from 'bare-allowed';
+    107 │ const { "default": d2 } = await import('bare-allowed');
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
-  
-
-```
-
-```
-invalid.js:106:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden2' from 'default-allowed'.
-  
-    105 │ import { forbidden1 } from 'default-allowed';
-  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-        │         ^^^^^^^^^^
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-  
-  i Only the following imports from 'default-allowed' are allowed:
-  
-  - default
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:106:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:106:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden3' from 'default-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    105 │ import { forbidden1 } from 'default-allowed';
-  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-        │                     ^^^^^^^^^^
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    104 │ import d0 from 'bare-allowed';
+    105 │ export { default as d1 } from 'bare-allowed';
+  > 106 │ import { default as d1 } from 'bare-allowed';
+        │          ^^^^^^^
+    107 │ const { "default": d2 } = await import('bare-allowed');
+    108 │ const { default: d3 } = await import('bare-allowed');
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
-  
-
-```
-
-```
-invalid.js:106:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'default-allowed'.
-  
-    105 │ import { forbidden1 } from 'default-allowed';
-  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-        │                                     ^^^^^^^^^^^^
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-  
-  i Only the following imports from 'default-allowed' are allowed:
-  
-  - default
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:107:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:107:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'default-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    105 │ import { forbidden1 } from 'default-allowed';
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                   ^^^^^^^^^^
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    109 │ 
+    105 │ export { default as d1 } from 'bare-allowed';
+    106 │ import { default as d1 } from 'bare-allowed';
+  > 107 │ const { "default": d2 } = await import('bare-allowed');
+        │         ^^^^^^^^^
+    108 │ const { default: d3 } = await import('bare-allowed');
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
-  
-
-```
-
-```
-invalid.js:107:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden3' from 'default-allowed'.
-  
-    105 │ import { forbidden1 } from 'default-allowed';
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                               ^^^^^^^^^^
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    109 │ 
-  
-  i Only the following imports from 'default-allowed' are allowed:
-  
-  - default
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:107:63 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:108:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden4' from 'default-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    105 │ import { forbidden1 } from 'default-allowed';
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                                               ^^^^^^^^^^^^
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    109 │ 
+    106 │ import { default as d1 } from 'bare-allowed';
+    107 │ const { "default": d2 } = await import('bare-allowed');
+  > 108 │ const { default: d3 } = await import('bare-allowed');
+        │         ^^^^^^^
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
-  
-
-```
-
-```
-invalid.js:108:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden2' from 'default-allowed'.
-  
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                            ^^^^^^^^^^
-    109 │ 
-    110 │ import { forbidden1 } from 'namespace-allowed';
-  
-  i Only the following imports from 'default-allowed' are allowed:
-  
-  - default
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:108:56 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:109:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden3' from 'default-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                                        ^^^^^^^^^^
-    109 │ 
-    110 │ import { forbidden1 } from 'namespace-allowed';
+    107 │ const { "default": d2 } = await import('bare-allowed');
+    108 │ const { default: d3 } = await import('bare-allowed');
+  > 109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+        │          ^^^^^^^
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
+  - Side-effect only import
   
-
-```
 
 ```
-invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden4' from 'default-allowed'.
+```
+invalid.js:109:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'bare-allowed'.
   
-    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
-    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                                                        ^^^^^^^^^^^^
-    109 │ 
-    110 │ import { forbidden1 } from 'namespace-allowed';
+    107 │ const { "default": d2 } = await import('bare-allowed');
+    108 │ const { default: d3 } = await import('bare-allowed');
+  > 109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+        │                         ^^^^^^^^^^
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
   
-  i Only the following imports from 'default-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - default
+  - Side-effect only import
   
 
 ```
@@ -2360,18 +2249,37 @@ invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden1' from 'namespace-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    109 │ 
-  > 110 │ import { forbidden1 } from 'namespace-allowed';
-        │          ^^^^^^^^^^
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    108 │ const { default: d3 } = await import('bare-allowed');
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+  > 110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+        │          ^^^^^^^
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
+  - Side-effect only import
+  
+
+```
+
+```
+invalid.js:110:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'bare-allowed'.
+  
+    108 │ const { default: d3 } = await import('bare-allowed');
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+  > 110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+        │                         ^^^^^^^^^^
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2379,17 +2287,18 @@ invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  ! Do not import 'forbidden2' from 'bare-allowed'.
   
-    110 │ import { forbidden1 } from 'namespace-allowed';
-  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+  > 111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
         │         ^^^^^^^^^^
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
+  - Side-effect only import
   
 
 ```
@@ -2397,149 +2306,94 @@ invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:111:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden3' from 'namespace-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    110 │ import { forbidden1 } from 'namespace-allowed';
-  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-        │                     ^^^^^^^^^^
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    109 │ export { default as d4, forbidden1 } from 'bare-allowed';
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+  > 111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+        │                     ^^^^^^^
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
-  
-
-```
-
-```
-invalid.js:111:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'namespace-allowed'.
-  
-    110 │ import { forbidden1 } from 'namespace-allowed';
-  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-        │                                     ^^^^^^^^^^^^
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:112:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:112:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  ! Do not import 'forbidden3' from 'bare-allowed'.
   
-    110 │ import { forbidden1 } from 'namespace-allowed';
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                     ^^^^^^^^^^
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+  > 112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+        │         ^^^^^^^^^^
+    113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     114 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:112:49 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:112:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden3' from 'namespace-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    110 │ import { forbidden1 } from 'namespace-allowed';
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                                 ^^^^^^^^^^
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    110 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+  > 112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+        │                     ^^^^^^^
+    113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     114 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:112:65 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:113:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden4' from 'namespace-allowed'.
+  ! Do not import 'forbidden4' from 'bare-allowed'.
   
-    110 │ import { forbidden1 } from 'namespace-allowed';
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-        │                                                                 ^^^^^^^^^^^^
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  > 113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+        │         ^^^^^^^^^^^^
     114 │ 
+    115 │ export { forbidden1 } from 'default-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
+  - Side-effect only import
   
 
 ```
 
 ```
-invalid.js:113:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:113:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  ! Do not import 'default' from 'bare-allowed'.
   
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                              ^^^^^^^^^^
+    111 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    112 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  > 113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+        │                           ^^^^^^^^^
     114 │ 
-    115 │ import { forbidden1 } from 'bare-allowed';
+    115 │ export { forbidden1 } from 'default-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed:
+  i Only the following imports from 'bare-allowed' are allowed:
   
-  - *
-  
-
-```
-
-```
-invalid.js:113:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden3' from 'namespace-allowed'.
-  
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                                          ^^^^^^^^^^
-    114 │ 
-    115 │ import { forbidden1 } from 'bare-allowed';
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
-  
-
-```
-
-```
-invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Do not import 'forbidden4' from 'namespace-allowed'.
-  
-    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
-    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-        │                                                                          ^^^^^^^^^^^^
-    114 │ 
-    115 │ import { forbidden1 } from 'bare-allowed';
-  
-  i Only the following imports from 'namespace-allowed' are allowed:
-  
-  - *
+  - Side-effect only import
   
 
 ```
@@ -2547,14 +2401,430 @@ invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Do not import 'forbidden1' from 'default-allowed'.
+  
+    113 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    114 │ 
+  > 115 │ export { forbidden1 } from 'default-allowed';
+        │          ^^^^^^^^^^
+    116 │ import { forbidden1 } from 'default-allowed';
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:116:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'default-allowed'.
+  
+    115 │ export { forbidden1 } from 'default-allowed';
+  > 116 │ import { forbidden1 } from 'default-allowed';
+        │          ^^^^^^^^^^
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:117:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'default-allowed'.
+  
+    115 │ export { forbidden1 } from 'default-allowed';
+    116 │ import { forbidden1 } from 'default-allowed';
+  > 117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │         ^^^^^^^^^^
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:117:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'default-allowed'.
+  
+    115 │ export { forbidden1 } from 'default-allowed';
+    116 │ import { forbidden1 } from 'default-allowed';
+  > 117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │                     ^^^^^^^^^^
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:117:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'default-allowed'.
+  
+    115 │ export { forbidden1 } from 'default-allowed';
+    116 │ import { forbidden1 } from 'default-allowed';
+  > 117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │                                     ^^^^^^^^^^^^
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:118:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'default-allowed'.
+  
+    116 │ import { forbidden1 } from 'default-allowed';
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                   ^^^^^^^^^^
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    120 │ 
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:118:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'default-allowed'.
+  
+    116 │ import { forbidden1 } from 'default-allowed';
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                               ^^^^^^^^^^
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    120 │ 
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:118:63 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'default-allowed'.
+  
+    116 │ import { forbidden1 } from 'default-allowed';
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                               ^^^^^^^^^^^^
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    120 │ 
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:119:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'default-allowed'.
+  
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                            ^^^^^^^^^^
+    120 │ 
+    121 │ export { forbidden1 } from 'namespace-allowed';
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:119:56 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'default-allowed'.
+  
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                        ^^^^^^^^^^
+    120 │ 
+    121 │ export { forbidden1 } from 'namespace-allowed';
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:119:72 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'default-allowed'.
+  
+    117 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    118 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                                        ^^^^^^^^^^^^
+    120 │ 
+    121 │ export { forbidden1 } from 'namespace-allowed';
+  
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
+  
+
+```
+
+```
+invalid.js:121:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'namespace-allowed'.
+  
+    119 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    120 │ 
+  > 121 │ export { forbidden1 } from 'namespace-allowed';
+        │          ^^^^^^^^^^
+    122 │ import { forbidden1 } from 'namespace-allowed';
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:122:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'namespace-allowed'.
+  
+    121 │ export { forbidden1 } from 'namespace-allowed';
+  > 122 │ import { forbidden1 } from 'namespace-allowed';
+        │          ^^^^^^^^^^
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:123:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  
+    121 │ export { forbidden1 } from 'namespace-allowed';
+    122 │ import { forbidden1 } from 'namespace-allowed';
+  > 123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │         ^^^^^^^^^^
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:123:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
+  
+    121 │ export { forbidden1 } from 'namespace-allowed';
+    122 │ import { forbidden1 } from 'namespace-allowed';
+  > 123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │                     ^^^^^^^^^^
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:123:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
+  
+    121 │ export { forbidden1 } from 'namespace-allowed';
+    122 │ import { forbidden1 } from 'namespace-allowed';
+  > 123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │                                     ^^^^^^^^^^^^
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:124:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  
+    122 │ import { forbidden1 } from 'namespace-allowed';
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                     ^^^^^^^^^^
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    126 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:124:49 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
+  
+    122 │ import { forbidden1 } from 'namespace-allowed';
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                 ^^^^^^^^^^
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    126 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:124:65 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
+  
+    122 │ import { forbidden1 } from 'namespace-allowed';
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                                 ^^^^^^^^^^^^
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    126 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:125:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
+  
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                              ^^^^^^^^^^
+    126 │ 
+    127 │ export { forbidden1 } from 'bare-allowed';
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:125:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
+  
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                          ^^^^^^^^^^
+    126 │ 
+    127 │ export { forbidden1 } from 'bare-allowed';
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:125:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
+  
+    123 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    124 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                                          ^^^^^^^^^^^^
+    126 │ 
+    127 │ export { forbidden1 } from 'bare-allowed';
+  
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
+  
+
+```
+
+```
+invalid.js:127:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Do not import 'forbidden1' from 'bare-allowed'.
   
-    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    114 │ 
-  > 115 │ import { forbidden1 } from 'bare-allowed';
+    125 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    126 │ 
+  > 127 │ export { forbidden1 } from 'bare-allowed';
         │          ^^^^^^^^^^
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    128 │ import { forbidden1 } from 'bare-allowed';
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2564,15 +2834,34 @@ invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:128:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'bare-allowed'.
+  
+    127 │ export { forbidden1 } from 'bare-allowed';
+  > 128 │ import { forbidden1 } from 'bare-allowed';
+        │          ^^^^^^^^^^
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
+  
+
+```
+
+```
+invalid.js:129:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    127 │ export { forbidden1 } from 'bare-allowed';
+    128 │ import { forbidden1 } from 'bare-allowed';
+  > 129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
         │         ^^^^^^^^^^
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2582,15 +2871,16 @@ invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 
 ```
-invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:129:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    127 │ export { forbidden1 } from 'bare-allowed';
+    128 │ import { forbidden1 } from 'bare-allowed';
+  > 129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
         │                     ^^^^^^^^^^
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2600,15 +2890,16 @@ invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:129:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    127 │ export { forbidden1 } from 'bare-allowed';
+    128 │ import { forbidden1 } from 'bare-allowed';
+  > 129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
         │                                     ^^^^^^^^^^^^
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2618,16 +2909,16 @@ invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:130:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    128 │ import { forbidden1 } from 'bare-allowed';
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
         │                                ^^^^^^^^^^
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    119 │ 
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2637,16 +2928,16 @@ invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:130:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    128 │ import { forbidden1 } from 'bare-allowed';
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
         │                                            ^^^^^^^^^^
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    119 │ 
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2656,16 +2947,16 @@ invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:130:60 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'bare-allowed'.
   
-    115 │ import { forbidden1 } from 'bare-allowed';
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    128 │ import { forbidden1 } from 'bare-allowed';
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
         │                                                            ^^^^^^^^^^^^
-    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
-    119 │ 
+    131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2675,15 +2966,15 @@ invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:131:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden2' from 'bare-allowed'.
   
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
         │                                         ^^^^^^^^^^
-    119 │ 
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2693,15 +2984,15 @@ invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:131:53 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden3' from 'bare-allowed'.
   
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
         │                                                     ^^^^^^^^^^
-    119 │ 
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   
@@ -2711,15 +3002,15 @@ invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━�
 ```
 
 ```
-invalid.js:118:69 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:131:69 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Do not import 'forbidden4' from 'bare-allowed'.
   
-    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
-    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
-  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    129 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    130 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 131 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
         │                                                                     ^^^^^^^^^^^^
-    119 │ 
+    132 │ 
   
   i Only the following imports from 'bare-allowed' are allowed:
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -1,11 +1,128 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
+snapshot_kind: text
 ---
 # Input
 ```jsx
 import eslint from 'eslint';
 const l = require('lodash');
+
+import 'bare-forbidden';
+import 'namespace-allowed';
+import 'default-allowed';
+import 'default-and-member-allowed';
+
+import * as n1 from 'namespace-forbidden';
+const n2 = await import('namespace-forbidden');
+const n2b = ((await (import('namespace-forbidden'))));
+const n3 = import('namespace-forbidden');
+const n3b = (import('namespace-forbidden'));
+import('namespace-forbidden').then(n4 => { });
+import('namespace-forbidden').then((n5) => { });
+import('namespace-forbidden').then(function (n6) { });
+((import('namespace-forbidden'))).then(((n6 => { })));
+((import('namespace-forbidden'))).then((((n7) => { })));
+((import('namespace-forbidden'))).then(((function (n8) { })));
+
+import d0 from 'default-forbidden';
+import { default as d1 } from 'default-forbidden';
+const { "default": d2 } = await import('default-forbidden');
+const { default: d3 } = await import('default-forbidden');
+import { default as d4, allowed1 } from 'default-forbidden';
+const { allowed2, default: d5 } = await import('default-forbidden');
+const { allowed3, default: d6 } = import('default-forbidden');
+const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+
+import { allowed5, forbidden1 } from 'member-forbidden';
+const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+// require() returns the default import, not a namespace object,
+// so this import corresponds to default.allowed1 (and not namespace.allowed1)
+// and is therefore *NOT* allowed.
+const { allowed1 } = require('default-forbidden');
+const { allowed2 } = require('namespace-allowed');
+const { allowed3 } = require('member-allowed');
+
+import * as n1 from 'default-allowed';
+const n2 = await import('default-allowed');
+const n2b = ((await (import('default-allowed'))));
+const n3 = import('default-allowed');
+const n3b = (import('default-allowed'));
+import('default-allowed').then(n4 => { });
+import('default-allowed').then((n5) => { });
+import('default-allowed').then(function (n6) { });
+((import('default-allowed'))).then(((n6 => { })));
+((import('default-allowed'))).then((((n7) => { })));
+((import('default-allowed'))).then(((function (n8) { })));
+
+import * as n1 from 'member-allowed';
+const n2 = await import('member-allowed');
+const n2b = ((await (import('member-allowed'))));
+const n3 = import('member-allowed');
+const n3b = (import('member-allowed'));
+import('member-allowed').then(n4 => { });
+import('member-allowed').then((n5) => { });
+import('member-allowed').then(function (n6) { });
+((import('member-allowed'))).then(((n6 => { })));
+((import('member-allowed'))).then((((n7) => { })));
+((import('member-allowed'))).then(((function (n8) { })));
+
+import * as n1 from 'bare-allowed';
+const n2 = await import('bare-allowed');
+const n2b = ((await (import('bare-allowed'))));
+const n3 = import('bare-allowed');
+const n3b = (import('bare-allowed'));
+import('bare-allowed').then(n4 => { });
+import('bare-allowed').then((n5) => { });
+import('bare-allowed').then(function (n6) { });
+((import('bare-allowed'))).then(((n6 => { })));
+((import('bare-allowed'))).then((((n7) => { })));
+((import('bare-allowed'))).then(((function (n8) { })));
+
+import d0 from 'namespace-allowed';
+import { default as d1 } from 'namespace-allowed';
+const { "default": d2 } = await import('namespace-allowed');
+const { default: d3 } = await import('namespace-allowed');
+import { default as d4, forbidden1 } from 'namespace-allowed';
+const { forbidden2, default: d5 } = await import('namespace-allowed');
+const { forbidden3, default: d6 } = import('namespace-allowed');
+const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+
+import d0 from 'member-allowed';
+import { default as d1 } from 'member-allowed';
+const { "default": d2 } = await import('member-allowed');
+const { default: d3 } = await import('member-allowed');
+import { default as d4, forbidden1 } from 'member-allowed';
+const { forbidden2, default: d5 } = await import('member-allowed');
+const { forbidden3, default: d6 } = import('member-allowed');
+const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+
+import d0 from 'bare-allowed';
+import { default as d1 } from 'bare-allowed';
+const { "default": d2 } = await import('bare-allowed');
+const { default: d3 } = await import('bare-allowed');
+import { default as d4, forbidden1 } from 'bare-allowed';
+const { forbidden2, default: d5 } = await import('bare-allowed');
+const { forbidden3, default: d6 } = import('bare-allowed');
+const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+
+import { forbidden1 } from 'default-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+import { forbidden1 } from 'namespace-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+
+import { forbidden1 } from 'bare-allowed';
+const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
 
 ```
 
@@ -32,8 +149,1993 @@ invalid.js:2:19 lint/nursery/noRestrictedImports ━━━━━━━━━━�
   > 2 │ const l = require('lodash');
       │                   ^^^^^^^^
     3 │ 
+    4 │ import 'bare-forbidden';
   
 
 ```
 
+```
+invalid.js:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Importing bare-forbidden is not allowed
+  
+    2 │ const l = require('lodash');
+    3 │ 
+  > 4 │ import 'bare-forbidden';
+      │        ^^^^^^^^^^^^^^^^
+    5 │ import 'namespace-allowed';
+    6 │ import 'default-allowed';
+  
+
+```
+
+```
+invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    4 │ import 'bare-forbidden';
+  > 5 │ import 'namespace-allowed';
+      │        ^^^^^^^^^^^^^^^^^^^
+    6 │ import 'default-allowed';
+    7 │ import 'default-and-member-allowed';
+  
+
+```
+
+```
+invalid.js:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    4 │ import 'bare-forbidden';
+    5 │ import 'namespace-allowed';
+  > 6 │ import 'default-allowed';
+      │        ^^^^^^^^^^^^^^^^^
+    7 │ import 'default-and-member-allowed';
+    8 │ 
+  
+
+```
+
+```
+invalid.js:9:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+     7 │ import 'default-and-member-allowed';
+     8 │ 
+   > 9 │ import * as n1 from 'namespace-forbidden';
+       │        ^
+    10 │ const n2 = await import('namespace-forbidden');
+    11 │ const n2b = ((await (import('namespace-forbidden'))));
+  
+
+```
+
+```
+invalid.js:10:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+     9 │ import * as n1 from 'namespace-forbidden';
+  > 10 │ const n2 = await import('namespace-forbidden');
+       │       ^^
+    11 │ const n2b = ((await (import('namespace-forbidden'))));
+    12 │ const n3 = import('namespace-forbidden');
+  
+
+```
+
+```
+invalid.js:11:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+     9 │ import * as n1 from 'namespace-forbidden';
+    10 │ const n2 = await import('namespace-forbidden');
+  > 11 │ const n2b = ((await (import('namespace-forbidden'))));
+       │       ^^^
+    12 │ const n3 = import('namespace-forbidden');
+    13 │ const n3b = (import('namespace-forbidden'));
+  
+
+```
+
+```
+invalid.js:12:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    10 │ const n2 = await import('namespace-forbidden');
+    11 │ const n2b = ((await (import('namespace-forbidden'))));
+  > 12 │ const n3 = import('namespace-forbidden');
+       │       ^^
+    13 │ const n3b = (import('namespace-forbidden'));
+    14 │ import('namespace-forbidden').then(n4 => { });
+  
+
+```
+
+```
+invalid.js:13:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    11 │ const n2b = ((await (import('namespace-forbidden'))));
+    12 │ const n3 = import('namespace-forbidden');
+  > 13 │ const n3b = (import('namespace-forbidden'));
+       │       ^^^
+    14 │ import('namespace-forbidden').then(n4 => { });
+    15 │ import('namespace-forbidden').then((n5) => { });
+  
+
+```
+
+```
+invalid.js:14:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    12 │ const n3 = import('namespace-forbidden');
+    13 │ const n3b = (import('namespace-forbidden'));
+  > 14 │ import('namespace-forbidden').then(n4 => { });
+       │                                    ^^
+    15 │ import('namespace-forbidden').then((n5) => { });
+    16 │ import('namespace-forbidden').then(function (n6) { });
+  
+
+```
+
+```
+invalid.js:15:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    13 │ const n3b = (import('namespace-forbidden'));
+    14 │ import('namespace-forbidden').then(n4 => { });
+  > 15 │ import('namespace-forbidden').then((n5) => { });
+       │                                     ^^
+    16 │ import('namespace-forbidden').then(function (n6) { });
+    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+  
+
+```
+
+```
+invalid.js:16:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    14 │ import('namespace-forbidden').then(n4 => { });
+    15 │ import('namespace-forbidden').then((n5) => { });
+  > 16 │ import('namespace-forbidden').then(function (n6) { });
+       │                                              ^^
+    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+  
+
+```
+
+```
+invalid.js:17:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    15 │ import('namespace-forbidden').then((n5) => { });
+    16 │ import('namespace-forbidden').then(function (n6) { });
+  > 17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+       │                                          ^^
+    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+  
+
+```
+
+```
+invalid.js:18:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    16 │ import('namespace-forbidden').then(function (n6) { });
+    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+  > 18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+       │                                           ^^
+    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    20 │ 
+  
+
+```
+
+```
+invalid.js:19:52 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-forbidden is not allowed
+  
+    17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
+    18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
+  > 19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+       │                                                    ^^
+    20 │ 
+    21 │ import d0 from 'default-forbidden';
+  
+
+```
+
+```
+invalid.js:21:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
+    20 │ 
+  > 21 │ import d0 from 'default-forbidden';
+       │        ^^
+    22 │ import { default as d1 } from 'default-forbidden';
+    23 │ const { "default": d2 } = await import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:22:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    21 │ import d0 from 'default-forbidden';
+  > 22 │ import { default as d1 } from 'default-forbidden';
+       │          ^^^^^^^
+    23 │ const { "default": d2 } = await import('default-forbidden');
+    24 │ const { default: d3 } = await import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:23:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    21 │ import d0 from 'default-forbidden';
+    22 │ import { default as d1 } from 'default-forbidden';
+  > 23 │ const { "default": d2 } = await import('default-forbidden');
+       │         ^^^^^^^^^
+    24 │ const { default: d3 } = await import('default-forbidden');
+    25 │ import { default as d4, allowed1 } from 'default-forbidden';
+  
+
+```
+
+```
+invalid.js:24:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    22 │ import { default as d1 } from 'default-forbidden';
+    23 │ const { "default": d2 } = await import('default-forbidden');
+  > 24 │ const { default: d3 } = await import('default-forbidden');
+       │         ^^^^^^^
+    25 │ import { default as d4, allowed1 } from 'default-forbidden';
+    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:25:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    23 │ const { "default": d2 } = await import('default-forbidden');
+    24 │ const { default: d3 } = await import('default-forbidden');
+  > 25 │ import { default as d4, allowed1 } from 'default-forbidden';
+       │          ^^^^^^^
+    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    27 │ const { allowed3, default: d6 } = import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:26:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    24 │ const { default: d3 } = await import('default-forbidden');
+    25 │ import { default as d4, allowed1 } from 'default-forbidden';
+  > 26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+       │                   ^^^^^^^
+    27 │ const { allowed3, default: d6 } = import('default-forbidden');
+    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+  
+
+```
+
+```
+invalid.js:27:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    25 │ import { default as d4, allowed1 } from 'default-forbidden';
+    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+  > 27 │ const { allowed3, default: d6 } = import('default-forbidden');
+       │                   ^^^^^^^
+    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    29 │ 
+  
+
+```
+
+```
+invalid.js:28:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    26 │ const { allowed2, default: d5 } = await import('default-forbidden');
+    27 │ const { allowed3, default: d6 } = import('default-forbidden');
+  > 28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+       │                         ^^^^^^^^^
+    29 │ 
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  
+
+```
+
+```
+invalid.js:30:20 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
+    29 │ 
+  > 30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+       │                    ^^^^^^^^^^
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+
+```
+
+```
+invalid.js:31:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+       │                   ^^^^^^^^^^
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:31:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+       │                               ^^^^^^^^^^
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:31:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+  > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+       │                                               ^^^^^^^^^^^^
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:32:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+       │                                              ^^^^^^^^^^
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ 
+  
+
+```
+
+```
+invalid.js:32:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+       │                                                          ^^^^^^^^^^
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ 
+  
+
+```
+
+```
+invalid.js:32:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    30 │ import { allowed5, forbidden1 } from 'member-forbidden';
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+  > 32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+       │                                                                          ^^^^^^^^^^^^
+    33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    34 │ 
+  
+
+```
+
+```
+invalid.js:33:55 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+       │                                                       ^^^^^^^^^^
+    34 │ 
+    35 │ // require() returns the default import, not a namespace object,
+  
+
+```
+
+```
+invalid.js:33:67 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+       │                                                                   ^^^^^^^^^^
+    34 │ 
+    35 │ // require() returns the default import, not a namespace object,
+  
+
+```
+
+```
+invalid.js:33:83 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-forbidden is not allowed
+  
+    31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
+    32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 33 │ import('member-forbidden').then(function ({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+       │                                                                                   ^^^^^^^^^^^^
+    34 │ 
+    35 │ // require() returns the default import, not a namespace object,
+  
+
+```
+
+```
+invalid.js:38:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-forbidden is not allowed
+  
+    36 │ // so this import corresponds to default.allowed1 (and not namespace.allowed1)
+    37 │ // and is therefore *NOT* allowed.
+  > 38 │ const { allowed1 } = require('default-forbidden');
+       │                              ^^^^^^^^^^^^^^^^^^^
+    39 │ const { allowed2 } = require('namespace-allowed');
+    40 │ const { allowed3 } = require('member-allowed');
+  
+
+```
+
+```
+invalid.js:39:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    37 │ // and is therefore *NOT* allowed.
+    38 │ const { allowed1 } = require('default-forbidden');
+  > 39 │ const { allowed2 } = require('namespace-allowed');
+       │                              ^^^^^^^^^^^^^^^^^^^
+    40 │ const { allowed3 } = require('member-allowed');
+    41 │ 
+  
+
+```
+
+```
+invalid.js:40:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    38 │ const { allowed1 } = require('default-forbidden');
+    39 │ const { allowed2 } = require('namespace-allowed');
+  > 40 │ const { allowed3 } = require('member-allowed');
+       │                              ^^^^^^^^^^^^^^^^
+    41 │ 
+    42 │ import * as n1 from 'default-allowed';
+  
+
+```
+
+```
+invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    40 │ const { allowed3 } = require('member-allowed');
+    41 │ 
+  > 42 │ import * as n1 from 'default-allowed';
+       │        ^
+    43 │ const n2 = await import('default-allowed');
+    44 │ const n2b = ((await (import('default-allowed'))));
+  
+
+```
+
+```
+invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    42 │ import * as n1 from 'default-allowed';
+  > 43 │ const n2 = await import('default-allowed');
+       │       ^^
+    44 │ const n2b = ((await (import('default-allowed'))));
+    45 │ const n3 = import('default-allowed');
+  
+
+```
+
+```
+invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    42 │ import * as n1 from 'default-allowed';
+    43 │ const n2 = await import('default-allowed');
+  > 44 │ const n2b = ((await (import('default-allowed'))));
+       │       ^^^
+    45 │ const n3 = import('default-allowed');
+    46 │ const n3b = (import('default-allowed'));
+  
+
+```
+
+```
+invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    43 │ const n2 = await import('default-allowed');
+    44 │ const n2b = ((await (import('default-allowed'))));
+  > 45 │ const n3 = import('default-allowed');
+       │       ^^
+    46 │ const n3b = (import('default-allowed'));
+    47 │ import('default-allowed').then(n4 => { });
+  
+
+```
+
+```
+invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    44 │ const n2b = ((await (import('default-allowed'))));
+    45 │ const n3 = import('default-allowed');
+  > 46 │ const n3b = (import('default-allowed'));
+       │       ^^^
+    47 │ import('default-allowed').then(n4 => { });
+    48 │ import('default-allowed').then((n5) => { });
+  
+
+```
+
+```
+invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    45 │ const n3 = import('default-allowed');
+    46 │ const n3b = (import('default-allowed'));
+  > 47 │ import('default-allowed').then(n4 => { });
+       │                                ^^
+    48 │ import('default-allowed').then((n5) => { });
+    49 │ import('default-allowed').then(function (n6) { });
+  
+
+```
+
+```
+invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    46 │ const n3b = (import('default-allowed'));
+    47 │ import('default-allowed').then(n4 => { });
+  > 48 │ import('default-allowed').then((n5) => { });
+       │                                 ^^
+    49 │ import('default-allowed').then(function (n6) { });
+    50 │ ((import('default-allowed'))).then(((n6 => { })));
+  
+
+```
+
+```
+invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    47 │ import('default-allowed').then(n4 => { });
+    48 │ import('default-allowed').then((n5) => { });
+  > 49 │ import('default-allowed').then(function (n6) { });
+       │                                          ^^
+    50 │ ((import('default-allowed'))).then(((n6 => { })));
+    51 │ ((import('default-allowed'))).then((((n7) => { })));
+  
+
+```
+
+```
+invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    48 │ import('default-allowed').then((n5) => { });
+    49 │ import('default-allowed').then(function (n6) { });
+  > 50 │ ((import('default-allowed'))).then(((n6 => { })));
+       │                                      ^^
+    51 │ ((import('default-allowed'))).then((((n7) => { })));
+    52 │ ((import('default-allowed'))).then(((function (n8) { })));
+  
+
+```
+
+```
+invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    49 │ import('default-allowed').then(function (n6) { });
+    50 │ ((import('default-allowed'))).then(((n6 => { })));
+  > 51 │ ((import('default-allowed'))).then((((n7) => { })));
+       │                                       ^^
+    52 │ ((import('default-allowed'))).then(((function (n8) { })));
+    53 │ 
+  
+
+```
+
+```
+invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    50 │ ((import('default-allowed'))).then(((n6 => { })));
+    51 │ ((import('default-allowed'))).then((((n7) => { })));
+  > 52 │ ((import('default-allowed'))).then(((function (n8) { })));
+       │                                                ^^
+    53 │ 
+    54 │ import * as n1 from 'member-allowed';
+  
+
+```
+
+```
+invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    52 │ ((import('default-allowed'))).then(((function (n8) { })));
+    53 │ 
+  > 54 │ import * as n1 from 'member-allowed';
+       │        ^
+    55 │ const n2 = await import('member-allowed');
+    56 │ const n2b = ((await (import('member-allowed'))));
+  
+
+```
+
+```
+invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    54 │ import * as n1 from 'member-allowed';
+  > 55 │ const n2 = await import('member-allowed');
+       │       ^^
+    56 │ const n2b = ((await (import('member-allowed'))));
+    57 │ const n3 = import('member-allowed');
+  
+
+```
+
+```
+invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    54 │ import * as n1 from 'member-allowed';
+    55 │ const n2 = await import('member-allowed');
+  > 56 │ const n2b = ((await (import('member-allowed'))));
+       │       ^^^
+    57 │ const n3 = import('member-allowed');
+    58 │ const n3b = (import('member-allowed'));
+  
+
+```
+
+```
+invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    55 │ const n2 = await import('member-allowed');
+    56 │ const n2b = ((await (import('member-allowed'))));
+  > 57 │ const n3 = import('member-allowed');
+       │       ^^
+    58 │ const n3b = (import('member-allowed'));
+    59 │ import('member-allowed').then(n4 => { });
+  
+
+```
+
+```
+invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    56 │ const n2b = ((await (import('member-allowed'))));
+    57 │ const n3 = import('member-allowed');
+  > 58 │ const n3b = (import('member-allowed'));
+       │       ^^^
+    59 │ import('member-allowed').then(n4 => { });
+    60 │ import('member-allowed').then((n5) => { });
+  
+
+```
+
+```
+invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    57 │ const n3 = import('member-allowed');
+    58 │ const n3b = (import('member-allowed'));
+  > 59 │ import('member-allowed').then(n4 => { });
+       │                               ^^
+    60 │ import('member-allowed').then((n5) => { });
+    61 │ import('member-allowed').then(function (n6) { });
+  
+
+```
+
+```
+invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    58 │ const n3b = (import('member-allowed'));
+    59 │ import('member-allowed').then(n4 => { });
+  > 60 │ import('member-allowed').then((n5) => { });
+       │                                ^^
+    61 │ import('member-allowed').then(function (n6) { });
+    62 │ ((import('member-allowed'))).then(((n6 => { })));
+  
+
+```
+
+```
+invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    59 │ import('member-allowed').then(n4 => { });
+    60 │ import('member-allowed').then((n5) => { });
+  > 61 │ import('member-allowed').then(function (n6) { });
+       │                                         ^^
+    62 │ ((import('member-allowed'))).then(((n6 => { })));
+    63 │ ((import('member-allowed'))).then((((n7) => { })));
+  
+
+```
+
+```
+invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    60 │ import('member-allowed').then((n5) => { });
+    61 │ import('member-allowed').then(function (n6) { });
+  > 62 │ ((import('member-allowed'))).then(((n6 => { })));
+       │                                     ^^
+    63 │ ((import('member-allowed'))).then((((n7) => { })));
+    64 │ ((import('member-allowed'))).then(((function (n8) { })));
+  
+
+```
+
+```
+invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    61 │ import('member-allowed').then(function (n6) { });
+    62 │ ((import('member-allowed'))).then(((n6 => { })));
+  > 63 │ ((import('member-allowed'))).then((((n7) => { })));
+       │                                      ^^
+    64 │ ((import('member-allowed'))).then(((function (n8) { })));
+    65 │ 
+  
+
+```
+
+```
+invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    62 │ ((import('member-allowed'))).then(((n6 => { })));
+    63 │ ((import('member-allowed'))).then((((n7) => { })));
+  > 64 │ ((import('member-allowed'))).then(((function (n8) { })));
+       │                                               ^^
+    65 │ 
+    66 │ import * as n1 from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    64 │ ((import('member-allowed'))).then(((function (n8) { })));
+    65 │ 
+  > 66 │ import * as n1 from 'bare-allowed';
+       │        ^
+    67 │ const n2 = await import('bare-allowed');
+    68 │ const n2b = ((await (import('bare-allowed'))));
+  
+
+```
+
+```
+invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    66 │ import * as n1 from 'bare-allowed';
+  > 67 │ const n2 = await import('bare-allowed');
+       │       ^^
+    68 │ const n2b = ((await (import('bare-allowed'))));
+    69 │ const n3 = import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    66 │ import * as n1 from 'bare-allowed';
+    67 │ const n2 = await import('bare-allowed');
+  > 68 │ const n2b = ((await (import('bare-allowed'))));
+       │       ^^^
+    69 │ const n3 = import('bare-allowed');
+    70 │ const n3b = (import('bare-allowed'));
+  
+
+```
+
+```
+invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    67 │ const n2 = await import('bare-allowed');
+    68 │ const n2b = ((await (import('bare-allowed'))));
+  > 69 │ const n3 = import('bare-allowed');
+       │       ^^
+    70 │ const n3b = (import('bare-allowed'));
+    71 │ import('bare-allowed').then(n4 => { });
+  
+
+```
+
+```
+invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    68 │ const n2b = ((await (import('bare-allowed'))));
+    69 │ const n3 = import('bare-allowed');
+  > 70 │ const n3b = (import('bare-allowed'));
+       │       ^^^
+    71 │ import('bare-allowed').then(n4 => { });
+    72 │ import('bare-allowed').then((n5) => { });
+  
+
+```
+
+```
+invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    69 │ const n3 = import('bare-allowed');
+    70 │ const n3b = (import('bare-allowed'));
+  > 71 │ import('bare-allowed').then(n4 => { });
+       │                             ^^
+    72 │ import('bare-allowed').then((n5) => { });
+    73 │ import('bare-allowed').then(function (n6) { });
+  
+
+```
+
+```
+invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    70 │ const n3b = (import('bare-allowed'));
+    71 │ import('bare-allowed').then(n4 => { });
+  > 72 │ import('bare-allowed').then((n5) => { });
+       │                              ^^
+    73 │ import('bare-allowed').then(function (n6) { });
+    74 │ ((import('bare-allowed'))).then(((n6 => { })));
+  
+
+```
+
+```
+invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    71 │ import('bare-allowed').then(n4 => { });
+    72 │ import('bare-allowed').then((n5) => { });
+  > 73 │ import('bare-allowed').then(function (n6) { });
+       │                                       ^^
+    74 │ ((import('bare-allowed'))).then(((n6 => { })));
+    75 │ ((import('bare-allowed'))).then((((n7) => { })));
+  
+
+```
+
+```
+invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    72 │ import('bare-allowed').then((n5) => { });
+    73 │ import('bare-allowed').then(function (n6) { });
+  > 74 │ ((import('bare-allowed'))).then(((n6 => { })));
+       │                                   ^^
+    75 │ ((import('bare-allowed'))).then((((n7) => { })));
+    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+  
+
+```
+
+```
+invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    73 │ import('bare-allowed').then(function (n6) { });
+    74 │ ((import('bare-allowed'))).then(((n6 => { })));
+  > 75 │ ((import('bare-allowed'))).then((((n7) => { })));
+       │                                    ^^
+    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    77 │ 
+  
+
+```
+
+```
+invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    74 │ ((import('bare-allowed'))).then(((n6 => { })));
+    75 │ ((import('bare-allowed'))).then((((n7) => { })));
+  > 76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+       │                                             ^^
+    77 │ 
+    78 │ import d0 from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    76 │ ((import('bare-allowed'))).then(((function (n8) { })));
+    77 │ 
+  > 78 │ import d0 from 'namespace-allowed';
+       │        ^^
+    79 │ import { default as d1 } from 'namespace-allowed';
+    80 │ const { "default": d2 } = await import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    78 │ import d0 from 'namespace-allowed';
+  > 79 │ import { default as d1 } from 'namespace-allowed';
+       │          ^^^^^^^
+    80 │ const { "default": d2 } = await import('namespace-allowed');
+    81 │ const { default: d3 } = await import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    78 │ import d0 from 'namespace-allowed';
+    79 │ import { default as d1 } from 'namespace-allowed';
+  > 80 │ const { "default": d2 } = await import('namespace-allowed');
+       │         ^^^^^^^^^
+    81 │ const { default: d3 } = await import('namespace-allowed');
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    79 │ import { default as d1 } from 'namespace-allowed';
+    80 │ const { "default": d2 } = await import('namespace-allowed');
+  > 81 │ const { default: d3 } = await import('namespace-allowed');
+       │         ^^^^^^^
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    80 │ const { "default": d2 } = await import('namespace-allowed');
+    81 │ const { default: d3 } = await import('namespace-allowed');
+  > 82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+       │          ^^^^^^^
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:82:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    80 │ const { "default": d2 } = await import('namespace-allowed');
+    81 │ const { default: d3 } = await import('namespace-allowed');
+  > 82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+       │                         ^^^^^^^^^^
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    81 │ const { default: d3 } = await import('namespace-allowed');
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+  > 83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+       │         ^^^^^^^^^^
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:83:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    81 │ const { default: d3 } = await import('namespace-allowed');
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+  > 83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+       │                     ^^^^^^^
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+  
+
+```
+
+```
+invalid.js:84:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+  > 84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+       │         ^^^^^^^^^^
+    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    86 │ 
+  
+
+```
+
+```
+invalid.js:84:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+  > 84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+       │                     ^^^^^^^
+    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    86 │ 
+  
+
+```
+
+```
+invalid.js:85:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  > 85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+       │         ^^^^^^^^^^^^
+    86 │ 
+    87 │ import d0 from 'member-allowed';
+  
+
+```
+
+```
+invalid.js:85:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
+    84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
+  > 85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+       │                           ^^^^^^^^^
+    86 │ 
+    87 │ import d0 from 'member-allowed';
+  
+
+```
+
+```
+invalid.js:87:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+    86 │ 
+  > 87 │ import d0 from 'member-allowed';
+       │        ^^
+    88 │ import { default as d1 } from 'member-allowed';
+    89 │ const { "default": d2 } = await import('member-allowed');
+  
+
+```
+
+```
+invalid.js:88:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    87 │ import d0 from 'member-allowed';
+  > 88 │ import { default as d1 } from 'member-allowed';
+       │          ^^^^^^^
+    89 │ const { "default": d2 } = await import('member-allowed');
+    90 │ const { default: d3 } = await import('member-allowed');
+  
+
+```
+
+```
+invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    87 │ import d0 from 'member-allowed';
+    88 │ import { default as d1 } from 'member-allowed';
+  > 89 │ const { "default": d2 } = await import('member-allowed');
+       │         ^^^^^^^^^
+    90 │ const { default: d3 } = await import('member-allowed');
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+  
+
+```
+
+```
+invalid.js:90:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    88 │ import { default as d1 } from 'member-allowed';
+    89 │ const { "default": d2 } = await import('member-allowed');
+  > 90 │ const { default: d3 } = await import('member-allowed');
+       │         ^^^^^^^
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+  
+
+```
+
+```
+invalid.js:91:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    89 │ const { "default": d2 } = await import('member-allowed');
+    90 │ const { default: d3 } = await import('member-allowed');
+  > 91 │ import { default as d4, forbidden1 } from 'member-allowed';
+       │          ^^^^^^^
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+  
+
+```
+
+```
+invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    89 │ const { "default": d2 } = await import('member-allowed');
+    90 │ const { default: d3 } = await import('member-allowed');
+  > 91 │ import { default as d4, forbidden1 } from 'member-allowed';
+       │                         ^^^^^^^^^^
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+  
+
+```
+
+```
+invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    90 │ const { default: d3 } = await import('member-allowed');
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+  > 92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+       │         ^^^^^^^^^^
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+  
+
+```
+
+```
+invalid.js:92:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    90 │ const { default: d3 } = await import('member-allowed');
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+  > 92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+       │                     ^^^^^^^
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+  
+
+```
+
+```
+invalid.js:93:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+  > 93 │ const { forbidden3, default: d6 } = import('member-allowed');
+       │         ^^^^^^^^^^
+    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    95 │ 
+  
+
+```
+
+```
+invalid.js:93:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    91 │ import { default as d4, forbidden1 } from 'member-allowed';
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+  > 93 │ const { forbidden3, default: d6 } = import('member-allowed');
+       │                     ^^^^^^^
+    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    95 │ 
+  
+
+```
+
+```
+invalid.js:94:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+  > 94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+       │         ^^^^^^^^^^^^
+    95 │ 
+    96 │ import d0 from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing member-allowed is not allowed
+  
+    92 │ const { forbidden2, default: d5 } = await import('member-allowed');
+    93 │ const { forbidden3, default: d6 } = import('member-allowed');
+  > 94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+       │                           ^^^^^^^^^
+    95 │ 
+    96 │ import d0 from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:96:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+    95 │ 
+  > 96 │ import d0 from 'bare-allowed';
+       │        ^^
+    97 │ import { default as d1 } from 'bare-allowed';
+    98 │ const { "default": d2 } = await import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    96 │ import d0 from 'bare-allowed';
+  > 97 │ import { default as d1 } from 'bare-allowed';
+       │          ^^^^^^^
+    98 │ const { "default": d2 } = await import('bare-allowed');
+    99 │ const { default: d3 } = await import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:98:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     96 │ import d0 from 'bare-allowed';
+     97 │ import { default as d1 } from 'bare-allowed';
+   > 98 │ const { "default": d2 } = await import('bare-allowed');
+        │         ^^^^^^^^^
+     99 │ const { default: d3 } = await import('bare-allowed');
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:99:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     97 │ import { default as d1 } from 'bare-allowed';
+     98 │ const { "default": d2 } = await import('bare-allowed');
+   > 99 │ const { default: d3 } = await import('bare-allowed');
+        │         ^^^^^^^
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:100:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     98 │ const { "default": d2 } = await import('bare-allowed');
+     99 │ const { default: d3 } = await import('bare-allowed');
+  > 100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+        │          ^^^^^^^
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     98 │ const { "default": d2 } = await import('bare-allowed');
+     99 │ const { default: d3 } = await import('bare-allowed');
+  > 100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+        │                         ^^^^^^^^^^
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     99 │ const { default: d3 } = await import('bare-allowed');
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+  > 101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+        │         ^^^^^^^^^^
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+     99 │ const { default: d3 } = await import('bare-allowed');
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+  > 101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+        │                     ^^^^^^^
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+  
+
+```
+
+```
+invalid.js:102:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+  > 102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+        │         ^^^^^^^^^^
+    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    104 │ 
+  
+
+```
+
+```
+invalid.js:102:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    100 │ import { default as d4, forbidden1 } from 'bare-allowed';
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+  > 102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+        │                     ^^^^^^^
+    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    104 │ 
+  
+
+```
+
+```
+invalid.js:103:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  > 103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+        │         ^^^^^^^^^^^^
+    104 │ 
+    105 │ import { forbidden1 } from 'default-allowed';
+  
+
+```
+
+```
+invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
+    102 │ const { forbidden3, default: d6 } = import('bare-allowed');
+  > 103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+        │                           ^^^^^^^^^
+    104 │ 
+    105 │ import { forbidden1 } from 'default-allowed';
+  
+
+```
+
+```
+invalid.js:105:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+    104 │ 
+  > 105 │ import { forbidden1 } from 'default-allowed';
+        │          ^^^^^^^^^^
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+
+```
+
+```
+invalid.js:106:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │         ^^^^^^^^^^
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:106:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │                     ^^^^^^^^^^
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:106:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+  > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+        │                                     ^^^^^^^^^^^^
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:107:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                   ^^^^^^^^^^
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    109 │ 
+  
+
+```
+
+```
+invalid.js:107:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                               ^^^^^^^^^^
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    109 │ 
+  
+
+```
+
+```
+invalid.js:107:63 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    105 │ import { forbidden1 } from 'default-allowed';
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+  > 107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                               ^^^^^^^^^^^^
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    109 │ 
+  
+
+```
+
+```
+invalid.js:108:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                            ^^^^^^^^^^
+    109 │ 
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.js:108:56 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                        ^^^^^^^^^^
+    109 │ 
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing default-allowed is not allowed
+  
+    106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
+    107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                                        ^^^^^^^^^^^^
+    109 │ 
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    109 │ 
+  > 110 │ import { forbidden1 } from 'namespace-allowed';
+        │          ^^^^^^^^^^
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+
+```
+
+```
+invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │         ^^^^^^^^^^
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:111:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │                     ^^^^^^^^^^
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:111:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+  > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+        │                                     ^^^^^^^^^^^^
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:112:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                     ^^^^^^^^^^
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    114 │ 
+  
+
+```
+
+```
+invalid.js:112:49 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                 ^^^^^^^^^^
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    114 │ 
+  
+
+```
+
+```
+invalid.js:112:65 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    110 │ import { forbidden1 } from 'namespace-allowed';
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+  > 112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                                 ^^^^^^^^^^^^
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    114 │ 
+  
+
+```
+
+```
+invalid.js:113:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                              ^^^^^^^^^^
+    114 │ 
+    115 │ import { forbidden1 } from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:113:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                          ^^^^^^^^^^
+    114 │ 
+    115 │ import { forbidden1 } from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing namespace-allowed is not allowed
+  
+    111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
+    112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                                          ^^^^^^^^^^^^
+    114 │ 
+    115 │ import { forbidden1 } from 'bare-allowed';
+  
+
+```
+
+```
+invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    114 │ 
+  > 115 │ import { forbidden1 } from 'bare-allowed';
+        │          ^^^^^^^^^^
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  
+
+```
+
+```
+invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+        │         ^^^^^^^^^^
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+        │                     ^^^^^^^^^^
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+  > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+        │                                     ^^^^^^^^^^^^
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+  
+
+```
+
+```
+invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                ^^^^^^^^^^
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    119 │ 
+  
+
+```
+
+```
+invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                            ^^^^^^^^^^
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    119 │ 
+  
+
+```
+
+```
+invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    115 │ import { forbidden1 } from 'bare-allowed';
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+  > 117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+        │                                                            ^^^^^^^^^^^^
+    118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+    119 │ 
+  
+
+```
+
+```
+invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                         ^^^^^^^^^^
+    119 │ 
+  
+
+```
+
+```
+invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                     ^^^^^^^^^^
+    119 │ 
+  
+
+```
+
+```
+invalid.js:118:69 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Importing bare-forbidden is not allowed
+  
+    116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
+    117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
+  > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
+        │                                                                     ^^^^^^^^^^^^
+    119 │ 
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -157,7 +157,7 @@ invalid.js:2:19 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'bare-forbidden'.
+  ! Do not import 'bare-forbidden' through a side-effect import.
   
     2 │ const l = require('lodash');
     3 │ 
@@ -172,7 +172,7 @@ invalid.js:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'namespace-allowed'.
+  ! Do not import 'namespace-allowed' through a side-effect import.
   
     4 │ import 'bare-forbidden';
   > 5 │ import 'namespace-allowed';
@@ -188,7 +188,7 @@ invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'default-allowed'.
+  ! Do not import 'default-allowed' through a side-effect import.
   
     4 │ import 'bare-forbidden';
     5 │ import 'namespace-allowed';

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -180,7 +180,9 @@ invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     6 │ import 'default-allowed';
     7 │ import 'default-and-member-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -197,7 +199,9 @@ invalid.js:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     7 │ import 'default-and-member-allowed';
     8 │ 
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -689,7 +693,9 @@ invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     43 │ const n2 = await import('default-allowed');
     44 │ const n2b = ((await (import('default-allowed'))));
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -705,7 +711,9 @@ invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     44 │ const n2b = ((await (import('default-allowed'))));
     45 │ const n3 = import('default-allowed');
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -722,7 +730,9 @@ invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     45 │ const n3 = import('default-allowed');
     46 │ const n3b = (import('default-allowed'));
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -739,7 +749,9 @@ invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     46 │ const n3b = (import('default-allowed'));
     47 │ import('default-allowed').then(n4 => { });
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -756,7 +768,9 @@ invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     47 │ import('default-allowed').then(n4 => { });
     48 │ import('default-allowed').then((n5) => { });
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -773,7 +787,9 @@ invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
     48 │ import('default-allowed').then((n5) => { });
     49 │ import('default-allowed').then(function (n6) { });
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -790,7 +806,9 @@ invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━
     49 │ import('default-allowed').then(function (n6) { });
     50 │ ((import('default-allowed'))).then(((n6 => { })));
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -807,7 +825,9 @@ invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━
     50 │ ((import('default-allowed'))).then(((n6 => { })));
     51 │ ((import('default-allowed'))).then((((n7) => { })));
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -824,7 +844,9 @@ invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
     51 │ ((import('default-allowed'))).then((((n7) => { })));
     52 │ ((import('default-allowed'))).then(((function (n8) { })));
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -841,7 +863,9 @@ invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
     52 │ ((import('default-allowed'))).then(((function (n8) { })));
     53 │ 
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -858,7 +882,9 @@ invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━
     53 │ 
     54 │ import * as n1 from 'member-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -875,7 +901,17 @@ invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     55 │ const n2 = await import('member-allowed');
     56 │ const n2b = ((await (import('member-allowed'))));
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -891,7 +927,17 @@ invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     56 │ const n2b = ((await (import('member-allowed'))));
     57 │ const n3 = import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -908,7 +954,17 @@ invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     57 │ const n3 = import('member-allowed');
     58 │ const n3b = (import('member-allowed'));
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -925,7 +981,17 @@ invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     58 │ const n3b = (import('member-allowed'));
     59 │ import('member-allowed').then(n4 => { });
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -942,7 +1008,17 @@ invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     59 │ import('member-allowed').then(n4 => { });
     60 │ import('member-allowed').then((n5) => { });
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -959,7 +1035,17 @@ invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     60 │ import('member-allowed').then((n5) => { });
     61 │ import('member-allowed').then(function (n6) { });
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -976,7 +1062,17 @@ invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
     61 │ import('member-allowed').then(function (n6) { });
     62 │ ((import('member-allowed'))).then(((n6 => { })));
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -993,7 +1089,17 @@ invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━
     62 │ ((import('member-allowed'))).then(((n6 => { })));
     63 │ ((import('member-allowed'))).then((((n7) => { })));
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1010,7 +1116,17 @@ invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━
     63 │ ((import('member-allowed'))).then((((n7) => { })));
     64 │ ((import('member-allowed'))).then(((function (n8) { })));
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1027,7 +1143,17 @@ invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
     64 │ ((import('member-allowed'))).then(((function (n8) { })));
     65 │ 
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1044,7 +1170,17 @@ invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━
     65 │ 
     66 │ import * as n1 from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1061,7 +1197,9 @@ invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     67 │ const n2 = await import('bare-allowed');
     68 │ const n2b = ((await (import('bare-allowed'))));
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1077,7 +1215,9 @@ invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     68 │ const n2b = ((await (import('bare-allowed'))));
     69 │ const n3 = import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1094,7 +1234,9 @@ invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     69 │ const n3 = import('bare-allowed');
     70 │ const n3b = (import('bare-allowed'));
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1111,7 +1253,9 @@ invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     70 │ const n3b = (import('bare-allowed'));
     71 │ import('bare-allowed').then(n4 => { });
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1128,7 +1272,9 @@ invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     71 │ import('bare-allowed').then(n4 => { });
     72 │ import('bare-allowed').then((n5) => { });
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1145,7 +1291,9 @@ invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━
     72 │ import('bare-allowed').then((n5) => { });
     73 │ import('bare-allowed').then(function (n6) { });
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1162,7 +1310,9 @@ invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
     73 │ import('bare-allowed').then(function (n6) { });
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1179,7 +1329,9 @@ invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
     75 │ ((import('bare-allowed'))).then((((n7) => { })));
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1196,7 +1348,9 @@ invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━
     75 │ ((import('bare-allowed'))).then((((n7) => { })));
     76 │ ((import('bare-allowed'))).then(((function (n8) { })));
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1213,7 +1367,9 @@ invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━
     76 │ ((import('bare-allowed'))).then(((function (n8) { })));
     77 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1230,7 +1386,9 @@ invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━
     77 │ 
     78 │ import d0 from 'namespace-allowed';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1247,7 +1405,9 @@ invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     79 │ import { default as d1 } from 'namespace-allowed';
     80 │ const { "default": d2 } = await import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1263,7 +1423,9 @@ invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     80 │ const { "default": d2 } = await import('namespace-allowed');
     81 │ const { default: d3 } = await import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1280,7 +1442,9 @@ invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     81 │ const { default: d3 } = await import('namespace-allowed');
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1297,7 +1461,9 @@ invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1314,7 +1480,9 @@ invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1331,7 +1499,9 @@ invalid.js:82:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1348,7 +1518,9 @@ invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1365,7 +1537,9 @@ invalid.js:83:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1382,7 +1556,9 @@ invalid.js:84:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
     86 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1399,7 +1575,9 @@ invalid.js:84:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
     86 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1416,7 +1594,9 @@ invalid.js:85:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     86 │ 
     87 │ import d0 from 'member-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1433,7 +1613,9 @@ invalid.js:85:27 lint/nursery/noRestrictedImports ━━━━━━━━━━
     86 │ 
     87 │ import d0 from 'member-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -1450,7 +1632,17 @@ invalid.js:87:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     88 │ import { default as d1 } from 'member-allowed';
     89 │ const { "default": d2 } = await import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1466,7 +1658,17 @@ invalid.js:88:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     89 │ const { "default": d2 } = await import('member-allowed');
     90 │ const { default: d3 } = await import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1483,7 +1685,17 @@ invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     90 │ const { default: d3 } = await import('member-allowed');
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1500,7 +1712,17 @@ invalid.js:90:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1517,7 +1739,17 @@ invalid.js:91:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1534,7 +1766,17 @@ invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1551,7 +1793,17 @@ invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1568,7 +1820,17 @@ invalid.js:92:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1585,7 +1847,17 @@ invalid.js:93:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
     95 │ 
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1602,7 +1874,17 @@ invalid.js:93:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
     95 │ 
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1619,7 +1901,17 @@ invalid.js:94:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     95 │ 
     96 │ import d0 from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1636,7 +1928,17 @@ invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━
     95 │ 
     96 │ import d0 from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -1653,7 +1955,9 @@ invalid.js:96:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     97 │ import { default as d1 } from 'bare-allowed';
     98 │ const { "default": d2 } = await import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1669,7 +1973,9 @@ invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     98 │ const { "default": d2 } = await import('bare-allowed');
     99 │ const { default: d3 } = await import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1686,7 +1992,9 @@ invalid.js:98:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
      99 │ const { default: d3 } = await import('bare-allowed');
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1703,7 +2011,9 @@ invalid.js:99:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1720,7 +2030,9 @@ invalid.js:100:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1737,7 +2049,9 @@ invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━�
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1754,7 +2068,9 @@ invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1771,7 +2087,9 @@ invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1788,7 +2106,9 @@ invalid.js:102:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     104 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1805,7 +2125,9 @@ invalid.js:102:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     104 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1822,7 +2144,9 @@ invalid.js:103:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     104 │ 
     105 │ import { forbidden1 } from 'default-allowed';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1839,7 +2163,9 @@ invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━�
     104 │ 
     105 │ import { forbidden1 } from 'default-allowed';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -1856,7 +2182,9 @@ invalid.js:105:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1872,7 +2200,9 @@ invalid.js:106:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1888,7 +2218,9 @@ invalid.js:106:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1904,7 +2236,9 @@ invalid.js:106:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1921,7 +2255,9 @@ invalid.js:107:35 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1938,7 +2274,9 @@ invalid.js:107:47 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1955,7 +2293,9 @@ invalid.js:107:63 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1972,7 +2312,9 @@ invalid.js:108:44 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -1989,7 +2331,9 @@ invalid.js:108:56 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -2006,7 +2350,9 @@ invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -2023,7 +2369,9 @@ invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2039,7 +2387,9 @@ invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2055,7 +2405,9 @@ invalid.js:111:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2071,7 +2423,9 @@ invalid.js:111:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2088,7 +2442,9 @@ invalid.js:112:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2105,7 +2461,9 @@ invalid.js:112:49 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2122,7 +2480,9 @@ invalid.js:112:65 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2139,7 +2499,9 @@ invalid.js:113:46 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2156,7 +2518,9 @@ invalid.js:113:58 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2173,7 +2537,9 @@ invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -2190,7 +2556,9 @@ invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2206,7 +2574,9 @@ invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2222,7 +2592,9 @@ invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2238,7 +2610,9 @@ invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2255,7 +2629,9 @@ invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2272,7 +2648,9 @@ invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2289,7 +2667,9 @@ invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2305,7 +2685,9 @@ invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━�
         │                                         ^^^^^^^^^^
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2321,7 +2703,9 @@ invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━�
         │                                                     ^^^^^^^^^^
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -2337,7 +2721,9 @@ invalid.js:118:69 lint/nursery/noRestrictedImports ━━━━━━━━━�
         │                                                                     ^^^^^^^^^^^^
     119 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.js.snap
@@ -157,7 +157,7 @@ invalid.js:2:19 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '' from 'bare-forbidden'.
   
     2 │ const l = require('lodash');
     3 │ 
@@ -172,7 +172,7 @@ invalid.js:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import '' from 'namespace-allowed'.
   
     4 │ import 'bare-forbidden';
   > 5 │ import 'namespace-allowed';
@@ -180,13 +180,15 @@ invalid.js:5:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     6 │ import 'default-allowed';
     7 │ import 'default-and-member-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '' from 'default-allowed'.
   
     4 │ import 'bare-forbidden';
     5 │ import 'namespace-allowed';
@@ -195,13 +197,15 @@ invalid.js:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     7 │ import 'default-and-member-allowed';
     8 │ 
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:9:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
      7 │ import 'default-and-member-allowed';
      8 │ 
@@ -216,7 +220,7 @@ invalid.js:9:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:10:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
      9 │ import * as n1 from 'namespace-forbidden';
   > 10 │ const n2 = await import('namespace-forbidden');
@@ -230,7 +234,7 @@ invalid.js:10:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:11:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
      9 │ import * as n1 from 'namespace-forbidden';
     10 │ const n2 = await import('namespace-forbidden');
@@ -245,7 +249,7 @@ invalid.js:11:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:12:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     10 │ const n2 = await import('namespace-forbidden');
     11 │ const n2b = ((await (import('namespace-forbidden'))));
@@ -260,7 +264,7 @@ invalid.js:12:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:13:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     11 │ const n2b = ((await (import('namespace-forbidden'))));
     12 │ const n3 = import('namespace-forbidden');
@@ -275,7 +279,7 @@ invalid.js:13:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:14:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     12 │ const n3 = import('namespace-forbidden');
     13 │ const n3b = (import('namespace-forbidden'));
@@ -290,7 +294,7 @@ invalid.js:14:36 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:15:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     13 │ const n3b = (import('namespace-forbidden'));
     14 │ import('namespace-forbidden').then(n4 => { });
@@ -305,7 +309,7 @@ invalid.js:15:37 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:16:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     14 │ import('namespace-forbidden').then(n4 => { });
     15 │ import('namespace-forbidden').then((n5) => { });
@@ -320,7 +324,7 @@ invalid.js:16:46 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:17:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     15 │ import('namespace-forbidden').then((n5) => { });
     16 │ import('namespace-forbidden').then(function (n6) { });
@@ -335,7 +339,7 @@ invalid.js:17:42 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:18:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     16 │ import('namespace-forbidden').then(function (n6) { });
     17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
@@ -350,7 +354,7 @@ invalid.js:18:43 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:19:52 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-forbidden is not allowed
+  ! Do not import '*' from 'namespace-forbidden'.
   
     17 │ ((import('namespace-forbidden'))).then(((n6 => { })));
     18 │ ((import('namespace-forbidden'))).then((((n7) => { })));
@@ -365,7 +369,7 @@ invalid.js:19:52 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:21:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     19 │ ((import('namespace-forbidden'))).then(((function (n8) { })));
     20 │ 
@@ -380,7 +384,7 @@ invalid.js:21:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:22:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     21 │ import d0 from 'default-forbidden';
   > 22 │ import { default as d1 } from 'default-forbidden';
@@ -394,7 +398,7 @@ invalid.js:22:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:23:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     21 │ import d0 from 'default-forbidden';
     22 │ import { default as d1 } from 'default-forbidden';
@@ -409,7 +413,7 @@ invalid.js:23:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:24:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     22 │ import { default as d1 } from 'default-forbidden';
     23 │ const { "default": d2 } = await import('default-forbidden');
@@ -424,7 +428,7 @@ invalid.js:24:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:25:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     23 │ const { "default": d2 } = await import('default-forbidden');
     24 │ const { default: d3 } = await import('default-forbidden');
@@ -439,7 +443,7 @@ invalid.js:25:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:26:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     24 │ const { default: d3 } = await import('default-forbidden');
     25 │ import { default as d4, allowed1 } from 'default-forbidden';
@@ -454,7 +458,7 @@ invalid.js:26:19 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:27:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     25 │ import { default as d4, allowed1 } from 'default-forbidden';
     26 │ const { allowed2, default: d5 } = await import('default-forbidden');
@@ -469,7 +473,7 @@ invalid.js:27:19 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:28:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default' from 'default-forbidden'.
   
     26 │ const { allowed2, default: d5 } = await import('default-forbidden');
     27 │ const { allowed3, default: d6 } = import('default-forbidden');
@@ -484,7 +488,7 @@ invalid.js:28:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:30:20 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden1' from 'member-forbidden'.
   
     28 │ const { "allowed4": a1, "default": d7 } = import('default-forbidden');
     29 │ 
@@ -499,7 +503,7 @@ invalid.js:30:20 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:31:19 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
   > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -513,7 +517,7 @@ invalid.js:31:19 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:31:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
   > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -527,7 +531,7 @@ invalid.js:31:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:31:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
   > 31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -541,7 +545,7 @@ invalid.js:31:47 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:32:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -556,7 +560,7 @@ invalid.js:32:46 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:32:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -571,7 +575,7 @@ invalid.js:32:58 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:32:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'member-forbidden'.
   
     30 │ import { allowed5, forbidden1 } from 'member-forbidden';
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
@@ -586,7 +590,7 @@ invalid.js:32:74 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:33:55 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'member-forbidden'.
   
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
     32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -601,7 +605,7 @@ invalid.js:33:55 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:33:67 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'member-forbidden'.
   
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
     32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -616,7 +620,7 @@ invalid.js:33:67 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:33:83 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'member-forbidden'.
   
     31 │ const { allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('member-forbidden');
     32 │ import('member-forbidden').then(({ allowed6, forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -631,7 +635,7 @@ invalid.js:33:83 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:38:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-forbidden is not allowed
+  ! Do not import 'default-forbidden'.
   
     36 │ // so this import corresponds to default.allowed1 (and not namespace.allowed1)
     37 │ // and is therefore *NOT* allowed.
@@ -646,7 +650,7 @@ invalid.js:38:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:39:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'namespace-allowed'.
   
     37 │ // and is therefore *NOT* allowed.
     38 │ const { allowed1 } = require('default-forbidden');
@@ -661,7 +665,7 @@ invalid.js:39:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:40:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'member-allowed'.
   
     38 │ const { allowed1 } = require('default-forbidden');
     39 │ const { allowed2 } = require('namespace-allowed');
@@ -676,7 +680,7 @@ invalid.js:40:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     40 │ const { allowed3 } = require('member-allowed');
     41 │ 
@@ -685,13 +689,15 @@ invalid.js:42:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     43 │ const n2 = await import('default-allowed');
     44 │ const n2b = ((await (import('default-allowed'))));
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     42 │ import * as n1 from 'default-allowed';
   > 43 │ const n2 = await import('default-allowed');
@@ -699,13 +705,15 @@ invalid.js:43:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     44 │ const n2b = ((await (import('default-allowed'))));
     45 │ const n3 = import('default-allowed');
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     42 │ import * as n1 from 'default-allowed';
     43 │ const n2 = await import('default-allowed');
@@ -714,13 +722,15 @@ invalid.js:44:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     45 │ const n3 = import('default-allowed');
     46 │ const n3b = (import('default-allowed'));
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     43 │ const n2 = await import('default-allowed');
     44 │ const n2b = ((await (import('default-allowed'))));
@@ -729,13 +739,15 @@ invalid.js:45:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     46 │ const n3b = (import('default-allowed'));
     47 │ import('default-allowed').then(n4 => { });
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     44 │ const n2b = ((await (import('default-allowed'))));
     45 │ const n3 = import('default-allowed');
@@ -744,13 +756,15 @@ invalid.js:46:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     47 │ import('default-allowed').then(n4 => { });
     48 │ import('default-allowed').then((n5) => { });
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     45 │ const n3 = import('default-allowed');
     46 │ const n3b = (import('default-allowed'));
@@ -759,13 +773,15 @@ invalid.js:47:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
     48 │ import('default-allowed').then((n5) => { });
     49 │ import('default-allowed').then(function (n6) { });
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     46 │ const n3b = (import('default-allowed'));
     47 │ import('default-allowed').then(n4 => { });
@@ -774,13 +790,15 @@ invalid.js:48:33 lint/nursery/noRestrictedImports ━━━━━━━━━━
     49 │ import('default-allowed').then(function (n6) { });
     50 │ ((import('default-allowed'))).then(((n6 => { })));
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     47 │ import('default-allowed').then(n4 => { });
     48 │ import('default-allowed').then((n5) => { });
@@ -789,13 +807,15 @@ invalid.js:49:42 lint/nursery/noRestrictedImports ━━━━━━━━━━
     50 │ ((import('default-allowed'))).then(((n6 => { })));
     51 │ ((import('default-allowed'))).then((((n7) => { })));
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     48 │ import('default-allowed').then((n5) => { });
     49 │ import('default-allowed').then(function (n6) { });
@@ -804,13 +824,15 @@ invalid.js:50:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
     51 │ ((import('default-allowed'))).then((((n7) => { })));
     52 │ ((import('default-allowed'))).then(((function (n8) { })));
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     49 │ import('default-allowed').then(function (n6) { });
     50 │ ((import('default-allowed'))).then(((n6 => { })));
@@ -819,13 +841,15 @@ invalid.js:51:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
     52 │ ((import('default-allowed'))).then(((function (n8) { })));
     53 │ 
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import '*' from 'default-allowed'.
   
     50 │ ((import('default-allowed'))).then(((n6 => { })));
     51 │ ((import('default-allowed'))).then((((n7) => { })));
@@ -834,13 +858,15 @@ invalid.js:52:48 lint/nursery/noRestrictedImports ━━━━━━━━━━
     53 │ 
     54 │ import * as n1 from 'member-allowed';
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     52 │ ((import('default-allowed'))).then(((function (n8) { })));
     53 │ 
@@ -849,13 +875,15 @@ invalid.js:54:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     55 │ const n2 = await import('member-allowed');
     56 │ const n2b = ((await (import('member-allowed'))));
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     54 │ import * as n1 from 'member-allowed';
   > 55 │ const n2 = await import('member-allowed');
@@ -863,13 +891,15 @@ invalid.js:55:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     56 │ const n2b = ((await (import('member-allowed'))));
     57 │ const n3 = import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     54 │ import * as n1 from 'member-allowed';
     55 │ const n2 = await import('member-allowed');
@@ -878,13 +908,15 @@ invalid.js:56:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     57 │ const n3 = import('member-allowed');
     58 │ const n3b = (import('member-allowed'));
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     55 │ const n2 = await import('member-allowed');
     56 │ const n2b = ((await (import('member-allowed'))));
@@ -893,13 +925,15 @@ invalid.js:57:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     58 │ const n3b = (import('member-allowed'));
     59 │ import('member-allowed').then(n4 => { });
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     56 │ const n2b = ((await (import('member-allowed'))));
     57 │ const n3 = import('member-allowed');
@@ -908,13 +942,15 @@ invalid.js:58:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     59 │ import('member-allowed').then(n4 => { });
     60 │ import('member-allowed').then((n5) => { });
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     57 │ const n3 = import('member-allowed');
     58 │ const n3b = (import('member-allowed'));
@@ -923,13 +959,15 @@ invalid.js:59:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     60 │ import('member-allowed').then((n5) => { });
     61 │ import('member-allowed').then(function (n6) { });
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     58 │ const n3b = (import('member-allowed'));
     59 │ import('member-allowed').then(n4 => { });
@@ -938,13 +976,15 @@ invalid.js:60:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
     61 │ import('member-allowed').then(function (n6) { });
     62 │ ((import('member-allowed'))).then(((n6 => { })));
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     59 │ import('member-allowed').then(n4 => { });
     60 │ import('member-allowed').then((n5) => { });
@@ -953,13 +993,15 @@ invalid.js:61:41 lint/nursery/noRestrictedImports ━━━━━━━━━━
     62 │ ((import('member-allowed'))).then(((n6 => { })));
     63 │ ((import('member-allowed'))).then((((n7) => { })));
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     60 │ import('member-allowed').then((n5) => { });
     61 │ import('member-allowed').then(function (n6) { });
@@ -968,13 +1010,15 @@ invalid.js:62:37 lint/nursery/noRestrictedImports ━━━━━━━━━━
     63 │ ((import('member-allowed'))).then((((n7) => { })));
     64 │ ((import('member-allowed'))).then(((function (n8) { })));
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     61 │ import('member-allowed').then(function (n6) { });
     62 │ ((import('member-allowed'))).then(((n6 => { })));
@@ -983,13 +1027,15 @@ invalid.js:63:38 lint/nursery/noRestrictedImports ━━━━━━━━━━
     64 │ ((import('member-allowed'))).then(((function (n8) { })));
     65 │ 
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import '*' from 'member-allowed'.
   
     62 │ ((import('member-allowed'))).then(((n6 => { })));
     63 │ ((import('member-allowed'))).then((((n7) => { })));
@@ -998,13 +1044,15 @@ invalid.js:64:47 lint/nursery/noRestrictedImports ━━━━━━━━━━
     65 │ 
     66 │ import * as n1 from 'bare-allowed';
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     64 │ ((import('member-allowed'))).then(((function (n8) { })));
     65 │ 
@@ -1013,13 +1061,15 @@ invalid.js:66:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     67 │ const n2 = await import('bare-allowed');
     68 │ const n2b = ((await (import('bare-allowed'))));
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     66 │ import * as n1 from 'bare-allowed';
   > 67 │ const n2 = await import('bare-allowed');
@@ -1027,13 +1077,15 @@ invalid.js:67:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     68 │ const n2b = ((await (import('bare-allowed'))));
     69 │ const n3 = import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     66 │ import * as n1 from 'bare-allowed';
     67 │ const n2 = await import('bare-allowed');
@@ -1042,13 +1094,15 @@ invalid.js:68:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     69 │ const n3 = import('bare-allowed');
     70 │ const n3b = (import('bare-allowed'));
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     67 │ const n2 = await import('bare-allowed');
     68 │ const n2b = ((await (import('bare-allowed'))));
@@ -1057,13 +1111,15 @@ invalid.js:69:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     70 │ const n3b = (import('bare-allowed'));
     71 │ import('bare-allowed').then(n4 => { });
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     68 │ const n2b = ((await (import('bare-allowed'))));
     69 │ const n3 = import('bare-allowed');
@@ -1072,13 +1128,15 @@ invalid.js:70:7 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     71 │ import('bare-allowed').then(n4 => { });
     72 │ import('bare-allowed').then((n5) => { });
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     69 │ const n3 = import('bare-allowed');
     70 │ const n3b = (import('bare-allowed'));
@@ -1087,13 +1145,15 @@ invalid.js:71:29 lint/nursery/noRestrictedImports ━━━━━━━━━━
     72 │ import('bare-allowed').then((n5) => { });
     73 │ import('bare-allowed').then(function (n6) { });
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     70 │ const n3b = (import('bare-allowed'));
     71 │ import('bare-allowed').then(n4 => { });
@@ -1102,13 +1162,15 @@ invalid.js:72:30 lint/nursery/noRestrictedImports ━━━━━━━━━━
     73 │ import('bare-allowed').then(function (n6) { });
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     71 │ import('bare-allowed').then(n4 => { });
     72 │ import('bare-allowed').then((n5) => { });
@@ -1117,13 +1179,15 @@ invalid.js:73:39 lint/nursery/noRestrictedImports ━━━━━━━━━━
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
     75 │ ((import('bare-allowed'))).then((((n7) => { })));
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     72 │ import('bare-allowed').then((n5) => { });
     73 │ import('bare-allowed').then(function (n6) { });
@@ -1132,13 +1196,15 @@ invalid.js:74:35 lint/nursery/noRestrictedImports ━━━━━━━━━━
     75 │ ((import('bare-allowed'))).then((((n7) => { })));
     76 │ ((import('bare-allowed'))).then(((function (n8) { })));
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     73 │ import('bare-allowed').then(function (n6) { });
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
@@ -1147,13 +1213,15 @@ invalid.js:75:36 lint/nursery/noRestrictedImports ━━━━━━━━━━
     76 │ ((import('bare-allowed'))).then(((function (n8) { })));
     77 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import '*' from 'bare-allowed'.
   
     74 │ ((import('bare-allowed'))).then(((n6 => { })));
     75 │ ((import('bare-allowed'))).then((((n7) => { })));
@@ -1162,13 +1230,15 @@ invalid.js:76:45 lint/nursery/noRestrictedImports ━━━━━━━━━━
     77 │ 
     78 │ import d0 from 'namespace-allowed';
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     76 │ ((import('bare-allowed'))).then(((function (n8) { })));
     77 │ 
@@ -1177,13 +1247,15 @@ invalid.js:78:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     79 │ import { default as d1 } from 'namespace-allowed';
     80 │ const { "default": d2 } = await import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     78 │ import d0 from 'namespace-allowed';
   > 79 │ import { default as d1 } from 'namespace-allowed';
@@ -1191,13 +1263,15 @@ invalid.js:79:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     80 │ const { "default": d2 } = await import('namespace-allowed');
     81 │ const { default: d3 } = await import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     78 │ import d0 from 'namespace-allowed';
     79 │ import { default as d1 } from 'namespace-allowed';
@@ -1206,13 +1280,15 @@ invalid.js:80:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     81 │ const { default: d3 } = await import('namespace-allowed');
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     79 │ import { default as d1 } from 'namespace-allowed';
     80 │ const { "default": d2 } = await import('namespace-allowed');
@@ -1221,13 +1297,15 @@ invalid.js:81:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     80 │ const { "default": d2 } = await import('namespace-allowed');
     81 │ const { default: d3 } = await import('namespace-allowed');
@@ -1236,13 +1314,15 @@ invalid.js:82:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:82:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden1' from 'namespace-allowed'.
   
     80 │ const { "default": d2 } = await import('namespace-allowed');
     81 │ const { default: d3 } = await import('namespace-allowed');
@@ -1251,13 +1331,15 @@ invalid.js:82:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
   
     81 │ const { default: d3 } = await import('namespace-allowed');
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
@@ -1265,6 +1347,8 @@ invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
        │         ^^^^^^^^^^
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
   
 
 ```
@@ -1272,7 +1356,7 @@ invalid.js:83:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:83:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     81 │ const { default: d3 } = await import('namespace-allowed');
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
@@ -1281,13 +1365,15 @@ invalid.js:83:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:84:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
   
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
@@ -1296,13 +1382,15 @@ invalid.js:84:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
     86 │ 
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:84:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     82 │ import { default as d4, forbidden1 } from 'namespace-allowed';
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
@@ -1311,13 +1399,15 @@ invalid.js:84:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
     86 │ 
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:85:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
   
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
@@ -1326,13 +1416,15 @@ invalid.js:85:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     86 │ 
     87 │ import d0 from 'member-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:85:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'default' from 'namespace-allowed'.
   
     83 │ const { forbidden2, default: d5 } = await import('namespace-allowed');
     84 │ const { forbidden3, default: d6 } = import('namespace-allowed');
@@ -1341,13 +1433,15 @@ invalid.js:85:27 lint/nursery/noRestrictedImports ━━━━━━━━━━
     86 │ 
     87 │ import d0 from 'member-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:87:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     85 │ const { "forbidden4": f4, "default": d7 } = import('namespace-allowed');
     86 │ 
@@ -1356,13 +1450,15 @@ invalid.js:87:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     88 │ import { default as d1 } from 'member-allowed';
     89 │ const { "default": d2 } = await import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:88:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     87 │ import d0 from 'member-allowed';
   > 88 │ import { default as d1 } from 'member-allowed';
@@ -1370,13 +1466,15 @@ invalid.js:88:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     89 │ const { "default": d2 } = await import('member-allowed');
     90 │ const { default: d3 } = await import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     87 │ import d0 from 'member-allowed';
     88 │ import { default as d1 } from 'member-allowed';
@@ -1385,13 +1483,15 @@ invalid.js:89:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     90 │ const { default: d3 } = await import('member-allowed');
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:90:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     88 │ import { default as d1 } from 'member-allowed';
     89 │ const { "default": d2 } = await import('member-allowed');
@@ -1400,13 +1500,15 @@ invalid.js:90:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:91:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     89 │ const { "default": d2 } = await import('member-allowed');
     90 │ const { default: d3 } = await import('member-allowed');
@@ -1415,13 +1517,15 @@ invalid.js:91:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'forbidden1' from 'member-allowed'.
   
     89 │ const { "default": d2 } = await import('member-allowed');
     90 │ const { default: d3 } = await import('member-allowed');
@@ -1430,13 +1534,15 @@ invalid.js:91:25 lint/nursery/noRestrictedImports ━━━━━━━━━━
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'forbidden2' from 'member-allowed'.
   
     90 │ const { default: d3 } = await import('member-allowed');
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
@@ -1444,6 +1550,8 @@ invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
        │         ^^^^^^^^^^
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
   
 
 ```
@@ -1451,7 +1559,7 @@ invalid.js:92:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.js:92:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     90 │ const { default: d3 } = await import('member-allowed');
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
@@ -1460,13 +1568,15 @@ invalid.js:92:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:93:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'forbidden3' from 'member-allowed'.
   
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
@@ -1475,13 +1585,15 @@ invalid.js:93:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
     95 │ 
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:93:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     91 │ import { default as d4, forbidden1 } from 'member-allowed';
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
@@ -1490,13 +1602,15 @@ invalid.js:93:21 lint/nursery/noRestrictedImports ━━━━━━━━━━
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
     95 │ 
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:94:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'forbidden4' from 'member-allowed'.
   
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
@@ -1505,13 +1619,15 @@ invalid.js:94:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     95 │ 
     96 │ import d0 from 'bare-allowed';
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing member-allowed is not allowed
+  ! Do not import 'default' from 'member-allowed'.
   
     92 │ const { forbidden2, default: d5 } = await import('member-allowed');
     93 │ const { forbidden3, default: d6 } = import('member-allowed');
@@ -1520,13 +1636,15 @@ invalid.js:94:27 lint/nursery/noRestrictedImports ━━━━━━━━━━
     95 │ 
     96 │ import d0 from 'bare-allowed';
   
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
 
 ```
 
 ```
 invalid.js:96:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
     94 │ const { "forbidden4": f4, "default": d7 } = import('member-allowed');
     95 │ 
@@ -1535,13 +1653,15 @@ invalid.js:96:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     97 │ import { default as d1 } from 'bare-allowed';
     98 │ const { "default": d2 } = await import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
     96 │ import d0 from 'bare-allowed';
   > 97 │ import { default as d1 } from 'bare-allowed';
@@ -1549,13 +1669,15 @@ invalid.js:97:10 lint/nursery/noRestrictedImports ━━━━━━━━━━
     98 │ const { "default": d2 } = await import('bare-allowed');
     99 │ const { default: d3 } = await import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:98:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
      96 │ import d0 from 'bare-allowed';
      97 │ import { default as d1 } from 'bare-allowed';
@@ -1564,13 +1686,15 @@ invalid.js:98:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
      99 │ const { default: d3 } = await import('bare-allowed');
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:99:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
      97 │ import { default as d1 } from 'bare-allowed';
      98 │ const { "default": d2 } = await import('bare-allowed');
@@ -1579,13 +1703,15 @@ invalid.js:99:9 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:100:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
      98 │ const { "default": d2 } = await import('bare-allowed');
      99 │ const { default: d3 } = await import('bare-allowed');
@@ -1594,13 +1720,15 @@ invalid.js:100:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden1' from 'bare-allowed'.
   
      98 │ const { "default": d2 } = await import('bare-allowed');
      99 │ const { default: d3 } = await import('bare-allowed');
@@ -1609,13 +1737,15 @@ invalid.js:100:25 lint/nursery/noRestrictedImports ━━━━━━━━━�
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'bare-allowed'.
   
      99 │ const { default: d3 } = await import('bare-allowed');
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
@@ -1623,6 +1753,8 @@ invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
         │         ^^^^^^^^^^
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
   
 
 ```
@@ -1630,7 +1762,7 @@ invalid.js:101:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
 ```
 invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
      99 │ const { default: d3 } = await import('bare-allowed');
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
@@ -1639,13 +1771,15 @@ invalid.js:101:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:102:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'bare-allowed'.
   
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
@@ -1654,13 +1788,15 @@ invalid.js:102:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     104 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:102:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
     100 │ import { default as d4, forbidden1 } from 'bare-allowed';
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
@@ -1669,13 +1805,15 @@ invalid.js:102:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     104 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:103:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'bare-allowed'.
   
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
@@ -1684,13 +1822,15 @@ invalid.js:103:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     104 │ 
     105 │ import { forbidden1 } from 'default-allowed';
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'default' from 'bare-allowed'.
   
     101 │ const { forbidden2, default: d5 } = await import('bare-allowed');
     102 │ const { forbidden3, default: d6 } = import('bare-allowed');
@@ -1699,13 +1839,15 @@ invalid.js:103:27 lint/nursery/noRestrictedImports ━━━━━━━━━�
     104 │ 
     105 │ import { forbidden1 } from 'default-allowed';
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:105:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden1' from 'default-allowed'.
   
     103 │ const { "forbidden4": f4, "default": d7 } = import('bare-allowed');
     104 │ 
@@ -1714,13 +1856,15 @@ invalid.js:105:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:106:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden2' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
   > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1728,13 +1872,15 @@ invalid.js:106:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:106:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden3' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
   > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1742,13 +1888,15 @@ invalid.js:106:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:106:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden4' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
   > 106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1756,13 +1904,15 @@ invalid.js:106:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:107:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden2' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1771,13 +1921,15 @@ invalid.js:107:35 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:107:47 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden3' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1786,13 +1938,15 @@ invalid.js:107:47 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:107:63 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden4' from 'default-allowed'.
   
     105 │ import { forbidden1 } from 'default-allowed';
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
@@ -1801,13 +1955,15 @@ invalid.js:107:63 lint/nursery/noRestrictedImports ━━━━━━━━━�
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:108:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden2' from 'default-allowed'.
   
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1816,13 +1972,15 @@ invalid.js:108:44 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:108:56 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden3' from 'default-allowed'.
   
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1831,13 +1989,15 @@ invalid.js:108:56 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing default-allowed is not allowed
+  ! Do not import 'forbidden4' from 'default-allowed'.
   
     106 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('default-allowed');
     107 │ import('default-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1846,13 +2006,15 @@ invalid.js:108:72 lint/nursery/noRestrictedImports ━━━━━━━━━�
     109 │ 
     110 │ import { forbidden1 } from 'namespace-allowed';
   
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
 
 ```
 
 ```
 invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden1' from 'namespace-allowed'.
   
     108 │ import('default-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     109 │ 
@@ -1861,13 +2023,15 @@ invalid.js:110:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
   > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1875,13 +2039,15 @@ invalid.js:111:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:111:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
   > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1889,13 +2055,15 @@ invalid.js:111:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:111:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
   > 111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1903,13 +2071,15 @@ invalid.js:111:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:112:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1918,13 +2088,15 @@ invalid.js:112:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:112:49 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1933,13 +2105,15 @@ invalid.js:112:49 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:112:65 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
   
     110 │ import { forbidden1 } from 'namespace-allowed';
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
@@ -1948,13 +2122,15 @@ invalid.js:112:65 lint/nursery/noRestrictedImports ━━━━━━━━━�
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:113:46 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden2' from 'namespace-allowed'.
   
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1963,13 +2139,15 @@ invalid.js:113:46 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:113:58 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden3' from 'namespace-allowed'.
   
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1978,13 +2156,15 @@ invalid.js:113:58 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing namespace-allowed is not allowed
+  ! Do not import 'forbidden4' from 'namespace-allowed'.
   
     111 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('namespace-allowed');
     112 │ import('namespace-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -1993,13 +2173,15 @@ invalid.js:113:74 lint/nursery/noRestrictedImports ━━━━━━━━━�
     114 │ 
     115 │ import { forbidden1 } from 'bare-allowed';
   
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
 
 ```
 
 ```
 invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden1' from 'bare-allowed'.
   
     113 │ import('namespace-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     114 │ 
@@ -2008,13 +2190,15 @@ invalid.js:115:10 lint/nursery/noRestrictedImports ━━━━━━━━━�
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
   > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2022,13 +2206,15 @@ invalid.js:116:9 lint/nursery/noRestrictedImports ━━━━━━━━━━
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
   > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2036,13 +2222,15 @@ invalid.js:116:21 lint/nursery/noRestrictedImports ━━━━━━━━━�
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
   > 116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2050,13 +2238,15 @@ invalid.js:116:37 lint/nursery/noRestrictedImports ━━━━━━━━━�
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2065,13 +2255,15 @@ invalid.js:117:32 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2080,13 +2272,15 @@ invalid.js:117:44 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'bare-allowed'.
   
     115 │ import { forbidden1 } from 'bare-allowed';
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
@@ -2095,13 +2289,15 @@ invalid.js:117:60 lint/nursery/noRestrictedImports ━━━━━━━━━�
     118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
     119 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden2' from 'bare-allowed'.
   
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -2109,13 +2305,15 @@ invalid.js:118:41 lint/nursery/noRestrictedImports ━━━━━━━━━�
         │                                         ^^^^^^^^^^
     119 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden3' from 'bare-allowed'.
   
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
@@ -2123,19 +2321,23 @@ invalid.js:118:53 lint/nursery/noRestrictedImports ━━━━━━━━━�
         │                                                     ^^^^^^^^^^
     119 │ 
   
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
 
 ```
 
 ```
 invalid.js:118:69 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Importing bare-forbidden is not allowed
+  ! Do not import 'forbidden4' from 'bare-allowed'.
   
     116 │ const { forbidden2, forbidden3: f1, "forbidden4": f2 } = await import('bare-allowed');
     117 │ import('bare-allowed').then(({ forbidden2, forbidden3: f1, "forbidden4": f2 }) => { })
   > 118 │ import('bare-allowed').then(function ({ forbidden2, forbidden3: f1, "forbidden4": f2 }) { })
         │                                                                     ^^^^^^^^^^^^
     119 │ 
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
@@ -9,7 +9,71 @@
 					"options": {
 						"paths": {
 							"eslint": "Importing Eslint is forbidden",
-							"lodash": "It's not recommended to use lodash"
+							"lodash": "It's not recommended to use lodash",
+							"bare-forbidden": {
+								"message": "Importing bare-forbidden is not allowed",
+								"importNames": [
+									""
+								]
+							},
+							"default-forbidden": {
+								"message": "Importing default-forbidden is not allowed",
+								"importNames": [
+									"default"
+								]
+							},
+							"namespace-forbidden": {
+								"message": "Importing namespace-forbidden is not allowed",
+								"importNames": [
+									"*"
+								]
+							},
+							"member-forbidden": {
+								"message": "Importing member-forbidden is not allowed",
+								"importNames": [
+									"forbidden1",
+									"forbidden2",
+									"forbidden3",
+									"forbidden4",
+									"forbidden5",
+									"forbidden6",
+									"forbidden7",
+									"forbidden8",
+									"forbidden9"
+								]
+							},
+							"bare-allowed": {
+								"message": "Importing bare-forbidden is not allowed",
+								"allowImportNames": [
+									""
+								]
+							},
+							"default-allowed": {
+								"message": "Importing default-allowed is not allowed",
+								"allowImportNames": [
+									"default"
+								]
+							},
+							"namespace-allowed": {
+								"message": "Importing namespace-allowed is not allowed",
+								"allowImportNames": [
+									"*"
+								]
+							},
+							"member-allowed": {
+								"message": "Importing member-allowed is not allowed",
+								"allowImportNames": [
+									"allowed1",
+									"allowed2",
+									"allowed3",
+									"allowed4",
+									"allowed5",
+									"allowed6",
+									"allowed7",
+									"allowed8",
+									"allowed9"
+								]
+							}
 						}
 					}
 				}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.options.json
@@ -11,25 +11,21 @@
 							"eslint": "Importing Eslint is forbidden",
 							"lodash": "It's not recommended to use lodash",
 							"bare-forbidden": {
-								"message": "Importing bare-forbidden is not allowed",
 								"importNames": [
 									""
 								]
 							},
 							"default-forbidden": {
-								"message": "Importing default-forbidden is not allowed",
 								"importNames": [
 									"default"
 								]
 							},
 							"namespace-forbidden": {
-								"message": "Importing namespace-forbidden is not allowed",
 								"importNames": [
 									"*"
 								]
 							},
 							"member-forbidden": {
-								"message": "Importing member-forbidden is not allowed",
 								"importNames": [
 									"forbidden1",
 									"forbidden2",
@@ -43,25 +39,21 @@
 								]
 							},
 							"bare-allowed": {
-								"message": "Importing bare-forbidden is not allowed",
 								"allowImportNames": [
 									""
 								]
 							},
 							"default-allowed": {
-								"message": "Importing default-allowed is not allowed",
 								"allowImportNames": [
 									"default"
 								]
 							},
 							"namespace-allowed": {
-								"message": "Importing namespace-allowed is not allowed",
 								"allowImportNames": [
 									"*"
 								]
 							},
 							"member-allowed": {
-								"message": "Importing member-allowed is not allowed",
 								"allowImportNames": [
 									"allowed1",
 									"allowed2",

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts
@@ -1,0 +1,34 @@
+import 'bare-forbidden';
+import 'default-allowed';
+import 'default-forbidden';
+import 'namespace-allowed';
+import 'namespace-forbidden';
+import 'member-allowed';
+import 'member-forbidden';
+
+import * as n1 from 'namespace-forbidden';
+import * as n2 from 'default-allowed';
+import * as n3 from 'member-allowed';
+import * as n4 from 'bare-allowed';
+
+import type d0 from 'default-forbidden';
+import type d1 from 'member-allowed';
+import type d2 from 'namespace-allowed';
+import type d3 from 'bare-allowed';
+
+import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+import { type default as d6, type allowed3 } from 'namespace-allowed';
+import { type default as d7, type allowed4 } from 'bare-allowed';
+
+import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+import type { default as d10, allowed7 } from 'namespace-allowed';
+import type { default as d11, allowed8 } from 'bare-allowed';
+
+import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
@@ -67,7 +67,9 @@ invalid.ts:2:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     3 │ import 'default-forbidden';
     4 │ import 'namespace-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -84,7 +86,9 @@ invalid.ts:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     5 │ import 'namespace-forbidden';
     6 │ import 'member-allowed';
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -101,7 +105,17 @@ invalid.ts:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     7 │ import 'member-forbidden';
     8 │ 
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -132,7 +146,9 @@ invalid.ts:10:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     11 │ import * as n3 from 'member-allowed';
     12 │ import * as n4 from 'bare-allowed';
   
-  i Only the following imports from 'default-allowed' are allowed: default.
+  i Only the following imports from 'default-allowed' are allowed:
+  
+  - default
   
 
 ```
@@ -149,7 +165,17 @@ invalid.ts:11:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     12 │ import * as n4 from 'bare-allowed';
     13 │ 
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -166,7 +192,9 @@ invalid.ts:12:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
     13 │ 
     14 │ import type d0 from 'default-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -197,7 +225,17 @@ invalid.ts:15:13 lint/nursery/noRestrictedImports ━━━━━━━━━━
     16 │ import type d2 from 'namespace-allowed';
     17 │ import type d3 from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -214,7 +252,9 @@ invalid.ts:16:13 lint/nursery/noRestrictedImports ━━━━━━━━━━
     17 │ import type d3 from 'bare-allowed';
     18 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -231,7 +271,9 @@ invalid.ts:17:13 lint/nursery/noRestrictedImports ━━━━━━━━━━
     18 │ 
     19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -262,7 +304,17 @@ invalid.ts:20:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
     22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -279,7 +331,9 @@ invalid.ts:21:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
     23 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -296,7 +350,9 @@ invalid.ts:21:35 lint/nursery/noRestrictedImports ━━━━━━━━━━
     22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
     23 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -313,7 +369,9 @@ invalid.ts:22:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     23 │ 
     24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -330,7 +388,9 @@ invalid.ts:22:35 lint/nursery/noRestrictedImports ━━━━━━━━━━
     23 │ 
     24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -361,7 +421,17 @@ invalid.ts:25:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
     27 │ import type { default as d11, allowed8 } from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -378,7 +448,9 @@ invalid.ts:26:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     27 │ import type { default as d11, allowed8 } from 'bare-allowed';
     28 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -395,7 +467,9 @@ invalid.ts:26:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     27 │ import type { default as d11, allowed8 } from 'bare-allowed';
     28 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -412,7 +486,9 @@ invalid.ts:27:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     28 │ 
     29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -429,7 +505,9 @@ invalid.ts:27:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     28 │ 
     29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -475,7 +553,17 @@ invalid.ts:30:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
     32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -491,7 +579,17 @@ invalid.ts:30:32 lint/nursery/noRestrictedImports ━━━━━━━━━━
     31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
     32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -538,7 +636,17 @@ invalid.ts:32:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -555,7 +663,17 @@ invalid.ts:32:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -572,7 +690,17 @@ invalid.ts:32:43 lint/nursery/noRestrictedImports ━━━━━━━━━━
     33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
   
-  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  i Only the following imports from 'member-allowed' are allowed:
+  
+  - allowed1
+  - allowed2
+  - allowed3
+  - allowed4
+  - allowed5
+  - allowed6
+  - allowed7
+  - allowed8
+  - allowed9
   
 
 ```
@@ -589,7 +717,9 @@ invalid.ts:33:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
     35 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -606,7 +736,9 @@ invalid.ts:33:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
     35 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -623,7 +755,9 @@ invalid.ts:33:43 lint/nursery/noRestrictedImports ━━━━━━━━━━
     34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
     35 │ 
   
-  i Only the following imports from 'namespace-allowed' are allowed: *.
+  i Only the following imports from 'namespace-allowed' are allowed:
+  
+  - *
   
 
 ```
@@ -639,7 +773,9 @@ invalid.ts:34:15 lint/nursery/noRestrictedImports ━━━━━━━━━━
        │               ^^^^^^^
     35 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -655,7 +791,9 @@ invalid.ts:34:31 lint/nursery/noRestrictedImports ━━━━━━━━━━
        │                               ^^^^^^^^^^
     35 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```
@@ -671,7 +809,9 @@ invalid.ts:34:43 lint/nursery/noRestrictedImports ━━━━━━━━━━
        │                                           ^^^^^^^^^^
     35 │ 
   
-  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  i Only the following imports from 'bare-allowed' are allowed:
+  
+  - Side-effect only import
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
@@ -46,7 +46,7 @@ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed'
 ```
 invalid.ts:1:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'bare-forbidden'.
+  ! Do not import 'bare-forbidden' through a side-effect import.
   
   > 1 │ import 'bare-forbidden';
       │        ^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ invalid.ts:1:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.ts:2:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'default-allowed'.
+  ! Do not import 'default-allowed' through a side-effect import.
   
     1 │ import 'bare-forbidden';
   > 2 │ import 'default-allowed';
@@ -75,7 +75,7 @@ invalid.ts:2:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.ts:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'namespace-allowed'.
+  ! Do not import 'namespace-allowed' through a side-effect import.
   
     2 │ import 'default-allowed';
     3 │ import 'default-forbidden';
@@ -92,7 +92,7 @@ invalid.ts:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━�
 ```
 invalid.ts:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Do not import '' from 'member-allowed'.
+  ! Do not import 'member-allowed' through a side-effect import.
   
     4 │ import 'namespace-allowed';
     5 │ import 'namespace-forbidden';

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/invalid.ts.snap
@@ -1,0 +1,677 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+snapshot_kind: text
+---
+# Input
+```ts
+import 'bare-forbidden';
+import 'default-allowed';
+import 'default-forbidden';
+import 'namespace-allowed';
+import 'namespace-forbidden';
+import 'member-allowed';
+import 'member-forbidden';
+
+import * as n1 from 'namespace-forbidden';
+import * as n2 from 'default-allowed';
+import * as n3 from 'member-allowed';
+import * as n4 from 'bare-allowed';
+
+import type d0 from 'default-forbidden';
+import type d1 from 'member-allowed';
+import type d2 from 'namespace-allowed';
+import type d3 from 'bare-allowed';
+
+import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+import { type default as d6, type allowed3 } from 'namespace-allowed';
+import { type default as d7, type allowed4 } from 'bare-allowed';
+
+import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+import type { default as d10, allowed7 } from 'namespace-allowed';
+import type { default as d11, allowed8 } from 'bare-allowed';
+
+import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+
+```
+
+# Diagnostics
+```
+invalid.ts:1:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '' from 'bare-forbidden'.
+  
+  > 1 │ import 'bare-forbidden';
+      │        ^^^^^^^^^^^^^^^^
+    2 │ import 'default-allowed';
+    3 │ import 'default-forbidden';
+  
+
+```
+
+```
+invalid.ts:2:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '' from 'default-allowed'.
+  
+    1 │ import 'bare-forbidden';
+  > 2 │ import 'default-allowed';
+      │        ^^^^^^^^^^^^^^^^^
+    3 │ import 'default-forbidden';
+    4 │ import 'namespace-allowed';
+  
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
+
+```
+
+```
+invalid.ts:4:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '' from 'namespace-allowed'.
+  
+    2 │ import 'default-allowed';
+    3 │ import 'default-forbidden';
+  > 4 │ import 'namespace-allowed';
+      │        ^^^^^^^^^^^^^^^^^^^
+    5 │ import 'namespace-forbidden';
+    6 │ import 'member-allowed';
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:6:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '' from 'member-allowed'.
+  
+    4 │ import 'namespace-allowed';
+    5 │ import 'namespace-forbidden';
+  > 6 │ import 'member-allowed';
+      │        ^^^^^^^^^^^^^^^^
+    7 │ import 'member-forbidden';
+    8 │ 
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:9:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'namespace-forbidden'.
+  
+     7 │ import 'member-forbidden';
+     8 │ 
+   > 9 │ import * as n1 from 'namespace-forbidden';
+       │        ^
+    10 │ import * as n2 from 'default-allowed';
+    11 │ import * as n3 from 'member-allowed';
+  
+
+```
+
+```
+invalid.ts:10:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'default-allowed'.
+  
+     9 │ import * as n1 from 'namespace-forbidden';
+  > 10 │ import * as n2 from 'default-allowed';
+       │        ^
+    11 │ import * as n3 from 'member-allowed';
+    12 │ import * as n4 from 'bare-allowed';
+  
+  i Only the following imports from 'default-allowed' are allowed: default.
+  
+
+```
+
+```
+invalid.ts:11:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'member-allowed'.
+  
+     9 │ import * as n1 from 'namespace-forbidden';
+    10 │ import * as n2 from 'default-allowed';
+  > 11 │ import * as n3 from 'member-allowed';
+       │        ^
+    12 │ import * as n4 from 'bare-allowed';
+    13 │ 
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:12:8 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import '*' from 'bare-allowed'.
+  
+    10 │ import * as n2 from 'default-allowed';
+    11 │ import * as n3 from 'member-allowed';
+  > 12 │ import * as n4 from 'bare-allowed';
+       │        ^
+    13 │ 
+    14 │ import type d0 from 'default-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:14:13 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'default-forbidden'.
+  
+    12 │ import * as n4 from 'bare-allowed';
+    13 │ 
+  > 14 │ import type d0 from 'default-forbidden';
+       │             ^^
+    15 │ import type d1 from 'member-allowed';
+    16 │ import type d2 from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.ts:15:13 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    14 │ import type d0 from 'default-forbidden';
+  > 15 │ import type d1 from 'member-allowed';
+       │             ^^
+    16 │ import type d2 from 'namespace-allowed';
+    17 │ import type d3 from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:16:13 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    14 │ import type d0 from 'default-forbidden';
+    15 │ import type d1 from 'member-allowed';
+  > 16 │ import type d2 from 'namespace-allowed';
+       │             ^^
+    17 │ import type d3 from 'bare-allowed';
+    18 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:17:13 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'bare-allowed'.
+  
+    15 │ import type d1 from 'member-allowed';
+    16 │ import type d2 from 'namespace-allowed';
+  > 17 │ import type d3 from 'bare-allowed';
+       │             ^^
+    18 │ 
+    19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:19:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'default-forbidden'.
+  
+    17 │ import type d3 from 'bare-allowed';
+    18 │ 
+  > 19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+       │               ^^^^^^^
+    20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+    21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.ts:20:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+  > 20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+       │               ^^^^^^^
+    21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+    22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:21:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+    20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+  > 21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+       │               ^^^^^^^
+    22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+    23 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:21:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'allowed3' from 'namespace-allowed'.
+  
+    19 │ import { type default as d4, type allowed1, type allowed2 as a2 } from 'default-forbidden';
+    20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+  > 21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+       │                                   ^^^^^^^^
+    22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+    23 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:22:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'bare-allowed'.
+  
+    20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+    21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+  > 22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+       │               ^^^^^^^
+    23 │ 
+    24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:22:35 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'allowed4' from 'bare-allowed'.
+  
+    20 │ import { type default as d5, type allowed2, type allowed3 as a3 } from 'member-allowed';
+    21 │ import { type default as d6, type allowed3 } from 'namespace-allowed';
+  > 22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+       │                                   ^^^^^^^^
+    23 │ 
+    24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:24:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'default-forbidden'.
+  
+    22 │ import { type default as d7, type allowed4 } from 'bare-allowed';
+    23 │ 
+  > 24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+       │               ^^^^^^^
+    25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+    26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.ts:25:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+  > 25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+       │               ^^^^^^^
+    26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+    27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:26:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+    25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+  > 26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+       │               ^^^^^^^
+    27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+    28 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:26:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'allowed7' from 'namespace-allowed'.
+  
+    24 │ import type { default as d8, allowed5, allowed6 as a6 } from 'default-forbidden';
+    25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+  > 26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+       │                               ^^^^^^^^
+    27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+    28 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:27:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'bare-allowed'.
+  
+    25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+    26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+  > 27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+       │               ^^^^^^^
+    28 │ 
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:27:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'allowed8' from 'bare-allowed'.
+  
+    25 │ import type { default as d9, allowed6, allowed7 as a7 } from 'member-allowed';
+    26 │ import type { default as d10, allowed7 } from 'namespace-allowed';
+  > 27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+       │                               ^^^^^^^^
+    28 │ 
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:29:36 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden1' from 'member-forbidden'.
+  
+    27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+    28 │ 
+  > 29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+       │                                    ^^^^^^^^^^
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+  
+
+```
+
+```
+invalid.ts:29:53 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'member-forbidden'.
+  
+    27 │ import type { default as d11, allowed8 } from 'bare-allowed';
+    28 │ 
+  > 29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+       │                                                     ^^^^^^^^^^
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+  
+
+```
+
+```
+invalid.ts:30:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden2' from 'member-allowed'.
+  
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+  > 30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+       │               ^^^^^^^^^^
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:30:32 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'member-allowed'.
+  
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+  > 30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+       │                                ^^^^^^^^^^
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:31:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden3' from 'member-forbidden'.
+  
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+  > 31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+       │                               ^^^^^^^^^^
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.ts:31:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'member-forbidden'.
+  
+    29 │ import { type default as d12, type forbidden1, type forbidden2 as f2 } from 'member-forbidden';
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+  > 31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+       │                                           ^^^^^^^^^^
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+  
+
+```
+
+```
+invalid.ts:32:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'member-allowed'.
+  
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+  > 32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+       │               ^^^^^^^
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:32:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden4' from 'member-allowed'.
+  
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+  > 32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+       │                               ^^^^^^^^^^
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:32:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden5' from 'member-allowed'.
+  
+    30 │ import { type forbidden2, type forbidden3 as f3 } from 'member-allowed';
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+  > 32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+       │                                           ^^^^^^^^^^
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+  
+  i Only the following imports from 'member-allowed' are allowed: allowed1, allowed2, allowed3, allowed4, allowed5, allowed6, allowed7, allowed8, allowed9.
+  
+
+```
+
+```
+invalid.ts:33:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'namespace-allowed'.
+  
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+  > 33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+       │               ^^^^^^^
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+    35 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:33:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden5' from 'namespace-allowed'.
+  
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+  > 33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+       │                               ^^^^^^^^^^
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+    35 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:33:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden6' from 'namespace-allowed'.
+  
+    31 │ import type { default as d13, forbidden3, forbidden4 as f4 } from 'member-forbidden';
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+  > 33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+       │                                           ^^^^^^^^^^
+    34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+    35 │ 
+  
+  i Only the following imports from 'namespace-allowed' are allowed: *.
+  
+
+```
+
+```
+invalid.ts:34:15 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'default' from 'bare-allowed'.
+  
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+  > 34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+       │               ^^^^^^^
+    35 │ 
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:34:31 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden6' from 'bare-allowed'.
+  
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+  > 34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+       │                               ^^^^^^^^^^
+    35 │ 
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```
+
+```
+invalid.ts:34:43 lint/nursery/noRestrictedImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Do not import 'forbidden7' from 'bare-allowed'.
+  
+    32 │ import type { default as d14, forbidden4, forbidden5 as f5 } from 'member-allowed';
+    33 │ import type { default as d15, forbidden5, forbidden6 as f6 } from 'namespace-allowed';
+  > 34 │ import type { default as d16, forbidden6, forbidden7 as f7 } from 'bare-allowed';
+       │                                           ^^^^^^^^^^
+    35 │ 
+  
+  i Only the following imports from 'bare-allowed' are allowed: side-effect import.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
@@ -1,1 +1,92 @@
 const path = require('lodash');
+
+import eslint from 'eslint';
+const l = require('lodash');
+
+import 'bare-allowed';
+
+import * as n1 from 'namespace-allowed';
+const n2 = await import('namespace-allowed');
+const n2b = ((await (import('namespace-allowed'))));
+const n3 = import('namespace-allowed');
+const n3b = (import('namespace-allowed'));
+import('namespace-allowed').then(n4 => { });
+import('namespace-allowed').then((n5) => { });
+import('namespace-allowed').then(function (n6) { });
+((import('namespace-allowed'))).then(((n6 => { })));
+((import('namespace-allowed'))).then((((n7) => { })));
+((import('namespace-allowed'))).then(((function (n8) { })));
+
+import d0 from 'default-and-member-allowed';
+import { default as d1 } from 'default-and-member-allowed';
+const { "default": d2 } = await import('default-and-member-allowed');
+const { default: d3 } = await import('default-and-member-allowed');
+import { default as d4, allowed1 } from 'default-and-member-allowed';
+const { allowed2, default: d5 } = await import('default-and-member-allowed');
+const { allowed3, default: d6 } = import('default-and-member-allowed');
+const { "allowed4": a1, "default": d7 } = import('default-and-member-allowed');
+
+import { allowed2, allowed3 as a3 } from 'member-allowed';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('member-allowed');
+import('member-allowed').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('member-allowed').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+// require() returns the default import, not a namespace object,
+// so this import corresponds to default.* (and not namespace.*).
+const d0 = require('default-allowed');
+const d1 = require('namespace-forbidden');
+const d2 = require('member-forbidden');
+const { some, random, identifiers } = require('default-allowed');
+const { some, random, identifiers } = require('namespace-forbidden');
+const { some, random, identifiers } = require('member-forbidden');
+
+import * as n1 from 'bare-forbidden';
+const n2 = await import('bare-forbidden');
+const n2b = ((await (import('bare-forbidden'))));
+const n3 = import('bare-forbidden');
+const n3b = (import('bare-forbidden'));
+import('bare-forbidden').then(n4 => { });
+import('bare-forbidden').then((n5) => { });
+import('bare-forbidden').then(function (n6) { });
+((import('bare-forbidden'))).then(((n6 => { })));
+((import('bare-forbidden'))).then((((n7) => { })));
+((import('bare-forbidden'))).then(((function (n8) { })));
+
+import * as n1 from 'default-forbidden';
+const n2 = await import('default-forbidden');
+const n2b = ((await (import('default-forbidden'))));
+const n3 = import('default-forbidden');
+const n3b = (import('default-forbidden'));
+import('default-forbidden').then(n4 => { });
+import('default-forbidden').then((n5) => { });
+import('default-forbidden').then(function (n6) { });
+((import('default-forbidden'))).then(((n6 => { })));
+((import('default-forbidden'))).then((((n7) => { })));
+((import('default-forbidden'))).then(((function (n8) { })));
+
+import * as n1 from 'member-forbidden';
+const n2 = await import('member-forbidden');
+const n2b = ((await (import('member-forbidden'))));
+const n3 = import('member-forbidden');
+const n3b = (import('member-forbidden'));
+import('member-forbidden').then(n4 => { });
+import('member-forbidden').then((n5) => { });
+import('member-forbidden').then(function (n6) { });
+((import('member-forbidden'))).then(((n6 => { })));
+((import('member-forbidden'))).then((((n7) => { })));
+((import('member-forbidden'))).then(((function (n8) { })));
+
+import { allowed2, allowed3 as a3 } from 'bare-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('bare-forbidden');
+import('bare-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('bare-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+import { allowed2, allowed3 as a3 } from 'default-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('default-forbidden');
+import('default-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('default-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+import { allowed2, allowed3 as a3 } from 'namespace-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('namespace-forbidden');
+import('namespace-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('namespace-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js
@@ -5,6 +5,7 @@ const l = require('lodash');
 
 import 'bare-allowed';
 
+export * from 'namespace-allowed';
 import * as n1 from 'namespace-allowed';
 const n2 = await import('namespace-allowed');
 const n2b = ((await (import('namespace-allowed'))));
@@ -17,15 +18,19 @@ import('namespace-allowed').then(function (n6) { });
 ((import('namespace-allowed'))).then((((n7) => { })));
 ((import('namespace-allowed'))).then(((function (n8) { })));
 
+export { default } from 'default-and-member-allowed';
 import d0 from 'default-and-member-allowed';
+export { default as d1 } from 'default-and-member-allowed';
 import { default as d1 } from 'default-and-member-allowed';
 const { "default": d2 } = await import('default-and-member-allowed');
 const { default: d3 } = await import('default-and-member-allowed');
+export { default as d4, allowed1 } from 'default-and-member-allowed';
 import { default as d4, allowed1 } from 'default-and-member-allowed';
 const { allowed2, default: d5 } = await import('default-and-member-allowed');
 const { allowed3, default: d6 } = import('default-and-member-allowed');
 const { "allowed4": a1, "default": d7 } = import('default-and-member-allowed');
 
+export { allowed2, allowed3 as a3 } from 'member-allowed';
 import { allowed2, allowed3 as a3 } from 'member-allowed';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('member-allowed');
 import('member-allowed').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
@@ -40,6 +45,7 @@ const { some, random, identifiers } = require('default-allowed');
 const { some, random, identifiers } = require('namespace-forbidden');
 const { some, random, identifiers } = require('member-forbidden');
 
+export * from 'bare-forbidden';
 import * as n1 from 'bare-forbidden';
 const n2 = await import('bare-forbidden');
 const n2b = ((await (import('bare-forbidden'))));
@@ -52,6 +58,7 @@ import('bare-forbidden').then(function (n6) { });
 ((import('bare-forbidden'))).then((((n7) => { })));
 ((import('bare-forbidden'))).then(((function (n8) { })));
 
+export * from 'default-forbidden';
 import * as n1 from 'default-forbidden';
 const n2 = await import('default-forbidden');
 const n2b = ((await (import('default-forbidden'))));
@@ -64,6 +71,7 @@ import('default-forbidden').then(function (n6) { });
 ((import('default-forbidden'))).then((((n7) => { })));
 ((import('default-forbidden'))).then(((function (n8) { })));
 
+export * from 'member-forbidden';
 import * as n1 from 'member-forbidden';
 const n2 = await import('member-forbidden');
 const n2b = ((await (import('member-forbidden'))));
@@ -76,16 +84,19 @@ import('member-forbidden').then(function (n6) { });
 ((import('member-forbidden'))).then((((n7) => { })));
 ((import('member-forbidden'))).then(((function (n8) { })));
 
+export { allowed2, allowed3 as a3 } from 'bare-forbidden';
 import { allowed2, allowed3 as a3 } from 'bare-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('bare-forbidden');
 import('bare-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
 import('bare-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
 
+export { allowed2, allowed3 as a3 } from 'default-forbidden';
 import { allowed2, allowed3 as a3 } from 'default-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('default-forbidden');
 import('default-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
 import('default-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
 
+export { allowed2, allowed3 as a3 } from 'namespace-forbidden';
 import { allowed2, allowed3 as a3 } from 'namespace-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('namespace-forbidden');
 import('namespace-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
@@ -1,11 +1,101 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
+snapshot_kind: text
 ---
 # Input
 ```jsx
 const path = require('lodash');
 
+import eslint from 'eslint';
+const l = require('lodash');
+
+import 'bare-allowed';
+
+import * as n1 from 'namespace-allowed';
+const n2 = await import('namespace-allowed');
+const n2b = ((await (import('namespace-allowed'))));
+const n3 = import('namespace-allowed');
+const n3b = (import('namespace-allowed'));
+import('namespace-allowed').then(n4 => { });
+import('namespace-allowed').then((n5) => { });
+import('namespace-allowed').then(function (n6) { });
+((import('namespace-allowed'))).then(((n6 => { })));
+((import('namespace-allowed'))).then((((n7) => { })));
+((import('namespace-allowed'))).then(((function (n8) { })));
+
+import d0 from 'default-and-member-allowed';
+import { default as d1 } from 'default-and-member-allowed';
+const { "default": d2 } = await import('default-and-member-allowed');
+const { default: d3 } = await import('default-and-member-allowed');
+import { default as d4, allowed1 } from 'default-and-member-allowed';
+const { allowed2, default: d5 } = await import('default-and-member-allowed');
+const { allowed3, default: d6 } = import('default-and-member-allowed');
+const { "allowed4": a1, "default": d7 } = import('default-and-member-allowed');
+
+import { allowed2, allowed3 as a3 } from 'member-allowed';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('member-allowed');
+import('member-allowed').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('member-allowed').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+// require() returns the default import, not a namespace object,
+// so this import corresponds to default.* (and not namespace.*).
+const d0 = require('default-allowed');
+const d1 = require('namespace-forbidden');
+const d2 = require('member-forbidden');
+const { some, random, identifiers } = require('default-allowed');
+const { some, random, identifiers } = require('namespace-forbidden');
+const { some, random, identifiers } = require('member-forbidden');
+
+import * as n1 from 'bare-forbidden';
+const n2 = await import('bare-forbidden');
+const n2b = ((await (import('bare-forbidden'))));
+const n3 = import('bare-forbidden');
+const n3b = (import('bare-forbidden'));
+import('bare-forbidden').then(n4 => { });
+import('bare-forbidden').then((n5) => { });
+import('bare-forbidden').then(function (n6) { });
+((import('bare-forbidden'))).then(((n6 => { })));
+((import('bare-forbidden'))).then((((n7) => { })));
+((import('bare-forbidden'))).then(((function (n8) { })));
+
+import * as n1 from 'default-forbidden';
+const n2 = await import('default-forbidden');
+const n2b = ((await (import('default-forbidden'))));
+const n3 = import('default-forbidden');
+const n3b = (import('default-forbidden'));
+import('default-forbidden').then(n4 => { });
+import('default-forbidden').then((n5) => { });
+import('default-forbidden').then(function (n6) { });
+((import('default-forbidden'))).then(((n6 => { })));
+((import('default-forbidden'))).then((((n7) => { })));
+((import('default-forbidden'))).then(((function (n8) { })));
+
+import * as n1 from 'member-forbidden';
+const n2 = await import('member-forbidden');
+const n2b = ((await (import('member-forbidden'))));
+const n3 = import('member-forbidden');
+const n3b = (import('member-forbidden'));
+import('member-forbidden').then(n4 => { });
+import('member-forbidden').then((n5) => { });
+import('member-forbidden').then(function (n6) { });
+((import('member-forbidden'))).then(((n6 => { })));
+((import('member-forbidden'))).then((((n7) => { })));
+((import('member-forbidden'))).then(((function (n8) { })));
+
+import { allowed2, allowed3 as a3 } from 'bare-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('bare-forbidden');
+import('bare-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('bare-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+import { allowed2, allowed3 as a3 } from 'default-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('default-forbidden');
+import('default-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('default-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
+import { allowed2, allowed3 as a3 } from 'namespace-forbidden';
+const { allowed2, allowed3: a3, "allowed4": a4 } = await import('namespace-forbidden');
+import('namespace-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
+import('namespace-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
+
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.js.snap
@@ -12,6 +12,7 @@ const l = require('lodash');
 
 import 'bare-allowed';
 
+export * from 'namespace-allowed';
 import * as n1 from 'namespace-allowed';
 const n2 = await import('namespace-allowed');
 const n2b = ((await (import('namespace-allowed'))));
@@ -24,15 +25,19 @@ import('namespace-allowed').then(function (n6) { });
 ((import('namespace-allowed'))).then((((n7) => { })));
 ((import('namespace-allowed'))).then(((function (n8) { })));
 
+export { default } from 'default-and-member-allowed';
 import d0 from 'default-and-member-allowed';
+export { default as d1 } from 'default-and-member-allowed';
 import { default as d1 } from 'default-and-member-allowed';
 const { "default": d2 } = await import('default-and-member-allowed');
 const { default: d3 } = await import('default-and-member-allowed');
+export { default as d4, allowed1 } from 'default-and-member-allowed';
 import { default as d4, allowed1 } from 'default-and-member-allowed';
 const { allowed2, default: d5 } = await import('default-and-member-allowed');
 const { allowed3, default: d6 } = import('default-and-member-allowed');
 const { "allowed4": a1, "default": d7 } = import('default-and-member-allowed');
 
+export { allowed2, allowed3 as a3 } from 'member-allowed';
 import { allowed2, allowed3 as a3 } from 'member-allowed';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('member-allowed');
 import('member-allowed').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
@@ -47,6 +52,7 @@ const { some, random, identifiers } = require('default-allowed');
 const { some, random, identifiers } = require('namespace-forbidden');
 const { some, random, identifiers } = require('member-forbidden');
 
+export * from 'bare-forbidden';
 import * as n1 from 'bare-forbidden';
 const n2 = await import('bare-forbidden');
 const n2b = ((await (import('bare-forbidden'))));
@@ -59,6 +65,7 @@ import('bare-forbidden').then(function (n6) { });
 ((import('bare-forbidden'))).then((((n7) => { })));
 ((import('bare-forbidden'))).then(((function (n8) { })));
 
+export * from 'default-forbidden';
 import * as n1 from 'default-forbidden';
 const n2 = await import('default-forbidden');
 const n2b = ((await (import('default-forbidden'))));
@@ -71,6 +78,7 @@ import('default-forbidden').then(function (n6) { });
 ((import('default-forbidden'))).then((((n7) => { })));
 ((import('default-forbidden'))).then(((function (n8) { })));
 
+export * from 'member-forbidden';
 import * as n1 from 'member-forbidden';
 const n2 = await import('member-forbidden');
 const n2b = ((await (import('member-forbidden'))));
@@ -83,16 +91,19 @@ import('member-forbidden').then(function (n6) { });
 ((import('member-forbidden'))).then((((n7) => { })));
 ((import('member-forbidden'))).then(((function (n8) { })));
 
+export { allowed2, allowed3 as a3 } from 'bare-forbidden';
 import { allowed2, allowed3 as a3 } from 'bare-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('bare-forbidden');
 import('bare-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
 import('bare-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
 
+export { allowed2, allowed3 as a3 } from 'default-forbidden';
 import { allowed2, allowed3 as a3 } from 'default-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('default-forbidden');
 import('default-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })
 import('default-forbidden').then(function ({ allowed2, allowed3: a3, "allowed4": a4 }) { })
 
+export { allowed2, allowed3 as a3 } from 'namespace-forbidden';
 import { allowed2, allowed3 as a3 } from 'namespace-forbidden';
 const { allowed2, allowed3: a3, "allowed4": a4 } = await import('namespace-forbidden');
 import('namespace-forbidden').then(({ allowed2, allowed3: a3, "allowed4": a4 }) => { })

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
@@ -9,25 +9,21 @@
 						"paths": {
 							"node:fs": "Importing from node:fs is forbidden",
 							"bare-forbidden": {
-								"message": "Importing bare-forbidden is not allowed",
 								"importNames": [
 									""
 								]
 							},
 							"default-forbidden": {
-								"message": "Importing default-forbidden is not allowed",
 								"importNames": [
 									"default"
 								]
 							},
 							"namespace-forbidden": {
-								"message": "Importing namespace-forbidden is not allowed",
 								"importNames": [
 									"*"
 								]
 							},
 							"member-forbidden": {
-								"message": "Importing member-forbidden is not allowed",
 								"importNames": [
 									"forbidden1",
 									"forbidden2",
@@ -41,13 +37,11 @@
 								]
 							},
 							"bare-allowed": {
-								"message": "Importing bare-forbidden is not allowed",
 								"allowImportNames": [
 									""
 								]
 							},
 							"default-and-member-allowed": {
-								"message": "Importing default-and-member-allowed is not allowed",
 								"allowImportNames": [
 									"default",
 									"allowed1",
@@ -62,13 +56,11 @@
 								]
 							},
 							"namespace-allowed": {
-								"message": "Importing namespace-allowed is not allowed",
 								"allowImportNames": [
 									"*"
 								]
 							},
 							"member-allowed": {
-								"message": "Importing member-allowed is not allowed",
 								"allowImportNames": [
 									"allowed1",
 									"allowed2",

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.options.json
@@ -7,7 +7,80 @@
 					"level": "error",
 					"options": {
 						"paths": {
-							"node:fs": "Importing from node:fs is forbidden"
+							"node:fs": "Importing from node:fs is forbidden",
+							"bare-forbidden": {
+								"message": "Importing bare-forbidden is not allowed",
+								"importNames": [
+									""
+								]
+							},
+							"default-forbidden": {
+								"message": "Importing default-forbidden is not allowed",
+								"importNames": [
+									"default"
+								]
+							},
+							"namespace-forbidden": {
+								"message": "Importing namespace-forbidden is not allowed",
+								"importNames": [
+									"*"
+								]
+							},
+							"member-forbidden": {
+								"message": "Importing member-forbidden is not allowed",
+								"importNames": [
+									"forbidden1",
+									"forbidden2",
+									"forbidden3",
+									"forbidden4",
+									"forbidden5",
+									"forbidden6",
+									"forbidden7",
+									"forbidden8",
+									"forbidden9"
+								]
+							},
+							"bare-allowed": {
+								"message": "Importing bare-forbidden is not allowed",
+								"allowImportNames": [
+									""
+								]
+							},
+							"default-and-member-allowed": {
+								"message": "Importing default-and-member-allowed is not allowed",
+								"allowImportNames": [
+									"default",
+									"allowed1",
+									"allowed2",
+									"allowed3",
+									"allowed4",
+									"allowed5",
+									"allowed6",
+									"allowed7",
+									"allowed8",
+									"allowed9"
+								]
+							},
+							"namespace-allowed": {
+								"message": "Importing namespace-allowed is not allowed",
+								"allowImportNames": [
+									"*"
+								]
+							},
+							"member-allowed": {
+								"message": "Importing member-allowed is not allowed",
+								"allowImportNames": [
+									"allowed1",
+									"allowed2",
+									"allowed3",
+									"allowed4",
+									"allowed5",
+									"allowed6",
+									"allowed7",
+									"allowed8",
+									"allowed9"
+								]
+							}
 						}
 					}
 				}

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
@@ -1,1 +1,22 @@
-declare module "node:fs" {}
+declare module "node:fs" { }
+
+import 'bare-allowed';
+import 'default-forbidden';
+import 'namespace-forbidden';
+import 'member-forbidden';
+
+import * as n1 from 'namespace-allowed';
+import * as n2 from 'default-forbidden';
+import * as n3 from 'member-forbidden';
+
+import type d0 from 'default-and-member-allowed';
+import type d1 from 'member-forbidden';
+import type d2 from 'namespace-forbidden';
+
+import { type default as d3, type allowed1, type allowed2 as a2 } from 'default-and-member-allowed';
+import { type default as d4, type allowed2, type allowed3 as a3 } from 'member-forbidden';
+import { type default as d5, type allowed3, type allowed4 as a4 } from 'namespace-forbidden';
+
+import type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member-allowed';
+import type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
+import type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts
@@ -20,3 +20,15 @@ import { type default as d5, type allowed3, type allowed4 as a4 } from 'namespac
 import type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member-allowed';
 import type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
 import type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';
+
+export * as n1 from 'namespace-allowed';
+export * as n2 from 'default-forbidden';
+export * as n3 from 'member-forbidden';
+
+export { type allowed1, type allowed2 as a2 } from 'default-and-member-allowed';
+export { type allowed2, type allowed3 as a3 } from 'member-forbidden';
+export { type allowed3, type allowed4 as a4 } from 'namespace-forbidden';
+
+export type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member-allowed';
+export type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
+export type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
@@ -1,8 +1,31 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.ts
+snapshot_kind: text
 ---
 # Input
 ```ts
-declare module "node:fs" {}
+declare module "node:fs" { }
+
+import 'bare-allowed';
+import 'default-forbidden';
+import 'namespace-forbidden';
+import 'member-forbidden';
+
+import * as n1 from 'namespace-allowed';
+import * as n2 from 'default-forbidden';
+import * as n3 from 'member-forbidden';
+
+import type d0 from 'default-and-member-allowed';
+import type d1 from 'member-forbidden';
+import type d2 from 'namespace-forbidden';
+
+import { type default as d3, type allowed1, type allowed2 as a2 } from 'default-and-member-allowed';
+import { type default as d4, type allowed2, type allowed3 as a3 } from 'member-forbidden';
+import { type default as d5, type allowed3, type allowed4 as a4 } from 'namespace-forbidden';
+
+import type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member-allowed';
+import type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
+import type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';
+
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noRestrictedImports/valid.ts.snap
@@ -28,4 +28,16 @@ import type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member
 import type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
 import type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';
 
+export * as n1 from 'namespace-allowed';
+export * as n2 from 'default-forbidden';
+export * as n3 from 'member-forbidden';
+
+export { type allowed1, type allowed2 as a2 } from 'default-and-member-allowed';
+export { type allowed2, type allowed3 as a3 } from 'member-forbidden';
+export { type allowed3, type allowed4 as a4 } from 'namespace-forbidden';
+
+export type { default as d6, allowed5, allowed6 as a6 } from 'default-and-member-allowed';
+export type { default as d7, allowed6, allowed7 as a7 } from 'member-forbidden';
+export type { default as d8, allowed7, allowed8 as a8 } from 'namespace-forbidden';
+
 ```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2531,7 +2531,7 @@ export interface UseImportExtensionsOptions {
  */
 export interface RestrictedImportsOptions {
 	/**
-	 * A list of names that should trigger the rule
+	 * A list of import paths that should trigger the rule
 	 */
 	paths: {};
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2531,7 +2531,7 @@ export interface UseImportExtensionsOptions {
  */
 export interface RestrictedImportsOptions {
 	/**
-	 * A list of import paths that should trigger the rule
+	 * A list of import paths that should trigger the rule.
 	 */
 	paths: {};
 }

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1214,19 +1214,16 @@
 			"properties": {
 				"allowImportNames": {
 					"description": "Names of the exported members that allowed to be not be used.",
-					"default": [],
 					"type": "array",
 					"items": { "type": "string" }
 				},
 				"importNames": {
 					"description": "Names of the exported members that should not be used.",
-					"default": [],
 					"type": "array",
 					"items": { "type": "string" }
 				},
 				"message": {
 					"description": "The message to display when this module is imported.",
-					"default": "",
 					"type": "string"
 				}
 			},

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1197,6 +1197,41 @@
 			},
 			"additionalProperties": false
 		},
+		"CustomRestrictedImport": {
+			"anyOf": [
+				{
+					"description": "The message to display when this module is imported.",
+					"type": "string"
+				},
+				{
+					"description": "Additional options to configure the message and allowed/disallowed import names.",
+					"allOf": [{ "$ref": "#/definitions/CustomRestrictedImportOptions" }]
+				}
+			]
+		},
+		"CustomRestrictedImportOptions": {
+			"type": "object",
+			"properties": {
+				"allowImportNames": {
+					"description": "Names of the exported members that allowed to be not be used.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"importNames": {
+					"description": "Names of the exported members that should not be used.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				},
+				"message": {
+					"description": "The message to display when this module is imported.",
+					"default": "",
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
 		"CustomRestrictedType": {
 			"anyOf": [
 				{ "type": "string" },
@@ -2761,9 +2796,11 @@
 			"type": "object",
 			"properties": {
 				"paths": {
-					"description": "A list of names that should trigger the rule",
+					"description": "A list of import paths that should trigger the rule",
 					"type": "object",
-					"additionalProperties": { "type": "string" }
+					"additionalProperties": {
+						"$ref": "#/definitions/CustomRestrictedImport"
+					}
 				}
 			},
 			"additionalProperties": false

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2796,7 +2796,7 @@
 			"type": "object",
 			"properties": {
 				"paths": {
-					"description": "A list of import paths that should trigger the rule",
+					"description": "A list of import paths that should trigger the rule.",
 					"type": "object",
 					"additionalProperties": {
 						"$ref": "#/definitions/CustomRestrictedImport"


### PR DESCRIPTION
## Summary
Extend `noRestrictedImports` with the option to use `importNames` and `allowImportNames` to specify the set of (dis)allowed imports.

## Motivation:
1. The [`no-restricted-imports` ESLint](https://eslint.org/docs/latest/rules/no-restricted-imports#importnames) provides the feature.
2. Personal need: I needed it to make sure that when using the `react-i18next` library, I'm always retrieving the `t` function from the `useTranslation` hook, instead of using `import { t } from 'i18next'`. 

## Example Configuration
```json
{
    "options": {
        "paths": {
            "lodash": "Using lodash is not encouraged",
            "underscore": "Using underscore is not encouraged",
            "import-foo": {
                "importNames": ["Bar"],
                "message": "Please use Bar from /import-bar/baz/ instead."
            },
            "import-bar": {
              "allowImportNames": ["Bar"],
              "message": "Please use only Bar from import-bar."
            }
        }
    }
}
```

## Test Plan

Extensive snapshot tests for all different variations of `import`, `import()` and `require()` are included in this PR.
