### PR TITLE
fix(analyzer): don't use organize imports implicitly

### DIFF
--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -1540,6 +1540,48 @@ import * as something from "../something";
 }
 
 #[test]
+fn applies_organize_imports_bug_4552() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let config = r#"{
+        "organizeImports": {
+                "enabled": true,
+                "ignore": ["index.ts"]
+        },
+        "linter": {
+                "enabled": true,
+                "rules": {
+                        "recommended": true
+                }
+        }
+}"#;
+    let file_path = Path::new("biome.json");
+    fs.insert(file_path.into(), config.as_bytes());
+
+    let file_path = Path::new("index.ts");
+    let content = r#"import { secondFunction, firstFunction } from "./import";
+"#;
+    fs.insert(file_path.into(), content.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", file_path.as_os_str().to_str().unwrap()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "applies_organize_imports_bug_4552",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn shows_organize_imports_diff_on_check() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/diagnostic_level.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -50,12 +51,6 @@ src/index.js organizeImports ━━━━━━━━━━━━━━━━━
       2 │ + import·{·graphql,·useFragment,·useMutation·}·from·"react-relay";
     3 3 │   
   
-
-```
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/sorts_imports_check.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `file.astro`
 
@@ -38,12 +39,6 @@ file.astro organizeImports ━━━━━━━━━━━━━━━━━�
     4 4 │   ---
     5 5 │   <div></div>
   
-
-```
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/sorts_imports_check.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `file.svelte`
 
@@ -38,12 +39,6 @@ file.svelte organizeImports ━━━━━━━━━━━━━━━━━�
     4 4 │   </script>
     5 5 │   <div></div>
   
-
-```
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/sorts_imports_check.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `file.vue`
 
@@ -38,12 +39,6 @@ file.vue organizeImports ━━━━━━━━━━━━━━━━━━�
     4 4 │   </script>
     5 5 │   <template></template>
   
-
-```
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_command.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `index.css`
 
@@ -110,12 +111,6 @@ reporter/analyzer ━━━━━━━━━━━━━━━━━━━━�
   lint/suspicious/noDoubleEquals                   8 (8 error(s), 0 warning(s), 0 info(s))
   lint/suspicious/noRedeclare                      12 (12 error(s), 0 warning(s), 0 info(s))
   lint/suspicious/noDebugger                       8 (8 error(s), 0 warning(s), 0 info(s))
-
-```
-
-```block
-Skipped 2 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --write --unsafe
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_check/applies_organize_imports_bug_4552.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/applies_organize_imports_bug_4552.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: content
+snapshot_kind: text
+---
+## `biome.json`
+
+```json
+{
+  "organizeImports": {
+    "enabled": true,
+    "ignore": ["index.ts"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}
+```
+
+## `index.ts`
+
+```ts
+import { secondFunction, firstFunction } from "./import";
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/dont_applies_organize_imports_for_ignored_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/dont_applies_organize_imports_for_ignored_file.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -17,12 +18,6 @@ import * as something from "../something";
 ```
 
 # Emitted Messages
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
-
-```
 
 ```block
 Checked 1 file in <TIME>. No fixes applied.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/shows_organize_imports_diff_on_check.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `check.js`
 
@@ -33,12 +34,6 @@ check.js organizeImports ━━━━━━━━━━━━━━━━━━�
     2 2 │   import * as something from "../something";
     3 3 │   
   
-
-```
-
-```block
-Skipped 1 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
 
 ```
 

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -1643,6 +1643,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore = "To enable when import sorting will be part of the actions"]
 async fn pull_code_actions_with_import_sorting() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create(None).into_inner();

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1262,7 +1262,8 @@ impl<'a, 'b> AssistsVisitor<'a, 'b> {
             .settings
             .is_some_and(|settings| settings.organize_imports.enabled);
         if organize_imports_enabled && self.import_sorting.match_rule::<R>() {
-            self.enabled_rules.push(self.import_sorting);
+            // for now, we need to disable import sorting rule because we still have the top level organize import workspace action
+            self.disabled_rules.push(self.import_sorting);
             return;
         }
         // Do not report unused suppression comment diagnostics if:


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4552

We aren't ready to move the organize import to be a simple assist action, so we need to turn it off completely. 

This PR fixes the false positive. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a test case

<!-- What demonstrates that your implementation is correct? -->
