### PR TITLE
refactor(analyzer): severity in metadata

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -8,11 +8,11 @@ use biome_console::fmt::Display;
 use biome_console::{markup, MarkupBuf};
 use biome_diagnostics::advice::CodeSuggestionAdvice;
 use biome_diagnostics::location::AsSpan;
-use biome_diagnostics::Applicability;
 use biome_diagnostics::{
     Advices, Category, Diagnostic, DiagnosticTags, Location, LogCategory, MessageAndDescription,
     Visit,
 };
+use biome_diagnostics::{Applicability, Severity};
 use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Language, TextRange};
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -41,6 +41,8 @@ pub struct RuleMetadata {
     pub sources: &'static [RuleSource],
     /// The source kind of the rule
     pub source_kind: Option<RuleSourceKind>,
+    /// The default severity of the rule
+    pub severity: Severity,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -328,6 +330,7 @@ impl RuleMetadata {
             fix_kind: FixKind::None,
             sources: &[],
             source_kind: None,
+            severity: Severity::Information,
         }
     }
 
@@ -361,6 +364,11 @@ impl RuleMetadata {
 
     pub const fn language(mut self, language: &'static str) -> Self {
         self.language = language;
+        self
+    }
+
+    pub const fn severity(mut self, severity: Severity) -> Self {
+        self.severity = severity;
         self
     }
 

--- a/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
@@ -6,6 +6,7 @@ use biome_css_syntax::{
     AnyCssAtRule, AnyCssGenericComponentValue, AnyCssValue, CssAtRule,
     CssGenericComponentValueList, CssGenericProperty, CssSyntaxKind,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, SyntaxNodeCast, TextRange};
 use biome_string_case::StrLikeExtension;
 
@@ -65,6 +66,7 @@ declare_lint_rule! {
         name: "useGenericFontNames",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("font-family-no-missing-generic-family-keyword")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{CssFunction, CssParameter};
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 use biome_rowan::AstSeparatedList;
 use biome_string_case::StrLikeExtension;
@@ -47,6 +48,7 @@ declare_lint_rule! {
         name: "noInvalidDirectionInLinearGradient",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("function-linear-gradient-no-nonstandard-direction")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_grid_areas.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_grid_areas.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::CssDeclarationOrRuleList;
+use biome_diagnostics::Severity;
 use biome_rowan::{TextRange, TokenText};
 
 use rustc_hash::FxHashSet;
@@ -53,6 +54,7 @@ declare_lint_rule! {
         name: "noInvalidGridAreas",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("named-grid-areas-no-invalid")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_position_at_import_rule.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_position_at_import_rule.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssRule, CssRuleList};
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 
 declare_lint_rule! {
@@ -31,6 +32,7 @@ declare_lint_rule! {
         name: "noInvalidPositionAtImportRule",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("no-invalid-position-at-import-rule")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_function.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_function.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::CssFunction;
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 
 use crate::utils::{is_custom_function, is_function_keyword};
@@ -36,6 +37,7 @@ declare_lint_rule! {
         name: "noUnknownFunction",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("function-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_media_feature_name.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_media_feature_name.rs
@@ -8,6 +8,7 @@ use biome_css_syntax::{
     AnyCssMediaTypeQuery, AnyCssQueryFeature, CssMediaAndCondition, CssMediaConditionQuery,
     CssMediaOrCondition, CssMediaQueryList,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 
 use crate::utils::is_media_feature_name;
@@ -71,6 +72,7 @@ declare_lint_rule! {
         name: "noUnknownMediaFeatureName",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("media-feature-name-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::CssGenericProperty;
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 use biome_string_case::StrLikeExtension;
 
@@ -61,6 +62,7 @@ declare_lint_rule! {
         name: "noUnknownProperty",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("property-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_unit.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_unit.rs
@@ -5,6 +5,7 @@ use biome_console::markup;
 use biome_css_syntax::{
     AnyCssDimension, CssFunction, CssGenericProperty, CssQueryFeaturePlain, CssSyntaxKind,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::{SyntaxNodeCast, TextRange};
 use biome_string_case::StrLikeExtension;
 
@@ -64,6 +65,7 @@ declare_lint_rule! {
         name: "noUnknownUnit",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("unit-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
@@ -5,6 +5,7 @@ use biome_console::markup;
 use biome_css_syntax::{
     AnyCssPseudoClassNth, CssPseudoClassFunctionSelectorList, CssPseudoClassNthSelector,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, SyntaxNodeCast};
 
 declare_lint_rule! {
@@ -57,6 +58,7 @@ declare_lint_rule! {
         name: "noUnmatchableAnbSelector",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("selector-anb-no-unmatchable")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_descending_specificity.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_descending_specificity.rs
@@ -4,6 +4,7 @@ use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnosti
 use biome_console::markup;
 use biome_css_semantic::model::{Rule as CssSemanticRule, RuleId, SemanticModel, Specificity};
 use biome_css_syntax::{AnyCssSelector, CssRoot};
+use biome_diagnostics::Severity;
 use biome_rowan::TextRange;
 
 use biome_rowan::AstNode;
@@ -76,6 +77,7 @@ declare_lint_rule! {
         name: "noDescendingSpecificity",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("no-descending-specificity")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_custom_properties.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_custom_properties.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::Entry;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_css_syntax::CssDeclarationOrRuleList;
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 use rustc_hash::FxHashMap;
 
@@ -40,6 +41,7 @@ declare_lint_rule! {
         name: "noDuplicateCustomProperties",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("declaration-block-no-duplicate-custom-properties")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, collections::hash_map::Entry};
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_css_syntax::CssDeclarationOrRuleList;
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 use biome_string_case::StrOnlyExtension;
 use rustc_hash::FxHashMap;
@@ -39,6 +40,7 @@ declare_lint_rule! {
         name: "noDuplicateProperties",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("declaration-block-no-duplicate-properties")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_css_syntax::{AnyCssProperty, CssDashedIdentifier, CssDeclaration, CssSyntaxKind};
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 
 use crate::services::semantic::Semantic;
@@ -117,6 +118,7 @@ declare_lint_rule! {
         name: "noMissingVarFunction",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("custom-property-no-missing-var-function")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
@@ -13,6 +13,7 @@ use biome_css_syntax::{
     CssPseudoClassFunctionSelector, CssPseudoClassFunctionSelectorList,
     CssPseudoClassFunctionValueList, CssPseudoClassIdentifier, CssPseudoElementSelector,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::{declare_node_union, AstNode, TextRange};
 use biome_string_case::StrLikeExtension;
 
@@ -62,6 +63,7 @@ declare_lint_rule! {
         name: "noUnknownPseudoClass",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("selector-pseudo-class-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssPseudoElement, CssPseudoElementSelector};
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 use biome_string_case::StrLikeExtension;
 
@@ -54,6 +55,7 @@ declare_lint_rule! {
         name: "noUnknownPseudoElement",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("selector-pseudo-element-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_type_selector.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_type_selector.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::CssTypeSelector;
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 
 use crate::utils::is_known_type_selector;
@@ -54,6 +55,7 @@ declare_lint_rule! {
         name: "noUnknownTypeSelector",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("selector-type-no-unknown")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssAtRule, AnyCssRule, CssImportAtRule, CssRuleList};
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 use biome_string_case::StrOnlyExtension;
 
@@ -51,6 +52,7 @@ declare_lint_rule! {
         name: "noDuplicateAtImportRules",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("no-duplicate-at-import-rules")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssGenericComponentValue, AnyCssValue, CssGenericProperty};
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 use biome_string_case::StrLikeExtension;
 
@@ -48,6 +49,7 @@ declare_lint_rule! {
         name: "noDuplicateFontNames",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("font-family-no-duplicate-names")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssKeyframesItem, AnyCssKeyframesSelector, CssKeyframesBlock};
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 use biome_string_case::StrLikeExtension;
 
@@ -42,6 +43,7 @@ declare_lint_rule! {
         name: "noDuplicateSelectorsKeyframeBlock",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources:&[RuleSource::Stylelint("keyframe-block-no-duplicate-selectors")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_empty_block.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_empty_block.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::stmt_ext::CssBlockLike;
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 
 declare_lint_rule! {
@@ -47,6 +48,7 @@ declare_lint_rule! {
         name: "noEmptyBlock",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("block-no-empty")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_important_in_keyframe.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_important_in_keyframe.rs
@@ -5,6 +5,7 @@ use biome_console::markup;
 use biome_css_syntax::{
     AnyCssDeclarationBlock, AnyCssKeyframesItem, CssDeclarationImportant, CssKeyframesBlock,
 };
+use biome_diagnostics::Severity;
 use biome_rowan::AstNode;
 
 declare_lint_rule! {
@@ -45,6 +46,7 @@ declare_lint_rule! {
         name: "noImportantInKeyframe",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources:&[RuleSource::Stylelint("keyframe-declaration-no-important")],
     }
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_css_syntax::{AnyCssDeclarationName, CssGenericProperty, CssLanguage, CssSyntaxKind};
+use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, Language, SyntaxNode, TextRange, WalkEvent};
 
 fn remove_vendor_prefix<'a>(prop: &'a str, prefix: &'a str) -> &'a str {
@@ -72,6 +73,7 @@ declare_lint_rule! {
         name: "noShorthandPropertyOverrides",
         language: "css",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Stylelint("declaration-block-no-shorthand-property-overrides")],
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_access_key.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxAttribute, JsxAttributeList};
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -41,6 +42,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-access-key")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttributeValue, AnyNumberLikeExpression};
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -51,6 +52,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-aria-hidden-on-focusable")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_unsupported_elements.rs
@@ -6,6 +6,7 @@ use biome_analyze::{
 };
 use biome_aria_metadata::AriaAttribute;
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
 
@@ -41,6 +42,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("aria-unsupported-elements")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_autofocus.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxAttribute};
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -61,6 +62,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-autofocus")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_blank_target.rs
@@ -3,6 +3,7 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{
     jsx_attribute, jsx_attribute_initializer_clause, jsx_attribute_list, jsx_ident, jsx_name,
     jsx_string, jsx_string_literal, token,
@@ -78,6 +79,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("jsx-no-target-blank")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_distracting_elements.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::*;
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -42,6 +43,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-distracting-elements")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_header_scope.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -42,6 +43,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("scope")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_interactive_element_to_noninteractive_role.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -41,6 +42,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-interactive-element-to-noninteractive-role")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_label_without_control.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsxAttribute, AnyJsxAttributeName, AnyJsxAttributeValue, AnyJsxElementName, AnyJsxTag,
     JsSyntaxKind, JsxAttribute,
@@ -90,6 +91,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("label-has-associated-control")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -3,6 +3,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
 
@@ -50,6 +51,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-to-interactive-role")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_tabindex.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
 };
 use biome_aria::AriaRoles;
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     jsx_ext::AnyJsxElement, AnyJsxAttributeValue, AnyNumberLikeExpression, TextRange,
 };
@@ -52,6 +53,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-noninteractive-tabindex")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -4,6 +4,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_factory::make::{jsx_string, jsx_string_literal};
 use biome_js_semantic::SemanticModel;
@@ -53,6 +54,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("tabindex-no-positive")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_alt.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsTemplateElement, AnyJsxAttributeValue,
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("img-redundant-alt")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_redundant_roles.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
 };
 use biome_aria::{roles::AriaRoleDefinition, AriaRoles};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     jsx_ext::AnyJsxElement, AnyJsxAttributeValue, JsxAttribute, JsxAttributeList,
 };
@@ -48,6 +49,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-redundant-roles")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_svg_without_title.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxAttribute, JsxChildList, JsxElement};
 use biome_rowan::{AstNode, AstNodeList};
 use biome_string_case::StrLikeExtension;
@@ -102,6 +103,7 @@ declare_lint_rule! {
         name: "noSvgWithoutTitle",
         language: "jsx",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::{fmt::Display, fmt::Formatter, markup};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, static_value::StaticValue, TextRange};
 use biome_rowan::AstNode;
 
@@ -51,6 +52,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("alt-text")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("anchor-has-content")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_activedescendant_with_tabindex.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{
     jsx_attribute, jsx_attribute_initializer_clause, jsx_attribute_list, jsx_ident, jsx_name,
     jsx_string, jsx_string_literal, token,
@@ -53,6 +54,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("aria-activedescendant-has-tabindex")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -2,6 +2,7 @@ use crate::services::aria::Aria;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxAttribute;
 use biome_rowan::AstNode;
@@ -44,6 +45,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("role-has-required-aria-props")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_button_type.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsxElementName, JsCallExpression, JsxAttribute, JsxOpeningElement, JsxSelfClosingElement,
     TextRange,
@@ -42,6 +43,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("button-has-type")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_aria::AriaRoles;
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttributeValue};
 use biome_rowan::AstNode;
 
@@ -43,6 +44,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("interactive-supports-focus")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, JsxElement};
 use biome_rowan::AstNode;
 
@@ -61,6 +62,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("heading-has-content")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, TextRange};
 use biome_rowan::AstNode;
 
@@ -60,6 +61,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("html-has-lang")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::AstNode;
 
@@ -66,6 +67,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("iframe-has-title")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_click_events.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{jsx_ext::AnyJsxElement, AnyJsxAttribute, AnyJsxElementName};
 use biome_rowan::AstNode;
 use biome_string_case::StrLikeExtension;
@@ -63,6 +64,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("click-events-have-key-events")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_key_with_mouse_events.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_key_with_mouse_events.rs
@@ -2,6 +2,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::AstNode;
 
@@ -45,6 +46,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("mouse-events-have-key-events")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_media_caption.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{AnyJsxChild, JsxElement, TextRange};
 use biome_rowan::AstNode;
@@ -37,6 +38,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("media-has-caption")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_semantic_elements.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_aria::AriaRoles;
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsxAttribute, JsxOpeningElement};
 use biome_rowan::TextRange;
 
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("prefer-tag-over-role")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, TextRange};
 
@@ -77,6 +78,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("anchor-is-valid")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_props.rs
@@ -5,6 +5,7 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_aria_metadata::AriaAttribute;
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::JsxAttribute;
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
@@ -32,6 +33,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("aria-props")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_role.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, BatchMutationExt};
 use serde::{Deserialize, Serialize};
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("aria-role")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_aria_values.rs
@@ -4,6 +4,7 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_aria_metadata::{AriaAttribute, AriaValueType};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsSyntaxToken, JsxAttribute, TextRange};
 use biome_rowan::AstNode;
 
@@ -53,6 +54,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("aria-proptypes")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_lang.rs
@@ -2,6 +2,7 @@ use crate::services::aria::Aria;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::{AstNode, TextRange};
 declare_lint_rule! {
@@ -34,6 +35,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("lang")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_banned_types.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     JsReferenceIdentifier, JsSyntaxKind, TextRange, TsIntersectionTypeElementList, TsObjectType,
@@ -93,6 +94,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("ban-types")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_empty_type_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_empty_type_parameters.rs
@@ -1,6 +1,7 @@
 use biome_analyze::Ast;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsSyntaxKind, TsTypeParameters};
 use biome_rowan::{AstNode, AstSeparatedList, SyntaxNodeOptionExt};
 
@@ -39,6 +40,7 @@ declare_lint_rule! {
         name: "noEmptyTypeParameters",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsCallExpression, JsLanguage, JsStaticMemberExpression};
 use biome_rowan::{AstNode, Language, SyntaxNode, SyntaxNodeOptionExt, TextRange, WalkEvent};
 
@@ -56,6 +57,7 @@ declare_lint_rule! {
         name: "noExcessiveNestedTestSuites",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintJest("max-nested-describe")],
         source_kind: RuleSourceKind::SameLogic,
     }

--- a/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_extra_boolean_cast.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     is_in_boolean_context, is_negation, AnyJsExpression, JsCallArgumentList, JsCallArguments,
     JsCallExpression, JsNewExpression, JsSyntaxNode, JsUnaryOperator,
@@ -59,6 +60,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-extra-boolean-cast")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_for_each.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsExpression, AnyJsMemberExpression, JsCallExpression};
 use biome_rowan::{AstNode, AstSeparatedList};
 
@@ -69,6 +70,7 @@ declare_lint_rule! {
             RuleSource::Clippy("needless_for_each"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_multiple_spaces_in_regular_expression_literals.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsRegexLiteralExpression, JsSyntaxKind, JsSyntaxToken, TextRange, TextSize};
 use biome_rowan::BatchMutationExt;
 use std::{fmt::Write, ops::Range};
@@ -50,6 +51,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-regex-spaces")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClass, AnyJsClassMember, JsGetterClassMember, JsMethodClassMember, JsPropertyClassMember,
     JsSetterClassMember, TsGetterSignatureClassMember, TsIndexSignatureClassMember,
@@ -99,6 +100,7 @@ declare_lint_rule! {
             RuleSource::EslintUnicorn("no-static-only-class"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_this_in_static.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsClass, AnyJsClassMember, AnyJsExpression, JsArrowFunctionExpression, JsSuperExpression,
@@ -82,6 +83,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintMysticatea("no-this-in-static")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsTryStatement, JsStatementList, TextRange};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-useless-catch")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsCallArgument, AnyJsClass, AnyJsConstructorParameter, AnyJsFormalParameter,
     JsCallExpression, JsConstructorClassMember,
@@ -122,6 +123,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("no-useless-constructor"),
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_empty_export.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsModuleItem, JsExport, JsModuleItemList, JsSyntaxToken};
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
 
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-useless-empty-export")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -4,6 +4,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{
     js_string_literal_expression, jsx_expression_child, jsx_string, jsx_string_literal,
     jsx_tag_expression, token, JsxExpressionChildBuilder,
@@ -64,6 +65,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("jsx-no-useless-fragment")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_label.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsStatement, JsLabeledStatement, JsSyntaxKind};
 
 use crate::JsRuleAction;
@@ -37,6 +38,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-extra-label")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_lone_block_statements.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsStatement, AnyJsSwitchClause, JsBlockStatement, JsFileSource, JsLabeledStatement,
@@ -47,6 +48,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-lone-blocks")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_rename.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExportNamedSpecifier, AnyJsNamedImportSpecifier, AnyJsObjectBindingPatternMember,
@@ -62,6 +63,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-useless-rename")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_switch_case.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsSwitchClause, JsCaseClause, JsDefaultClause};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, Direction};
 
@@ -62,6 +63,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintUnicorn("no-useless-switch-case")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_ternary.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsConditionalExpression, JsSyntaxKind,
@@ -57,6 +58,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unneeded-ternary")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_this_alias.rs
@@ -6,6 +6,7 @@ use biome_analyze::{
     RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::{
@@ -57,6 +58,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintTypeScript("no-this-alias")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 
 use biome_js_factory::make;
 use biome_js_syntax::{
@@ -81,6 +82,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-unnecessary-type-constraint")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/no_with.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_with.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::JsWithStatement;
 
 use biome_rowan::AstNode;
@@ -28,6 +29,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-with")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     Rule, RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsFunctionBody, AnyJsStatement, JsConstructorClassMember, JsFileSource,
@@ -72,6 +73,7 @@ declare_lint_rule! {
         sources: &[RuleSource::Eslint("prefer-arrow-callback")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_flat_map.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{ident, js_name};
 use biome_js_syntax::{AnyJsExpression, AnyJsMemberExpression, AnyJsName, JsCallExpression};
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt};
@@ -39,6 +40,7 @@ declare_lint_rule! {
             RuleSource::Clippy("map_flatten"),
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_literal_keys.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsComputedMember, AnyJsMemberExpression, AnyJsName, AnyJsObjectMemberName,
@@ -52,6 +53,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("dot-notation")
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -1,6 +1,7 @@
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsMemberExpression, AnyJsName, JsLogicalExpression, JsLogicalOperator,
@@ -76,6 +77,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintTypeScript("prefer-optional-chain")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::js_regex_literal_expression;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -48,6 +49,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-regex-literals")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_simple_number_keys.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsObjectMember, JsLiteralMemberName, JsObjectExpression, JsSyntaxKind, JsSyntaxToken,
@@ -47,6 +48,7 @@ declare_lint_rule! {
         name: "useSimpleNumberKeys",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsCallExpression, JsxAttribute};
 use biome_rowan::{declare_node_union, AstNode, TextRange};
 declare_lint_rule! {
@@ -28,6 +29,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-children-prop")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
@@ -3,6 +3,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{self};
 use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
 use biome_js_syntax::{JsIdentifierAssignment, JsSyntaxKind};
@@ -52,6 +53,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-const-assign")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_condition.rs
@@ -1,6 +1,7 @@
 use crate::{services::semantic::Semantic, utils::rename::RenamableNode};
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsArrayElement, AnyJsExpression, AnyJsLiteralExpression, AnyJsStatement,
@@ -85,6 +86,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-constant-condition")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constructor_return.rs
@@ -2,6 +2,7 @@ use biome_analyze::context::RuleContext;
 use biome_analyze::RuleSource;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsConstructorClassMember, JsReturnStatement};
 use biome_rowan::AstNode;
 
@@ -49,6 +50,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-constructor-return")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_empty_character_class_in_regex.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::JsRegexLiteralExpression;
 use biome_rowan::{TextRange, TextSize};
 
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-empty-character-class")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_empty_pattern.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_empty_pattern.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsArrayBindingPattern, JsObjectBindingPattern};
 use biome_rowan::{declare_node_union, AstNode, AstSeparatedList};
 
@@ -40,6 +41,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-empty-pattern")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{ident, js_call_argument_list, js_call_arguments, js_name, token};
 use biome_js_syntax::{
     AnyJsExpression, AnyJsFunctionBody, AnyJsMemberExpression, AnyJsName, AnyJsStatement,
@@ -39,6 +40,7 @@ declare_lint_rule! {
         name: "noFlatMapIdentity",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Clippy("flat_map_identity")],
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_global_object_calls.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_global_object_calls.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{global_identifier, AnyJsExpression, JsCallExpression, JsNewExpression};
 use biome_rowan::{declare_node_union, SyntaxResult, TextRange};
 use std::{fmt::Display, str::FromStr};
@@ -89,6 +90,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-obj-calls")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_inner_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_inner_declarations.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsDeclaration, JsFileSource, JsStatementList, JsSyntaxKind};
 use biome_rowan::AstNode;
 
@@ -93,6 +94,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-inner-declarations")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_builtin_instantiation.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     global_identifier, static_value::StaticValue, AnyJsExpression, JsCallExpression,
@@ -79,6 +80,7 @@ declare_lint_rule! {
             RuleSource::Eslint("no-new-native-nonconstructor"),
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_constructor_super.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_constructor_super.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClass, AnyJsExpression, JsAssignmentOperator, JsConstructorClassMember, JsLogicalOperator,
 };
@@ -51,6 +52,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("constructor-super")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -1,6 +1,7 @@
 use crate::{services::control_flow::AnyJsControlFlowRoot, services::semantic::SemanticServices};
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     binding_ext::{AnyJsBindingDeclaration, AnyJsIdentifierBinding},
     AnyJsExportNamedSpecifier, AnyJsIdentifierUsage,
@@ -66,6 +67,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("no-use-before-define"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::JsStringLiteralExpression;
 use biome_rowan::{AstNode, BatchMutationExt, TextRange};
@@ -57,6 +58,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-nonoctal-decimal-escape")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_precision_loss.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_precision_loss.rs
@@ -4,6 +4,7 @@ use std::ops::RangeInclusive;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 
 use biome_js_syntax::numbers::split_into_radix_and_number;
 use biome_js_syntax::JsNumberLiteralExpression;
@@ -55,6 +56,7 @@ declare_lint_rule! {
             RuleSource::Clippy("lossy_float_literal")
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_render_return_value.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_render_return_value.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsCallExpression, JsExpressionStatement};
 use biome_rowan::AstNode;
 
@@ -34,6 +35,7 @@ declare_lint_rule! {
         name: "noRenderReturnValue",
         language: "jsx",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_self_assign.rs
@@ -1,6 +1,7 @@
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     inner_string_text, AnyJsArrayAssignmentPatternElement, AnyJsArrayElement, AnyJsAssignment,
     AnyJsAssignmentPattern, AnyJsExpression, AnyJsLiteralExpression, AnyJsName,
@@ -72,6 +73,7 @@ declare_lint_rule! {
             RuleSource::Clippy("self_assignment"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_setter_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_setter_return.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsReturnStatement, JsSetterClassMember, JsSetterObjectMember};
 use biome_rowan::{declare_node_union, AstNode};
 
@@ -70,6 +71,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-setter-return")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::*;
 use biome_rowan::{declare_node_union, AstNode, AstSeparatedList, BatchMutationExt};
@@ -39,6 +40,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Clippy("match_str_case_mismatch")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_switch_declarations.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsDeclaration, AnyJsStatement, AnyJsSwitchClause, JsVariableStatement, TriviaPieceKind, T,
@@ -74,6 +75,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-case-declarations")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_unnecessary_continue.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unnecessary_continue.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsContinueStatement, JsLabeledStatement, JsSyntaxKind, JsSyntaxNode};
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -73,6 +74,7 @@ declare_lint_rule! {
         name: "noUnnecessaryContinue",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
@@ -1,10 +1,12 @@
 use std::{cmp::Ordering, collections::VecDeque, num::NonZeroU32, vec::IntoIter};
 
+use crate::services::control_flow::{ControlFlowGraph, JsControlFlowGraph};
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
     ExceptionHandler, ExceptionHandlerKind, Instruction, InstructionKind,
 };
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     JsBlockStatement, JsCaseClause, JsDefaultClause, JsDoWhileStatement, JsForInStatement,
     JsForOfStatement, JsForStatement, JsFunctionBody, JsIfStatement, JsLabeledStatement,
@@ -14,8 +16,6 @@ use biome_js_syntax::{
 use biome_rowan::{declare_node_union, AstNode, NodeOrToken};
 use roaring::bitmap::RoaringBitmap;
 use rustc_hash::FxHashMap;
-
-use crate::services::control_flow::{ControlFlowGraph, JsControlFlowGraph};
 
 declare_lint_rule! {
     /// Disallow unreachable code
@@ -53,6 +53,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unreachable")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
@@ -4,6 +4,7 @@ use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
     ExceptionHandlerKind, InstructionKind,
 };
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClass, AnyJsExpression, JsCallExpression, JsConstructorClassMember, JsSyntaxKind,
     JsThrowStatement, TextRange, WalkEvent,
@@ -67,6 +68,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-this-before-super")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unsafe_finally.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unsafe_finally.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::*;
 use biome_rowan::{declare_node_union, AstNode};
 
@@ -130,6 +131,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unsafe-finally")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unsafe_optional_chaining.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsAssignmentPattern, AnyJsBindingPattern, AnyJsOptionalChainExpression,
     JsArrayAssignmentPatternElement, JsAssignmentExpression, JsAwaitExpression, JsCallExpression,
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unsafe-optional-chaining")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_labels.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     RuleSource, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsStatement, JsBreakStatement, JsContinueStatement, JsFileSource, JsLabeledStatement,
     JsLanguage, TextRange, WalkEvent,
@@ -64,6 +65,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unused-labels")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_elements_with_children.rs
@@ -4,6 +4,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{jsx_attribute_list, jsx_self_closing_element};
 use biome_js_syntax::{
     AnyJsxAttribute, JsCallExpression, JsPropertyObjectMember, JsxAttribute, JsxElement,
@@ -35,6 +36,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("void-dom-elements-no-children")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }
@@ -43,27 +45,13 @@ declare_node_union! {
     pub NoVoidElementsWithChildrenQuery = JsxElement | JsCallExpression | JsxSelfClosingElement
 }
 
+const VOID_ELEMENTS: [&str; 16] = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "menuitem",
+    "meta", "param", "source", "track", "wbr",
+];
 /// Returns true if the name of the element belong to a self-closing element
 fn is_void_dom_element(element_name: &str) -> bool {
-    matches!(
-        element_name,
-        "area"
-            | "base"
-            | "br"
-            | "col"
-            | "embed"
-            | "hr"
-            | "img"
-            | "input"
-            | "keygen"
-            | "link"
-            | "menuitem"
-            | "meta"
-            | "param"
-            | "source"
-            | "track"
-            | "wbr"
-    )
+    VOID_ELEMENTS.contains(&element_name)
 }
 
 pub enum NoVoidElementsWithChildrenCause {

--- a/crates/biome_js_analyze/src/lint/correctness/no_void_type_return.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_void_type_return.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, AnyTsReturnType, JsArrowFunctionExpression, JsFunctionDeclaration,
     JsFunctionExportDefaultDeclaration, JsFunctionExpression, JsGetterClassMember,
@@ -90,6 +91,7 @@ declare_lint_rule! {
         name: "noVoidTypeReturn",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -64,6 +65,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("use-isnan")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_analyze::{RuleSource, RuleSourceKind};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsFunctionBody, AnyJsMemberExpression, AnyJsObjectMember, AnyJsxAttribute,
@@ -42,6 +43,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintReact("jsx-key")],
         source_kind: RuleSourceKind::SameLogic,
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/use_valid_for_direction.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_valid_for_direction.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, JsAssignmentOperator, JsBinaryOperator, JsForStatement,
     JsIdentifierAssignment, JsIdentifierExpression, JsPostUpdateOperator, JsUnaryOperator,
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("for-direction")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/use_yield.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_yield.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyFunctionLike, JsLanguage, JsYieldExpression, TextRange, WalkEvent};
 use biome_rowan::{AstNode, AstNodeList, Language, SyntaxNode, TextSize};
 
@@ -42,6 +43,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("require-yield")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_duplicate_else_if.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsExpression, JsIfStatement, JsLogicalOperator};
 use biome_rowan::{AstNode, SyntaxNodeCast, TextRange};
 
@@ -51,6 +52,7 @@ declare_lint_rule! {
         name: "noDuplicateElseIf",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::Eslint("no-dupe-else-if")],
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_regex.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsRegexLiteralExpression, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::{AstNode, BatchMutationExt, TextRange, TextSize};
 
@@ -44,6 +45,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-useless-escape")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_aria_props_supported_by_role.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_aria_props_supported_by_role.rs
@@ -1,6 +1,7 @@
 use crate::services::aria::Aria;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_rowan::AstNode;
 
@@ -37,6 +38,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintJsxA11y("role-supports-aria-props")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_member_accessibility.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_member_accessibility.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClassMemberName, JsConstructorClassMember, JsGetterClassMember, JsMethodClassMember,
     JsPropertyClassMember, JsSetterClassMember, TsAccessibilityModifier,
@@ -217,6 +218,7 @@ declare_lint_rule! {
         name: "useConsistentMemberAccessibility",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintTypeScript("explicit-member-accessibility")],
     }
 }

--- a/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_strict_mode.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     RuleDiagnostic,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{JsScript, JsSyntaxKind, JsSyntaxToken, T};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt};
@@ -39,6 +40,7 @@ declare_lint_rule! {
         name: "useStrictMode",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_accumulating_spread.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     AnyJsFunction, AnyJsMemberExpression, JsCallArgumentList, JsCallArguments, JsCallExpression,
@@ -50,6 +51,7 @@ declare_lint_rule! {
         name: "noAccumulatingSpread",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/performance/no_delete.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_delete.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsAssignmentPattern, AnyJsExpression, JsComputedMemberExpressionFields,
@@ -60,6 +61,7 @@ declare_lint_rule! {
         name: "noDelete",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsxAttributeName, JsCallExpression, JsxAttribute};
 use biome_rowan::{declare_node_union, AstNode, TextRange};
 
@@ -31,6 +32,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-danger")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     JsCallExpression, JsPropertyObjectMember, JsSyntaxNode, JsxAttribute, JsxElement,
@@ -40,6 +41,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-danger-with-children")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/security/no_global_eval.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_global_eval.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{global_identifier, AnyJsExpression};
 use biome_rowan::AstNode;
 
@@ -55,6 +56,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-eval")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/style/no_arguments.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_arguments.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::SemanticServices;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::TextRange;
 
 declare_lint_rule! {
@@ -30,6 +31,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-rest-params")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/style/no_comma_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_comma_operator.rs
@@ -1,5 +1,6 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsForStatement, JsSequenceExpression};
 use biome_rowan::AstNode;
 
@@ -42,6 +43,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-sequences")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, AnyTsPropertyAnnotation, AnyTsVariableAnnotation, JsFormalParameter,
     JsInitializerClause, JsPropertyClassMember, JsSyntaxKind, JsVariableDeclaration,
@@ -98,6 +99,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-inferrable-types")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_non_null_assertion.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, TsNonNullAssertionAssignment, TsNonNullAssertionExpression, T,
@@ -49,6 +50,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-non-null-assertion")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::{AllBindingWriteReferencesIter, Reference, ReferencesExtensions};
 use biome_js_syntax::{AnyJsBinding, AnyJsBindingPattern, AnyJsFormalParameter, AnyJsParameter};
 use biome_rowan::AstNode;
@@ -59,6 +60,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-param-reassign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsTemplateElement, JsTemplateExpression,
@@ -42,6 +43,7 @@ declare_lint_rule! {
         name: "noUnusedTemplateLiteral",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_useless_else.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
     RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsStatement, JsIfStatement, JsStatementList, JsSyntaxKind};
 use biome_rowan::{
@@ -94,6 +95,7 @@ declare_lint_rule! {
         ],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/no_var.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_var.rs
@@ -5,6 +5,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsVariableDeclaration, JsModule, JsScript, JsSyntaxKind, TsGlobalDeclaration,
@@ -41,6 +42,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-var")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_as_const_assertion.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyTsName, AnyTsType, JsInitializerClause,
@@ -49,6 +50,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("prefer-as-const")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_const.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_const.rs
@@ -6,6 +6,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 
 use biome_js_factory::make;
 use biome_js_semantic::{ReferencesExtensions, Scope, SemanticModel, SemanticScopeExtensions};
@@ -78,6 +79,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-const")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_default_parameter_last.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsFormalParameter, JsInitializerClause, JsSyntaxToken, TsPropertyParameter};
 use biome_rowan::{declare_node_union, AstNode, BatchMutationExt, Direction};
 
@@ -56,6 +57,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("default-param-last")
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_enum_initializers.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsExpression, AnyJsLiteralExpression, JsSyntaxKind, TsEnumDeclaration};
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("prefer-enum-initializers")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_exponentiation_operator.rs
@@ -3,6 +3,7 @@ use crate::JsRuleAction;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::{make, syntax::T};
 use biome_js_syntax::{
     global_identifier, AnyJsCallArgument, AnyJsExpression, AnyJsMemberExpression, JsBinaryOperator,
@@ -58,6 +59,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-exponentiation-operator")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_export_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_export_type.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExportNamedSpecifier, JsExportNamedClause, JsExportNamedFromClause, JsFileSource,
@@ -67,6 +68,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintTypeScript("consistent-type-exports")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_import_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_import_type.rs
@@ -8,6 +8,7 @@ use biome_analyze::{
     RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
@@ -116,6 +117,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintTypeScript("consistent-type-imports")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_literal_enum_members.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, AnyJsMemberExpression, JsUnaryOperator,
     TsEnumDeclaration,
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("prefer-literal-enum-member")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_nodejs_import_protocol.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{inner_string_text, AnyJsImportLike, JsSyntaxKind, JsSyntaxToken};
 use biome_rowan::BatchMutationExt;
 
@@ -53,6 +54,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintUnicorn("prefer-node-protocol")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     global_identifier, static_value::StaticValue, AnyJsExpression, JsUnaryExpression,
@@ -70,6 +71,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintUnicorn("prefer-number-properties")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
@@ -3,6 +3,7 @@ use crate::{ast_utils, JsRuleAction};
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -59,6 +60,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-numeric-literals")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsxTag, JsSyntaxToken, JsxElement, JsxOpeningElementFields, T};
 use biome_rowan::{AstNode, AstNodeList, BatchMutationExt, TriviaPiece};
@@ -89,6 +90,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintStylistic("jsx-self-closing-comp")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_function_type.rs
@@ -2,6 +2,7 @@ use crate::JsRuleAction;
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_factory::make::ts_type_alias_declaration;
 use biome_js_syntax::AnyTsType::TsThisType;
@@ -81,6 +82,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("prefer-function-type")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_single_var_declarator.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     JsSyntaxKind, JsSyntaxToken, JsVariableDeclarationFields, JsVariableStatement,
@@ -45,6 +46,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("one-var")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_template.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_template.rs
@@ -1,6 +1,7 @@
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::AnyJsTemplateElement;
 use biome_js_syntax::{
@@ -50,6 +51,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("prefer-template")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/style/use_while.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_while.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsStatement, JsForStatement, T};
 use biome_rowan::{trim_leading_trivia_pieces, AstNode, BatchMutationExt};
@@ -42,6 +43,7 @@ declare_lint_rule! {
         name: "useWhile",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintSonarJs("prefer-while")],
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_approximative_numeric_constant.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     numbers::split_into_radix_and_number, AnyJsExpression, AnyJsLiteralExpression,
@@ -47,6 +48,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Clippy("approx_constant")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -3,6 +3,7 @@ use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsFunction, AnyJsMemberExpression, AnyJsTemplateElement,
     JsBinaryExpression, JsCallArgumentList, JsCallArguments, JsCallExpression, JsFormalParameter,
@@ -69,6 +70,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-array-index-key")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_assign_in_expressions.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     JsAssignmentExpression, JsExpressionStatement, JsForStatement, JsParenthesizedExpression,
     JsSequenceExpression,
@@ -48,6 +49,7 @@ declare_lint_rule! {
         sources: &[RuleSource::Eslint("no-cond-assign")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_async_promise_executor.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_async_promise_executor.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsCallArgument, AnyJsExpression, AnyJsFunction, JsNewExpression, JsNewExpressionFields,
 };
@@ -44,6 +45,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-async-promise-executor")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_catch_assign.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::JsCatchClause;
 use biome_rowan::{AstNode, TextRange};
@@ -40,6 +41,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-ex-assign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_class_assign.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::{Reference, ReferencesExtensions};
 use biome_js_syntax::AnyJsClass;
 
@@ -71,6 +72,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-class-assign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsxChild, JsSyntaxKind, JsSyntaxToken, JsxText};
 use biome_rowan::{AstNode, BatchMutationExt, TextRange, TextSize};
@@ -73,6 +74,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("jsx-no-comment-textnodes")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_compare_neg_zero.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsBinaryExpression, JsSyntaxKind, JsUnaryOperator,
@@ -38,6 +39,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-compare-neg-zero")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_confusing_labels.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_confusing_labels.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource, RuleSourceKind};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsStatement, JsFileSource, JsLabeledStatement};
 
 declare_lint_rule! {
@@ -62,6 +63,7 @@ declare_lint_rule! {
         sources: &[RuleSource::Eslint("no-labels")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_confusing_void_type.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_diagnostics::Applicability;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyTsType, JsSyntaxKind, JsSyntaxNode, TsConditionalType, TsVoidType, T};
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -63,6 +64,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-invalid-void-type")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_const_enum.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_const_enum.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::TsEnumDeclaration;
 use biome_rowan::{chain_trivia_pieces, trim_leading_trivia_pieces, AstNode, BatchMutationExt};
 
@@ -39,6 +40,7 @@ declare_lint_rule! {
         name: "noConstEnum",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_control_characters_in_regex.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     static_value::StaticValue, AnyJsExpression, JsCallArguments, JsCallExpression, JsNewExpression,
     JsRegexLiteralExpression,
@@ -65,6 +66,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-control-regex")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_debugger.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::JsDebuggerStatement;
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -30,6 +31,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-debugger")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
@@ -2,6 +2,7 @@ use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsExpression, AnyJsLiteralExpression, JsBinaryExpression, T};
 use biome_js_syntax::{JsSyntaxKind::*, JsSyntaxToken};
@@ -79,6 +80,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("eqeqeq")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_case.rs
@@ -1,6 +1,7 @@
 use crate::utils::is_node_equal;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsExpression, AnyJsSwitchClause, JsSwitchStatement};
 use biome_rowan::{AstNode, TextRange};
 
@@ -86,6 +87,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-duplicate-case")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
@@ -1,5 +1,6 @@
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClassMemberName, JsClassMemberList, JsGetterClassMember, JsMethodClassMember,
     JsPropertyClassMember, JsSetterClassMember, JsStaticModifier, JsSyntaxList, TextRange,
@@ -93,6 +94,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("no-dupe-class-members")
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::jsx_ext::AnyJsxElement;
 use biome_js_syntax::{AnyJsxAttribute, JsxAttribute};
 use biome_rowan::AstNode;
@@ -36,6 +37,7 @@ declare_lint_rule! {
         language: "jsx",
         sources: &[RuleSource::EslintReact("jsx-no-duplicate-props")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -2,6 +2,7 @@ use crate::utils::batch::JsBatchMutation;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsObjectMember, JsGetterObjectMember, JsObjectExpression, JsSetterObjectMember,
 };
@@ -60,6 +61,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-dupe-keys")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_parameters.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_parameters.rs
@@ -1,6 +1,7 @@
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::parameter_ext::{AnyJsParameterList, AnyJsParameters, AnyParameter};
 use biome_js_syntax::{
     AnyJsArrayBindingPatternElement, AnyJsBinding, AnyJsBindingPattern,
@@ -43,6 +44,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-dupe-args")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor, VisitorContext,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsExpression, JsCallExpression, JsLanguage, TextRange};
 use biome_rowan::{AstNode, Language, SyntaxNode, WalkEvent};
 
@@ -61,6 +62,7 @@ declare_lint_rule! {
         name: "noDuplicateTestHooks",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintJest("no-duplicate-hooks")],
         source_kind: RuleSourceKind::Inspired,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_empty_interface.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource, RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::{
     make,
     syntax::{AnyTsType, T},
@@ -52,6 +53,7 @@ declare_lint_rule! {
         sources: &[RuleSource::EslintTypeScript("no-empty-interface")],
         source_kind: RuleSourceKind::Inspired,
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_explicit_any.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_explicit_any.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{TsAnyType, TsTypeConstraintClause};
 use biome_rowan::AstNode;
 
@@ -57,6 +58,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-explicit-any")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     RuleDiagnostic, RuleSource, RuleSourceKind, ServiceBag, Visitor,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     assign_ext::AnyJsMemberAssignment, AnyJsExpression, AnyJsRoot, JsAssignmentExpression,
     JsCallExpression, JsExport, JsLanguage,
@@ -41,6 +42,7 @@ declare_lint_rule! {
         name: "noExportsInTest",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintJest("no-export")],
         source_kind: RuleSourceKind::Inspired,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_extra_non_null_assertion.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsExpression, JsSyntaxKind, TsNonNullAssertionAssignment,
     TsNonNullAssertionExpression,
@@ -51,6 +52,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-extra-non-null-assertion")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_fallthrough_switch_clause.rs
@@ -6,6 +6,7 @@ use biome_control_flow::{
     builder::{BlockId, ROOT_BLOCK_ID},
     ExceptionHandlerKind, InstructionKind,
 };
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsDefaultClause, JsLanguage, JsSwitchStatement, JsSyntaxNode};
 use biome_rowan::{AstNode, AstNodeList, TextRange, WalkEvent};
 use roaring::RoaringBitmap;
@@ -60,6 +61,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-fallthrough")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
@@ -4,6 +4,7 @@ use biome_analyze::{
     RuleSourceKind,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{JsCallExpression, TextRange};
 use biome_rowan::{AstNode, BatchMutationExt, NodeOrToken};
@@ -36,6 +37,7 @@ declare_lint_rule! {
         name: "noFocusedTests",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         sources: &[RuleSource::EslintJest("no-focused-tests")],
         source_kind: RuleSourceKind::Inspired,
         fix_kind: FixKind::Unsafe,

--- a/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_function_assign.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::{Reference, ReferencesExtensions};
 use biome_js_syntax::{JsFunctionDeclaration, JsIdentifierBinding};
 use biome_rowan::AstNode;
@@ -99,6 +100,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-func-assign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_assign.rs
@@ -4,6 +4,7 @@ use crate::services::semantic::SemanticServices;
 use biome_analyze::RuleSource;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsSyntaxKind, TextRange};
 
 declare_lint_rule! {
@@ -44,6 +45,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-global-assign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_finite.rs
@@ -1,6 +1,7 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{global_identifier, AnyJsExpression, T};
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -31,6 +32,7 @@ declare_lint_rule! {
         name: "noGlobalIsFinite",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_global_is_nan.rs
@@ -1,6 +1,7 @@
 use crate::{services::semantic::Semantic, JsRuleAction};
 use biome_analyze::{context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{global_identifier, AnyJsExpression, T};
 use biome_rowan::{AstNode, BatchMutationExt};
@@ -32,6 +33,7 @@ declare_lint_rule! {
         name: "noGlobalIsNan",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_implicit_any_let.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_implicit_any_let.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsFileSource, JsVariableDeclaration, JsVariableDeclarator};
 
 declare_lint_rule! {
@@ -38,6 +39,7 @@ declare_lint_rule! {
         name: "noImplicitAnyLet",
         language: "ts",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_import_assign.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::{AnyJsImportSpecifier, JsIdentifierAssignment, JsIdentifierBinding};
 
@@ -52,6 +53,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-import-assign")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_label_var.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsLabeledStatement, JsSyntaxNode, JsSyntaxToken};
 use biome_rowan::AstNode;
 
@@ -28,6 +29,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-label-var")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     global_identifier, static_value::StaticValue, AnyJsCallArgument, AnyJsExpression,
@@ -64,6 +65,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-misleading-character-class")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_instantiator.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClassMember, AnyTsType, AnyTsTypeMember, ClassMemberName, JsClassDeclaration,
     JsSyntaxToken, TsDeclareStatement, TsInterfaceDeclaration, TsReferenceType,
@@ -54,6 +55,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-misused-new")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsExpression, JsAssignmentExpression, JsAssignmentOperator, JsBinaryExpression,
 };
@@ -53,6 +54,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Clippy("misrefactored_assign_op")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make::{self};
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
@@ -60,6 +61,7 @@ declare_lint_rule! {
             RuleSource::Eslint("prefer-object-has-own")
         ],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -2,6 +2,7 @@ use crate::services::semantic::SemanticServices;
 use biome_analyze::{context::RuleContext, Rule, RuleDiagnostic};
 use biome_analyze::{declare_lint_rule, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_semantic::Scope;
 use biome_js_syntax::binding_ext::AnyJsBindingDeclaration;
 use biome_js_syntax::{JsSyntaxKind, TextRange};
@@ -67,6 +68,7 @@ declare_lint_rule! {
             RuleSource::EslintTypeScript("no-redeclare"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redundant_use_strict.rs
@@ -1,6 +1,7 @@
 use crate::JsRuleAction;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClass, JsDirective, JsDirectiveList, JsFileSource, JsFunctionBody, JsModule, JsScript,
 };
@@ -84,6 +85,7 @@ declare_lint_rule! {
         name: "noRedundantUseStrict",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_self_compare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_self_compare.rs
@@ -1,6 +1,7 @@
 use crate::utils::is_node_equal;
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
+use biome_diagnostics::Severity;
 use biome_js_syntax::JsBinaryExpression;
 use biome_rowan::AstNode;
 
@@ -33,6 +34,7 @@ declare_lint_rule! {
             RuleSource::Clippy("eq_op"),
         ],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::JsIdentifierBinding;
 use biome_rowan::AstNode;
 
@@ -38,6 +39,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-shadow-restricted-names")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_sparse_array.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsArrayElement, AnyJsExpression, JsArrayExpression, TriviaPieceKind};
 use biome_rowan::{AstNode, AstNodeExt, AstSeparatedList, BatchMutationExt};
@@ -24,6 +25,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-sparse-arrays")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsxTag, JsxChildList};
 use biome_rowan::{AstNodeList, TextRange};
 
@@ -47,6 +48,7 @@ declare_lint_rule! {
         name: "noSuspiciousSemicolonInJsx",
         language: "js",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
@@ -1,6 +1,7 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic};
 use biome_analyze::{Ast, RuleSource};
 use biome_console::{markup, MarkupBuf};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsArrayElement, AnyJsAssignment, AnyJsAssignmentPattern, AnyJsCallArgument,
     AnyJsDeclarationClause, AnyJsExportClause, AnyJsExportNamedSpecifier, AnyJsExpression,
@@ -88,6 +89,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintUnicorn("no-thenable")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_declaration_merging.rs
@@ -1,6 +1,7 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{binding_ext::AnyJsBindingDeclaration, TsInterfaceDeclaration};
 use biome_rowan::{AstNode, TextRange};
 
@@ -46,6 +47,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("no-unsafe-declaration-merging")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{is_negation, AnyJsExpression, JsInExpression, JsInstanceofExpression};
 use biome_rowan::{declare_node_union, AstNode, AstNodeExt, BatchMutationExt};
@@ -37,6 +38,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("no-unsafe-negation")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_default_switch_clause_last.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_default_switch_clause_last.rs
@@ -1,6 +1,7 @@
 use biome_analyze::context::RuleContext;
 use biome_analyze::{declare_lint_rule, Ast, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsCaseClause, JsDefaultClause};
 use biome_rowan::{AstNode, Direction};
 
@@ -75,6 +76,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("default-case-last")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_getter_return.rs
@@ -2,6 +2,7 @@ use crate::ControlFlowGraph;
 use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
 use biome_console::markup;
 use biome_control_flow::{builder::ROOT_BLOCK_ID, ExceptionHandlerKind, InstructionKind};
+use biome_diagnostics::Severity;
 use biome_js_syntax::{JsGetterClassMember, JsGetterObjectMember, JsReturnStatement};
 use biome_rowan::{AstNode, NodeOrToken, TextRange};
 use roaring::RoaringBitmap;
@@ -63,6 +64,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("getter-return")],
         recommended: true,
+        severity: Severity::Error,
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_is_array.rs
@@ -3,6 +3,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     global_identifier, AnyJsCallArgument, AnyJsExpression, JsInstanceofExpression, T,
@@ -41,6 +42,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::EslintUnicorn("no-instanceof-array")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_namespace_keyword.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{JsSyntaxToken, TsModuleDeclaration, T};
 use biome_rowan::BatchMutationExt;
@@ -45,6 +46,7 @@ declare_lint_rule! {
         language: "ts",
         sources: &[RuleSource::EslintTypeScript("prefer-namespace-keyword")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Safe,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/use_valid_typeof.rs
@@ -2,6 +2,7 @@ use biome_analyze::{
     context::RuleContext, declare_lint_rule, Ast, FixKind, Rule, RuleDiagnostic, RuleSource,
 };
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsExpression, AnyJsLiteralExpression, JsBinaryExpression, JsBinaryExpressionFields,
@@ -74,6 +75,7 @@ declare_lint_rule! {
         language: "js",
         sources: &[RuleSource::Eslint("valid-typeof")],
         recommended: true,
+        severity: Severity::Error,
         fix_kind: FixKind::Unsafe,
     }
 }

--- a/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -1,5 +1,6 @@
 use biome_analyze::{context::RuleContext, declare_lint_rule, Ast, Rule, RuleDiagnostic};
 use biome_console::markup;
+use biome_diagnostics::Severity;
 use biome_json_syntax::{JsonMemberName, JsonObjectValue, TextRange};
 use biome_rowan::{AstNode, AstSeparatedList};
 use rustc_hash::FxHashMap;
@@ -31,6 +32,7 @@ declare_lint_rule! {
         name: "noDuplicateObjectKeys",
         language: "json",
         recommended: true,
+        severity: Severity::Error,
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/biomejs/biome/issues/4626

This PR:
- adds `severity` to the `RuleMeta`
- adds a custom `severity` to only recommended rules. The reason why I did this refactor was because we don't know yet which rules will  be an error, a warning or an information, but as for now all the recommended rules we have, are supposed to raise an error, this isn't, technically, a breaking change

Of course, this is just a facade change because `severity` isn't used yet. We will follow up with another PR to change the codegen

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current CI should pass

<!-- What demonstrates that your implementation is correct? -->
