### PR TITLE
feat(parser): better control on JSX parsing

### DIFF
--- a/.changeset/add_new_option_javascriptjsxeverywhere.md
+++ b/.changeset/add_new_option_javascriptjsxeverywhere.md
@@ -1,0 +1,11 @@
+---
+cli: minor
+---
+
+# Add new option `javascript.parser.jsxEverywhere`
+
+This new option allows to control whether Biome should expect JSX syntax in `.js`/`.ts` files.
+
+When `jsxEverywhere` is set to `false`, having JSX syntax like `<div></div>` inside `.js`/`.ts` files will result in a **parsing error**.
+
+This option defaults to `true`.

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -26,7 +26,7 @@ pub struct JavascriptConfiguration {
     pub assists: JavascriptAssists,
 
     /// Parsing options
-    #[partial(type, bpaf(external(partial_javascript_parser), optional))]
+    #[partial(type, bpaf(pure(Default::default()), optional))]
     pub parser: JavascriptParser,
 
     /// A list of global bindings that should be ignored by the analyzers
@@ -39,32 +39,43 @@ pub struct JavascriptConfiguration {
     #[partial(bpaf(pure(Default::default()), hide))]
     pub jsx_runtime: JsxRuntime,
 
-    #[partial(type, bpaf(external(partial_javascript_organize_imports), optional))]
+    #[partial(type, bpaf(pure(Default::default()), optional))]
     pub organize_imports: JavascriptOrganizeImports,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, Partial, PartialEq, Serialize)]
-#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(derive(Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
 #[partial(serde(default, deny_unknown_fields))]
 pub struct JavascriptOrganizeImports {}
 
 /// Options that changes how the JavaScript parser behaves
-#[derive(Clone, Debug, Default, Deserialize, Eq, Partial, PartialEq, Serialize)]
-#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Clone, Deserializable, Eq, Merge, PartialEq))]
 #[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
 #[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
 pub struct JavascriptParser {
     /// It enables the experimental and unsafe parsing of parameter decorators
     ///
     /// These decorators belong to an old proposal, and they are subject to change.
-    #[partial(bpaf(hide))]
     pub unsafe_parameter_decorators_enabled: bool,
 
     /// Enables parsing of Grit metavariables.
     /// Defaults to `false`.
-    #[partial(bpaf(hide))]
     pub grit_metavariables: bool,
+
+    /// When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.
+    pub jsx_everywhere: bool,
+}
+
+impl Default for JavascriptParser {
+    fn default() -> Self {
+        Self {
+            jsx_everywhere: true,
+            grit_metavariables: false,
+            unsafe_parameter_decorators_enabled: false,
+        }
+    }
 }
 
 /// Indicates the type of runtime or transformation used for interpreting JSX.

