### PR TITLE
fix(noUselessFragments): fix Infinite loop case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - Fixed `useSortedClasses` false positive and Supplementary test case ([#3394](https://github.com/biomejs/biome/issues/3394)) Contributed by @hangaoke1
 - [noLabelWithoutControl](https://biomejs.dev/linter/rules/no-label-without-control/) detects button tags as input ([#4511])(https://github.com/biomejs/biome/issues/4511). Contributed by @unvalley
 
+- [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/) now handles `JsxAttributeInitializerClause`, ensuring that fragments inside expressions like `<A b=<></> />` are preserved. ([#4208](https://github.com/biomejs/biome/issues/4208)). Contributed by @MaxtuneLee
+
 ### Parser
 
 #### Bug fixes

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -10,8 +10,9 @@ use biome_js_factory::make::{
 };
 use biome_js_syntax::{
     AnyJsExpression, AnyJsxChild, AnyJsxElementName, AnyJsxTag, JsLanguage, JsLogicalExpression,
-    JsParenthesizedExpression, JsSyntaxKind, JsxChildList, JsxElement, JsxExpressionAttributeValue,
-    JsxExpressionChild, JsxFragment, JsxTagExpression, JsxText, T,
+    JsParenthesizedExpression, JsSyntaxKind, JsxAttributeInitializerClause, JsxChildList,
+    JsxElement, JsxExpressionAttributeValue, JsxExpressionChild, JsxFragment, JsxTagExpression,
+    JsxText, T,
 };
 use biome_rowan::{declare_node_union, AstNode, AstNodeList, BatchMutation, BatchMutationExt};
 
@@ -129,7 +130,7 @@ impl Rule for NoUselessFragments {
             NoUselessFragmentsQuery::JsxFragment(fragment) => {
                 let parents_where_fragments_must_be_preserved = node.syntax().parent().map_or(
                     false,
-                    |parent| match JsxTagExpression::try_cast(parent) {
+                    |parent| match JsxTagExpression::try_cast(parent.clone()) {
                         Ok(parent) => parent
                             .syntax()
                             .parent()
@@ -162,7 +163,7 @@ impl Rule for NoUselessFragments {
                                         | JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER
                                 )
                             }),
-                        Err(_) => false,
+                        Err(_) => JsxAttributeInitializerClause::try_cast(parent.clone()).is_ok(),
                     },
                 );
 
@@ -402,6 +403,8 @@ impl Rule for NoUselessFragments {
                 // a syntax error
                 return None;
             }
+        } else if let Some(_parent) = node.parent::<JsxAttributeInitializerClause>() {
+            return None;
         }
 
         Some(JsRuleAction::new(

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4208.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4208.jsx
@@ -1,0 +1,2 @@
+/* should not generate diagnostics */
+<A b=<></> />

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4208.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4208.jsx.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_4208.jsx
+snapshot_kind: text
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+<A b=<></> />
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Related issue: https://github.com/biomejs/biome/issues/4208

Fixes https://github.com/biomejs/biome/issues/4208

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This PR addresses an issue where the parent of a fragment is not a `JsxTagExpression` in the case of`<A x-some-prop=<></>></>`. To resolve this, I added a handling case for `JsxAttributeInitializerClause` to ensure that the fragment is preserved.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case in `crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4208.jsx` to ensure the rule does not generate diagnostics for valid JSX attribute initializer clauses.
<!-- What demonstrates that your implementation is correct? -->

