### PR TITLE
fix(analyzer): suppression comment fails with inner comments in functions

### DIFF
--- a/.changeset/fixanalyzer_suppression_comment_fails_with_inner_comments_in_functions.md
+++ b/.changeset/fixanalyzer_suppression_comment_fails_with_inner_comments_in_functions.md
@@ -1,0 +1,18 @@
+---
+cli: patch
+biome_analyze: patch
+---
+
+# Suppression comment should not fail with inner comments in functions
+
+The follwing code:
+
+```ts
+// biome-ignore lint/complexity/useArrowFunction: not work
+const foo0 = function (bar: string) {
+	// biome-ignore lint/style/noParameterAssign: work
+	bar = "baz";
+};
+```
+
+The suppression comment `// biome-ignore lint/style/noParameterAssign: work` will not be invalid.

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -2,7 +2,6 @@
 
 use biome_console::markup;
 use biome_parser::AnyParse;
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops;
@@ -448,19 +447,15 @@ where
                     let index =
                         self.suppressions
                             .line_suppressions
-                            .binary_search_by(|suppression| {
-                                if suppression.text_range.end() < entry.text_range.start() {
-                                    Ordering::Less
-                                } else if entry.text_range.end() < suppression.text_range.start() {
-                                    Ordering::Greater
-                                } else {
-                                    Ordering::Equal
-                                }
+                            .partition_point(|suppression| {
+                                suppression.text_range.end() < entry.text_range.start()
                             });
 
-                    index
-                        .ok()
-                        .map(|index| &mut self.suppressions.line_suppressions[index])
+                    if index >= self.suppressions.line_suppressions.len() {
+                        None
+                    } else {
+                        Some(&mut self.suppressions.line_suppressions[index])
+                    }
                 }
             };
 


### PR DESCRIPTION
## Summary

closes: #4519 

This is a little change, but it's hard for me to find and fix it.

Use the case from the issue as examples:

```ts
// biome-ignore lint/complexity/useArrowFunction: not work
const foo0 = function (bar: string) {
	// biome-ignore lint/style/noParameterAssign: work
	bar = "baz";
};
```

There are two suppression comments in the code:

```bash
// biome-ignore lint/complexity/useArrowFunction: not work
// biome-ignore lint/style/noParameterAssign: work
```

In the logic of the https://github.com/biomejs/biome/blob/main/crates/biome_analyze/src/lib.rs#L371 , the method `flush_matches` will choose the second suppression for the code: `function (bar: string)`, so it will not match the rule `lint/complexity/useArrowFunction` but match `lint/style/noParameterAssign`. So it will cause the problem of the issue describes.

I just change the logic of `self.suppressions.line_suppressions.binary_search(|suppression| {...})` and change the priority of the `suppresion_range`.

## Test Plan

~~Sorry, i can't add test case for this change, because this test case need to enable two rules (`lint/complexity/useArrowFunction` and `lint/style/noParameterAssign`) for a test file, now the biome rule's test case of  `biome_js_analyzer` is generated by the directory name(only allow enable single rule in a file). But i test my pr at my local file, and it can be passed: i change the code of `quick_test` and enable two rules for a test case and it can work.~~

I add test case at `biome_js_analyzer/src/lib.rs` as unit test case.

