### PR TITLE
refactor: protect scanned files against closing by LSP

### DIFF
--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -71,6 +71,7 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
         content: FileContent::FromClient(biome_config_content.to_string()),
         version: 0,
         document_file_source: Some(JsonFileSource::json().into()),
+        persist_node_cache: false,
     })?;
     let parsed = parse_json_with_cache(
         &biome_config_content,

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -544,6 +544,7 @@ pub fn execute_mode(
                         path: report_file.clone(),
                         version: 0,
                         document_file_source: None,
+                        persist_node_cache: false,
                     })?;
                     let code = session.app.workspace.format_file(FormatFileParams {
                         path: report_file.clone(),

--- a/crates/biome_cli/src/execute/process_file/workspace_file.rs
+++ b/crates/biome_cli/src/execute/process_file/workspace_file.rs
@@ -41,6 +41,7 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
                 path: biome_path,
                 version: 0,
                 content: FileContent::FromClient(input.clone()),
+                persist_node_cache: false,
             },
         )
         .with_file_path_and_code(path.display().to_string(), category!("internalError/fs"))?;

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -50,6 +50,7 @@ pub(crate) fn run<'a>(
                 version: 0,
                 content: FileContent::FromClient(content.into()),
                 document_file_source: None,
+                persist_node_cache: false,
             })?;
             let printed = workspace.format_file(FormatFileParams {
                 path: biome_path.clone(),
@@ -82,6 +83,7 @@ pub(crate) fn run<'a>(
             version: 0,
             content: FileContent::FromClient(content.into()),
             document_file_source: None,
+            persist_node_cache: false,
         })?;
         // apply fix file of the linter
         let file_features = workspace.file_features(SupportsFeatureParams {

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -193,6 +193,10 @@ impl BiomePath {
     pub fn is_to_inspect(&self) -> bool {
         self.kind.contains(FileKind::Inspectable)
     }
+
+    pub fn to_path_buf(&self) -> PathBuf {
+        self.path.clone()
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -211,6 +215,12 @@ impl Deref for BiomePath {
 
     fn deref(&self) -> &Self::Target {
         &self.path
+    }
+}
+
+impl From<BiomePath> for PathBuf {
+    fn from(path: BiomePath) -> Self {
+        path.path
     }
 }
 

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -34,6 +34,7 @@ pub(crate) async fn did_open(
         version,
         content: FileContent::FromClient(content),
         document_file_source: Some(language_hint),
+        persist_node_cache: true,
     })?;
 
     session.insert_document(url.clone(), doc);

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -372,7 +372,9 @@ impl LanguageServer for LSPServer {
                 let result = self
                     .session
                     .workspace
-                    .unregister_project_folder(UnregisterProjectFolderParams { path: project_path })
+                    .unregister_project_folder(UnregisterProjectFolderParams {
+                        path: project_path.into(),
+                    })
                     .map_err(into_lsp_error);
 
                 if let Err(err) = result {

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -2,7 +2,6 @@ pub mod documentation;
 pub mod file_handlers;
 
 pub mod matcher;
-mod scanner;
 pub mod settings;
 pub mod workspace;
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1,3 +1,4 @@
+use super::scanner::scan;
 use super::{
     ChangeFileParams, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams, FeatureName,
     FileContent, FixFileResult, FormatFileParams, FormatOnTypeParams, FormatRangeParams,
@@ -13,7 +14,6 @@ use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
 };
 use crate::is_dir;
-use crate::scanner::scan;
 use crate::settings::WorkspaceSettings;
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, OrganizeImportsParams,
@@ -34,25 +34,53 @@ use biome_project::{NodeJsProject, PackageJson, PackageType, Project};
 use biome_rowan::NodeCache;
 use indexmap::IndexSet;
 use papaya::HashMap;
+use rustc_hash::FxBuildHasher;
 use std::ffi::OsStr;
+use std::panic::RefUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{panic::RefUnwindSafe, sync::RwLock};
+use std::sync::{Mutex, RwLock};
 use tracing::{debug, info, info_span};
 
 pub(super) struct WorkspaceServer {
     /// features available throughout the application
     features: Features,
+
     /// global settings object for this workspace
     settings: WorkspaceSettings,
+
     /// Stores the document (text content + version number) associated with a URL
-    documents: HashMap<BiomePath, Document>,
+    documents: HashMap<BiomePath, Document, FxBuildHasher>,
+
     /// The current focused project
     current_project_path: RwLock<Option<BiomePath>>,
+
     /// Stores the document sources used across the workspace
     file_sources: RwLock<IndexSet<DocumentFileSource>>,
+
     /// Stores patterns to search for.
-    patterns: HashMap<PatternId, GritQuery>,
+    patterns: HashMap<PatternId, GritQuery, FxBuildHasher>,
+
+    /// Node cache for faster parsing of modified documents.
+    ///
+    /// ## Concurrency
+    ///
+    /// Because `NodeCache` cannot be cloned, and `papaya` doesn't give us owned
+    /// instances of stored values, we use an `std` hash map here, wrapped in a
+    /// `Mutex`. The node cache is only used by writers, meaning this wouldn't
+    /// be a great use case for `papaya` anyway. But it does mean we need to be
+    /// careful for deadlocks, and release guards to the mutex as soon as we
+    /// can.
+    ///
+    /// Additionally, we only use the node cache for documents opened through
+    /// the LSP proxy, since the editor use case is the one where we benefit
+    /// most from low-latency parsing, and having a document open in an editor
+    /// gives us a clear signal that edits -- and thus reparsing -- is to be
+    /// anticipated. For other documents, the performance degradation due to
+    /// lock contention would not be worth the potential of faster reparsing
+    /// that may never actually happen.
+    node_cache: Mutex<std::collections::HashMap<PathBuf, NodeCache>>,
+
     /// File system implementation.
     fs: Box<dyn FileSystem>,
 }
@@ -65,7 +93,7 @@ pub(super) struct WorkspaceServer {
 /// could lead too hard to debug issues)
 impl RefUnwindSafe for WorkspaceServer {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Document {
     pub(crate) content: String,
     pub(crate) version: i32,
@@ -76,6 +104,14 @@ pub(crate) struct Document {
 
     /// The result of the parser (syntax tree + diagnostics).
     pub(crate) syntax: AnyParse,
+
+    /// If `true`, this indicates the document has been opened by the scanner,
+    /// and should be unloaded only when the project is unregistered.
+    ///
+    /// Note it doesn't matter if the file is *also* opened explicitly through
+    /// the LSP Proxy, for instance. In such a case, the scanner's "claim" on
+    /// the file should be considered leading.
+    opened_by_scanner: bool,
 }
 
 impl WorkspaceServer {
@@ -92,6 +128,7 @@ impl WorkspaceServer {
             current_project_path: RwLock::default(),
             file_sources: RwLock::default(),
             patterns: Default::default(),
+            node_cache: Default::default(),
             fs,
         }
     }
@@ -168,22 +205,140 @@ impl WorkspaceServer {
         let _ = current_project_path.insert(path);
     }
 
-    /// Register a new project in the current workspace
+    /// Registers a new project in the current workspace.
     fn register_project(&self, path: PathBuf) -> ProjectKey {
         self.settings.insert_project(path)
     }
 
-    /// Sets the current project of the current workspace
+    /// Sets the current project of the current workspace.
     fn set_current_project(&self, project_key: ProjectKey) {
         self.settings.set_current_project(project_key);
     }
 
-    /// Checks whether the current path belongs to another project.
+    /// Checks whether the given `path` belongs to another registered project.
     ///
-    /// If there's a match, and the match is for a project **other than** the current project, it
-    /// returns the new key.
+    /// If there's a match, and the match is for a project **other than** the
+    /// current project, it returns the key of that project.
     fn path_belongs_to_other_project(&self, path: &BiomePath) -> Option<ProjectKey> {
         self.settings.path_belongs_to_other_project(path)
+    }
+
+    /// Opens the file and marks it as opened by the scanner.
+    pub(super) fn open_file_by_scanner(
+        &self,
+        params: OpenFileParams,
+    ) -> Result<(), WorkspaceError> {
+        self.open_file_internal(true, params)
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn open_file_internal(
+        &self,
+        opened_by_scanner: bool,
+        params: OpenFileParams,
+    ) -> Result<(), WorkspaceError> {
+        let mut source = params
+            .document_file_source
+            .unwrap_or(DocumentFileSource::from_path(&params.path));
+        let manifest = self.get_current_manifest()?;
+
+        if let DocumentFileSource::Js(js) = &mut source {
+            if let Some(manifest) = manifest {
+                if manifest.r#type == Some(PackageType::Commonjs) && js.file_extension() == "js" {
+                    js.set_module_kind(ModuleKind::Script);
+                }
+            }
+        }
+
+        if let Some(project_key) = self.path_belongs_to_other_project(&params.path) {
+            self.set_current_project(project_key);
+        }
+
+        let content = match params.content {
+            FileContent::FromClient(content) => content,
+            FileContent::FromServer => self.fs.read_file_from_path(&params.path)?,
+        };
+
+        let mut index = self.set_source(source);
+        let mut node_cache = NodeCache::default();
+        let parsed = self.parse(&params.path, &content, index, &mut node_cache)?;
+
+        if let Some(language) = parsed.language {
+            index = self.set_source(language);
+        }
+
+        if params.persist_node_cache {
+            self.node_cache
+                .lock()
+                .unwrap()
+                .insert(params.path.to_path_buf(), node_cache);
+        }
+
+        {
+            let mut document = Document {
+                content,
+                version: params.version,
+                file_source_index: index,
+                syntax: parsed.any_parse,
+                opened_by_scanner,
+            };
+
+            let documents = self.documents.pin();
+
+            // This isn't handled atomically, so in theory two calls to
+            // `open_file()` could happen concurrently and one would overwrite
+            // the other's entry without considering the merging we do here.
+            // This would mostly be problematic if someone opens and closes a
+            // file in their IDE at just the right moment while scanning is
+            // still in progress. In such a case, the file could be gone from
+            // the workspace by the time we get to the service data extraction.
+            // This is why we check again on insertion below, and worst-case we
+            // may end up needing to do another update. That still leaves a tiny
+            // theoretical window during which another `close_file()` could have
+            // caused undesirable side-effects, but:
+            // - This window is already _very_ unlikely to occur, due to the
+            //   first check we do.
+            // - This window is also _very_ small, so the `open_file()` and
+            //   `close_file()` calls would need to arrive effectively
+            //   simultaneously.
+            //
+            // To prevent this with a 100% guarantee would require us to use
+            // `update_or_insert()`, which is atomic, but that requires cloning
+            // the document, which seems hardly worth it.
+            // That said, I don't think this code is particularly pretty either
+            // :sweat_smile:
+            if let Some(existing) = documents.get(&params.path) {
+                if existing.opened_by_scanner {
+                    document.opened_by_scanner = true;
+                }
+
+                if existing.version > params.version {
+                    document.version = existing.version;
+                }
+            }
+
+            let opened_by_scanner = document.opened_by_scanner;
+            let version = document.version;
+
+            if let Some(existing) = documents.insert(params.path.clone(), document) {
+                if (existing.opened_by_scanner && !opened_by_scanner)
+                    || (existing.version > version)
+                {
+                    documents.update(params.path, |document| {
+                        let mut document = document.clone();
+                        if existing.opened_by_scanner && !opened_by_scanner {
+                            document.opened_by_scanner = true;
+                        }
+                        if existing.version > version {
+                            document.version = version;
+                        }
+                        document
+                    });
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Retrieves the parser result for a given file, calculating it if the file was not yet parsed.
@@ -202,6 +357,7 @@ impl WorkspaceServer {
         biome_path: &BiomePath,
         content: &str,
         file_source_index: usize,
+        node_cache: &mut NodeCache,
     ) -> Result<ParseResult, WorkspaceError> {
         let Some(file_source) = self.get_source(file_source_index) else {
             return Err(WorkspaceError::not_found());
@@ -218,7 +374,7 @@ impl WorkspaceServer {
             file_source,
             content,
             self.settings.get_current_settings().as_ref(),
-            &mut NodeCache::default(),
+            node_cache,
         );
         Ok(parsed)
     }
@@ -363,49 +519,8 @@ impl Workspace for WorkspaceServer {
         Ok(())
     }
 
-    /// Adds a new file to the workspace.
-    #[tracing::instrument(level = "trace", skip(self))]
     fn open_file(&self, params: OpenFileParams) -> Result<(), WorkspaceError> {
-        let mut source = params
-            .document_file_source
-            .unwrap_or(DocumentFileSource::from_path(&params.path));
-        let manifest = self.get_current_manifest()?;
-
-        if let DocumentFileSource::Js(js) = &mut source {
-            if let Some(manifest) = manifest {
-                if manifest.r#type == Some(PackageType::Commonjs) && js.file_extension() == "js" {
-                    js.set_module_kind(ModuleKind::Script);
-                }
-            }
-        }
-
-        if let Some(project_key) = self.path_belongs_to_other_project(&params.path) {
-            self.set_current_project(project_key);
-        }
-
-        let content = match params.content {
-            FileContent::FromClient(content) => content,
-            FileContent::FromServer => self.fs.read_file_from_path(&params.path)?,
-        };
-
-        let mut index = self.set_source(source);
-        let parsed = self.parse(&params.path, &content, index)?;
-
-        if let Some(language) = parsed.language {
-            index = self.set_source(language);
-        }
-
-        self.documents.pin().insert(
-            params.path,
-            Document {
-                content,
-                version: params.version,
-                file_source_index: index,
-                syntax: parsed.any_parse,
-            },
-        );
-
-        Ok(())
+        self.open_file_internal(false, params)
     }
 
     fn set_manifest_for_project(
@@ -427,6 +542,7 @@ impl Workspace for WorkspaceServer {
                 version: params.version,
                 file_source_index: index,
                 syntax: parsed.into(),
+                opened_by_scanner: false,
             },
         );
         Ok(())
@@ -490,7 +606,24 @@ impl Workspace for WorkspaceServer {
         &self,
         params: UnregisterProjectFolderParams,
     ) -> Result<(), WorkspaceError> {
+        // Limit the scope of the pin and the lock inside.
+        {
+            let documents = self.documents.pin();
+            let mut node_cache = self.node_cache.lock().unwrap();
+            for (path, document) in documents.iter() {
+                if document.opened_by_scanner
+                    && self
+                        .settings
+                        .path_belongs_only_to_project_with_path(path, &params.path)
+                {
+                    documents.remove(path);
+                    node_cache.remove(params.path.as_path());
+                }
+            }
+        }
+
         self.settings.remove_project(params.path.as_path());
+
         Ok(())
     }
 
@@ -557,22 +690,46 @@ impl Workspace for WorkspaceServer {
     /// Changes the content of an open file.
     fn change_file(&self, params: ChangeFileParams) -> Result<(), WorkspaceError> {
         let documents = self.documents.pin();
-        let index = documents
+        let (index, opened_by_scanner) = documents
             .get(&params.path)
             .map(|document| {
                 debug_assert!(params.version > document.version);
-                document.file_source_index
+                (document.file_source_index, document.opened_by_scanner)
             })
             .ok_or_else(WorkspaceError::not_found)?;
 
-        let parsed = self.parse(&params.path, &params.content, index)?;
+        // We remove the node cache for the document, if it exists.
+        // This is done so that we need to hold the lock as short as possible
+        // (it's released directly after the statement). The potential downside
+        // is that if two calls to `change_file()` happen concurrently, then the
+        // second would have a cache miss, and not update the cache either.
+        // This seems an unlikely scenario however, and the impact is small
+        // anyway, so this seems a worthwhile tradeoff.
+        let node_cache = self
+            .node_cache
+            .lock()
+            .unwrap()
+            .remove(params.path.as_path());
+
+        let persist_node_cache = node_cache.is_some();
+        let mut node_cache = node_cache.unwrap_or_default();
+
+        let parsed = self.parse(&params.path, &params.content, index, &mut node_cache)?;
 
         let document = Document {
             content: params.content,
             version: params.version,
             file_source_index: index,
             syntax: parsed.any_parse,
+            opened_by_scanner,
         };
+
+        if persist_node_cache {
+            self.node_cache
+                .lock()
+                .unwrap()
+                .insert(params.path.to_path_buf(), node_cache);
+        }
 
         documents
             .insert(params.path, document)
@@ -580,12 +737,27 @@ impl Workspace for WorkspaceServer {
         Ok(())
     }
 
-    /// Removes a file from the workspace.
+    /// Closes a file that is opened in the workspace.
+    ///
+    /// This only unloads the document from the workspace if the file is NOT
+    /// opened by the scanner as well. If the scanner has opened the file, it
+    /// may still be required for multi-file analysis.
     fn close_file(&self, params: CloseFileParams) -> Result<(), WorkspaceError> {
-        self.documents
-            .pin()
-            .remove(&params.path)
-            .ok_or_else(WorkspaceError::not_found)?;
+        {
+            let documents = self.documents.pin();
+            let document = documents
+                .get(&params.path)
+                .ok_or_else(WorkspaceError::not_found)?;
+            if !document.opened_by_scanner {
+                documents.remove(&params.path);
+            }
+        }
+
+        self.node_cache
+            .lock()
+            .unwrap()
+            .remove(params.path.as_path());
+
         Ok(())
     }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -34,7 +34,7 @@ use biome_project::{NodeJsProject, PackageJson, PackageType, Project};
 use biome_rowan::NodeCache;
 use indexmap::IndexSet;
 use papaya::HashMap;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::ffi::OsStr;
 use std::panic::RefUnwindSafe;
 use std::path::{Path, PathBuf};
@@ -66,7 +66,7 @@ pub(super) struct WorkspaceServer {
     /// ## Concurrency
     ///
     /// Because `NodeCache` cannot be cloned, and `papaya` doesn't give us owned
-    /// instances of stored values, we use an `std` hash map here, wrapped in a
+    /// instances of stored values, we use an `FxHashMap` here, wrapped in a
     /// `Mutex`. The node cache is only used by writers, meaning this wouldn't
     /// be a great use case for `papaya` anyway. But it does mean we need to be
     /// careful for deadlocks, and release guards to the mutex as soon as we
@@ -79,7 +79,7 @@ pub(super) struct WorkspaceServer {
     /// anticipated. For other documents, the performance degradation due to
     /// lock contention would not be worth the potential of faster reparsing
     /// that may never actually happen.
-    node_cache: Mutex<std::collections::HashMap<PathBuf, NodeCache>>,
+    node_cache: Mutex<FxHashMap<PathBuf, NodeCache>>,
 
     /// File system implementation.
     fs: Box<dyn FileSystem>,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2748,6 +2748,12 @@ export interface OpenFileParams {
 	content: FileContent;
 	documentFileSource?: DocumentFileSource;
 	path: BiomePath;
+	/**
+	* Set to `true` to persist the node cache used during parsing, in order to speed up subsequent reparsing if the document has been edited.
+
+This should only be enabled if reparsing is to be expected, such as when the file is opened through the LSP Proxy. 
+	 */
+	persistNodeCache?: boolean;
 	version: number;
 }
 export type FileContent =


### PR DESCRIPTION
## Summary

By having both project scanning inside the workspace server, and explicit opening/closing of files through the workspace protocol, we run into a risk: What if a file was opened by the scanner, but for instance the LSP Proxy asks it to be closed? If we really close it, the analyzer wouldn't be able to extract information from it anymore.

With this PR, we protect against this scenario by tracking whether files have been opened by the scanner, and we keep them loaded in the server even when they're being closed through the workspace protocol.

I also re-added the ability to persist the node cache, but made it an option, so that the LSP Proxy can request a persistent node cache to speed up reparsing during editing, while we don't add overhead for any of the other open files in the workspace. When a file is closed through the workspace protocol, even if we keep it loaded because of the scanner, at least we can clean up the node cache.

## Test Plan

Added a test case.
