### PR TITLE
refactor(js_syntax): separate AnyJsImportLike and AnyJsImportSourceLike

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_nodejs_modules.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nodejs_modules.rs
@@ -2,7 +2,7 @@ use crate::globals::is_node_builtin_module;
 use crate::services::manifest::Manifest;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
-use biome_js_syntax::{inner_string_text, AnyJsImportClause, AnyJsImportLike};
+use biome_js_syntax::{inner_string_text, AnyJsImportClause, AnyJsImportSourceLike};
 use biome_rowan::AstNode;
 use biome_rowan::TextRange;
 
@@ -47,7 +47,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoNodejsModules {
-    type Query = Manifest<AnyJsImportLike>;
+    type Query = Manifest<AnyJsImportSourceLike>;
     type State = TextRange;
     type Signals = Option<Self::State>;
     type Options = ();
@@ -57,7 +57,7 @@ impl Rule for NoNodejsModules {
         if node.is_in_ts_module_declaration() {
             return None;
         }
-        if let AnyJsImportLike::JsModuleSource(module_source) = &node {
+        if let AnyJsImportSourceLike::JsModuleSource(module_source) = &node {
             if let Some(import_clause) = module_source.parent::<AnyJsImportClause>() {
                 if import_clause.type_token().is_some() {
                     // Ignore type-only imports

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -4,7 +4,7 @@ use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnosti
 use biome_console::markup;
 use biome_deserialize::{Deserializable, DeserializableType};
 use biome_deserialize_macros::Deserializable;
-use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike};
+use biome_js_syntax::{AnyJsImportClause, AnyJsImportSourceLike};
 use biome_rowan::AstNode;
 
 use crate::utils::restricted_glob::{CandidatePath, RestrictedGlob};
@@ -199,7 +199,7 @@ pub struct RuleState {
 }
 
 impl Rule for NoUndeclaredDependencies {
-    type Query = Manifest<AnyJsImportLike>;
+    type Query = Manifest<AnyJsImportSourceLike>;
     type State = RuleState;
     type Signals = Option<Self::State>;
     type Options = NoUndeclaredDependenciesOptions;

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -223,7 +223,7 @@ impl Rule for NoUndeclaredDependencies {
                 || (is_optional_dependency_available && ctx.is_optional_dependency(package_name))
         };
 
-        let token_text = node.inner_string_text()?;
+        let token_text = node.module_source_text()?;
         let package_name = parse_package_name(token_text.text())?;
         if is_available(package_name)
             // Self package imports

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -6,7 +6,7 @@ use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule,
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
 use biome_js_factory::make;
-use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxToken};
+use biome_js_syntax::{inner_string_text, AnyJsImportSourceLike, JsSyntaxToken};
 use biome_rowan::BatchMutationExt;
 
 use crate::JsRuleAction;
@@ -141,7 +141,7 @@ pub struct SuggestedExtensionMapping {
 }
 
 impl Rule for UseImportExtensions {
-    type Query = Ast<AnyJsImportLike>;
+    type Query = Ast<AnyJsImportSourceLike>;
     type State = UseImportExtensionsState;
     type Signals = Option<Self::State>;
     type Options = Box<UseImportExtensionsOptions>;
@@ -205,7 +205,7 @@ pub struct UseImportExtensionsState {
 
 fn get_extensionless_import(
     file_ext: &str,
-    node: &AnyJsImportLike,
+    node: &AnyJsImportSourceLike,
     custom_suggested_imports: &FxHashMap<Box<str>, SuggestedExtensionMapping>,
 ) -> Option<UseImportExtensionsState> {
     let module_name_token = node.module_name_token()?;

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_imports.rs
@@ -2,7 +2,7 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
-use biome_js_syntax::{inner_string_text, AnyJsImportLike};
+use biome_js_syntax::{inner_string_text, AnyJsImportSourceLike};
 use biome_rowan::TextRange;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -70,7 +70,7 @@ pub struct RestrictedImportsOptions {
 }
 
 impl Rule for NoRestrictedImports {
-    type Query = Ast<AnyJsImportLike>;
+    type Query = Ast<AnyJsImportSourceLike>;
     type State = (TextRange, String);
     type Signals = Option<Self::State>;
     type Options = Box<RestrictedImportsOptions>;

--- a/crates/biome_js_analyze/src/lint/style/use_node_assert_strict.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_node_assert_strict.rs
@@ -1,7 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
-use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
+use biome_js_syntax::{inner_string_text, AnyJsImportSourceLike, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::BatchMutationExt;
 
 declare_lint_rule! {
@@ -33,7 +33,7 @@ declare_lint_rule! {
 }
 
 impl Rule for UseNodeAssertStrict {
-    type Query = Ast<AnyJsImportLike>;
+    type Query = Ast<AnyJsImportSourceLike>;
     type State = JsSyntaxToken;
     type Signals = Option<Self::State>;
     type Options = ();

--- a/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
@@ -2,7 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
-use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
+use biome_js_syntax::{inner_string_text, AnyJsImportSourceLike, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::BatchMutationExt;
 
 use crate::services::manifest::Manifest;
@@ -58,7 +58,7 @@ declare_lint_rule! {
 }
 
 impl Rule for UseNodejsImportProtocol {
-    type Query = Manifest<AnyJsImportLike>;
+    type Query = Manifest<AnyJsImportSourceLike>;
     type State = JsSyntaxToken;
     type Signals = Option<Self::State>;
     type Options = ();

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -226,7 +226,7 @@ impl AnyJsImportSourceLike {
     /// let any_import_specifier = AnyJsImportSourceLike::JsModuleSource(source_name);
     /// assert_eq!(any_import_specifier.inner_string_text().unwrap().text(), "foo")
     /// ```
-    pub fn inner_string_text(&self) -> Option<TokenText> {
+    pub fn module_source_text(&self) -> Option<TokenText> {
         match self {
             AnyJsImportSourceLike::JsModuleSource(source) => source.inner_string_text().ok(),
             AnyJsImportSourceLike::JsCallExpression(expression) => {

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -210,26 +210,26 @@ declare_node_union! {
     ///    import("lodash")
     /// // ^^^^^^^^^^^^^^^^
     /// ```
-    pub AnyJsImportLike = JsModuleSource | JsCallExpression |  JsImportCallExpression
+    pub AnyJsImportSourceLike = JsModuleSource | JsCallExpression |  JsImportCallExpression
 }
 
-impl AnyJsImportLike {
+impl AnyJsImportSourceLike {
     /// Returns the inner text of specifier:
     ///
     /// ## Examples
     ///
     /// ```
     /// use biome_js_factory::make;
-    /// use biome_js_syntax::AnyJsImportLike;
+    /// use biome_js_syntax::AnyJsImportSourceLike;
     ///
     /// let source_name = make::js_module_source(make::js_string_literal("foo"));
-    /// let any_import_specifier = AnyJsImportLike::JsModuleSource(source_name);
+    /// let any_import_specifier = AnyJsImportSourceLike::JsModuleSource(source_name);
     /// assert_eq!(any_import_specifier.inner_string_text().unwrap().text(), "foo")
     /// ```
     pub fn inner_string_text(&self) -> Option<TokenText> {
         match self {
-            AnyJsImportLike::JsModuleSource(source) => source.inner_string_text().ok(),
-            AnyJsImportLike::JsCallExpression(expression) => {
+            AnyJsImportSourceLike::JsModuleSource(source) => source.inner_string_text().ok(),
+            AnyJsImportSourceLike::JsCallExpression(expression) => {
                 let callee = expression.callee().ok()?;
                 let name = callee.as_js_reference_identifier()?.value_token().ok()?;
                 if name.text_trimmed() == "require" {
@@ -247,7 +247,7 @@ impl AnyJsImportLike {
                     None
                 }
             }
-            AnyJsImportLike::JsImportCallExpression(import_call) => {
+            AnyJsImportSourceLike::JsImportCallExpression(import_call) => {
                 let [Some(argument)] = import_call.arguments().ok()?.get_arguments_by_index([0])
                 else {
                     return None;
@@ -268,16 +268,16 @@ impl AnyJsImportLike {
     ///
     /// ```
     /// use biome_js_factory::make;
-    /// use biome_js_syntax::AnyJsImportLike;
+    /// use biome_js_syntax::AnyJsImportSourceLike;
     ///
     /// let source_name = make::js_module_source(make::js_string_literal("foo"));
-    /// let any_import_specifier = AnyJsImportLike::JsModuleSource(source_name);
+    /// let any_import_specifier = AnyJsImportSourceLike::JsModuleSource(source_name);
     /// assert_eq!(any_import_specifier.module_name_token().unwrap().text(), "\"foo\"")
     /// ```
     pub fn module_name_token(&self) -> Option<JsSyntaxToken> {
         match self {
-            AnyJsImportLike::JsModuleSource(source) => source.value_token().ok(),
-            AnyJsImportLike::JsCallExpression(expression) => {
+            AnyJsImportSourceLike::JsModuleSource(source) => source.value_token().ok(),
+            AnyJsImportSourceLike::JsCallExpression(expression) => {
                 let callee = expression.callee().ok()?;
                 let name = callee.as_js_reference_identifier()?.value_token().ok()?;
                 if name.text_trimmed() == "require" {
@@ -295,7 +295,7 @@ impl AnyJsImportLike {
                     None
                 }
             }
-            AnyJsImportLike::JsImportCallExpression(import_call) => {
+            AnyJsImportSourceLike::JsImportCallExpression(import_call) => {
                 let [Some(argument)] = import_call.arguments().ok()?.get_arguments_by_index([0])
                 else {
                     return None;
@@ -320,21 +320,21 @@ impl AnyJsImportLike {
     ///
     /// ```
     /// use biome_js_factory::make;
-    /// use biome_js_syntax::{AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
+    /// use biome_js_syntax::{AnyJsImportSourceLike, JsSyntaxKind, JsSyntaxToken};
     ///
     /// let module_token = JsSyntaxToken::new_detached(JsSyntaxKind::MODULE_KW, "module", [], []);
     /// let module_source = make::js_module_source(make::js_string_literal("foo"));
     /// let module_declaration = make::ts_external_module_declaration(module_token, module_source.into()).build();
-    /// let any_import_specifier = AnyJsImportLike::JsModuleSource(module_declaration.source().unwrap().as_js_module_source().unwrap().clone());
+    /// let any_import_specifier = AnyJsImportSourceLike::JsModuleSource(module_declaration.source().unwrap().as_js_module_source().unwrap().clone());
     /// assert!(any_import_specifier.is_in_ts_module_declaration());
     ///
     /// let module_source = make::js_module_source(make::js_string_literal("bar"));
-    /// let any_import_specifier = AnyJsImportLike::JsModuleSource(module_source.into());
+    /// let any_import_specifier = AnyJsImportSourceLike::JsModuleSource(module_source.into());
     /// assert!(!any_import_specifier.is_in_ts_module_declaration());
     /// ```
     pub fn is_in_ts_module_declaration(&self) -> bool {
         // It first has to be a JsModuleSource
-        matches!(self, AnyJsImportLike::JsModuleSource(_))
+        matches!(self, AnyJsImportSourceLike::JsModuleSource(_))
             && matches!(
                 self.syntax().parent().kind(),
                 Some(JsSyntaxKind::TS_EXTERNAL_MODULE_DECLARATION)

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -10,7 +10,7 @@ use biome_rowan::{
 };
 
 impl JsImport {
-    /// It checks if the source of an import against the string `source_to_check`
+    /// Returns the source of an import.
     ///
     /// ## Examples
     ///
@@ -28,6 +28,26 @@ impl JsImport {
     /// ```
     pub fn source_text(&self) -> SyntaxResult<TokenText> {
         self.import_clause()?.source()?.inner_string_text()
+    }
+
+    /// Returns the whole token text of the import source specifier.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use biome_js_factory::make;
+    /// use biome_js_syntax::T;
+    ///
+    /// let source = make::js_module_source(make::js_string_literal("react"));
+    /// let binding = make::js_identifier_binding(make::ident("React"));
+    /// let specifier = make::js_default_import_specifier(binding.into());
+    /// let clause = make::js_import_default_clause(specifier, make::token(T![from]), source.into()).build();
+    /// let import = make::js_import(make::token(T![import]), clause.into()).build();
+    ///
+    /// assert_eq!(import.source_token().unwrap().text(), "\"react\"");
+    /// ```
+    pub fn source_token(&self) -> SyntaxResult<SyntaxToken<crate::JsLanguage>>{
+        self.import_clause()?.source()?.value_token()
     }
 }
 


### PR DESCRIPTION
## Summary

Split off from #4596. For some strange reason, the current implementation of `AnyJsImportLike` uses `JsModuleSource` to match occurences of `JsImport`, `JsExportNamedFromClause` and `JsExportClause`. This renames the "old" `AnyJsImportLike` to `AnyJsImportSourceLike`, and crates a new `AnyJsImportLike` with the more fitting types instead.