### PR TITLE
perf: use `AppendOnlyVec` for `file_sources`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
+name = "append-only-vec"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7992085ec035cfe96992dd31bfd495a2ebd31969bb95f624471cb6c0b349e571"
+
+[[package]]
 name = "ascii_table"
 version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1161,7 @@ dependencies = [
 name = "biome_service"
 version = "0.0.0"
 dependencies = [
+ "append-only-vec",
  "biome_analyze",
  "biome_configuration",
  "biome_console",

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -14,6 +14,7 @@ version              = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+append-only-vec          = "0.1.7"
 biome_analyze            = { workspace = true, features = ["serde"] }
 biome_configuration      = { workspace = true, features = ["schema"] }
 biome_console            = { workspace = true }


### PR DESCRIPTION
## Summary

This is a small tweak to use `AppendOnlyVec` for `WorkspaceServer::file_sources`, instead of `RwLock<IndexSet>`.

The advantage is that with `AppendOnlyVec` we don't need to use a lock anymore, and we can still do fast lookup by index (probably a bit faster than a plain `IndexSet` even). The downside is that insertion needs to iterate over the entire vector, but then we don't expect many file sources to exist anyway.

It results in a modest performance improvement, bringing the performance of checking the entire `unleash` repository down from ~630ms to ~620ms, so about a 1.5% improvement.

## Test Plan

CI should remain green.
