### PR TITLE
feat(Formatter): add space inside option

### DIFF
--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -254,6 +254,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             bracket_spacing: Some(value.bracket_spacing.into()),
             jsx_quote_style: Some(jsx_quote_style),
             attribute_position: Some(AttributePosition::default()),
+            space_inside_stuff: None,
         };
         let js_config = biome_configuration::PartialJavascriptConfiguration {
             formatter: Some(js_formatter),

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -2,7 +2,6 @@ use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
     AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
-    SpaceInBrackets,
 };
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -56,10 +55,6 @@ pub struct FormatterConfiguration {
     #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
     pub bracket_spacing: BracketSpacing,
 
-    /// @todo
-    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
-    pub space_in_brackets: SpaceInBrackets,
-
     /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
     /// match these patterns.
     #[partial(bpaf(hide))]
@@ -87,7 +82,6 @@ impl PartialFormatterConfiguration {
             line_width: self.line_width.unwrap_or_default(),
             attribute_position: self.attribute_position.unwrap_or_default(),
             bracket_spacing: self.bracket_spacing.unwrap_or_default(),
-            space_in_brackets: self.space_in_brackets.unwrap_or_default(),
             ignore: self.ignore.clone().unwrap_or_default(),
             include: self.include.clone().unwrap_or_default(),
             use_editorconfig: self.use_editorconfig.unwrap_or_default(),
@@ -107,7 +101,6 @@ impl Default for FormatterConfiguration {
             line_width: LineWidth::default(),
             attribute_position: AttributePosition::default(),
             bracket_spacing: Default::default(),
-            space_in_brackets: Default::default(),
             ignore: Default::default(),
             include: Default::default(),
             // TODO: Biome 2.0: change to true

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -2,6 +2,7 @@ use biome_deserialize::StringSet;
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
     AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    SpaceInBrackets,
 };
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -55,6 +56,10 @@ pub struct FormatterConfiguration {
     #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
     pub bracket_spacing: BracketSpacing,
 
+    /// @todo
+    #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
+    pub space_in_brackets: SpaceInBrackets,
+
     /// A list of Unix shell style patterns. The formatter will ignore files/folders that will
     /// match these patterns.
     #[partial(bpaf(hide))]
@@ -82,6 +87,7 @@ impl PartialFormatterConfiguration {
             line_width: self.line_width.unwrap_or_default(),
             attribute_position: self.attribute_position.unwrap_or_default(),
             bracket_spacing: self.bracket_spacing.unwrap_or_default(),
+            space_in_brackets: self.space_in_brackets.unwrap_or_default(),
             ignore: self.ignore.clone().unwrap_or_default(),
             include: self.include.clone().unwrap_or_default(),
             use_editorconfig: self.use_editorconfig.unwrap_or_default(),
@@ -101,6 +107,7 @@ impl Default for FormatterConfiguration {
             line_width: LineWidth::default(),
             attribute_position: AttributePosition::default(),
             bracket_spacing: Default::default(),
+            space_in_brackets: Default::default(),
             ignore: Default::default(),
             include: Default::default(),
             // TODO: Biome 2.0: change to true

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -90,7 +90,7 @@ pub struct JavascriptFormatter {
     pub quote_style: QuoteStyle,
 
     /// @todo
-    #[partial(bpaf(long("space_inside_stuff"), argument("true|false"), optional))]
+    #[partial(bpaf(long("space-inside-stuff"), argument("true|false"), optional))]
     pub space_inside_stuff: SpaceInsideStuff,
 
     // it's also a top-level configurable property.

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,6 +1,7 @@
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
     AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+    SpaceInsideStuff,
 };
 use biome_js_formatter::context::{
     trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
@@ -88,6 +89,10 @@ pub struct JavascriptFormatter {
     #[partial(bpaf(long("quote-style"), argument("double|single"), optional))]
     pub quote_style: QuoteStyle,
 
+    /// @todo
+    #[partial(bpaf(long("space_inside_stuff"), argument("true|false"), optional))]
+    pub space_inside_stuff: SpaceInsideStuff,
+
     // it's also a top-level configurable property.
     /// The attribute position style in jsx elements. Defaults to auto.
     #[partial(bpaf(
@@ -122,6 +127,7 @@ impl PartialJavascriptFormatter {
             line_width: self.line_width,
             quote_style: self.quote_style.unwrap_or_default(),
             attribute_position: self.attribute_position,
+            space_inside_stuff: self.space_inside_stuff.unwrap_or_default(),
         }
     }
 }
@@ -145,6 +151,7 @@ impl Default for JavascriptFormatter {
             line_width: Default::default(),
             quote_style: Default::default(),
             attribute_position: Default::default(),
+            space_inside_stuff: Default::default(),
         }
     }
 }

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -2,8 +2,8 @@
 use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;
+use crate::prelude::*;
 use crate::{format, write, AttributePosition, BracketSpacing};
-use crate::{prelude::*, SpaceInBrackets};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions, TransformSourceMap,
@@ -208,10 +208,6 @@ impl FormatOptions for IrFormatOptions {
         BracketSpacing::default()
     }
 
-    fn space_in_brackets(&self) -> SpaceInBrackets {
-        SpaceInBrackets::default()
-    }
-
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions {
             indent_width: self.indent_width(),
@@ -220,7 +216,6 @@ impl FormatOptions for IrFormatOptions {
             indent_style: IndentStyle::Space,
             attribute_position: self.attribute_position(),
             bracket_spacing: self.bracket_spacing(),
-            space_in_brackets: self.space_in_brackets(),
         }
     }
 }

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -2,8 +2,8 @@
 use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;
-use crate::prelude::*;
 use crate::{format, write, AttributePosition, BracketSpacing};
+use crate::{prelude::*, SpaceInBrackets};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions, TransformSourceMap,
@@ -208,6 +208,10 @@ impl FormatOptions for IrFormatOptions {
         BracketSpacing::default()
     }
 
+    fn space_in_brackets(&self) -> SpaceInBrackets {
+        SpaceInBrackets::default()
+    }
+
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions {
             indent_width: self.indent_width(),
@@ -216,6 +220,7 @@ impl FormatOptions for IrFormatOptions {
             indent_style: IndentStyle::Space,
             attribute_position: self.attribute_position(),
             bracket_spacing: self.bracket_spacing(),
+            space_in_brackets: self.space_in_brackets(),
         }
     }
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -600,6 +600,54 @@ impl FromStr for BracketSpacing {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
+)]
+pub struct SpaceInBrackets(bool);
+
+impl SpaceInBrackets {
+    /// Return the boolean value for this [SpaceInBrackets]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for SpaceInBrackets {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl From<bool> for SpaceInBrackets {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for SpaceInBrackets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", self.value())
+    }
+}
+
+impl FromStr for SpaceInBrackets {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = bool::from_str(s);
+
+        match value {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for SpaceInBrackets. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -668,6 +716,9 @@ pub trait FormatOptions {
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     fn bracket_spacing(&self) -> BracketSpacing;
 
+    /// @todo
+    fn space_in_brackets(&self) -> SpaceInBrackets;
+
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
 }
@@ -718,6 +769,7 @@ pub struct SimpleFormatOptions {
     pub line_ending: LineEnding,
     pub attribute_position: AttributePosition,
     pub bracket_spacing: BracketSpacing,
+    pub space_in_brackets: SpaceInBrackets,
 }
 
 impl FormatOptions for SimpleFormatOptions {
@@ -743,6 +795,10 @@ impl FormatOptions for SimpleFormatOptions {
 
     fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
+    }
+
+    fn space_in_brackets(&self) -> SpaceInBrackets {
+        self.space_in_brackets
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -558,6 +558,54 @@ impl From<QuoteStyle> for Quote {
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
     serde(rename_all = "camelCase")
 )]
+pub struct SpaceInsideStuff(bool);
+
+impl SpaceInsideStuff {
+    /// Return the boolean value for this [SpaceInsideStuff]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for SpaceInsideStuff {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl From<bool> for SpaceInsideStuff {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for SpaceInsideStuff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", self.value())
+    }
+}
+
+impl FromStr for SpaceInsideStuff {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = bool::from_str(s);
+
+        match value {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for SpaceInsideStuff. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "camelCase")
+)]
 pub struct BracketSpacing(bool);
 
 impl BracketSpacing {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -552,7 +552,7 @@ impl From<QuoteStyle> for Quote {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
@@ -564,12 +564,6 @@ impl SpaceInsideStuff {
     /// Return the boolean value for this [SpaceInsideStuff]
     pub fn value(&self) -> bool {
         self.0
-    }
-}
-
-impl Default for SpaceInsideStuff {
-    fn default() -> Self {
-        Self(true)
     }
 }
 

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -600,54 +600,6 @@ impl FromStr for BracketSpacing {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
-    serde(rename_all = "camelCase")
-)]
-pub struct SpaceInBrackets(bool);
-
-impl SpaceInBrackets {
-    /// Return the boolean value for this [SpaceInBrackets]
-    pub fn value(&self) -> bool {
-        self.0
-    }
-}
-
-impl Default for SpaceInBrackets {
-    fn default() -> Self {
-        Self(true)
-    }
-}
-
-impl From<bool> for SpaceInBrackets {
-    fn from(value: bool) -> Self {
-        Self(value)
-    }
-}
-
-impl std::fmt::Display for SpaceInBrackets {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::write!(f, "{}", self.value())
-    }
-}
-
-impl FromStr for SpaceInBrackets {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let value = bool::from_str(s);
-
-        match value {
-            Ok(value) => Ok(Self(value)),
-            Err(_) => Err(
-                "Value not supported for SpaceInBrackets. Supported values are 'true' and 'false'.",
-            ),
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -716,9 +668,6 @@ pub trait FormatOptions {
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     fn bracket_spacing(&self) -> BracketSpacing;
 
-    /// @todo
-    fn space_in_brackets(&self) -> SpaceInBrackets;
-
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
 }
@@ -769,7 +718,6 @@ pub struct SimpleFormatOptions {
     pub line_ending: LineEnding,
     pub attribute_position: AttributePosition,
     pub bracket_spacing: BracketSpacing,
-    pub space_in_brackets: SpaceInBrackets,
 }
 
 impl FormatOptions for SimpleFormatOptions {
@@ -795,10 +743,6 @@ impl FormatOptions for SimpleFormatOptions {
 
     fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
-    }
-
-    fn space_in_brackets(&self) -> SpaceInBrackets {
-        self.space_in_brackets
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     AttributePosition, BracketSpacing, FormatOptions, IndentStyle, IndentWidth, LineEnding,
-    LineWidth, SpaceInBrackets,
+    LineWidth,
 };
 
 /// Options that affect how the [crate::Printer] prints the format tokens
@@ -24,9 +24,6 @@ pub struct PrinterOptions {
 
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     pub bracket_spacing: BracketSpacing,
-
-    /// @todo
-    pub space_in_brackets: SpaceInBrackets,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -106,12 +103,6 @@ impl PrinterOptions {
         self
     }
 
-    pub fn with_space_in_brackets(mut self, space_in_brackets: SpaceInBrackets) -> Self {
-        self.space_in_brackets = space_in_brackets;
-
-        self
-    }
-
     pub(crate) fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -146,7 +137,6 @@ impl Default for PrinterOptions {
             line_ending: LineEnding::Lf,
             attribute_position: AttributePosition::default(),
             bracket_spacing: BracketSpacing::default(),
-            space_in_brackets: SpaceInBrackets::default(),
         }
     }
 }

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     AttributePosition, BracketSpacing, FormatOptions, IndentStyle, IndentWidth, LineEnding,
-    LineWidth,
+    LineWidth, SpaceInBrackets,
 };
 
 /// Options that affect how the [crate::Printer] prints the format tokens
@@ -24,6 +24,9 @@ pub struct PrinterOptions {
 
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     pub bracket_spacing: BracketSpacing,
+
+    /// @todo
+    pub space_in_brackets: SpaceInBrackets,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -103,6 +106,12 @@ impl PrinterOptions {
         self
     }
 
+    pub fn with_space_in_brackets(mut self, space_in_brackets: SpaceInBrackets) -> Self {
+        self.space_in_brackets = space_in_brackets;
+
+        self
+    }
+
     pub(crate) fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -137,6 +146,7 @@ impl Default for PrinterOptions {
             line_ending: LineEnding::Lf,
             attribute_position: AttributePosition::default(),
             bracket_spacing: BracketSpacing::default(),
+            space_in_brackets: SpaceInBrackets::default(),
         }
     }
 }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -5,7 +5,8 @@ use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::printer::PrinterOptions;
 use biome_formatter::{
     AttributePosition, BracketSpacing, CstFormatContext, FormatContext, FormatElement,
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle, TransformSourceMap,
+    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle, SpaceInsideStuff,
+    TransformSourceMap,
 };
 use biome_js_syntax::{AnyJsFunctionBody, JsFileSource, JsLanguage};
 use std::fmt;
@@ -172,6 +173,9 @@ pub struct JsFormatOptions {
 
     /// Attribute position style. By default auto.
     attribute_position: AttributePosition,
+
+    // @todo
+    space_inside_stuff: SpaceInsideStuff,
 }
 
 impl JsFormatOptions {
@@ -191,6 +195,7 @@ impl JsFormatOptions {
             bracket_spacing: BracketSpacing::default(),
             bracket_same_line: BracketSameLine::default(),
             attribute_position: AttributePosition::default(),
+            space_inside_stuff: SpaceInsideStuff::default(),
         }
     }
 
@@ -201,6 +206,11 @@ impl JsFormatOptions {
 
     pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
         self.bracket_spacing = bracket_spacing;
+        self
+    }
+
+    pub fn with_space_inside_stuff(mut self, space_inside_stuff: SpaceInsideStuff) -> Self {
+        self.space_inside_stuff = space_inside_stuff;
         self
     }
 
@@ -271,6 +281,10 @@ impl JsFormatOptions {
         self.bracket_same_line = bracket_same_line;
     }
 
+    pub fn set_space_inside_stuff(&mut self, space_inside_stuff: SpaceInsideStuff) {
+        self.space_inside_stuff = space_inside_stuff;
+    }
+
     pub fn set_indent_style(&mut self, indent_style: IndentStyle) {
         self.indent_style = indent_style;
     }
@@ -316,6 +330,10 @@ impl JsFormatOptions {
 
     pub fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
+    }
+
+    pub fn space_inside_stuff(&self) -> SpaceInsideStuff {
+        self.space_inside_stuff
     }
 
     pub fn bracket_same_line(&self) -> BracketSameLine {

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -417,7 +417,8 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)?;
         writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())?;
         writeln!(f, "Bracket same line: {}", self.bracket_same_line.value())?;
