### PR TITLE
refactor(enovate): ignore hashbrown and grit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,7 +35,10 @@
       "ignoreDeps": [
         "syn",
         "quote",
-        "tower"
+        "tower",
+        "hashbrown",
+        "grit-pattern-matcher",
+        "grit-util"
       ]
     },
     {


### PR DESCRIPTION
## Summary

This PR adds temporary hashbrown and grit packages in the ignore list of Renovate because their upgrade [break Biome](https://github.com/biomejs/biome/pull/4406).
Ignoring them allows us to update other crates more easily.

## Test Plan

CI must pass.
