### PR TITLE
fix(noUnusedImports): don't report used val imported as type in an external module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noMisleadingCharacterClass](https://biomejs.dev/linter/rules/no-misleading-character-class/) no longer panics on malformed escape sequences that end with a multi-byte character ([#4587](https://github.com/biomejs/biome/issues/4587)). Contributed by @Conaclos
 
+- [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports/) no longer reports used values imported as types in an external module ([#3895])(https://github.com/biomejs/biome/issues/3895). Contributed by @Conaclos
+
 - Fixed a panic related to bogus import statements in `useExhaustiveDependencies` ([#4568](https://github.com/biomejs/biome/issues/4568)) Contributed by @dyc3
 
 ### Parser

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-inner-imports.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-inner-imports.ts
@@ -1,0 +1,4 @@
+declare module "mod" {
+    import type { Ns } from "other";
+    export const C: { prop: Ns.prop };
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-inner-imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/valid-inner-imports.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-inner-imports.ts
+snapshot_kind: text
+---
+# Input
+```ts
+declare module "mod" {
+    import type { Ns } from "other";
+    export const C: { prop: Ns.prop };
+}
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -1034,25 +1034,19 @@ impl SemanticEventExtractor {
                     };
                     self.stash.push_back(event);
                 }
-            } else if references.iter().all(|r| matches!(r, Reference::Export(_)))
-                && self.bindings.contains_key(&name.clone().dual())
-            {
-                // Don't report an export that exports at least a binding.
-            } else if let Some(parent) = self.scopes.last_mut() {
-                // Promote these references to the parent scope
-                let parent_references = parent.references.entry(name).or_default();
-                parent_references.append(&mut references);
-            } else if let Some(info) = self.bindings.get(&name.dual()).cloned() {
-                // We are in the global scope.
-                // Try to bind some of these references to the dual binding of `name`,
-                // otherwise raide `UnresolvedReference`.
+            } else if let Some(info) = self.bindings.get(&name.clone().dual()) {
+                let mut parent_references = self
+                    .scopes
+                    .last_mut()
+                    .map(|parent| parent.references.entry(name.clone()).or_default());
+                let is_dual_imported = info.is_imported();
                 for reference in references {
                     match reference {
                         Reference::Export(_) => {
                             // An export can export both a value and a type.
-                            // If a dual binding exists, then it exports to the dual binding.
+                            // If a dual binding exists, then it exports the dual binding.
                         }
-                        Reference::AmbientRead(range) if info.is_imported() => {
+                        Reference::AmbientRead(range) if is_dual_imported => {
                             // An ambient read can only read a value,
                             // but also an imported value as a type (with the `type` modifier)
                             let declaration_before_reference =
@@ -1072,14 +1066,22 @@ impl SemanticEventExtractor {
                             };
                             self.stash.push_back(event);
                         }
-                        _ => {
-                            self.stash.push_back(SemanticEvent::UnresolvedReference {
-                                is_read: !reference.is_write(),
-                                range: reference.range(),
-                            });
+                        reference => {
+                            if let Some(parent_references) = &mut parent_references {
+                                parent_references.push(reference);
+                            } else {
+                                self.stash.push_back(SemanticEvent::UnresolvedReference {
+                                    is_read: !reference.is_write(),
+                                    range: reference.range(),
+                                });
+                            }
                         }
                     }
                 }
+            } else if let Some(parent) = self.scopes.last_mut() {
+                // Promote these references to the parent scope
+                let parent_references = parent.references.entry(name).or_default();
+                parent_references.append(&mut references);
             } else {
                 // We are in the global scope. Raise `UnresolvedReference`.
                 for reference in references {


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/3895

This PR changes how we bind ambient read to imported type.
Previously, we waited to get in the global scope to try binding an ambient read (read of a value in an ambient context) to an `import type`. However, external modules and namespaces can also import stuff.
I changed the code to support it in any scope.

## Test Plan

I added a test
