### PR TITLE
feat(biome_glob): add dedicated crate for globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "biome_glob"
+version = "0.1.0"
+dependencies = [
+ "biome_deserialize",
+ "biome_text_size",
+ "globset",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "biome_graphql_analyze"
 version = "0.0.1"
 dependencies = [
@@ -741,6 +752,7 @@ dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
+ "biome_glob",
  "biome_js_factory",
  "biome_js_parser",
  "biome_js_semantic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ biome_diagnostics_categories = { version = "0.5.7", path = "./crates/biome_diagn
 biome_diagnostics_macros     = { version = "0.5.7", path = "./crates/biome_diagnostics_macros" }
 biome_formatter              = { version = "0.5.7", path = "./crates/biome_formatter" }
 biome_fs                     = { version = "0.5.7", path = "./crates/biome_fs" }
+biome_glob                   = { version = "0.1.0", path = "./crates/biome_glob" }
 biome_graphql_analyze        = { version = "0.0.1", path = "./crates/biome_graphql_analyze" }
 biome_graphql_factory        = { version = "0.1.0", path = "./crates/biome_graphql_factory" }
 biome_graphql_formatter      = { version = "0.1.0", path = "./crates/biome_graphql_formatter" }

--- a/crates/biome_glob/Cargo.toml
+++ b/crates/biome_glob/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+authors.workspace    = true
+categories.workspace = true
+description          = "<DESCRIPTION>"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_glob"
+repository.workspace = true
+version              = "0.1.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+biome_deserialize = { workspace = true, optional = true }
+biome_text_size   = { workspace = true, optional = true }
+globset           = { workspace = true }
+schemars          = { workspace = true, optional = true }
+serde             = { workspace = true, optional = true }
+
+[features]
+biome_deserialize = ["dep:biome_deserialize", "dep:biome_text_size"]
+schemars          = ["dep:schemars"]
+serde             = ["dep:serde"]

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -19,6 +19,7 @@ biome_control_flow       = { workspace = true }
 biome_deserialize        = { workspace = true, features = ["smallvec"] }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
+biome_glob               = { workspace = true, features = ["biome_deserialize", "schemars", "serde"] }
 biome_js_factory         = { workspace = true }
 biome_js_semantic        = { workspace = true }
 biome_js_syntax          = { workspace = true }

--- a/crates/biome_js_analyze/src/assists/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assists/source/organize_imports.rs
@@ -7,7 +7,7 @@ use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::JsModule;
 use biome_rowan::BatchMutationExt;
 
-use crate::{utils::restricted_glob::RestrictedGlob, JsRuleAction};
+use crate::JsRuleAction;
 
 pub mod legacy;
 pub mod util;
@@ -94,7 +94,7 @@ pub struct Options {
 #[serde(untagged)]
 pub enum ImportGroup {
     Predefined(PredefinedImportGroup),
-    Custom(RestrictedGlob),
+    Custom(biome_glob::Glob),
 }
 impl Deserializable for ImportGroup {
     fn deserialize(

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -7,7 +7,6 @@ use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike};
 use biome_rowan::AstNode;
 
-use crate::utils::restricted_glob::{CandidatePath, RestrictedGlob};
 use crate::{globals::is_node_builtin_module, services::manifest::Manifest};
 
 declare_lint_rule! {
@@ -95,7 +94,7 @@ enum DependencyAvailability {
     Bool(bool),
 
     /// Dependencies are available in files that matches any of the globs.
-    Patterns(Box<[RestrictedGlob]>),
+    Patterns(Box<[biome_glob::Glob]>),
 }
 
 impl Default for DependencyAvailability {
@@ -166,7 +165,9 @@ impl DependencyAvailability {
     fn is_available(&self, path: &Path) -> bool {
         match self {
             Self::Bool(b) => *b,
-            Self::Patterns(globs) => CandidatePath::new(&path).matches_with_exceptions(globs),
+            Self::Patterns(globs) => {
+                biome_glob::CandidatePath::new(&path).matches_with_exceptions(globs)
+            }
         }
     }
 }

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -4,7 +4,6 @@ use std::iter;
 
 pub mod batch;
 pub mod rename;
-pub mod restricted_glob;
 pub mod restricted_regex;
 #[cfg(test)]
 pub mod tests;

--- a/knope.toml
+++ b/knope.toml
@@ -215,6 +215,10 @@ versioned_files = ["crates/biome_graphql_semantic/Cargo.toml"]
 changelog       = "crates/biome_css_semantic/CHANGELOG.md"
 versioned_files = ["crates/biome_css_semantic/Cargo.toml"]
 
+[packages.biome_glob]
+changelog       = "crates/biome_glob/CHANGELOG.md"
+versioned_files = ["crates/biome_glob/Cargo.toml"]
+
 ## End of crates. DO NOT CHANGE!
 
 # Workflow to create a changeset


### PR DESCRIPTION
## Summary

Move `RetsrictedGlob` from `biome_js_analyze` to a dedicated crate.
This allows us to use `RetsrictedGlob` outside `biome_js_analyze`. 

Also, I renamed `RetsrictedGlob` into `Glob`. Possible alternative names are `GlobPattern` and `Pattern`.

I added some documentation for the crate and put optional dependencies behind feature flags.

## Test Plan

CI must pass.
