### PR TITLE
chore: drop `slotmap` and simplify locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "slotmap",
  "smallvec",
  "tests_macros",
  "tracing",
@@ -3597,16 +3596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,6 @@ serde                = { version = "1.0.215", features = ["derive"] }
 serde_ini            = "0.2.0"
 serde_json           = "1.0.133"
 similar              = "2.6.0"
-slotmap              = "1.0.7"
 smallvec             = { version = "1.13.2", features = ["union", "const_new", "serde"] }
 syn                  = "1.0.109"
 termcolor            = "1.4.1"

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -67,7 +67,6 @@ rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
 serde_json               = { workspace = true, features = ["raw_value"] }
-slotmap                  = { workspace = true, features = ["serde"] }
 smallvec                 = { workspace = true, features = ["serde"] }
 tracing                  = { workspace = true, features = ["attributes", "log"] }
 

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -78,6 +78,10 @@ impl WorkspaceError {
         Self::NotFound(NotFound)
     }
 
+    pub fn no_project() -> Self {
+        Self::NoProject(NoProject)
+    }
+
     pub fn file_ignored(path: String) -> Self {
         Self::FileIgnored(FileIgnored { path })
     }

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -388,7 +388,7 @@ impl biome_console::fmt::Display for DocumentFileSource {
 pub struct FixAllParams<'a> {
     pub(crate) parse: AnyParse,
     pub(crate) fix_file_mode: FixFileMode,
-    pub(crate) workspace: WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: WorkspaceSettingsHandle,
     /// Whether it should format the code action
     pub(crate) should_format: bool,
     pub(crate) biome_path: &'a BiomePath,
@@ -447,7 +447,7 @@ pub struct DebugCapabilities {
 #[derive(Debug)]
 pub(crate) struct LintParams<'a> {
     pub(crate) parse: AnyParse,
-    pub(crate) workspace: &'a WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: &'a WorkspaceSettingsHandle,
     pub(crate) language: DocumentFileSource,
     pub(crate) max_diagnostics: u32,
     pub(crate) path: &'a BiomePath,
@@ -468,7 +468,7 @@ pub(crate) struct LintResults {
 pub(crate) struct CodeActionsParams<'a> {
     pub(crate) parse: AnyParse,
     pub(crate) range: Option<TextRange>,
-    pub(crate) workspace: &'a WorkspaceSettingsHandle<'a>,
+    pub(crate) workspace: &'a WorkspaceSettingsHandle,
     pub(crate) path: &'a BiomePath,
     pub(crate) manifest: Option<PackageJson>,
     pub(crate) language: DocumentFileSource,

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -12,7 +12,7 @@ pub mod dome;
 #[cfg(feature = "schema")]
 pub mod workspace_types;
 
-use std::ops::Deref;
+use std::{fs, ops::Deref, path::Path};
 
 use serde::{Deserialize, Serialize};
 
@@ -68,4 +68,10 @@ impl<'app> Deref for WorkspaceRef<'app> {
             WorkspaceRef::Borrowed(inner) => *inner,
         }
     }
+}
+
+/// Returns `true` if `path` is a directory or
+/// if it is a symlink that resolves to a directory.
+fn is_dir(path: &Path) -> bool {
+    path.is_dir() || (path.is_symlink() && fs::read_link(path).is_ok_and(|path| path.is_dir()))
 }

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -5,6 +5,7 @@ use biome_console::markup;
 use biome_diagnostics::Diagnostic;
 use papaya::HashMap;
 pub use pattern::{MatchOptions, Pattern, PatternError};
+use rustc_hash::FxBuildHasher;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -74,7 +75,7 @@ struct Inner {
     /// Check [glob website](https://docs.rs/glob/latest/glob/struct.MatchOptions.html) for [MatchOptions]
     options: MatchOptions,
     /// Cached results for matches.
-    already_checked: HashMap<String, bool>,
+    already_checked: HashMap<String, bool, FxBuildHasher>,
 }
 
 impl Inner {

--- a/crates/biome_service/src/matcher/mod.rs
+++ b/crates/biome_service/src/matcher/mod.rs
@@ -1,51 +1,100 @@
 pub mod pattern;
 
+use biome_configuration::BiomeDiagnostic;
 use biome_console::markup;
 use biome_diagnostics::Diagnostic;
+use papaya::HashMap;
 pub use pattern::{MatchOptions, Pattern, PatternError};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use crate::WorkspaceError;
 
 /// A data structure to use when there's need to match a string or a path a against
 /// a unix shell style patterns
-#[derive(Debug, Default)]
-pub struct Matcher {
-    root: Option<PathBuf>,
-    patterns: Vec<Pattern>,
-    options: MatchOptions,
-    /// Whether the string was already checked
-    already_checked: RwLock<HashMap<String, bool>>,
-}
+#[derive(Clone, Debug, Default)]
+pub struct Matcher(Arc<Inner>);
 
 impl Matcher {
-    /// Creates a new Matcher with given options.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Creates a [Matcher] from a set of globs.
     ///
+    /// ## Errors
+    ///
+    /// It can raise an error if the patterns aren't valid
+    pub fn from_globs(
+        working_directory: Option<PathBuf>,
+        globs: Option<&[Box<str>]>,
+    ) -> Result<Matcher, WorkspaceError> {
+        let mut matcher = Inner::default();
+        if let Some(working_directory) = working_directory {
+            matcher.set_root(working_directory)
+        }
+        if let Some(string_set) = globs {
+            for pattern in string_set {
+                matcher.add_pattern(pattern).map_err(|err| {
+                    BiomeDiagnostic::new_invalid_ignore_pattern(
+                        pattern.to_string(),
+                        err.msg.to_string(),
+                    )
+                })?;
+            }
+        }
+        Ok(Self(Arc::new(matcher)))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Matches the given string against the stored patterns.
+    ///
+    /// Returns [true] if there's at least one match.
+    pub fn matches(&self, source: &str) -> bool {
+        self.0.matches(source)
+    }
+
+    /// Matches the given path against the stored patterns.
+    ///
+    /// Returns [true] if there's at least one match.
+    pub fn matches_path(&self, source: &Path) -> bool {
+        self.0.matches_path(source)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Inner {
+    root: Option<PathBuf>,
+    patterns: Vec<Pattern>,
     /// Check [glob website](https://docs.rs/glob/latest/glob/struct.MatchOptions.html) for [MatchOptions]
-    pub fn new(options: MatchOptions) -> Self {
+    options: MatchOptions,
+    /// Cached results for matches.
+    already_checked: HashMap<String, bool>,
+}
+
+impl Inner {
+    /// Creates a new Matcher with given options.
+    #[cfg(test)]
+    fn new(options: MatchOptions) -> Self {
         Self {
             root: None,
             patterns: Vec::new(),
             options,
-            already_checked: RwLock::new(HashMap::default()),
+            already_checked: HashMap::default(),
         }
     }
 
-    pub fn empty() -> Self {
-        Self {
-            root: None,
-            patterns: Vec::new(),
-            options: MatchOptions::default(),
-            already_checked: RwLock::new(HashMap::default()),
-        }
-    }
-
-    pub fn set_root(&mut self, root: PathBuf) {
+    fn set_root(&mut self, root: PathBuf) {
         self.root = Some(root);
     }
 
     /// It adds a unix shell style pattern
-    pub fn add_pattern(&mut self, pattern: &str) -> Result<(), PatternError> {
+    fn add_pattern(&mut self, pattern: &str) -> Result<(), PatternError> {
         let pattern = Pattern::new(pattern)?;
         self.patterns.push(pattern);
         Ok(())
@@ -54,33 +103,33 @@ impl Matcher {
     /// It matches the given string against the stored patterns.
     ///
     /// It returns [true] if there's at least a match
-    pub fn matches(&self, source: &str) -> bool {
-        let mut already_ignored = self.already_checked.write().unwrap();
-        if let Some(matches) = already_ignored.get(source) {
+    fn matches(&self, source: &str) -> bool {
+        let already_checked = self.already_checked.pin();
+        if let Some(matches) = already_checked.get(source) {
             return *matches;
         }
         for pattern in &self.patterns {
             if pattern.matches_with(source, self.options) || source.contains(pattern.as_str()) {
-                already_ignored.insert(source.to_string(), true);
+                already_checked.insert(source.to_string(), true);
                 return true;
             }
         }
-        already_ignored.insert(source.to_string(), false);
+        already_checked.insert(source.to_string(), false);
         false
     }
 
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.patterns.is_empty()
     }
 
     /// It matches the given path against the stored patterns
     ///
     /// It returns [true] if there's at least one match
-    pub fn matches_path(&self, source: &Path) -> bool {
+    fn matches_path(&self, source: &Path) -> bool {
         if self.is_empty() {
             return false;
         }
-        let mut already_checked = self.already_checked.write().unwrap();
+        let already_checked = self.already_checked.pin();
         let source_as_string = source.to_str();
         if let Some(source_as_string) = source_as_string {
             if let Some(matches) = already_checked.get(source_as_string) {
@@ -136,14 +185,14 @@ impl Diagnostic for PatternError {
 #[cfg(test)]
 mod test {
     use crate::matcher::pattern::MatchOptions;
-    use crate::matcher::Matcher;
+    use crate::matcher::Inner;
     use std::env;
 
     #[test]
     fn matches() {
         let current = env::current_dir().unwrap();
         let dir = format!("{}/**/*.rs", current.display());
-        let mut ignore = Matcher::new(MatchOptions::default());
+        let mut ignore = Inner::new(MatchOptions::default());
         ignore.add_pattern(&dir).unwrap();
         let path = env::current_dir().unwrap().join("src/workspace.rs");
         let result = ignore.matches(path.to_str().unwrap());
@@ -155,7 +204,7 @@ mod test {
     fn matches_path() {
         let current = env::current_dir().unwrap();
         let dir = format!("{}/**/*.rs", current.display());
-        let mut ignore = Matcher::new(MatchOptions::default());
+        let mut ignore = Inner::new(MatchOptions::default());
         ignore.add_pattern(&dir).unwrap();
         let path = env::current_dir().unwrap().join("src/workspace.rs");
         let result = ignore.matches_path(path.as_path());
@@ -167,7 +216,7 @@ mod test {
     fn matches_path_for_single_file_or_directory_name() {
         let dir = "inv";
         let valid_test_dir = "valid/";
-        let mut ignore = Matcher::new(MatchOptions::default());
+        let mut ignore = Inner::new(MatchOptions::default());
         ignore.add_pattern(dir).unwrap();
         ignore.add_pattern(valid_test_dir).unwrap();
 
@@ -185,7 +234,7 @@ mod test {
     #[test]
     fn matches_single_path() {
         let dir = "workspace.rs";
-        let mut ignore = Matcher::new(MatchOptions {
+        let mut ignore = Inner::new(MatchOptions {
             require_literal_separator: true,
             case_sensitive: true,
             require_literal_leading_dot: true,

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::workspace::{DocumentFileSource, ProjectKey, WorkspaceData};
+use crate::workspace::{DocumentFileSource, ProjectKey};
 use crate::{Matcher, WorkspaceError};
 use biome_analyze::{AnalyzerOptions, AnalyzerRules};
 use biome_configuration::analyzer::assist::{Actions, AssistConfiguration};
@@ -29,25 +29,22 @@ use biome_html_formatter::HtmlFormatOptions;
 use biome_html_syntax::HtmlLanguage;
 use biome_js_formatter::context::JsFormatOptions;
 use biome_js_parser::JsParserOptions;
-use biome_js_syntax::{JsFileSource, JsLanguage};
+use biome_js_syntax::JsLanguage;
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use biome_project::{NodeJsProject, PackageJson};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use rustc_hash::FxHashMap;
+use papaya::HashMap;
 use std::borrow::Cow;
+use std::num::NonZeroU64;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::RwLockWriteGuard;
-use std::{
-    num::NonZeroU64,
-    sync::{RwLock, RwLockReadGuard},
-};
+use std::sync::RwLock;
 use tracing::trace;
 
-#[derive(Debug, Default)]
 /// The information tracked for each project
+#[derive(Debug, Default)]
 pub struct ProjectData {
     /// The root path of the project. This path should be **absolute**.
     path: BiomePath,
@@ -57,94 +54,102 @@ pub struct ProjectData {
     project: Option<NodeJsProject>,
 }
 
-#[derive(Debug, Default)]
 /// Type that manages different projects inside the workspace.
+#[derive(Debug, Default)]
 pub struct WorkspaceSettings {
-    /// The data of the projects
-    data: WorkspaceData<ProjectData>,
+    /// The data of the projects.
+    data: HashMap<ProjectKey, ProjectData>,
     /// The ID of the current project.
-    current_project: ProjectKey,
+    current_project: RwLock<ProjectKey>,
 }
 
 impl WorkspaceSettings {
     pub fn get_current_project_key(&self) -> ProjectKey {
-        self.current_project
-    }
-
-    pub fn get_current_project_data_mut(&mut self) -> &mut ProjectData {
-        self.data
-            .get_mut(self.current_project)
-            .expect("You must have at least one workspace.")
+        *self.current_project.read().unwrap()
     }
 
     /// Retrieves the settings of the current workspace folder
-    pub fn get_current_settings(&self) -> Option<&Settings> {
+    pub fn get_current_settings(&self) -> Option<Settings> {
         trace!("Current key {:?}", self.current_project);
-        let data = self.data.get(self.current_project);
-        if let Some(data) = data {
-            Some(&data.settings)
-        } else {
-            None
-        }
+        self.data
+            .pin()
+            .get(&self.get_current_project_key())
+            .map(|data| data.settings.clone())
     }
 
-    pub fn get_current_manifest(&self) -> Option<&PackageJson> {
-        let data = self.data.get(self.current_project);
-        if let Some(data) = data {
-            data.project.as_ref().map(|project| &project.manifest)
-        } else {
-            None
-        }
+    /// Sets the settings of the current workspace folder.
+    pub fn set_current_settings(&self, settings: Settings) {
+        let data = self.data.pin();
+        let project_key = self.get_current_project_key();
+        let Some(project_data) = data.get(&project_key) else {
+            return;
+        };
+
+        let project_data = ProjectData {
+            path: project_data.path.clone(),
+            settings,
+            project: project_data.project.clone(),
+        };
+
+        data.insert(project_key, project_data);
     }
 
-    /// Retrieves a mutable reference of the settings of the current project
-    pub fn get_current_settings_mut(&mut self) -> &mut Settings {
-        &mut self
-            .data
-            .get_mut(self.current_project)
-            .expect("You must have at least one workspace.")
-            .settings
+    /// Retrieves the files settings of the current workspace folder
+    pub fn get_current_files_settings(&self) -> Option<FilesSettings> {
+        trace!("Current key {:?}", self.current_project);
+        self.data
+            .pin()
+            .get(&self.get_current_project_key())
+            .map(|data| data.settings.files.clone())
     }
 
-    /// Register the current project using its unique key
-    pub fn register_current_project(&mut self, key: ProjectKey) {
-        self.current_project = key;
+    pub fn get_current_manifest(&self) -> Option<PackageJson> {
+        self.data
+            .pin()
+            .get(&self.get_current_project_key())
+            .and_then(|data| data.project.as_ref())
+            .map(|project| project.manifest.clone())
     }
 
-    /// Insert a new project using its folder. Use [WorkspaceSettings::get_current_settings_mut] to retrieve
-    /// a mutable reference to its [Settings] and manipulate them.
-    pub fn insert_project(&mut self, workspace_path: impl Into<PathBuf>) -> ProjectKey {
+    /// Inserts a new project using its folder.
+    pub fn insert_project(&self, workspace_path: impl Into<PathBuf>) -> ProjectKey {
         let path = BiomePath::new(workspace_path.into());
         trace!("Insert workspace folder: {:?}", path);
-        self.data.insert(ProjectData {
-            path,
-            settings: Settings::default(),
-            project: None,
-        })
+        let key = ProjectKey::new();
+        self.data.pin().insert(
+            key,
+            ProjectData {
+                path,
+                settings: Settings::default(),
+                project: None,
+            },
+        );
+        key
     }
 
-    pub fn insert_manifest(&mut self, manifest: NodeJsProject) {
-        let project_data = self.get_current_project_data_mut();
-        let _ = project_data.project.insert(manifest);
+    pub fn insert_manifest(&self, manifest: NodeJsProject) {
+        let data = self.data.pin();
+        let project_key = self.get_current_project_key();
+        let Some(project_data) = data.get(&project_key) else {
+            return;
+        };
+
+        let project_data = ProjectData {
+            path: project_data.path.clone(),
+            settings: project_data.settings.clone(),
+            project: Some(manifest),
+        };
+
+        data.insert(project_key, project_data);
     }
 
     /// Remove a project using its folder.
-    pub fn remove_project(&mut self, workspace_path: &Path) {
-        let keys_to_remove = {
-            let mut data = vec![];
-            let iter = self.data.iter();
-
-            for (key, path_to_settings) in iter {
-                if path_to_settings.path.as_path() == workspace_path {
-                    data.push(key)
-                }
+    pub fn remove_project(&self, workspace_path: &Path) {
+        let data = self.data.pin();
+        for (key, path_to_settings) in data.iter() {
+            if path_to_settings.path.as_path() == workspace_path {
+                data.remove(key);
             }
-
-            data
-        };
-
-        for key in keys_to_remove {
-            self.data.remove(key)
         }
     }
 
@@ -156,36 +161,53 @@ impl WorkspaceSettings {
         if self.data.is_empty() {
             return None;
         }
+
+        let mut belongs_to_current = false;
+        let mut belongs_to_other = None;
         trace!("Current key: {:?}", self.current_project);
-        let iter = self.data.iter();
-        for (key, path_to_settings) in iter {
+        for (key, path_to_settings) in self.data.pin().iter() {
             trace!(
                 "Workspace path {:?}, file path {:?}",
                 path_to_settings.path,
                 path
             );
-            trace!("Iter key: {:?}", key);
-            if key == self.current_project {
-                continue;
-            }
-            if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
-                trace!("Update workspace to {:?}", key);
-                return Some(key);
+            trace!("Iter key: {key:?}");
+            if *key == self.get_current_project_key() {
+                belongs_to_current = true;
+            } else if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
+                trace!("Update workspace to {key:?}");
+                belongs_to_other = Some(*key);
             }
         }
-        None
+        belongs_to_other.filter(|_| !belongs_to_current)
     }
 
-    /// Checks if the current path belongs to a registered project.
-    ///
-    /// If there's a match, and the match **isn't** the current project, the function will mark the match as the current project.
-    pub fn set_current_project(&mut self, new_key: ProjectKey) {
-        self.current_project = new_key;
+    /// Checks whether the given `path` belongs to the current project and no
+    /// other project.
+    pub fn path_belongs_only_to_current_project(&self, path: &BiomePath) -> bool {
+        let mut belongs_to_current = false;
+        let mut belongs_to_other = false;
+        for (key, path_to_settings) in self.data.pin().iter() {
+            if path.strip_prefix(path_to_settings.path.as_path()).is_ok() {
+                if *key == self.get_current_project_key() {
+                    belongs_to_current = true;
+                } else {
+                    belongs_to_other = true;
+                }
+            }
+        }
+
+        belongs_to_current && !belongs_to_other
+    }
+
+    /// Sets which project is the current one by its key.
+    pub fn set_current_project(&self, key: ProjectKey) {
+        *self.current_project.write().unwrap() = key;
     }
 }
 
 /// Global settings for the entire workspace
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Settings {
     /// Formatter settings applied to all files in the workspaces
     pub formatter: FormatSettings,
@@ -397,7 +419,7 @@ impl Settings {
 }
 
 /// Formatter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FormatSettings {
     /// Enabled by default
     pub enabled: bool,
@@ -434,7 +456,7 @@ impl Default for FormatSettings {
 }
 
 /// Formatter settings for the entire workspace
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideFormatSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -450,7 +472,7 @@ pub struct OverrideFormatSettings {
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LinterSettings {
     /// Enabled by default
     pub enabled: bool,
@@ -477,7 +499,7 @@ impl Default for LinterSettings {
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideLinterSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -487,7 +509,7 @@ pub struct OverrideLinterSettings {
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct OrganizeImportsSettings {
     /// Enabled by default
     pub enabled: bool,
@@ -510,14 +532,14 @@ impl Default for OrganizeImportsSettings {
 }
 
 /// Organize imports settings for the entire workspace
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideOrganizeImportsSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
 }
 
 /// Linter settings for the entire workspace
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AssistSettings {
     /// Enabled by default
     pub enabled: bool,
@@ -544,7 +566,7 @@ impl Default for AssistSettings {
 }
 
 /// Assist settings for the entire workspace
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideAssistSettings {
     /// Enabled by default
     pub enabled: Option<bool>,
@@ -554,7 +576,7 @@ pub struct OverrideAssistSettings {
 }
 
 /// Static map of language names to language-specific settings
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LanguageListSettings {
     pub javascript: LanguageSettings<JsLanguage>,
     pub json: LanguageSettings<JsonLanguage>,
@@ -709,7 +731,7 @@ pub trait ServiceLanguage: biome_rowan::Language {
     ) -> AnalyzerOptions;
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct LanguageSettings<L: ServiceLanguage> {
     /// Formatter settings for this language
     pub formatter: L::FormatterSettings,
@@ -731,7 +753,7 @@ pub struct LanguageSettings<L: ServiceLanguage> {
 }
 
 /// Filesystem settings for the entire workspace
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct FilesSettings {
     /// File size limit in bytes
     pub max_size: NonZeroU64,
@@ -788,8 +810,14 @@ fn to_file_settings(
         Some(FilesSettings {
             max_size: config.max_size,
             git_ignore,
-            ignored_files: to_matcher(working_directory.clone(), Some(config.ignore.as_slice()))?,
-            included_files: to_matcher(working_directory, Some(config.include.as_slice()))?,
+            ignored_files: Matcher::from_globs(
+                working_directory.clone(),
+                Some(config.ignore.as_slice()),
+            )?,
+            included_files: Matcher::from_globs(
+                working_directory,
+                Some(config.include.as_slice()),
+            )?,
             ignore_unknown: config.ignore_unknown,
         })
     } else {
@@ -797,32 +825,24 @@ fn to_file_settings(
     })
 }
 
-/// Handle object holding a temporary lock on the workspace settings until
-/// the deferred language-specific options resolution is called
+/// Handle object holding a pin of the workspace settings until the deferred
+/// language-specific options resolution is called.
 #[derive(Debug)]
-pub struct WorkspaceSettingsHandle<'a> {
-    inner: RwLockReadGuard<'a, WorkspaceSettings>,
+pub struct WorkspaceSettingsHandle {
+    settings: Option<Settings>,
 }
 
-impl<'a> WorkspaceSettingsHandle<'a> {
-    pub(crate) fn new(settings: &'a RwLock<WorkspaceSettings>) -> Self {
-        Self {
-            inner: settings.read().unwrap(),
-        }
+impl From<Option<Settings>> for WorkspaceSettingsHandle {
+    fn from(settings: Option<Settings>) -> Self {
+        Self { settings }
     }
+}
 
+impl WorkspaceSettingsHandle {
     pub(crate) fn settings(&self) -> Option<&Settings> {
-        self.inner.get_current_settings()
+        self.settings.as_ref()
     }
-}
 
-impl<'a> AsRef<WorkspaceSettings> for WorkspaceSettingsHandle<'a> {
-    fn as_ref(&self) -> &WorkspaceSettings {
-        &self.inner
-    }
-}
-
-impl<'a> WorkspaceSettingsHandle<'a> {
     /// Resolve the formatting context for the given language
     pub(crate) fn format_options<L>(
         &self,
@@ -832,7 +852,7 @@ impl<'a> WorkspaceSettingsHandle<'a> {
     where
         L: ServiceLanguage,
     {
-        let settings = self.inner.get_current_settings();
+        let settings = self.settings();
         let formatter = settings.map(|s| &s.formatter);
         let overrides = settings.map(|s| &s.override_settings);
         let editor_settings = settings
@@ -850,15 +870,15 @@ impl<'a> WorkspaceSettingsHandle<'a> {
     where
         L: ServiceLanguage,
     {
-        let settings = self.inner.get_current_settings();
-        let linter = settings.map(|s| &s.linter);
+        let settings = self.settings();
+        let linter_settings = settings.map(|s| &s.linter);
         let overrides = settings.map(|s| &s.override_settings);
         let editor_settings = settings
             .map(|s| L::lookup_settings(&s.languages))
             .map(|result| &result.linter);
         L::resolve_analyzer_options(
             settings,
-            linter,
+            linter_settings,
             overrides,
             editor_settings,
             path,
@@ -868,25 +888,7 @@ impl<'a> WorkspaceSettingsHandle<'a> {
     }
 }
 
-pub struct WorkspaceSettingsHandleMut<'a> {
-    inner: RwLockWriteGuard<'a, WorkspaceSettings>,
-}
-
-impl<'a> WorkspaceSettingsHandleMut<'a> {
-    pub(crate) fn new(settings: &'a RwLock<WorkspaceSettings>) -> Self {
-        Self {
-            inner: settings.write().unwrap(),
-        }
-    }
-}
-
-impl<'a> AsMut<WorkspaceSettings> for WorkspaceSettingsHandleMut<'a> {
-    fn as_mut(&mut self) -> &mut WorkspaceSettings {
-        &mut self.inner
-    }
-}
-
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideSettings {
     pub patterns: Vec<OverrideSettingPattern>,
 }
@@ -1159,7 +1161,7 @@ impl OverrideSettings {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct OverrideSettingPattern {
     pub exclude: Matcher,
     pub include: Matcher,
@@ -1173,30 +1175,9 @@ pub struct OverrideSettingPattern {
     pub assist: OverrideAssistSettings,
     /// Language specific settings
     pub languages: LanguageListSettings,
-
-    // Cache
-    // For js format options, we use the file source as the cache key because
-    // the file source params will affect how tokens are treated during formatting.
-    // So we cannot reuse the same format options for all js-family files.
-    pub(crate) cached_js_format_options: RwLock<FxHashMap<JsFileSource, JsFormatOptions>>,
-    pub(crate) cached_json_format_options: RwLock<Option<JsonFormatOptions>>,
-    pub(crate) cached_css_format_options: RwLock<Option<CssFormatOptions>>,
-    pub(crate) cached_grit_format_options: RwLock<Option<GritFormatOptions>>,
-    pub(crate) cached_graphql_format_options: RwLock<Option<GraphqlFormatOptions>>,
-    pub(crate) cached_html_format_options: RwLock<Option<HtmlFormatOptions>>,
-    pub(crate) cached_js_parser_options: RwLock<Option<JsParserOptions>>,
-    pub(crate) _cached_json_parser_options: RwLock<Option<JsonParserOptions>>,
-    pub(crate) cached_css_parser_options: RwLock<Option<CssParserOptions>>,
 }
 impl OverrideSettingPattern {
     fn apply_overrides_to_js_format_options(&self, options: &mut JsFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_js_format_options.read() {
-            if let Some(cached_options) = readonly_cache.get(&options.source_type()) {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let js_formatter = &self.languages.javascript.formatter;
         let formatter = &self.formatter;
         if let Some(indent_style) = js_formatter.indent_style.or(formatter.indent_style) {
@@ -1241,21 +1222,9 @@ impl OverrideSettingPattern {
         {
             options.set_attribute_position(attribute_position);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_js_format_options.write() {
-            let options = options.clone();
-            writeonly_cache.insert(options.source_type(), options);
-        }
     }
 
     fn apply_overrides_to_json_format_options(&self, options: &mut JsonFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_json_format_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let json_formatter = &self.languages.json.formatter;
         let formatter = &self.formatter;
 
@@ -1274,21 +1243,9 @@ impl OverrideSettingPattern {
         if let Some(trailing_commas) = json_formatter.trailing_commas {
             options.set_trailing_commas(trailing_commas);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_json_format_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_css_format_options(&self, options: &mut CssFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_css_format_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let css_formatter = &self.languages.css.formatter;
         let formatter = &self.formatter;
 
@@ -1307,21 +1264,9 @@ impl OverrideSettingPattern {
         if let Some(quote_style) = css_formatter.quote_style {
             options.set_quote_style(quote_style);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_css_format_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_graphql_format_options(&self, options: &mut GraphqlFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_graphql_format_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let graphql_formatter = &self.languages.graphql.formatter;
         let formatter = &self.formatter;
 
@@ -1346,21 +1291,9 @@ impl OverrideSettingPattern {
         if let Some(quote_style) = graphql_formatter.quote_style {
             options.set_quote_style(quote_style);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_graphql_format_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_grit_format_options(&self, options: &mut GritFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_grit_format_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let grit_formatter = &self.languages.grit.formatter;
         let formatter = &self.formatter;
 
@@ -1376,21 +1309,9 @@ impl OverrideSettingPattern {
         if let Some(line_width) = grit_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_grit_format_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_html_format_options(&self, options: &mut HtmlFormatOptions) {
-        if let Ok(readonly_cache) = self.cached_html_format_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let html_formatter = &self.languages.html.formatter;
         let formatter = &self.formatter;
 
@@ -1406,29 +1327,12 @@ impl OverrideSettingPattern {
         if let Some(line_width) = html_formatter.line_width.or(formatter.line_width) {
             options.set_line_width(line_width);
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_html_format_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_js_parser_options(&self, options: &mut JsParserOptions) {
-        if let Ok(readonly_cache) = self.cached_js_parser_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = cached_options.clone();
-                return;
-            }
-        }
-
         let js_parser = &self.languages.javascript.parser;
 
         options.parse_class_parameter_decorators = js_parser.parse_class_parameter_decorators;
-
-        if let Ok(mut writeonly_cache) = self.cached_js_parser_options.write() {
-            let options = options.clone();
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     fn apply_overrides_to_json_parser_options(&self, options: &mut JsonParserOptions) {
@@ -1444,13 +1348,6 @@ impl OverrideSettingPattern {
     }
 
     fn apply_overrides_to_css_parser_options(&self, options: &mut CssParserOptions) {
-        if let Ok(readonly_cache) = self.cached_css_parser_options.read() {
-            if let Some(cached_options) = readonly_cache.as_ref() {
-                *options = *cached_options;
-                return;
-            }
-        }
-
         let css_parser = &self.languages.css.parser;
 
         if let Some(allow_wrong_line_comments) = css_parser.allow_wrong_line_comments {
@@ -1459,43 +1356,12 @@ impl OverrideSettingPattern {
         if let Some(css_modules) = css_parser.css_modules {
             options.css_modules = css_modules;
         }
-
-        if let Ok(mut writeonly_cache) = self.cached_css_parser_options.write() {
-            let options = *options;
-            let _ = writeonly_cache.insert(options);
-        }
     }
 
     #[allow(dead_code)]
     // NOTE: Currently not used because the rule options are typed using TypeId and Any, which isn't thread safe.
     // TODO: Find a way to cache this
     fn analyzer_rules_mut(&self, _analyzer_rules: &mut AnalyzerRules) {}
-}
-
-/// Creates a [Matcher] from a set of strings.
-///
-/// ## Errors
-///
-/// It can raise an error if the patterns aren't valid
-pub fn to_matcher(
-    working_directory: Option<PathBuf>,
-    globs: Option<&[Box<str>]>,
-) -> Result<Matcher, WorkspaceError> {
-    let mut matcher = Matcher::empty();
-    if let Some(working_directory) = working_directory {
-        matcher.set_root(working_directory)
-    }
-    if let Some(string_set) = globs {
-        for pattern in string_set {
-            matcher.add_pattern(pattern).map_err(|err| {
-                BiomeDiagnostic::new_invalid_ignore_pattern(
-                    pattern.to_string(),
-                    err.msg.to_string(),
-                )
-            })?;
-        }
-    }
-    Ok(matcher)
 }
 
 fn to_git_ignore(path: PathBuf, matches: &[String]) -> Result<Gitignore, WorkspaceError> {
@@ -1526,11 +1392,14 @@ pub fn to_organize_imports_settings(
 ) -> Result<OrganizeImportsSettings, WorkspaceError> {
     Ok(OrganizeImportsSettings {
         enabled: organize_imports.enabled,
-        ignored_files: to_matcher(
+        ignored_files: Matcher::from_globs(
             working_directory.clone(),
             Some(organize_imports.ignore.as_slice()),
         )?,
-        included_files: to_matcher(working_directory, Some(organize_imports.include.as_slice()))?,
+        included_files: Matcher::from_globs(
+            working_directory,
+            Some(organize_imports.include.as_slice()),
+        )?,
     })
 }
 
@@ -1597,8 +1466,8 @@ pub fn to_override_settings(
             to_graphql_language_settings(graphql, &current_settings.languages.graphql);
 
         let pattern_setting = OverrideSettingPattern {
-            include: to_matcher(working_directory.clone(), pattern.include.as_deref())?,
-            exclude: to_matcher(working_directory.clone(), pattern.ignore.as_deref())?,
+            include: Matcher::from_globs(working_directory.clone(), pattern.include.as_deref())?,
+            exclude: Matcher::from_globs(working_directory.clone(), pattern.ignore.as_deref())?,
             formatter,
             linter,
             organize_imports,
@@ -1733,8 +1602,11 @@ pub fn to_format_settings(
         format_with_errors: conf.format_with_errors,
         attribute_position: Some(conf.attribute_position),
         bracket_spacing: Some(conf.bracket_spacing),
-        ignored_files: to_matcher(working_directory.clone(), Some(conf.ignore.as_slice()))?,
-        included_files: to_matcher(working_directory, Some(conf.include.as_slice()))?,
+        ignored_files: Matcher::from_globs(
+            working_directory.clone(),
+            Some(conf.ignore.as_slice()),
+        )?,
+        included_files: Matcher::from_globs(working_directory, Some(conf.include.as_slice()))?,
     })
 }
 
@@ -1771,8 +1643,14 @@ pub fn to_linter_settings(
     Ok(LinterSettings {
         enabled: conf.enabled,
         rules: Some(conf.rules),
-        ignored_files: to_matcher(working_directory.clone(), Some(conf.ignore.as_slice()))?,
-        included_files: to_matcher(working_directory.clone(), Some(conf.include.as_slice()))?,
+        ignored_files: Matcher::from_globs(
+            working_directory.clone(),
+            Some(conf.ignore.as_slice()),
+        )?,
+        included_files: Matcher::from_globs(
+            working_directory.clone(),
+            Some(conf.include.as_slice()),
+        )?,
     })
 }
 
@@ -1796,8 +1674,14 @@ pub fn to_assist_settings(
     Ok(AssistSettings {
         enabled: conf.enabled,
         actions: Some(conf.actions),
-        ignored_files: to_matcher(working_directory.clone(), Some(conf.ignore.as_slice()))?,
-        included_files: to_matcher(working_directory.clone(), Some(conf.include.as_slice()))?,
+        ignored_files: Matcher::from_globs(
+            working_directory.clone(),
+            Some(conf.ignore.as_slice()),
+        )?,
+        included_files: Matcher::from_globs(
+            working_directory.clone(),
+            Some(conf.include.as_slice()),
+        )?,
     })
 }
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2738,7 +2738,7 @@ export interface RegisterProjectFolderParams {
 	path?: string;
 	setAsCurrentWorkspace: boolean;
 }
-export type ProjectKey = string;
+export type ProjectKey = number;
 export interface SetManifestForProjectParams {
 	content: string;
 	manifestPath: BiomePath;


### PR DESCRIPTION
## Summary

This PR drops the `slotmap` dependency in favor of `papaya`, and simplifies some of the locking inside the workspace settings.

The main tradeoff this makes is that we need to perform more cloning of the `Settings` struct, which is a rather large one. To mitigate the impact of this I changed `Matcher` such that is holds an `Arc` internally, making it cheap to clone. As part of this, I was also able to get rid of `Matcher`'s internal `RwLock` by utilizing `papaya` again.

## Test Plan

CI should remain green.

Also checked our release build against the `unleash` repository again. These are performance numbers I'm seeing on that repo (I re-ran each a couple of times to make sure these numbers aren't heavy outliers):
Biome 1.9.4: `Checked 4511 files in 729ms.`
`next`: `Checked 4511 files in 744ms.`
This PR: `Checked 4511 files in 540ms.`

Looks like this creates a nice boost :)
Note that both `next` and this PR now do the scanning upfront, but that doesn't yet result in any speedup of the analysis step of course...

Disclaimer: I don't really know whether the speedup is the result of dropping `slotmap` specifically, or because I dropped the "caching" of language settings, or maybe the primary speedup is less locking inside `Matcher`...