### PR TITLE
refactor: cleaned up workspaceError enum in biome_service/diagnostics.rs

### DIFF
--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -165,16 +165,6 @@ impl From<CantLoadExtendFile> for WorkspaceError {
     }
 }
 
-
-#[derive(Debug, Serialize, Deserialize, Diagnostic)]
-#[diagnostic(
-    category = "internalError/fs",
-    message(
-        message("The report can't be serialized, here's why: "{self.reason}),
-        description = "The report can't be serialized, here's why: {reason}"
-    )
-)]
-
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(
     category = "internalError/fs",

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -180,7 +180,6 @@ pub struct NotFound;
 )]
 pub struct FormatWithErrorsDisabled;
 
-
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(
     category = "internalError/fs",
@@ -501,8 +500,7 @@ impl Advices for ProtectedFileAdvice {
 #[cfg(test)]
 mod test {
     use crate::diagnostics::{
-        CantReadFile, FileIgnored, FileTooLarge, NotFound,
-        SourceFileNotSupported,
+        CantReadFile, FileIgnored, FileTooLarge, NotFound, SourceFileNotSupported,
     };
     use crate::file_handlers::DocumentFileSource;
     use crate::{TransportError, WorkspaceError};


### PR DESCRIPTION
## Summary

closes #4668  

I have removed the following unused variants from the `WorkspaceError` enum:  
- `ReportNotSerializable`  
- `DirtyWorkspace`  
- `CantReadDirectory`  

The motivation behind these changes is to eliminate unused code, thereby reducing bloat and improving maintainability.  