### PR TITLE
fix(css_formatter): don't wrap selector identation after css comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - Fix [#4026](https://github.com/biomejs/biome/issues/4026), don't move comments in `grid-template`. Contributed by @fireairforce
 
-- Fix [#4533](URL_ADDRESS.com/biomejs/biome/issues/4533), don't throw error when pseudeo class after a webkit scrollbar pseudeo element.
+- Fix [#4533](https://github.com/biomejs/biome/issues/4533), don't throw error when pseudeo class after a webkit scrollbar pseudeo element.
 
   The follow code will not report:
 
@@ -65,6 +65,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
   ```
 
   Contributed by @fireairforce
+
+- Fix [#4575](https://github.com/biomejs/biome/issues/4575), don't wrap selector identation after css comments. Contributed by @fireairforce
 
 ### JavaScript APIs
 

--- a/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
+++ b/crates/biome_css_formatter/src/css/selectors/complex_selector.rs
@@ -23,16 +23,47 @@ impl FormatNodeRule<CssComplexSelector> for FormatCssComplexSelector {
                 write!(f, [combinator.format()])
             }
         });
+        let mut has_leading_comments = false;
 
-        write!(
-            f,
-            [
-                left.format(),
-                soft_line_break_or_space(),
-                formatted_combinator,
-                space(),
-                right.format()
-            ]
-        )
+        let is_selector_list_first_child = node.syntax().parent().is_some_and(|parent| {
+            matches!(parent.kind(), CssSyntaxKind::CSS_SELECTOR_LIST)
+                && node.syntax().prev_sibling().is_none()
+        });
+
+        if let Some(computed_selector) = left.clone()?.as_css_compound_selector() {
+            let simple_selector_has_leading_comments = computed_selector
+                .simple_selector()
+                .and_then(|simple_selector| simple_selector.as_css_type_selector().cloned())
+                .and_then(|type_selector| type_selector.ident().ok()?.value_token().ok())
+                .is_some_and(|value_token| value_token.has_leading_comments());
+
+            let sub_selector_has_leading_comments = computed_selector
+                .sub_selectors()
+                .first()
+                .and_then(|sub_selector| sub_selector.as_css_class_selector().cloned())
+                .and_then(|class_selector| class_selector.dot_token().ok())
+                .is_some_and(|value_token| value_token.has_leading_comments());
+
+            has_leading_comments =
+                simple_selector_has_leading_comments || sub_selector_has_leading_comments;
+        }
+
+        if has_leading_comments && !is_selector_list_first_child {
+            write!(
+                f,
+                [left.format(), formatted_combinator, space(), right.format()]
+            )
+        } else {
+            write!(
+                f,
+                [
+                    left.format(),
+                    soft_line_break_or_space(),
+                    formatted_combinator,
+                    space(),
+                    right.format()
+                ]
+            )
+        }
     }
 }

--- a/crates/biome_css_formatter/tests/quick_test.rs
+++ b/crates/biome_css_formatter/tests/quick_test.rs
@@ -13,13 +13,14 @@ mod language {
 // use this test check if your snippet prints as you wish, without using a snapshot
 fn quick_test() {
     let src = r#"
-#grid {
-	grid-template-columns:
-	  1fr /* first comment */
-	  auto /* second comment */
-      60px /* fourth comment */
-	  2fr /* third comment */  
-  }
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector,
+/* 3some medium long comment */
+div selector {
+  background: green;
+}
 "#;
     let parse = parse_css(src, CssParserOptions::default());
     println!("{parse:#?}");

--- a/crates/biome_css_formatter/tests/specs/css/issue_3229.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/issue_3229.css.snap
@@ -84,17 +84,17 @@ foo
 
 /* input */
 foo
-	/* a comment */
+/* a comment */
 
-	.aRule {
+.aRule {
 	color: red;
 }
 
 /* first format */
 foo
-	/* a comment */
+/* a comment */
 
-	.aRule {
+.aRule {
 	color: red;
 }
 ```

--- a/crates/biome_css_formatter/tests/specs/css/selectors/selector_lists.css
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/selector_lists.css
@@ -15,3 +15,27 @@ h1, h2     , h3
 
 
 , h4,    h5,      h6 {}
+
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector {
+  background: red;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+div selector {
+  background: blue;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector,
+/* 3some medium long comment */
+div selector {
+  background: green;
+}

--- a/crates/biome_css_formatter/tests/specs/css/selectors/selector_lists.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/selectors/selector_lists.css.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: css/selectors/selector_lists.css
 ---
-
 # Input
 
 ```css
@@ -23,6 +22,31 @@ h1, h2     , h3
 
 
 , h4,    h5,      h6 {}
+
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector {
+  background: red;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+div selector {
+  background: blue;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector,
+/* 3some medium long comment */
+div selector {
+  background: green;
+}
+
 ```
 
 
@@ -62,11 +86,32 @@ h4,
 h5,
 h6 {
 }
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector {
+	background: red;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+div selector {
+	background: blue;
+}
+
+/* 1some medium long comment */
+.line1 selector,
+/* 2some medium long comment */
+.line1 selector,
+/* 3some medium long comment */
+div selector {
+	background: green;
+}
 ```
 
 # Lines exceeding max width of 80 characters
 ```
    12: div.another.really.long#selector.that.goes.past.the.line.length.with.a.single.selector {
 ```
-
-

--- a/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
+++ b/crates/biome_css_formatter/tests/specs/prettier/css/comments/selectors.css.snap
@@ -233,54 +233,51 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 -/* comment 29 */
 -.element /* comment 30 */ > /* comment 31 */ .element /* comment 32 */ {
 +/* comment 29 */ .element
-+  > /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
++> /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
  }
  /* comment 33 */
  .element
 -/* comment 34 */
 ->
--/* comment 35 */
++> /* comment 34 */
+ /* comment 35 */
 -.element
 -/* comment 36 */ {
-+  > /* comment 34 */
-+  /* comment 35 */
-+  .element /* comment 36 */
++.element /* comment 36 */
 +{
  }
  
 -/* comment 37 */
 -.element /* comment 38 */ + /* comment 39 */ .element /* comment 40 */ {
 +/* comment 37 */ .element
-+  + /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
+++ /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
  }
  /* comment 41 */
  .element
 -/* comment 42 */
 -+
--/* comment 43 */
+++ /* comment 42 */
+ /* comment 43 */
 -.element
 -/* comment 44 */ {
-+  + /* comment 42 */
-+  /* comment 43 */
-+  .element /* comment 44 */
++.element /* comment 44 */
 +{
  }
  
 -/* comment 45 */
 -.element /* comment 46 */ ~ /* comment 47 */ .element /* comment 48 */ {
 +/* comment 45 */ .element
-+  ~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
++~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
  }
  /* comment 49 */
  .element
 -/* comment 50 */
 -~
--/* comment 51 */
++~ /* comment 50 */
+ /* comment 51 */
 -.element
 -/* comment 52 */ {
-+  ~ /* comment 50 */
-+  /* comment 51 */
-+  .element /* comment 52 */
++.element /* comment 52 */
 +{
  }
  
@@ -436,40 +433,39 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
        /* comment 161 */
      } /* comment 162 */
      /* comment 163 */
-@@ -201,30 +188,34 @@
+@@ -201,30 +188,33 @@
    /* comment 165 */
  } /* comment 166 */
  
 -/* comment 167 */
 -article /* comment 168 */ :--heading /* comment 169 */ + /* comment 170 */ p /* comment 171 */ {
-+/* comment 167 */ article
-+  /* comment 168 */ :--heading
++/* comment 167 */ article /* comment 168 */ :--heading
 +  + /* comment 169 */ /* comment 170 */ p /* comment 171 */ {
  }
  
 -/* comment 172 */
 -.foo /* comment 173 */ :global /* comment 174 */.bar /* comment 175 */ {
-+/* comment 172 */ .foo
-+  /* comment 173 */ :global
++/* comment 172 */ .foo /* comment 173 */ :global
 +  /* comment 174 */ .bar /* comment 175 */ {
  }
 -/* comment 176 */
 -.foo /* comment 177 */ :global(/* comment 178 */.bar/* comment 179 */) /* comment 180 */ .baz /* comment 181 */ {
-+/* comment 176 */ .foo
-+  /* comment 177 */ :global(/* comment 178 */ .bar /* comment 179 */)
++/* comment 176 */ .foo /* comment 177 */ :global(
++    /* comment 178 */ .bar /* comment 179 */
++  )
 +  /* comment 180 */ .baz /* comment 181 */ {
  }
  
 -/* comment 182 */
 -.foo /* comment 183 */ :local /* comment 184 */ .bar /* comment 185 */ {
-+/* comment 182 */ .foo
-+  /* comment 183 */ :local
++/* comment 182 */ .foo /* comment 183 */ :local
 +  /* comment 184 */ .bar /* comment 185 */ {
  }
 -/* comment 186 */
 -.foo /* comment 187 */ :local(/* comment 188 */.foo/* comment 189 */) /* comment 190 */ .bar /* comment 191 */ {
-+/* comment 186 */ .foo
-+  /* comment 187 */ :local(/* comment 188 */ .foo /* comment 189 */)
++/* comment 186 */ .foo /* comment 187 */ :local(
++    /* comment 188 */ .foo /* comment 189 */
++  )
 +  /* comment 190 */ .bar /* comment 191 */ {
  }
  
@@ -536,35 +532,35 @@ input:not(/* comment 125 */[/* comment 126 */disabled/* comment 127 */]/* commen
 }
 
 /* comment 29 */ .element
-  > /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
+> /* comment 30 */ /* comment 31 */ .element /* comment 32 */ {
 }
 /* comment 33 */
 .element
-  > /* comment 34 */
-  /* comment 35 */
-  .element /* comment 36 */
+> /* comment 34 */
+/* comment 35 */
+.element /* comment 36 */
 {
 }
 
 /* comment 37 */ .element
-  + /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
++ /* comment 38 */ /* comment 39 */ .element /* comment 40 */ {
 }
 /* comment 41 */
 .element
-  + /* comment 42 */
-  /* comment 43 */
-  .element /* comment 44 */
++ /* comment 42 */
+/* comment 43 */
+.element /* comment 44 */
 {
 }
 
 /* comment 45 */ .element
-  ~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
+~ /* comment 46 */ /* comment 47 */ .element /* comment 48 */ {
 }
 /* comment 49 */
 .element
-  ~ /* comment 50 */
-  /* comment 51 */
-  .element /* comment 52 */
+~ /* comment 50 */
+/* comment 51 */
+.element /* comment 52 */
 {
 }
 
@@ -679,26 +675,25 @@ input:not(
   /* comment 165 */
 } /* comment 166 */
 
-/* comment 167 */ article
-  /* comment 168 */ :--heading
+/* comment 167 */ article /* comment 168 */ :--heading
   + /* comment 169 */ /* comment 170 */ p /* comment 171 */ {
 }
 
-/* comment 172 */ .foo
-  /* comment 173 */ :global
+/* comment 172 */ .foo /* comment 173 */ :global
   /* comment 174 */ .bar /* comment 175 */ {
 }
-/* comment 176 */ .foo
-  /* comment 177 */ :global(/* comment 178 */ .bar /* comment 179 */)
+/* comment 176 */ .foo /* comment 177 */ :global(
+    /* comment 178 */ .bar /* comment 179 */
+  )
   /* comment 180 */ .baz /* comment 181 */ {
 }
 
-/* comment 182 */ .foo
-  /* comment 183 */ :local
+/* comment 182 */ .foo /* comment 183 */ :local
   /* comment 184 */ .bar /* comment 185 */ {
 }
-/* comment 186 */ .foo
-  /* comment 187 */ :local(/* comment 188 */ .foo /* comment 189 */)
+/* comment 186 */ .foo /* comment 187 */ :local(
+    /* comment 188 */ .foo /* comment 189 */
+  )
   /* comment 190 */ .bar /* comment 191 */ {
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #4575 

I add special judge for the case like:

```css
/* 1some medium long comment */
.line1 selector,
/* 2some medium long comment */
.line1 selector,
/* 3some medium long comment */
div selector {
  background: green;
}
```

if there was a selector, it contains comments before, it will don't be wrapped by the ident(So i add judge in this case to remove the ident for the selector).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add test case.

<!-- What demonstrates that your implementation is correct? -->