--- a/crates/biome_js_parser/tests/js_test_suite/error/abstract_class_in_js.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/abstract_class_in_js.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 abstract class A {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/array_assignment_target_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/array_assignment_target_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 [a a, ++b, ] = test;
 [a, c, ...rest,] = test;
 [a = , = "test"] = test;

--- a/crates/biome_js_parser/tests/js_test_suite/error/array_assignment_target_rest_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/array_assignment_target_rest_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ([ ... ] = a);
 ([ ...c = "default" ] = a);
 ([ ...rest, other_assignment ] = a);

--- a/crates/biome_js_parser/tests/js_test_suite/error/array_binding_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/array_binding_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let [a b] = [1, 2];
 let [="default"] = [1, 2];
 let ["default"] = [1, 2];

--- a/crates/biome_js_parser/tests/js_test_suite/error/array_binding_rest_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/array_binding_rest_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let [ ... ] = a;
 let [ ...c = "default" ] = a;
 let [ ...rest, other_assignment ] = a;

--- a/crates/biome_js_parser/tests/js_test_suite/error/array_expr_incomplete.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/array_expr_incomplete.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = [
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/arrow_escaped_async.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/arrow_escaped_async.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 \u0061sync () => {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/arrow_rest_in_expr_in_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/arrow_rest_in_expr_in_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ((...a = "b" in {}) => {};;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/assign_eval_or_arguments.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/assign_eval_or_arguments.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 eval = 0
 eval ??= 2
 eval *= 4

--- a/crates/biome_js_parser/tests/js_test_suite/error/assign_expr_left.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/assign_expr_left.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ( = foo);
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/assign_expr_right.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/assign_expr_right.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (foo = );
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/async_arrow_expr_await_parameter.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/async_arrow_expr_await_parameter.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = async await => {}
 async() => { (a = await) => {} };
 async() => { (a = await 10) => {} };

--- a/crates/biome_js_parser/tests/js_test_suite/error/async_or_generator_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/async_or_generator_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) async function t() {}
 if (true) function* t() {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/await_in_module.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/await_in_module.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let await = 10;
 console.log(await);
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/await_in_non_async_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/await_in_non_async_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function test() { await 10; }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/await_in_parameter_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/await_in_parameter_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 async function test(a = await b()) {}
 function test2(a = await b()) {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/await_using_declaration_only_allowed_inside_an_async_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/await_using_declaration_only_allowed_inside_an_async_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() { await using x = y };
 foo = function() { await using x = y };
 foo = () => { await using x = y };

--- a/crates/biome_js_parser/tests/js_test_suite/error/binary_expressions_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/binary_expressions_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo(foo +);
 foo + * 2;
 !foo * bar;

--- a/crates/biome_js_parser/tests/js_test_suite/error/binding_identifier_invalid.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/binding_identifier_invalid.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 async () => { let await = 5; }
 function *foo() {
    let yield = 5;

--- a/crates/biome_js_parser/tests/js_test_suite/error/block_stmt_in_class.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/block_stmt_in_class.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class S{{}}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/bracket_expr_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/bracket_expr_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo[]
 foo?.[]
 foo[

--- a/crates/biome_js_parser/tests/js_test_suite/error/break_in_nested_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/break_in_nested_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 while (true) {
   function helper() {
     break;

--- a/crates/biome_js_parser/tests/js_test_suite/error/break_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/break_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() { break; }
 while (true) {
   break foo;

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_constructor_parameter.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_constructor_parameter.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { constructor(protected b) {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_constructor_parameter_readonly.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_constructor_parameter_readonly.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { constructor(readonly b) {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_decl_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_decl_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class {}
 class extends bar {}
 class foo { set {} }

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_declare_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_declare_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { declare foo }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_declare_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_declare_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { declare fn() {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_extends_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_extends_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A extends bar extends foo {}
 class B extends bar, foo {}
 class C implements B {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_implements.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_implements.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B implements C {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) class A {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_invalid_modifiers.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_invalid_modifiers.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A { public foo() {} }
 class B { static static foo() {} }
 class C { accessor foo() {} }

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_member_method_parameters.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_member_method_parameters.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { foo(a {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_member_modifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_member_modifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A { abstract foo; }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_member_static_accessor_precedence.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_member_static_accessor_precedence.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
     accessor static foo = 1;
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/class_property_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/class_property_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { lorem = ; }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/conditional_expr_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/conditional_expr_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo ? bar baz
 foo ? bar baz ? foo : bar
 foo ? bar :

--- a/crates/biome_js_parser/tests/js_test_suite/error/continue_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/continue_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() { continue; }
 while (true) {
   continue foo;

--- a/crates/biome_js_parser/tests/js_test_suite/error/debugger_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/debugger_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() {
   debugger {
     var something = "lorem";

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_class_declaration.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_class_declaration.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function bar() {
      @decorator
      let a;

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_class_declaration_top_level.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_class_declaration_top_level.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 @decorator
 let a;
 @decorator1 @decorator2

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_export.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_export.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() {
      @decorator
      export class Foo { }

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_export_class_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_export_class_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 @decorator
 export let a;
 @decorator1 @decorator2

--- a/crates/biome_js_parser/tests/js_test_suite/error/decorator_expression_class.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/decorator_expression_class.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = @decorator () => {};
 let b = @first @second function foo() {}
 let a = @decorator ( () => {} )

--- a/crates/biome_js_parser/tests/js_test_suite/error/do_while_no_continue_break.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/do_while_no_continue_break.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 do { } break (continue)
 do { } continue (break)
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/do_while_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/do_while_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 do while (true)
 do while ()
 do while true

--- a/crates/biome_js_parser/tests/js_test_suite/error/double_label.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/double_label.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 label1: {
   label2: {
     label1: {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/empty_parenthesized_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/empty_parenthesized_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ();
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/enum_in_js.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/enum_in_js.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 enum A {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/escaped_from.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/escaped_from.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export {} \u0066rom "./escaped-from.js";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/eval_arguments_assignment.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/eval_arguments_assignment.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 eval = "test";
 arguments = "test";
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/exponent_unary_unparenthesized.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/exponent_unary_unparenthesized.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 delete a.b ** 2;
 void ident ** 2;
 typeof ident ** 2;

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_as_identifier_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_as_identifier_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { as c }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_decl_not_top_level.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_decl_not_top_level.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 {
  export { pain } from "life";
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_default_expression_broken.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_default_expression_broken.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default ;
 export default @decorator
 export default

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_default_expression_clause_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_default_expression_clause_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default a, b;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_from_clause_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_from_clause_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export *;
 export * from 5;
 export as from "test";

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_named_clause_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_named_clause_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { default as "b" };
 export { "a" as b };
 export { as b };

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_named_from_clause_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_named_from_clause_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { as b } from "mod";
 export { a as 5 } from "mod";
 export { a b c } from "mod";

--- a/crates/biome_js_parser/tests/js_test_suite/error/export_variable_clause_error.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/export_variable_clause_error.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export let a = ;
 export const b;
 export let d, c;

--- a/crates/biome_js_parser/tests/js_test_suite/error/for_in_and_of_initializer_strict_mode.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/for_in_and_of_initializer_strict_mode.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for (var i = 0 in []) {}
 for (let i = 0 in []) {}
 for (const i = 0 in []) {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/for_of_async_identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/for_of_async_identifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let async;
 for (async of [1]) ;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/for_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/for_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ;; {}
 for let i = 5; i < 10; i++ {}
 for let i = 5; i < 10; ++i {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/formal_params_invalid.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/formal_params_invalid.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function (a++, c) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/formal_params_no_binding_element.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/formal_params_no_binding_element.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo(true) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_broken.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_broken.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo())})}{{{  {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_decl_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_decl_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function() {}
 function foo {}
 function {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_escaped_async.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_escaped_async.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 void \u0061sync function f(){}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_expression_id_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_expression_id_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (async function await() {});
 (function* yield() {});
 function* test() { function yield() {} }

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_id_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_id_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function* test() {
   function yield(test) {}
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/function_in_single_statement_context_strict.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/function_in_single_statement_context_strict.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) function a() {}
 label1: function b() {}
 while (true) function c() {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/getter_class_no_body.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/getter_class_no_body.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Getters {
   get foo()
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/identifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 yield;
 await;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/identifier_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/identifier_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 yield;
 await;
 async function test(await) {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/if_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/if_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) else {}
 if (true) else
 if else {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_as_identifier_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_as_identifier_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import { as c } from "test";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_assertion_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_assertion_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import "foo" assert { type, "json" };
 import "bar" \u{61}ssert { type: "json" };
 import { foo } assert { type: "json" };

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_attribute_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_attribute_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import "foo" with { type, "json" };
 import { foo } with { type: "json" };
 import foo2 from "foo.json" with { "type": "json", type: "html", "type": "js" };

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_decl_not_top_level.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_decl_not_top_level.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 {
  import foo from "bar";
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_err.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import;
 import *;
 import * as c, { a, b } from "c";

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_invalid_args.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_invalid_args.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import()
 import(...["foo"])
 import("foo", { assert: { type: 'json' } }, "bar")

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_keyword_in_expression_position.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_keyword_in_expression_position.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = import;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_no_meta.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_no_meta.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import.foo
 import.metaa
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/incomplete_parenthesized_sequence_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/incomplete_parenthesized_sequence_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (a,;
 (a, b, c;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/index_signature_class_member_in_js.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/index_signature_class_member_in_js.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
     [a: number]: string;
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/invalid_arg_list.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/invalid_arg_list.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo(...args) {}
 let a, b, c;
 foo(a,b;

--- a/crates/biome_js_parser/tests/js_test_suite/error/invalid_assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/invalid_assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ++a = b;
 (++a) = b;
 (a = b;

--- a/crates/biome_js_parser/tests/js_test_suite/error/invalid_method_recover.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/invalid_method_recover.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class {
   [1 + 1] = () => {
     let a=;

--- a/crates/biome_js_parser/tests/js_test_suite/error/invalid_using_declarations_inside_for_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/invalid_using_declarations_inside_for_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for (await using of x) {};
 for await (await using of x) {};
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_class_property_with_ts_annotation.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_class_property_with_ts_annotation.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
  a: string;
  b?: string;

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_formal_parameter_error.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_formal_parameter_error.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function a(x: string) {}
 function b(x?) {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_invalid_assignment.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_invalid_assignment.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ([=[(p[=[(p%]>([=[(p[=[(
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_regex_assignment.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_regex_assignment.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 /=0*_:m/=/*_:|
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_rewind_at_eof_token.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_rewind_at_eof_token.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (([zAgRvz=[=(e{V{
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_right_shift_comments.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_right_shift_comments.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 1 >> /* a comment */ > 2;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/js_type_variable_annotation.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/js_type_variable_annotation.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a: string, b!: number;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.json
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.json
@@ -1,0 +1,7 @@
+{
+  "javascript": {
+    "parser": {
+      "jsxEverywhere": false
+    }
+  }
+}

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.mjs
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.mjs
@@ -1,0 +1,3 @@
+function name() {
+	return <div></div>
+}

--- a/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.mjs.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/jsx_in_js.mjs.snap
@@ -1,0 +1,159 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+expression: snapshot
+snapshot_kind: text
+---
+## Input
+
+```js
+function name() {
+	return <div></div>
+}
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsFunctionDeclaration {
+            async_token: missing (optional),
+            function_token: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")],
+            star_token: missing (optional),
+            id: JsIdentifierBinding {
+                name_token: IDENT@9..13 "name" [] [],
+            },
+            type_parameters: missing (optional),
+            parameters: JsParameters {
+                l_paren_token: L_PAREN@13..14 "(" [] [],
+                items: JsParameterList [],
+                r_paren_token: R_PAREN@14..16 ")" [] [Whitespace(" ")],
+            },
+            return_type_annotation: missing (optional),
+            body: JsFunctionBody {
+                l_curly_token: L_CURLY@16..17 "{" [] [],
+                directives: JsDirectiveList [],
+                statements: JsStatementList [
+                    JsReturnStatement {
+                        return_token: RETURN_KW@17..26 "return" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")],
+                        argument: JsBogusExpression {
+                            items: [
+                                L_ANGLE@26..27 "<" [] [],
+                                TsReferenceType {
+                                    name: JsReferenceIdentifier {
+                                        value_token: IDENT@27..30 "div" [] [],
+                                    },
+                                    type_arguments: missing (optional),
+                                },
+                                R_ANGLE@30..31 ">" [] [],
+                                JsBogusExpression {
+                                    items: [
+                                        L_ANGLE@31..32 "<" [] [],
+                                        JsRegexLiteralExpression {
+                                            value_token: JS_REGEX_LITERAL@32..37 "/div>" [] [],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        semicolon_token: missing (optional),
+                    },
+                ],
+                r_curly_token: R_CURLY@37..39 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@39..40 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..40
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..39
+    0: JS_FUNCTION_DECLARATION@0..39
+      0: (empty)
+      1: FUNCTION_KW@0..9 "function" [] [Whitespace(" ")]
+      2: (empty)
+      3: JS_IDENTIFIER_BINDING@9..13
+        0: IDENT@9..13 "name" [] []
+      4: (empty)
+      5: JS_PARAMETERS@13..16
+        0: L_PAREN@13..14 "(" [] []
+        1: JS_PARAMETER_LIST@14..14
+        2: R_PAREN@14..16 ")" [] [Whitespace(" ")]
+      6: (empty)
+      7: JS_FUNCTION_BODY@16..39
+        0: L_CURLY@16..17 "{" [] []
+        1: JS_DIRECTIVE_LIST@17..17
+        2: JS_STATEMENT_LIST@17..37
+          0: JS_RETURN_STATEMENT@17..37
+            0: RETURN_KW@17..26 "return" [Newline("\n"), Whitespace("\t")] [Whitespace(" ")]
+            1: JS_BOGUS_EXPRESSION@26..37
+              0: L_ANGLE@26..27 "<" [] []
+              1: TS_REFERENCE_TYPE@27..30
+                0: JS_REFERENCE_IDENTIFIER@27..30
+                  0: IDENT@27..30 "div" [] []
+                1: (empty)
+              2: R_ANGLE@30..31 ">" [] []
+              3: JS_BOGUS_EXPRESSION@31..37
+                0: L_ANGLE@31..32 "<" [] []
+                1: JS_REGEX_LITERAL_EXPRESSION@32..37
+                  0: JS_REGEX_LITERAL@32..37 "/div>" [] []
+            2: (empty)
+        3: R_CURLY@37..39 "}" [Newline("\n")] []
+  4: EOF@39..40 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+jsx_in_js.mjs:2:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × type assertion are a TypeScript only feature. Convert your file to a TypeScript file or remove the syntax.
+  
+    1 │ function name() {
+  > 2 │ 	return <div></div>
+      │ 	       ^^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i TypeScript only syntax
+  
+jsx_in_js.mjs:2:20 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × unterminated regex literal
+  
+    1 │ function name() {
+  > 2 │ 	return <div></div>
+      │ 	                  
+    3 │ }
+    4 │ 
+  
+  i ...but the line ends here
+  
+    1 │ function name() {
+  > 2 │ 	return <div></div>
+      │ 	                  
+    3 │ }
+    4 │ 
+  
+  i a regex literal starts there...
+  
+    1 │ function name() {
+  > 2 │ 	return <div></div>
+      │ 	             ^
+    3 │ }
+    4 │ 
+  
+```

--- a/crates/biome_js_parser/tests/js_test_suite/error/labelled_function_decl_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/labelled_function_decl_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) label1: label2: function a() {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/labelled_function_declaration_strict_mode.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/labelled_function_declaration_strict_mode.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 label1: function a() {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/let_newline_in_async_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/let_newline_in_async_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 async function f() {
   let
   await 0;

--- a/crates/biome_js_parser/tests/js_test_suite/error/lexical_declaration_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/lexical_declaration_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) let a;
 while (true) const b = 5;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/literals.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/literals.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 00, 012, 08, 091, 0789 // parser errors
 01n, 0_0, 01.2 // lexer errors
 "test

--- a/crates/biome_js_parser/tests/js_test_suite/error/logical_expressions_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/logical_expressions_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo ?? * 2;
 !foo && bar;
 foo(foo ||)

--- a/crates/biome_js_parser/tests/js_test_suite/error/method_getter_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/method_getter_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo {
  get {}
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/multiple_default_exports_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/multiple_default_exports_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default (class {})
 export default a + b;
 export default (function a() {})

--- a/crates/biome_js_parser/tests/js_test_suite/error/new_exprs.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/new_exprs.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 new;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_binding_pattern.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_binding_pattern.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { 5 } } = { eval: "foo" };
 let { eval } = { eval: "foo" };
 let { 5, 6 } = { eval: "foo" };

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_expr_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_expr_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {, foo}
 let b = { foo bar }
 let b = { foo

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_expr_error_prop_name.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_expr_error_prop_name.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = { /: 6, /: /foo/ }
 let b = {{}}
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_expr_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_expr_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let b = { foo) }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_expr_non_ident_literal_prop.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_expr_non_ident_literal_prop.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let d = {5}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_expr_setter.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_expr_setter.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let b = {
  set foo() {
     return 5;

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_property_binding_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_property_binding_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { foo: , bar } = {}
 let { : lorem = "test" } = {}
 let { , ipsum: bazz } = {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_shorthand_property_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_shorthand_property_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { a b } = c
 let { = "test" } = c
 let { , d } = c

--- a/crates/biome_js_parser/tests/js_test_suite/error/object_shorthand_with_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/object_shorthand_with_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({ arrow = () => {} })
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/optional_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/optional_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { foo?; }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/paren_or_arrow_expr_invalid_params.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/paren_or_arrow_expr_invalid_params.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (5 + 5) => {}
 (a, ,b) => {}
 (a, b) =>;

--- a/crates/biome_js_parser/tests/js_test_suite/error/primary_expr_invalid_recovery.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/primary_expr_invalid_recovery.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = \; foo();
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/private_name_presence_check_recursive.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/private_name_presence_check_recursive.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
 	#prop;
 	test() {

--- a/crates/biome_js_parser/tests/js_test_suite/error/private_name_with_space.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/private_name_with_space.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
 	# test;
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/property_assignment_target_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/property_assignment_target_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({:y} = {});
 ({=y} = {});
 ({:="test"} = {});

--- a/crates/biome_js_parser/tests/js_test_suite/error/property_assignment_target_err_1.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/property_assignment_target_err_1.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 // here we have an invalid object member name '%'
 ({%: y} = {})
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/regex.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/regex.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 /[\p{Control}--[\t\n]]/vv;
 /[\p{Control}--[\t\n]]/uv;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/rest_property_assignment_target_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/rest_property_assignment_target_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({ ... } = a);
 ({ ...c = "default" } = a);
 ({ ...{a} } = b);

--- a/crates/biome_js_parser/tests/js_test_suite/error/rest_property_binding_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/rest_property_binding_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { ... } = a;
 let { ...c = "default" } = a;
 let { ...{a} } = b;

--- a/crates/biome_js_parser/tests/js_test_suite/error/return_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/return_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 return;
 return foo;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/semicolons_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/semicolons_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let foo = bar throw foo
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/sequence_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/sequence_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 1, 2, , 4
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/setter_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/setter_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Setters {
   set foo() {}
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/setter_class_no_body.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/setter_class_no_body.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Setters {
   set foo(a)
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/spread.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/spread.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 [...]
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/statements_closing_curly.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/statements_closing_curly.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 {
 "name": "troublesome-lib",
 "typings": "lib/index.d.ts",

--- a/crates/biome_js_parser/tests/js_test_suite/error/subscripts_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/subscripts_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo()?.baz[].;
 BAR`b
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/super_expression_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/super_expression_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Test extends B {
   test() {
     super();

--- a/crates/biome_js_parser/tests/js_test_suite/error/super_expression_in_constructor_parameter_list.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/super_expression_in_constructor_parameter_list.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A extends B { constructor(super()) {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/switch_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/switch_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 switch foo {}
 switch {}
 switch { var i = 0 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/template_after_optional_chain.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/template_after_optional_chain.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 obj.val?.prop`template`
 obj.val?.[expr]`template`
 obj.func?.(args)`template`

--- a/crates/biome_js_parser/tests/js_test_suite/error/template_literal.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/template_literal.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = `foo ${}`
 let b = `${a a}`
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/template_literal_unterminated.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/template_literal_unterminated.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = `${foo} bar
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/throw_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/throw_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 throw
 new Error("oh no :(")
 throw;

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_export_syntax_in_js.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_export_syntax_in_js.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a, b, c;
 export type { a };
 export { type b };

--- a/crates/biome_js_parser/tests/js_test_suite/error/ts_satisfies_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/ts_satisfies_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let x = "hello" satisfies string;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 delete ident;
 delete obj.#member;
 delete func().#member;

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_parenthesized.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_delete_parenthesized.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 delete (ident);
 delete ((ident));
 delete (obj.key, ident);

--- a/crates/biome_js_parser/tests/js_test_suite/error/unary_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unary_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ++ ;
 -- ;
 -;

--- a/crates/biome_js_parser/tests/js_test_suite/error/unicode_escape_unterminated.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unicode_escape_unterminated.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 \u1
 ```
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/unicode_escape_with_unicode_char.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unicode_escape_with_unicode_char.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 const v = \u1¡1
 ```
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/unterminated_unicode_codepoint.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/unterminated_unicode_codepoint.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let s = "\u{200";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/using_declaration_not_allowed_in_for_in_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/using_declaration_not_allowed_in_for_in_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for (using x in y) {};
 for (await using x in y) {};
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/using_declaration_statement_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/using_declaration_statement_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 using a;
 using {b};
 using c = d, e;

--- a/crates/biome_js_parser/tests/js_test_suite/error/var_decl_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/var_decl_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 var a =;
 const b = 5 let c = 5;
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/variable_declaration_statement_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/variable_declaration_statement_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a, { b } = { a: 10 }
 const c = 1, { d } = { a: 10 }
 const e;

--- a/crates/biome_js_parser/tests/js_test_suite/error/variable_declarator_list_empty.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/variable_declarator_list_empty.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 const;
 const
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/variable_declarator_list_incomplete.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/variable_declarator_list_incomplete.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 const a = 1,
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/while_stmt_err.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/while_stmt_err.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 while true {}
 while {}
 while (true {}

--- a/crates/biome_js_parser/tests/js_test_suite/error/yield_at_top_level_module.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/yield_at_top_level_module.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 yield 10;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/error/yield_expr_in_parameter_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/yield_expr_in_parameter_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function* test(a = yield "test") {}
 function test2(a = yield "test") {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/yield_in_non_generator_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/yield_in_non_generator_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() { yield bar; }
 function foo() { yield 10; }
 

--- a/crates/biome_js_parser/tests/js_test_suite/error/yield_in_non_generator_function_module.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/yield_in_non_generator_function_module.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() { yield; }
 function foo() { yield foo; }
 function foo() { yield *foo; }

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 [foo, bar] = baz;
 [,,,b,,c,] = baz;
 [a = "test", a.b, call().b] = baz;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_assignment_target_rest.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_assignment_target_rest.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ([ ...abcd ] = a);
 ([ ...(abcd) ] = a);
 ([ ...m.test ] = c);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_binding.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_binding.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = "b";
 let [c, b] = [1, 2];
 let [d, ...abcd] = [1];

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_binding_rest.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_binding_rest.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let [ ...abcd ] = a;
 let [ ...[x, y] ] = b;
 let [ ...[ ...a ] ] = c;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_element_in_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_element_in_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for(["a" in {}];;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 [foo, bar];
 [foo];
 [,foo];

--- a/crates/biome_js_parser/tests/js_test_suite/ok/array_or_object_member_assignment.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/array_or_object_member_assignment.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 [{
   get y() {
     throw new Test262Error('The property should not be accessed.');

--- a/crates/biome_js_parser/tests/js_test_suite/ok/arrow_expr_in_alternate.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/arrow_expr_in_alternate.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 a ? (b) : a => {};
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/arrow_in_constructor.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/arrow_in_constructor.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
   constructor() {
     () => { super() };

--- a/crates/biome_js_parser/tests/js_test_suite/ok/assign_eval_member_or_computed_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/assign_eval_member_or_computed_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 eval.foo = 10
 arguments[1] = "baz"
 eval[2] = "Chungking Express"

--- a/crates/biome_js_parser/tests/js_test_suite/ok/assign_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/assign_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo += bar = b ??= 3;
 foo -= bar;
 (foo = bar);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/assignment_shorthand_prop_with_initializer.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/assignment_shorthand_prop_with_initializer.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ({ arrow = () => {} } of [{}]) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo += bar = b ??= 3;
 a.foo -= bar;
 (foo = bar);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/async_arrow_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/async_arrow_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = async foo => {}
 let b = async (bar) => {}
 async (foo, bar, ...baz) => foo

--- a/crates/biome_js_parser/tests/js_test_suite/ok/async_continue_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/async_continue_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 async: for(a of b) continue async;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/async_function_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/async_function_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = async function() {};
 let b = async function foo() {};
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/async_ident.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/async_ident.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = async;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/async_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/async_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo {
  async foo() {}
  async *foo() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/await_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/await_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 async function test() {
   await inner();
   await (inner()) + await inner();

--- a/crates/biome_js_parser/tests/js_test_suite/ok/binary_expressions.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/binary_expressions.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 5 * 5
 6 ** 6 ** 7
 1 + 2 * 3

--- a/crates/biome_js_parser/tests/js_test_suite/ok/block_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/block_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 {}
 {{{{}}}}
 { foo = bar; }

--- a/crates/biome_js_parser/tests/js_test_suite/ok/bom_character.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/bom_character.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ﻿function foo ( ) {}
 ```
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/break_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/break_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 while (true) {
   break;
   foo: {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/call_arguments.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/call_arguments.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo(...args) {}
 let a, b, c, d;
 foo(a);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_declaration.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_declaration.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo {}
 class foo extends bar {}
 class foo extends foo.bar {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_declare.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_declare.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { declare() {} }
 class B { declare = foo }
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_decorator.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_decorator.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 @decorator
 class Foo { }
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_empty_element.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_empty_element.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo { ;;;;;;;;;; get foo() {};;;;}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = class {};
 let b = class foo {
  constructor() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_member_modifiers.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_member_modifiers.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A { public() {} }
 class A { static protected() {} }
 class A { static }

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_member_modifiers_no_asi.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_member_modifiers_no_asi.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
   static
   foo() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_named_abstract_is_valid_in_js.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_named_abstract_is_valid_in_js.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class abstract {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/class_static_constructor_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/class_static_constructor_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class B { static constructor() {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo[bar]
 foo[5 + 5]
 foo["bar"]

--- a/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_in.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_in.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ({}["x" in {}];;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_name_in.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/computed_member_name_in.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ({["x" in {}]: 3} ;;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/conditional_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/conditional_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo ? bar : baz
 foo ? bar : baz ? bar : baz
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/constructor_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/constructor_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Foo {
   constructor(a) {
     this.a = a;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/continue_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/continue_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 outer: while(true) {
 while (true) {
   continue;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/debugger_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/debugger_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 debugger;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/decorator_class_declaration.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/decorator_class_declaration.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() {
      @decorator
      class Foo { }

--- a/crates/biome_js_parser/tests/js_test_suite/ok/decorator_class_declaration_top_level.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/decorator_class_declaration_top_level.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 @decorator
 class Foo { }
 @first.field @second @(() => decorator)()

--- a/crates/biome_js_parser/tests/js_test_suite/ok/decorator_export_class_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/decorator_export_class_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export @decorator class Bar {};
 export @first @second class Foo {
     constructor() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/decorator_export_top_level.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/decorator_export_top_level.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 @decorator
 export class Foo { }
 @first.field @second @(() => decorator)()

--- a/crates/biome_js_parser/tests/js_test_suite/ok/decorator_expression_class.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/decorator_expression_class.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = @decorator class {};
 let b = @first @second class foo {
  constructor() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/destructuring_initializer_binding.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/destructuring_initializer_binding.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 const { value, f = (value) => value } = item
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/do-while-asi.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/do-while-asi.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 do do do ; while (x) while (x) while (x) x = 39;
 do do ; while (x); while (x) x = 39
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/do_while_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/do_while_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 do console.log("test"); while(true)
 do {
   console.log("test")

--- a/crates/biome_js_parser/tests/js_test_suite/ok/do_while_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/do_while_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 do { } while (true)
 do { throw Error("foo") } while (true)
 do { break; } while (true)

--- a/crates/biome_js_parser/tests/js_test_suite/ok/empty_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/empty_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/exponent_unary_parenthesized.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/exponent_unary_parenthesized.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (delete a.b) ** 2;
 (void ident) ** 2;
 (typeof ident) ** 2;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_as_identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_as_identifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { as };
 export { as as as }
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_class_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_class_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export class A {}
 export class A extends B {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_default_class_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_default_class_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default class {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_default_expression_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_default_expression_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default a;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_default_function_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_default_function_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export default function test(a, b) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_from_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_from_clause.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export {
     default as a } from "b";
 export { default as a } from "b";

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_function_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_function_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export function test(a, b) {}
 export function* test2(a, b) {}
 export async function test3(a, b, ) {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_named_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_named_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { a };
 export { a as z, b as "y", c as default }
 export { as };

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_named_from_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_named_from_clause.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export { a, default } from "mod";
 export { a as z, b as "y", c as default } from "mod"
 export { as } from "mod";

--- a/crates/biome_js_parser/tests/js_test_suite/ok/export_variable_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/export_variable_clause.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 export let a;
 export const b = 3;
 export var c, d, e = 3;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/for_await_async_identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/for_await_async_identifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let async;
 async function fn() {
   for await (async of [7]);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/for_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/for_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for (let i = 5; i < 10; i++) {}
 for (let { foo, bar } of {}) {}
 for (foo in {}) {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/for_with_in_in_parenthesized_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/for_with_in_in_parenthesized_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for((true,"selectionStart"in true);;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/function_decl.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/function_decl.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo1() {}
 function *foo2() {}
 async function *foo3() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/function_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/function_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = function() {}
 let b = function foo() {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/getter_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/getter_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Getters {
   get foo() {}
   get static() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/getter_object_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/getter_object_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {
   get foo() {
     return foo;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/grouping_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/grouping_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ((foo))
 (foo)
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/hoisted_declaration_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/hoisted_declaration_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) var a;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/identifier.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo;
 let accessor = 5;
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/if_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/if_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) {} else {}
 if (true) {}
 if (true) false

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_as_as_as_identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_as_as_as_identifier.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import { as as as } from "test";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_as_identifier.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_as_identifier.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import { as } from "test";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import "x" with { type: "json" }
 import "foo" with { "type": "json" };
 import foo from "foo.json" with { type: "json" };

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_bare_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_bare_clause.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import "test";
 import "no_semicolon"
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_call.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_call.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import("foo")
 import("foo", { assert: { type: 'json' } })
 import("foo", { with: { 'resolution-mode': 'import' } })

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_decl.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_decl.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import * as foo from "bla";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_default_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_default_clause.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import foo from "test";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_default_clauses.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_default_clauses.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import e, { f } from "b";
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_meta.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_meta.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import.meta
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_named_clause.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_named_clause.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import {} from "a";
 import { a, b, c, } from "b";
 import { f as x, default as w, "a-b-c" as y } from "b";

--- a/crates/biome_js_parser/tests/js_test_suite/ok/in_expr_in_arguments.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/in_expr_in_arguments.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function foo() {}
 for (foo("call" in foo);;) {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/js_class_property_member_modifiers.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/js_class_property_member_modifiers.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Test {
     static a = 1;
     accessor b = 1;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/js_parenthesized_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/js_parenthesized_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ((foo))
 (foo)
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/js_unary_expressions.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/js_unary_expressions.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 delete a['test'];
 void a;
 typeof a;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/labeled_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/labeled_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 label1: 1
 label1: 1
 label2: 2

--- a/crates/biome_js_parser/tests/js_test_suite/ok/labelled_statement_in_single_statement_context.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/labelled_statement_in_single_statement_context.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 if (true) label1: var a = 10;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/literals.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/literals.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 5
 true
 false

--- a/crates/biome_js_parser/tests/js_test_suite/ok/logical_expressions.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/logical_expressions.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo ?? bar
 a || b
 a && b

--- a/crates/biome_js_parser/tests/js_test_suite/ok/method_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/method_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Test {
   method() {}
   async asyncMethod() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/module.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/module.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 import a from "b";
 export { a };
 c();

--- a/crates/biome_js_parser/tests/js_test_suite/ok/new_exprs.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/new_exprs.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 new Foo()
 new foo;
 new.target

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({} = {});
 ({ bar, baz } = {});
 ({ bar: [baz = "baz"], foo = "foo", ...rest } = {});

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {};
 let b = {foo,}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_async_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_async_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {
   async foo() {},
   async *foo() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_generator_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_generator_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let b = { *foo() {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_ident_literal_prop.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_ident_literal_prop.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let b = { a: true }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_ident_prop.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_ident_prop.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({foo})
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let b = {
   foo() {},
   "bar"(a, b, c) {},

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_spread_prop.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_expr_spread_prop.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {...foo}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_member_name.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_member_name.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {"foo": foo, [6 + 6]: foo, bar: foo, 7: foo}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_prop_in_rhs.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_prop_in_rhs.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ({ a: "x" in {} };;) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_prop_name.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_prop_name.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {"foo": foo, [6 + 6]: foo, bar: foo, 7: foo}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_property_binding.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_property_binding.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { foo: bar  } = {}
 let { foo: bar_bar = baz } = {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/object_shorthand_property.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/object_shorthand_property.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { a, b } = c
 let { d = "default", e = call() } = c
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/parameter_list.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/parameter_list.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function evalInComputedPropertyKey({ [computed]: ignored }) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/paren_or_arrow_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/paren_or_arrow_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (foo);
 (foo) => {};
 (5 + 5);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/parenthesized_sequence_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/parenthesized_sequence_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 (a, b);
 (a, b, c);
 (a, b, c, d, e, f);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/pattern_with_default_in_keyword.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/pattern_with_default_in_keyword.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for ([a = "a" in {}] in []) {}
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/post_update_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/post_update_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo++
 foo--
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/postfix_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/postfix_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo++
 foo--
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/pre_update_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/pre_update_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ++foo
 --foo
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/private_name_presence_check.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/private_name_presence_check.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
 	#prop;
 	test() {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/property_assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/property_assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({x}= {});
 ({x: y}= {});
 ({x: y.test().z}= {});

--- a/crates/biome_js_parser/tests/js_test_suite/ok/property_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/property_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo {
   property
   declare;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/rest_property_assignment_target.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/rest_property_assignment_target.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ({ ...abcd } = a);
 ({ ...(abcd) } = a);
 ({ ...m.test } = c);

--- a/crates/biome_js_parser/tests/js_test_suite/ok/rest_property_binding.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/rest_property_binding.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let { ...abcd } = a;
 let { b: { ...a } } = c;
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/return_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/return_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 () => {
   return;
   return foo;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/scoped_declarations.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/scoped_declarations.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {
   test() {
     let a = "inner";

--- a/crates/biome_js_parser/tests/js_test_suite/ok/semicolons.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/semicolons.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let foo = bar;
 let foo2 = b;
 let foo3;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/sequence_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/sequence_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 1, 2, 3, 4, 5
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/setter_class_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/setter_class_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Setters {
   set foo(a) {}
   set bax(a,) {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/setter_object_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/setter_object_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = {
  set foo(value) {
  },

--- a/crates/biome_js_parser/tests/js_test_suite/ok/single_parameter_arrow_function_with_parameter_named_async.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/single_parameter_arrow_function_with_parameter_named_async.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let id = async => async;
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/static_generator_constructor_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/static_generator_constructor_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
 	static async * constructor() {}
 	static * constructor() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/static_initialization_block_member.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/static_initialization_block_member.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A {
   static a;
   static {

--- a/crates/biome_js_parser/tests/js_test_suite/ok/static_member_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/static_member_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo.bar
 foo.await
 foo.yield

--- a/crates/biome_js_parser/tests/js_test_suite/ok/static_method.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/static_method.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class foo {
  static foo(bar) {}
  static *foo() {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/subscripts.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/subscripts.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 foo`bar`
 foo(bar)(baz)(baz)[bar]
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/super_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/super_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class Test extends B {
   constructor() {
     super();

--- a/crates/biome_js_parser/tests/js_test_suite/ok/super_expression_in_constructor_parameter_list.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/super_expression_in_constructor_parameter_list.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class A extends B { constructor(c = super()) {} }
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/switch_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/switch_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 switch (foo) {
  case bar:
  default:

--- a/crates/biome_js_parser/tests/js_test_suite/ok/template_literal.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/template_literal.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 let a = `foo ${bar}`;
 let b = ``;
 let c = `${foo}`;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/this_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/this_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 this
 this.foo
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/throw_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/throw_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 throw new Error("foo");
 throw "foo"
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/try_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/try_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 try {} catch {}
 try {} catch (e) {}
 try {} catch {} finally {}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/ts_keyword_assignments.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/ts_keyword_assignments.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 declare = 1;
 abstract = 2;
 namespace = 3;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/type_arguments_like_expression.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/type_arguments_like_expression.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 ((0)<5>(6))
 
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/unary_delete.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/unary_delete.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 delete obj.key;
 delete (obj).key;
 delete obj.#member.key;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/unary_delete_nested.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/unary_delete_nested.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 class TestClass { #member = true; method() { delete func(this.#member) } }
 class TestClass { #member = true; method() { delete [this.#member] } }
 class TestClass { #member = true; method() { delete { key: this.#member } } }

--- a/crates/biome_js_parser/tests/js_test_suite/ok/unicode_escape_in_tagged_template.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/unicode_escape_in_tagged_template.js.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 tagged`\u0`;
 tagged`\u1¡1`;
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/using_declaration_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/using_declaration_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 using a = b;
 using c = d, e = _;
 using [g] = h;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/using_declarations_inside_for_statement.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/using_declarations_inside_for_statement.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 for (using x of y) {};
 for await (using x of y) {};
 for (await using x of y) {};

--- a/crates/biome_js_parser/tests/js_test_suite/ok/var_decl.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/var_decl.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 var a = 5;
 let { foo, bar } = 5;
 let bar2, foo2;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/while_stmt.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/while_stmt.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 while (true) {}
 while (5) {}
 

--- a/crates/biome_js_parser/tests/js_test_suite/ok/yield_expr.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/yield_expr.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function *foo() {
  yield foo;
  yield* foo;

--- a/crates/biome_js_parser/tests/js_test_suite/ok/yield_in_generator_function.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/yield_in_generator_function.js.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
+snapshot_kind: text
 ---
 ## Input
 
-```jsx
+```js
 function* foo() { yield 10; }
 function* foo() { yield *bar; }
 function* foo() { yield; }

--- a/crates/biome_js_syntax/src/file_source.rs
+++ b/crates/biome_js_syntax/src/file_source.rs
@@ -310,7 +310,8 @@ impl JsFileSource {
     pub fn try_from_extension(extension: &OsStr) -> Result<Self, FileSourceError> {
         // We assume the file extension is normalized to lowercase
         match extension.as_encoded_bytes() {
-            b"js" | b"mjs" | b"jsx" => Ok(Self::jsx()),
+            b"js" | b"mjs" => Ok(Self::js_module()),
+            b"jsx" => Ok(Self::jsx()),
             b"cjs" => Ok(Self::js_script()),
             b"ts" => Ok(Self::ts()),
             b"mts" | b"cts" => Ok(Self::ts_restricted()),

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -657,6 +657,7 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
         language_setting.parser.parse_class_parameter_decorators =
             javascript.parser.unsafe_parameter_decorators_enabled;
         language_setting.parser.grit_metavariables = javascript.parser.grit_metavariables;
+        language_setting.parser.jsx_everywhere = javascript.parser.jsx_everywhere;
 
         language_setting.globals = Some(javascript.globals);
         language_setting.environment = javascript.jsx_runtime.into();

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -545,6 +545,10 @@ export interface PartialJavascriptParser {
 	 */
 	gritMetavariables?: boolean;
 	/**
+	 * When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.
+	 */
+	jsxEverywhere?: boolean;
+	/**
 	* It enables the experimental and unsafe parsing of parameter decorators
 
 These decorators belong to an old proposal, and they are subject to change. 

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1714,6 +1714,10 @@
 					"description": "Enables parsing of Grit metavariables. Defaults to `false`.",
 					"type": ["boolean", "null"]
 				},
+				"jsxEverywhere": {
+					"description": "When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.",
+					"type": ["boolean", "null"]
+				},
 				"unsafeParameterDecoratorsEnabled": {
 					"description": "It enables the experimental and unsafe parsing of parameter decorators\n\nThese decorators belong to an old proposal, and they are subject to change.",
 					"type": ["boolean", "null"]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4716
Closes https://github.com/biomejs/biome/issues/4385

Adds a new option called `jsxEverything` inside `javascript.parser`. When set to `true`, JSX syntax is expected in `.js`/`.mjs` files. When set to `false`, it will result in a parsing error.

The option is `true` by default, so it's not a breaking change for our existing users. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added a new test case in the JS parser.

<!-- What demonstrates that your implementation is correct? -->