-        writeln!(f, "Attribute Position: {}", self.attribute_position)
+        writeln!(f, "Attribute Position: {}", self.attribute_position)?;
+        writeln!(f, "Space inside stuff: {}", self.space_inside_stuff)
     }
 }
 

--- a/crates/biome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/biome_js_formatter/src/js/statements/if_statement.rs
@@ -24,6 +24,7 @@ impl FormatNodeRule<JsIfStatement> for FormatJsIfStatement {
         let l_paren_token = l_paren_token?;
         let r_paren_token = r_paren_token?;
         let consequent = consequent?;
+        let should_insert_space_inside_parens = f.options().space_inside_stuff().value();
 
         write!(
             f,
@@ -33,7 +34,7 @@ impl FormatNodeRule<JsIfStatement> for FormatJsIfStatement {
                 l_paren_token.format(),
                 group(&soft_block_indent_with_maybe_space(
                     &test.format(),
-                    f.options().space_inside_stuff().value()
+                    should_insert_space_inside_parens
                 )),
                 r_paren_token.format(),
                 FormatStatementBody::new(&consequent),

--- a/crates/biome_js_formatter/src/js/statements/if_statement.rs
+++ b/crates/biome_js_formatter/src/js/statements/if_statement.rs
@@ -31,7 +31,10 @@ impl FormatNodeRule<JsIfStatement> for FormatJsIfStatement {
                 if_token.format(),
                 space(),
                 l_paren_token.format(),
-                group(&soft_block_indent(&test.format())),
+                group(&soft_block_indent_with_maybe_space(
+                    &test.format(),
+                    f.options().space_inside_stuff().value()
+                )),
                 r_paren_token.format(),
                 FormatStatementBody::new(&consequent),
             ]),]

--- a/crates/biome_js_formatter/tests/quick_test.rs
+++ b/crates/biome_js_formatter/tests/quick_test.rs
@@ -1,4 +1,4 @@
-use biome_formatter::{AttributePosition, IndentStyle, LineWidth, QuoteStyle};
+use biome_formatter::{AttributePosition, IndentStyle, LineWidth, QuoteStyle, SpaceInsideStuff};
 use biome_formatter_test::check_reformat::CheckReformat;
 use biome_js_formatter::context::{ArrowParentheses, JsFormatOptions, Semicolons};
 use biome_js_formatter::{format_node, JsFormatLanguage};
@@ -17,6 +17,7 @@ fn quick_test() {
 export let shim: typeof import("./foo2") = {
     Bar: Bar2
 };
+    if (true) {}
     "#;
     let source_type = JsFileSource::tsx();
     let tree = parse(
@@ -31,7 +32,8 @@ export let shim: typeof import("./foo2") = {
         .with_quote_style(QuoteStyle::Double)
         .with_jsx_quote_style(QuoteStyle::Single)
         .with_arrow_parentheses(ArrowParentheses::AsNeeded)
-        .with_attribute_position(AttributePosition::Multiline);
+        .with_attribute_position(AttributePosition::Multiline)
+        .with_space_inside_stuff(SpaceInsideStuff::from(false));
 
     let doc = format_node(options.clone(), &tree.syntax()).unwrap();
     let result = doc.print().unwrap();

--- a/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/array/array_nested.js
+snapshot_kind: text
 ---
 # Input
 
@@ -70,6 +71,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/array/binding_pattern.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/array/empty_lines.js
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/array/spaces.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/array/spread.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/es5/array_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/es5/array_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/array/trailing-comma/es5/array_trailing_comma.js
+info: js/module/array/trailing-commas/es5/array_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -39,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -72,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/none/array_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/none/array_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/array/trailing-comma/none/array_trailing_comma.js
+info: js/module/array/trailing-commas/none/array_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -39,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -72,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/arrow-comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -91,6 +93,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/arrow_chain_comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -75,6 +77,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/arrow_function.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -66,6 +68,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/arrow_nested.js
+snapshot_kind: text
 ---
 # Input
 
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -103,6 +105,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/arrow_test_callback.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -63,6 +65,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/assignment_binding_line_break.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/assignment_binding_line_break.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/assignment_binding_line_break.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -66,6 +68,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/call.js
+snapshot_kind: text
 ---
 # Input
 
@@ -73,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -147,6 +149,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/curried_indents.js
+snapshot_kind: text
 ---
 # Input
 
@@ -72,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -140,6 +142,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/currying.js
+snapshot_kind: text
 ---
 # Input
 
@@ -79,6 +80,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -170,6 +172,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/arrow/params.js
+snapshot_kind: text
 ---
 # Input
 
@@ -355,6 +356,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -683,6 +685,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/assignment/array-assignment-holes.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/assignment/assignment.js
+snapshot_kind: text
 ---
 # Input
 
@@ -198,6 +199,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/assignment/assignment_ignore.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/array-binding-holes.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -52,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/array_binding.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -59,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/identifier_binding.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -57,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/nested_bindings.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/nested_bindings.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/nested_bindings.js
+snapshot_kind: text
 ---
 # Input
 
@@ -80,6 +81,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -199,6 +201,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/binding/object_binding.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -67,6 +69,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/bom_character.js
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call/call_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/call_chain.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/call/call_chain.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/call/simple_arguments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -113,6 +114,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/call_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -98,6 +99,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/class/class.js
+snapshot_kind: text
 ---
 # Input
 
@@ -99,6 +100,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/class/class_comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/class/private_method.js
+snapshot_kind: text
 ---
 # Input
 
@@ -45,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -115,6 +116,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/import_exports.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/import_exports.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/comments/import_exports.js
+snapshot_kind: text
 ---
 # Input
 
@@ -43,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/comments/nested_comments/nested_comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -36,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -67,6 +69,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/declarations/variable_declaration.js
+snapshot_kind: text
 ---
 # Input
 
@@ -294,6 +295,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/class_members_call_decorator.js
+snapshot_kind: text
 ---
 # Input
 
@@ -121,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/class_members_mixed.js
+snapshot_kind: text
 ---
 # Input
 
@@ -121,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/class_members_simple.js
+snapshot_kind: text
 ---
 # Input
 
@@ -121,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/class_simple.js
+snapshot_kind: text
 ---
 # Input
 
@@ -77,6 +78,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/class_simple_call_decorator.js
+snapshot_kind: text
 ---
 # Input
 
@@ -77,6 +78,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/export_default_1.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/export_default_2.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/export_default_3.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/export_default_4.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/decorators/multiline.js
+snapshot_kind: text
 ---
 # Input
 
@@ -45,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/each/each.js
+snapshot_kind: text
 ---
 # Input
 
@@ -95,6 +96,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/bracket-spacing/export_bracket_spacing.js
+snapshot_kind: text
 ---
 # Input
 
@@ -48,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -98,6 +100,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/class_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/expression_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/from_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/function_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/named_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/named_from_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -48,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/es5/export_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/es5/export_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/trailing-commas/es5/export_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -60,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/none/export_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/none/export_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/trailing-commas/none/export_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -60,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/variable_declaration.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/binary_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -63,6 +64,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/binary_range_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/binaryish_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/call_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/call_arguments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/call_arguments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/computed-member-expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/conditional_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/import_meta_expression/import_meta_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -63,6 +65,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/literal_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/logical_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -141,6 +142,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/member-chain/complex_arguments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/member-chain/computed.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/member-chain/inline-merge.js
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/member-chain/multi_line.js
+snapshot_kind: text
 ---
 # Input
 
@@ -102,6 +103,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/member-chain/static_member_regex.js
+snapshot_kind: text
 ---
 # Input
 
@@ -53,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/nested_conditional_expression/nested_conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/nested_conditional_expression/nested_conditional_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/nested_conditional_expression/nested_conditional_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -75,6 +77,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/new_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/post_update_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/pre_update_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/sequence_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/static_member_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -49,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/this_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/unary_expression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/expression/unary_expression_verbatim_argument.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/function/function.js
+snapshot_kind: text
 ---
 # Input
 
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/function/function_args.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/function/function_comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -68,6 +69,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/ident.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/bare_import.js
+snapshot_kind: text
 ---
 # Input
 
@@ -52,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/bracket-spacing/import_bracket_spacing.js
+snapshot_kind: text
 ---
 # Input
 
@@ -58,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -106,6 +108,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/default_import.js
+snapshot_kind: text
 ---
 # Input
 
@@ -40,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/import_call.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/import_specifiers.js
+snapshot_kind: text
 ---
 # Input
 
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/named_import_clause.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/namespace_import.js
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/es5/import_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/es5/import_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/trailing-commas/es5/import_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -59,6 +60,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -120,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/none/import_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/none/import_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/trailing-commas/none/import_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -59,6 +60,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -120,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-1.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/indent-width/4/example-1.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -56,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-2.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/indent-width/4/example-2.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -84,6 +86,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-1.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/indent-width/8/example-1.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -56,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-2.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/indent-width/8/example-2.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -84,6 +86,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/interpreter-with-trailing-spaces.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/interpreter.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/interpreter_with_empty_line.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/invalid/block_stmt_err.js
+snapshot_kind: text
 ---
 # Input
 
@@ -39,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/invalid/if_stmt_err.js
+snapshot_kind: text
 ---
 # Input
 
@@ -45,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/cr/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/cr/line_ending.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/line-ending/cr/line_ending.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -84,6 +86,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/crlf/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/crlf/line_ending.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/line-ending/crlf/line_ending.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -84,6 +86,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/newlines.js
+snapshot_kind: text
 ---
 # Input
 
@@ -107,6 +108,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/class.js
+snapshot_kind: text
 ---
 # Input
 
@@ -147,6 +148,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -284,6 +286,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/issue2006.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -66,6 +68,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/no-semi.js
+snapshot_kind: text
 ---
 # Input
 
@@ -109,6 +110,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -221,6 +223,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/private-field.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -58,6 +60,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/semicolons-asi.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -52,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/no-semi/semicolons_range.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -56,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/number/number.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/number/number_with_space.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/computed_member.js
+snapshot_kind: text
 ---
 # Input
 
@@ -48,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/getter_setter.js
+snapshot_kind: text
 ---
 # Input
 
@@ -36,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/numeric-property.js
+snapshot_kind: text
 ---
 # Input
 
@@ -66,6 +67,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/object.js
+snapshot_kind: text
 ---
 # Input
 
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/object_comments.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/octal_literals_key.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/property_key.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/property_object_member.js
+snapshot_kind: text
 ---
 # Input
 
@@ -117,6 +118,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/es5/object_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/es5/object_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/trailing-commas/es5/object_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -70,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/none/object_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/none/object_trailing_commas.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/object/trailing-commas/none/object_trailing_commas.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -70,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses-with-space.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses-with-space.js
@@ -1,0 +1,22 @@
+let a = {
+	...spread,
+
+	foo() {
+	},
+
+	*foo() {
+	},
+	...spread,
+}
+
+const x = { apple: "banna"};
+
+const y = {
+	apple: "banana",
+};
+
+({a, b, c} = {a: 'apple', b: 'banana', c: 'coconut'});
+
+({
+	a, b, c
+} = {a: 'apple', b: 'banana', c: 'coconut' });

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses-with-space.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses-with-space.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/object/bracket-spacing/object_bracket_spacing.js
+info: js/module/parentheses-with-space.js
 snapshot_kind: text
 ---
 # Input
@@ -74,44 +74,4 @@ const y = {
 ({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
 
 ({ a, b, c } = { a: "apple", b: "banana", c: "coconut" });
-```
-
-## Output 1
-
------
-Indent style: Tab
-Indent width: 2
-Line ending: LF
-Line width: 80
-Quote style: Double Quotes
-JSX quote style: Double Quotes
-Quote properties: As needed
-Trailing commas: All
-Semicolons: Always
-Arrow parentheses: Always
-Bracket spacing: false
-Bracket same line: false
-Attribute Position: Auto
-Space inside stuff: false
------
-
-```js
-let a = {
-	...spread,
-
-	foo() {},
-
-	*foo() {},
-	...spread,
-};
-
-const x = {apple: "banna"};
-
-const y = {
-	apple: "banana",
-};
-
-({a, b, c} = {a: "apple", b: "banana", c: "coconut"});
-
-({a, b, c} = {a: "apple", b: "banana", c: "coconut"});
 ```

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/parentheses/range_parentheses_binary.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "spaceInsideStuff": true
+    }
+  }
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/parentheses.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/parentheses.js
@@ -1,0 +1,24 @@
+(foo++)?.();
+async () => {
+  (await foo)?.();
+}
+(+foo)?.();
++(+foo);
+class Foo extends (+Bar) {}
+class Foo extends (Bar ?? Baz) {}
+const foo = class extends (Bar ?? Baz) {}
+;(1)
+;(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
+
+(b + c)``;
+
+const foo = { ...(a || b) };
+
+async function *f() {
+  await (a || b);
+  yield (a && b);
+}
+
+const a = () => ({}?.() && a);
+
+(list || list2)?.[(list || list2)];

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/space_inside_stuff/parentheses.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/parentheses/parentheses.js
+info: js/module/parentheses/space_inside_stuff/parentheses.js
 snapshot_kind: text
 ---
 # Input
@@ -30,12 +30,64 @@ async function *f() {
 const a = () => ({}?.() && a);
 
 (list || list2)?.[(list || list2)];
+
 ```
 
 
 =============================
 
 # Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Space inside stuff: false
+-----
+
+```js
+(foo++)?.();
+async () => {
+	(await foo)?.();
+};
+(+foo)?.();
++(+foo);
+class Foo extends (+Bar) {}
+class Foo extends (Bar ?? Baz) {}
+const foo = class extends (Bar ?? Baz) {};
+1;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+
+(b + c)``;
+
+const foo = { ...(a || b) };
+
+async function* f() {
+	await (a || b);
+	yield a && b;
+}
+
+const a = () => ({})?.() && a;
+
+(list || list2)?.[list || list2];
+```
+
+# Lines exceeding max width of 80 characters
+```
+   11: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+```
 
 ## Output 1
 

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/range/range_parenthesis_after_semicol.js
+snapshot_kind: text
 ---
 # Input
 
@@ -39,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/range/range_parenthesis_after_semicol_1.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/script.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/block_statement.js
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/continue_stmt.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/do_while.js
+snapshot_kind: text
 ---
 # Input
 
@@ -43,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/empty_blocks.js
+snapshot_kind: text
 ---
 # Input
 
@@ -58,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/for_in.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/for_loop.js
+snapshot_kind: text
 ---
 # Input
 
@@ -46,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/for_of.js
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/if_chain.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/if_else.js
+snapshot_kind: text
 ---
 # Input
 
@@ -98,6 +99,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/return.js
+snapshot_kind: text
 ---
 # Input
 
@@ -54,6 +55,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/return_verbatim_argument.js
+snapshot_kind: text
 ---
 # Input
 
@@ -54,6 +55,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/statement.js
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/switch.js
+snapshot_kind: text
 ---
 # Input
 
@@ -80,6 +81,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch_comment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch_comment.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/switch_comment.js
+snapshot_kind: text
 ---
 # Input
 
@@ -47,6 +48,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/throw.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/try_catch_finally.js
+snapshot_kind: text
 ---
 # Input
 
@@ -55,6 +56,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/statement/while_loop.js
+snapshot_kind: text
 ---
 # Input
 
@@ -55,6 +56,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/directives.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quotePreserve/directives.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -57,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/parentheses_token.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quotePreserve/parentheses_token.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -52,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/properties_quotes.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quotePreserve/properties_quotes.js
+snapshot_kind: text
 ---
 # Input
 
@@ -72,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -137,6 +139,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/string.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quotePreserve/string.js
+snapshot_kind: text
 ---
 # Input
 
@@ -86,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -171,6 +173,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/directives.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quoteSingle/directives.js
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -57,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/parentheses_token.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quoteSingle/parentheses_token.js
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -52,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/properties_quotes.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quoteSingle/properties_quotes.js
+snapshot_kind: text
 ---
 # Input
 
@@ -72,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -137,6 +139,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/string.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quoteSingle/string.js
+snapshot_kind: text
 ---
 # Input
 
@@ -86,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js
@@ -171,6 +173,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/suppression.js
+snapshot_kind: text
 ---
 # Input
 
@@ -57,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/template/template.js
+snapshot_kind: text
 ---
 # Input
 
@@ -100,6 +101,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/with.js
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/script/script.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/script/script_with_bom.js
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/script/with.js
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/arrow_function.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -69,6 +70,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/attribute_escape.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -44,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_position/attribute_position.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_position/attribute_position.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/attribute_position/attribute_position.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -115,6 +117,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Multiline
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/attributes.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -105,6 +106,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: jsx/bracket_same_line/bracket_same_line.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -63,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -117,6 +118,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: true
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/comments.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/conditional.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -78,6 +79,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/element.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -359,6 +360,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/fragment.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/multiline_jsx_string/multiline_jsx_string.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -56,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/new-lines.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -79,6 +80,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/parentheses_range.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_double/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_double/quote_style.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/quote_style/jsx_double_string_double/quote_style.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -61,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_single/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_single/quote_style.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/quote_style/jsx_double_string_single/quote_style.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -61,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_double/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_double/quote_style.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/quote_style/jsx_single_string_double/quote_style.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -61,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_single/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_single/quote_style.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/quote_style/jsx_single_string_single/quote_style.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx
@@ -61,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/self_closing.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/smoke.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/text_children.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/text_children.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: jsx/text_children.jsx
+snapshot_kind: text
 ---
 # Input
 
@@ -130,6 +131,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/arrow/arrow_parentheses.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -42,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -76,6 +78,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/arrow/long_arrow_parentheses_with_line_break.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -44,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -80,6 +82,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/parameter_default_binding_line_break.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/parameter_default_binding_line_break.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/arrow/parameter_default_binding_line_break.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -49,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -84,6 +86,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/arrow_chain.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -40,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/assignment/as_assignment.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/assignment/assignment.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -42,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/assignment/assignment_comments.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/assignment/property_assignment_comments.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/assignment/type_assertion_assignment.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -43,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/binding/definite_variable.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/call_expression.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/accessor.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/assigment_layout.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -36,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/constructor_parameter.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -73,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/implements_clause.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/readonly_ambient_property.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -39,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/es5/class_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/es5/class_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/trailing_commas/es5/class_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -40,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -86,6 +88,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/none/class_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/none/class_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/class/trailing_commas/none/class_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -40,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -86,6 +88,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declaration/class.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -88,6 +89,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declaration/declare_function.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declaration/global_declaration.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declaration/interface.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -76,6 +77,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declaration/variable_declaration.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -116,6 +117,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/declare.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/decoartors.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -287,6 +288,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/decorators/class_members.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -123,6 +124,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_es5/enum_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_es5/enum_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/enum/trailing_commas_es5/enum_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -60,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_none/enum_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_none/enum_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/enum/trailing_commas_none/enum_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -60,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/as_expression.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/bracket-spacing/expression_bracket_spacing.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -96,6 +97,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -213,6 +215,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/non_null_expression.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/type_assertion_expression.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/type_expression.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -135,6 +136,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/expression/type_member.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -78,6 +79,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_100/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_100/function_parameters.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/function/parameters/line_width_100/function_parameters.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -118,6 +120,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_120/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_120/function_parameters.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/function/parameters/line_width_120/function_parameters.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -118,6 +120,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/es5/function_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/es5/function_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/function/trailing_commas/es5/function_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -66,6 +67,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -126,6 +128,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/none/function_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/none/function_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/function/trailing_commas/none/function_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -66,6 +67,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -126,6 +128,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/issue1511.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/issue1511.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/issue1511.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/export_clause.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -51,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/external_module_reference.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/import_type/import_types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/import_type/import_types.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/import_type/import_types.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -51,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -87,6 +89,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/module_declaration.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/qualified_module_name.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/no-semi/class.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -81,6 +82,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -154,6 +156,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/no-semi/non-null.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -56,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/no-semi/statements.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -43,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -77,6 +79,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/no-semi/types.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -42,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -80,6 +82,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_es5/object_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_es5/object_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/object/trailing_commas_es5/object_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -51,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -93,6 +95,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_none/object_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_none/object_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/object/trailing_commas_none/object_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -51,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -93,6 +95,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/issue-1356/parameter_type_annotation_semicolon.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/issue-1356/parameter_type_annotation_semicolon.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/parameters/issue-1356/parameter_type_annotation_semicolon.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -69,6 +71,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/parameters/parameters.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -31,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/parenthesis.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -38,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/simple_arguments.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -76,6 +77,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/statement/empty_block.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -30,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/statement/enum_statement.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/quotePreserve/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/quotePreserve/parameter_quotes.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/string/quotePreserve/parameter_quotes.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -64,6 +65,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -120,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/quoteSingle/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/quoteSingle/parameter_quotes.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/string/quoteSingle/parameter_quotes.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -64,6 +65,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -120,6 +122,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/suppressions.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/conditional.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -45,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/import_type.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -37,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type_with_resolution_mode.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type_with_resolution_mode.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/import_type_with_resolution_mode.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -33,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/injfer_in_intersection.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/injfer_in_union.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/intersection_type.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -87,6 +88,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/mapped_type.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -36,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/qualified_name.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/template_type.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -32,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/es5/type_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/es5/type_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/trailing-commas/es5/type_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -73,6 +75,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/none/type_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/none/type_trailing_commas.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/trailing-commas/none/type_trailing_commas.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -73,6 +75,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/union_type.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -278,6 +279,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/union/nested_union/nested_union.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/union/nested_union/nested_union.ts.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/union/nested_union/nested_union.ts
+snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts
@@ -74,6 +76,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/tsx/arrow/issue-2736.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/arrow/issue-2736.tsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: tsx/arrow/issue-2736.tsx
+snapshot_kind: text
 ---
 # Input
 
@@ -48,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```tsx

--- a/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: tsx/smoke.tsx
+snapshot_kind: text
 ---
 # Input
 
@@ -29,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```tsx

--- a/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: tsx/type_param.tsx
+snapshot_kind: text
 ---
 # Input
 
@@ -43,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Space inside stuff: false
 -----
 
 ```tsx

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -522,6 +522,10 @@ export interface PartialJavascriptFormatter {
 	 */
 	semicolons?: Semicolons;
 	/**
+	 * @todo
+	 */
+	spaceInsideStuff?: SpaceInsideStuff;
+	/**
 	 * Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
 	 */
 	trailingComma?: TrailingCommas;
@@ -698,6 +702,7 @@ export type QuoteStyle = "double" | "single";
 export type ArrowParentheses = "always" | "asNeeded";
 export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";
+export type SpaceInsideStuff = boolean;
 /**
  * Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1656,6 +1656,13 @@
 					"description": "Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.",
 					"anyOf": [{ "$ref": "#/definitions/Semicolons" }, { "type": "null" }]
 				},
+				"spaceInsideStuff": {
+					"description": "@todo",
+					"anyOf": [
+						{ "$ref": "#/definitions/SpaceInsideStuff" },
+						{ "type": "null" }
+					]
+				},
 				"trailingComma": {
 					"description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to \"all\".",
 					"anyOf": [
@@ -3367,6 +3374,7 @@
 			},
 			"additionalProperties": false
 		},
+		"SpaceInsideStuff": { "type": "boolean" },
 		"StableHookResult": {
 			"oneOf": [
 				{


### PR DESCRIPTION
# WIP

## Summary

Add formatting option to include spacing inside parentheses, square brackets, curly braces, and angle brackets.

For example, this input:

```ts
function id<TypeArg>(x: TypeArg): TypeArg {
	return x;
}
const arr = [1, 2, 3];
if (id(true)) {
	// …
}
```

Would be formatted as follows with a "space inside" option enabled:

```ts
function id< TypeArg > ( x: TypeArg ): TypeArg {
	return x;
}
const arr = [ 1, 2, 3 ];
if ( id( true ) ) {
	// …
}
```

See https://github.com/biomejs/biome/discussions/2360#discussioncomment-10690814.
Closes https://github.com/biomejs/biome/issues/4607 (eventually).

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
