### PR TITLE
refactor: track too large files inside workspace server

### DIFF
--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -290,7 +290,7 @@ pub struct FileIgnored {
     path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FileTooLarge {
     pub size: usize,
     pub limit: usize,


### PR DESCRIPTION
## Summary

As the workspace server will become responsible for scanning projects, we also need to move the check for too large files into the server. Because there will be a disconnect between the initiation of the scanning and the pulling of diagnostics, we need to persist the `FileTooLarge` diagnostics. This PR implements a minimum version of this.

Later, I want to implement a `pull_diagnostics_multiple()` workspace method that can pull diagnostics for a scanned project as a whole. At that point, the persisted `FileTooLarge` will serve so we can return the right diagnostic at that point. Do you foresee any issues with this approach, @ematipico ?

## Test Plan

Added a test case.
