### PR TITLE
docs: Remove misleading rule sources

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -51,10 +51,6 @@ declare_lint_rule! {
         version: "1.6.0",
         name: "noRestrictedImports",
         language: "js",
-        sources: &[
-            RuleSource::Eslint("no-restricted-imports"),
-            RuleSource::EslintTypeScript("no-restricted-imports"),
-        ],
         recommended: false,
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This makes the documentation say that this rule is the "same as" the eslint versions:

<img width="469" alt="image" src="https://github.com/user-attachments/assets/711847ab-93bb-4c5f-baf6-791970bdcb87">

But it's not as it doesn't support the `patterns` option, so this is misleading. Maybe there should be something saying this is a more limited version of those? Not sure how to support that in the docs though, suggestions welcome.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

No tests, just a documentation change.
