### PR TITLE
fix(js_parser): don't panic on declare@

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Don't panic when a multi-byte character is found in a unicode escape sequence ([#4564](https://github.com/biomejs/biome/issues/4564)). Contributed by @Conaclos
 
+- Don't panic when a declare statement is followed by an unexpected token.([#4562](https://github.com/biomejs/biome/issues/4562)). Contributed by @fireairforce
 ## v1.9.4 (2024-10-17)
 
 ### Analyzer

--- a/crates/biome_js_parser/src/syntax/js_parse_error.rs
+++ b/crates/biome_js_parser/src/syntax/js_parse_error.rs
@@ -131,6 +131,10 @@ pub(crate) fn expected_namespace_import(p: &JsParser, range: TextRange) -> Parse
     expected_any(&["namespace imports"], range, p)
 }
 
+pub(crate) fn expected_declare_statement(p: &JsParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("declare statement", range, p)
+}
+
 pub(crate) fn expected_namespace_or_named_import(
     p: &JsParser,
     range: TextRange,

--- a/crates/biome_js_parser/src/syntax/typescript/statement.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/statement.rs
@@ -9,7 +9,9 @@ use crate::syntax::expr::{is_nth_at_identifier, parse_name, ExpressionContext};
 use super::ts_parse_error::expected_ts_enum_member;
 use crate::state::EnterAmbientContext;
 use crate::syntax::auxiliary::{is_nth_at_declaration_clause, parse_declaration_clause};
-use crate::syntax::js_parse_error::{expected_identifier, expected_module_source};
+use crate::syntax::js_parse_error::{
+    expected_declare_statement, expected_identifier, expected_module_source,
+};
 use crate::syntax::module::{parse_module_item_list, parse_module_source, ModuleItemListParent};
 use crate::syntax::stmt::{semi, STMT_RECOVERY_SET};
 use crate::syntax::typescript::ts_parse_error::expected_ts_type;
@@ -241,8 +243,7 @@ pub(crate) fn parse_ts_declare_statement(p: &mut JsParser) -> ParsedSyntax {
         // test_err ts ts_declare_const_initializer
         // declare @decorator class D {}
         // declare @decorator abstract class D {}
-        parse_declaration_clause(p, stmt_start_pos)
-            .expect("Expected a declaration as guaranteed by is_at_ts_declare_statement")
+        parse_declaration_clause(p, stmt_start_pos).or_add_diagnostic(p, expected_declare_statement)
     });
 
     Present(m.complete(p, TS_DECLARE_STATEMENT))

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_export_declare.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_export_declare.ts
@@ -1,2 +1,4 @@
 export declare @decorator class D {}
 export declare @decorator abstract class D {}
+
+declare@

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_export_declare.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_export_declare.ts.snap
@@ -8,6 +8,7 @@ expression: snapshot
 export declare @decorator class D {}
 export declare @decorator abstract class D {}
 
+declare@
 ```
 
 
@@ -93,19 +94,32 @@ JsModule {
                 },
             ],
         },
+        JsBogusStatement {
+            items: [
+                DECLARE_KW@82..91 "declare" [Newline("\n"), Newline("\n")] [],
+                JsBogusStatement {
+                    items: [
+                        JsDecorator {
+                            at_token: AT@91..92 "@" [] [],
+                            expression: missing (required),
+                        },
+                    ],
+                },
+            ],
+        },
     ],
-    eof_token: EOF@82..83 "" [Newline("\n")] [],
+    eof_token: EOF@92..92 "" [] [],
 }
 ```
 
 ## CST
 
 ```
-0: JS_MODULE@0..83
+0: JS_MODULE@0..92
   0: (empty)
   1: (empty)
   2: JS_DIRECTIVE_LIST@0..0
-  3: JS_MODULE_ITEM_LIST@0..82
+  3: JS_MODULE_ITEM_LIST@0..92
     0: JS_BOGUS_STATEMENT@0..36
       0: JS_DECORATOR_LIST@0..0
       1: EXPORT_KW@0..7 "export" [] [Whitespace(" ")]
@@ -152,7 +166,13 @@ JsModule {
           7: L_CURLY@80..81 "{" [] []
           8: JS_CLASS_MEMBER_LIST@81..81
           9: R_CURLY@81..82 "}" [] []
-  4: EOF@82..83 "" [Newline("\n")] []
+    2: JS_BOGUS_STATEMENT@82..92
+      0: DECLARE_KW@82..91 "declare" [Newline("\n"), Newline("\n")] []
+      1: JS_BOGUS_STATEMENT@91..92
+        0: JS_DECORATOR@91..92
+          0: AT@91..92 "@" [] []
+          1: (empty)
+  4: EOF@92..92 "" [] []
 
 ```
 
@@ -178,7 +198,51 @@ ts_export_declare.ts:2:16 parse ━━━━━━━━━━━━━━━━
   > 2 │ export declare @decorator abstract class D {}
       │                ^^^^^^^^^^
     3 │ 
+    4 │ declare@
   
   i Decorators are only valid on class declarations, class expressions, and class methods.
+  
+ts_export_declare.ts:4:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected an expression but instead found the end of the file.
+  
+    2 │ export declare @decorator abstract class D {}
+    3 │ 
+  > 4 │ declare@
+      │         
+  
+  i Expected an expression here.
+  
+    2 │ export declare @decorator abstract class D {}
+    3 │ 
+  > 4 │ declare@
+      │         
+  
+ts_export_declare.ts:4:8 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Decorators are not valid here.
+  
+    2 │ export declare @decorator abstract class D {}
+    3 │ 
+  > 4 │ declare@
+      │        ^
+  
+  i Decorators are only valid on class declarations, class expressions, and class methods.
+  
+ts_export_declare.ts:4:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declare statement but instead found the end of the file.
+  
+    2 │ export declare @decorator abstract class D {}
+    3 │ 
+  > 4 │ declare@
+      │         
+  
+  i Expected a declare statement here.
+  
+    2 │ export declare @decorator abstract class D {}
+    3 │ 
+  > 4 │ declare@
+      │         
   
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #4562 

Now it will panic on:

```ts
declare@
```

so i replace `.expect()` with `.add_diagnostic()` at `parse_declare`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add test case for this.

<!-- What demonstrates that your implementation is correct? -->
