### PR TITLE
feat(useExplicitType): support explicit function argument types

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -147,6 +147,14 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "@typescript-eslint/explicit-module-boundary-types" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group.use_explicit_type.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/naming-convention" => {
             if !options.include_inspired {
                 results.has_inspired_rules = true;

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3422,7 +3422,7 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_deprecated_reason:
         Option<RuleConfiguration<biome_graphql_analyze::options::UseDeprecatedReason>>,
-    #[doc = "Require explicit return types on functions and class methods."]
+    #[doc = "Require explicit argument and return types on functions and class methods."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_explicit_type: Option<RuleConfiguration<biome_js_analyze::options::UseExplicitType>>,
     #[doc = "Enforces the use of a recommended display strategy with Google Fonts."]

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
@@ -121,3 +121,47 @@ declare namespace myLib {
 declare module "foo" {
 	export default function bar();
 }
+
+export default (a): void => {
+	return;
+};
+export function test(a: number, b) {
+	return;
+}
+
+class Human {
+	private name: string;
+
+	public toString(this): string {
+		return `Name ${this.name}`;
+	}
+}
+
+interface Array<Type> {
+	pop(): Type | undefined;
+	push(...items): number;
+}
+
+type MyObject = {
+	(input);
+	propertyName: string;
+};
+
+export function test({ a, b }): string {
+	return;
+}
+
+declare module "foo" {
+	export default function bar(a): string;
+}
+
+declare namespace myLib {
+	function makeGreeting(s): string;
+}
+
+export class Test {
+	constructor(a) {}
+	method(a): void {
+		return;
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
@@ -129,6 +129,50 @@ declare module "foo" {
 	export default function bar();
 }
 
+export default (a): void => {
+	return;
+};
+export function test(a: number, b) {
+	return;
+}
+
+class Human {
+	private name: string;
+
+	public toString(this): string {
+		return `Name ${this.name}`;
+	}
+}
+
+interface Array<Type> {
+	pop(): Type | undefined;
+	push(...items): number;
+}
+
+type MyObject = {
+	(input);
+	propertyName: string;
+};
+
+export function test({ a, b }): string {
+	return;
+}
+
+declare module "foo" {
+	export default function bar(a): string;
+}
+
+declare namespace myLib {
+	function makeGreeting(s): string;
+}
+
+export class Test {
+	constructor(a) {}
+	method(a): void {
+		return;
+	}
+}
+
 ```
 
 # Diagnostics
@@ -704,6 +748,229 @@ invalid.ts:122:17 lint/nursery/useExplicitType ━━━━━━━━━━━
   i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
   
   i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:125:17 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    123 │ }
+    124 │ 
+  > 125 │ export default (a): void => {
+        │                 ^
+    126 │ 	return;
+    127 │ };
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:128:8 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    126 │ 	return;
+    127 │ };
+  > 128 │ export function test(a: number, b) {
+        │        ^^^^^^^^^^^^^
+    129 │ 	return;
+    130 │ }
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:128:33 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'b' should be typed.
+  
+    126 │ 	return;
+    127 │ };
+  > 128 │ export function test(a: number, b) {
+        │                                 ^
+    129 │ 	return;
+    130 │ }
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:135:18 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'this' should be typed.
+  
+    133 │ 	private name: string;
+    134 │ 
+  > 135 │ 	public toString(this): string {
+        │ 	                ^^^^
+    136 │ 		return `Name ${this.name}`;
+    137 │ 	}
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:142:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument '...items' should be typed.
+  
+    140 │ interface Array<Type> {
+    141 │ 	pop(): Type | undefined;
+  > 142 │ 	push(...items): number;
+        │ 	     ^^^^^^^^
+    143 │ }
+    144 │ 
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:146:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Missing return type on function.
+  
+    145 │ type MyObject = {
+  > 146 │ 	(input);
+        │ 	^^^^^^^^
+    147 │ 	propertyName: string;
+    148 │ };
+  
+  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalid.ts:146:3 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'input' should be typed.
+  
+    145 │ type MyObject = {
+  > 146 │ 	(input);
+        │ 	 ^^^^^
+    147 │ 	propertyName: string;
+    148 │ };
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:150:22 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument '{ a, b }' should be typed.
+  
+    148 │ };
+    149 │ 
+  > 150 │ export function test({ a, b }): string {
+        │                      ^^^^^^^^
+    151 │ 	return;
+    152 │ }
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:155:30 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    154 │ declare module "foo" {
+  > 155 │ 	export default function bar(a): string;
+        │ 	                            ^
+    156 │ }
+    157 │ 
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:159:24 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 's' should be typed.
+  
+    158 │ declare namespace myLib {
+  > 159 │ 	function makeGreeting(s): string;
+        │ 	                      ^
+    160 │ }
+    161 │ 
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:163:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    162 │ export class Test {
+  > 163 │ 	constructor(a) {}
+        │ 	            ^
+    164 │ 	method(a): void {
+    165 │ 		return;
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
+  
+
+```
+
+```
+invalid.ts:164:9 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Argument 'a' should be typed.
+  
+    162 │ export class Test {
+    163 │ 	constructor(a) {}
+  > 164 │ 	method(a): void {
+        │ 	       ^
+    165 │ 		return;
+    166 │ 	}
+  
+  i Declaring the argument types makes the code self-documenting and can speed up TypeScript type checking.
+  
+  i Add type annotations to the function arguments.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
@@ -43,10 +43,10 @@ const func = () => x as const;
 // check allow expressions
 node.addEventListener("click", () => {});
 node.addEventListener("click", function () {});
-const foo = arr.map((i) => i * i);
+const foo = arr.map((i: number) => i * i);
 fn(() => {});
 fn(function () {});
-new Promise((resolve) => {});
+new Promise((resolve: () => void) => {});
 new Foo(1, () => {});
 [function () {}, () => {}];
 (function () {
@@ -128,4 +128,19 @@ declare namespace myLib {
 
 declare module "foo" {
 	export default function bar(): string;
+}
+
+export default function test(obj: { a: string }): void {
+	return;
+}
+export function add(a: number, b: number): number {
+	return a + b;
+}
+
+class Human {
+	private name: string;
+
+	public toString(this: Human): string {
+		return `Name ${this.name}`;
+	}
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
@@ -50,10 +50,10 @@ const func = () => x as const;
 // check allow expressions
 node.addEventListener("click", () => {});
 node.addEventListener("click", function () {});
-const foo = arr.map((i) => i * i);
+const foo = arr.map((i: number) => i * i);
 fn(() => {});
 fn(function () {});
-new Promise((resolve) => {});
+new Promise((resolve: () => void) => {});
 new Foo(1, () => {});
 [function () {}, () => {}];
 (function () {
@@ -135,6 +135,21 @@ declare namespace myLib {
 
 declare module "foo" {
 	export default function bar(): string;
+}
+
+export default function test(obj: { a: string }): void {
+	return;
+}
+export function add(a: number, b: number): number {
+	return a + b;
+}
+
+class Human {
+	private name: string;
+
+	public toString(this: Human): string {
+		return `Name ${this.name}`;
+	}
 }
 
 ```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1395,7 +1395,7 @@ export interface Nursery {
 	 */
 	useDeprecatedReason?: RuleConfiguration_for_Null;
 	/**
-	 * Require explicit return types on functions and class methods.
+	 * Require explicit argument and return types on functions and class methods.
 	 */
 	useExplicitType?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2469,7 +2469,7 @@
 					]
 				},
 				"useExplicitType": {
-					"description": "Require explicit return types on functions and class methods.",
+					"description": "Require explicit argument and return types on functions and class methods.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
related: https://github.com/biomejs/biome/issues/2017

This PR adds support for enforcing explicit type annotations on arguments in all functions and class methods. The rule is inspired by the [ explicit-module-boundary-types](https://typescript-eslint.io/rules/explicit-module-boundary-types/) rule, but it expands coverage beyond exported functions to include all functions and methods within a class.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->


<!-- What demonstrates that your implementation is correct? -->
