### PR TITLE
chore: use `papaya` in `PathInterner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "directories",
  "enumflags2",
  "oxc_resolver",
+ "papaya",
  "parking_lot",
  "rayon",
  "rustc-hash 2.0.0",
@@ -2807,8 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "papaya"
-version = "0.1.4"
-source = "git+https://github.com/ibraheemdev/papaya#14351ec7059b8a98f8e41262b4f2db6fb396cd6b"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71addb3836918693eecf8aa0f1c578798246b12c4d1171a079c53433fad72706"
 dependencies = [
  "seize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ indexmap             = { version = "2.6.0" }
 insta                = "1.41.1"
 natord               = "1.0.9"
 oxc_resolver         = "1.12.0"
-papaya               = { git = "https://github.com/ibraheemdev/papaya" }
+papaya               = "0.1.5"
 proc-macro2          = "1.0.86"
 quickcheck           = "1.0.3"
 quickcheck_macros    = "1.0.0"

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam         = { workspace = true }
 directories       = "5.0.1"
 enumflags2        = { workspace = true, features = ["serde"] }
 oxc_resolver      = { workspace = true }
+papaya            = { workspace = true }
 parking_lot       = { version = "0.12.3", features = ["arc_lock"] }
 rayon             = { workspace = true }
 rustc-hash        = { workspace = true }

--- a/crates/biome_fs/src/interner.rs
+++ b/crates/biome_fs/src/interner.rs
@@ -1,13 +1,13 @@
 use crossbeam::channel::{unbounded, Receiver, Sender};
-use rustc_hash::FxHashSet;
+use papaya::HashSet;
+use rustc_hash::FxBuildHasher;
 use std::path::PathBuf;
-use std::sync::RwLock;
 
 /// File paths interner cache
 ///
 /// The path interner stores an instance of [PathBuf]
 pub struct PathInterner {
-    storage: RwLock<FxHashSet<PathBuf>>,
+    storage: HashSet<PathBuf, FxBuildHasher>,
     handler: Sender<PathBuf>,
 }
 
@@ -15,7 +15,7 @@ impl PathInterner {
     pub fn new() -> (Self, Receiver<PathBuf>) {
         let (send, recv) = unbounded();
         let interner = Self {
-            storage: RwLock::new(FxHashSet::default()),
+            storage: HashSet::default(),
             handler: send,
         };
 
@@ -25,7 +25,7 @@ impl PathInterner {
     /// Insert the path.
     /// Returns `true` if the path was not previously inserted.
     pub fn intern_path(&self, path: PathBuf) -> bool {
-        let result = self.storage.write().unwrap().insert(path.clone());
+        let result = self.storage.pin().insert(path.clone());
         if result {
             self.handler.send(path).ok();
         }


### PR DESCRIPTION
## Summary

Presumably `papaya` only offers "reasonable" performance for write-heavy workloads, although I can't imagine it faring any worse than a plain `RwLock`, so I just want to see how this works :)

Also 0.1.5 was released with the WASM fix.

## Test Plan

CI should remain green.
