### PR TITLE
fix(migrate-eslint): allow null in file lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
   Contributed by @Conaclos
 
+- `biome migrate eslint` now correctly handles ESLint configuration with `null` values in file lists ([#4740](https://github.com/biomejs/biome/issues/4740)).
+  Contributed by @Conaclos
+
 ### Configuration
 
 ### Editors

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -323,8 +323,8 @@ mod tests {
     #[test]
     fn flat_config_single_config_object() {
         let flat_config = FlatConfigData(vec![FlatConfigObject {
-            files: vec!["*.js".to_string()],
-            ignores: vec!["*.test.js".to_string()],
+            files: ["*.js".to_string()].into_iter().collect(),
+            ignores: ["*.test.js".to_string()].into_iter().collect(),
             language_options: None,
             rules: Some(Rules(
                 [Rule::Any(Cow::Borrowed("eqeqeq"), Severity::Error)]
@@ -354,14 +354,14 @@ mod tests {
     fn flat_config_multiple_config_object() {
         let flat_config = FlatConfigData(vec![
             FlatConfigObject {
-                files: vec![],
-                ignores: vec!["*.test.js".to_string()],
+                files: ShorthandVec::default(),
+                ignores: ["*.test.js".to_string()].into_iter().collect(),
                 language_options: None,
                 rules: None,
             },
             FlatConfigObject {
-                files: vec![],
-                ignores: vec![],
+                files: ShorthandVec::default(),
+                ignores: ShorthandVec::default(),
                 language_options: None,
                 rules: Some(Rules(
                     [Rule::Any(Cow::Borrowed("eqeqeq"), Severity::Error)]
@@ -370,14 +370,14 @@ mod tests {
                 )),
             },
             FlatConfigObject {
-                files: vec![],
-                ignores: vec!["*.spec.js".to_string()],
+                files: ShorthandVec::default(),
+                ignores: ["*.spec.js".to_string()].into_iter().collect(),
                 language_options: None,
                 rules: None,
             },
             FlatConfigObject {
-                files: vec!["*.ts".to_string()],
-                ignores: vec![],
+                files: ["*.ts".to_string()].into_iter().collect(),
+                ignores: ShorthandVec::default(),
                 language_options: None,
                 rules: Some(Rules(
                     [Rule::Any(Cow::Borrowed("eqeqeq"), Severity::Off)]

--- a/crates/biome_cli/tests/commands/migrate_eslint.rs
+++ b/crates/biome_cli/tests/commands/migrate_eslint.rs
@@ -676,7 +676,7 @@ fn migrate_merge_with_overrides() {
     }"#;
     let eslintrc = r#"{
         "overrides": [{
-            "files": ["bin/*.js", "lib/*.js"],
+            "files": ["bin/*.js", "lib/*.js", null],
             "excludedFiles": "*.test.js",
             "rules": {
                 "eqeqeq": ["off"]

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_merge_with_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_merge_with_overrides.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -20,7 +21,7 @@ expression: content
 ```json
 {
         "overrides": [{
-            "files": ["bin/*.js", "lib/*.js"],
+            "files": ["bin/*.js", "lib/*.js", null],
             "excludedFiles": "*.test.js",
             "rules": {
                 "eqeqeq": ["off"]

--- a/crates/biome_deserialize/src/impls.rs
+++ b/crates/biome_deserialize/src/impls.rs
@@ -534,7 +534,11 @@ impl<T: Deserializable> Deserializable for Option<T> {
         name: &str,
         diagnostics: &mut Vec<DeserializationDiagnostic>,
     ) -> Option<Self> {
-        T::deserialize(value, name, diagnostics).map(Option::Some)
+        if value.visitable_type() == Some(crate::DeserializableType::Null) {
+            None
+        } else {
+            T::deserialize(value, name, diagnostics).map(Option::Some)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/4740

I relaxed the type of `files` and `ignores` in flat ESlint configurations to accept `null` in the list.

Also, we now accept a simple string instead of an array.
This is rejected by ESlint, however, this simplification allows us to reuse `ShorthandVec`.
This avoids adding an extra type.

I modified the implementation of the deserialization of `Option<T>` to accept `null`.

## Test Plan

I manually tested the fix and I added a related test.
