### PR TITLE
refactor(biome_console): add blanket implementation of `biome_console::fmt::Display` for `Box<_>`

### DIFF
--- a/crates/biome_console/src/fmt.rs
+++ b/crates/biome_console/src/fmt.rs
@@ -140,6 +140,16 @@ where
     }
 }
 
+// Blanket implementations of Display for boxed values
+impl<T> Display for Box<T>
+where
+    T: Display + ?Sized,
+{
+    fn fmt(&self, fmt: &mut Formatter) -> io::Result<()> {
+        T::fmt(&**self, fmt)
+    }
+}
+
 impl<T> Display for Cow<'_, T>
 where
     T: Display + ToOwned + ?Sized,


### PR DESCRIPTION
## Summary

As the title says: Provide `impl biome_console::fmt::Display for Box<T>` by delegating to `impl biome_console::fmt::Display for T`.

Needed for #4596 but valuable by itself.