### PR TITLE
feat(html): plumbing for new HTML options, make `bracket_same_line` global

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,6 +739,8 @@ dependencies = [
  "biome_suppression",
  "camino",
  "countme",
+ "schemars",
+ "serde",
  "tests_macros",
 ]
 

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -202,6 +202,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             line_width: Some(line_width),
             indent_style: Some(indent_style),
             line_ending: Some(value.end_of_line.into()),
+            bracket_same_line: Some(value.bracket_line.into()),
             attribute_position: Some(AttributePosition::default()),
             format_with_errors: Some(false),
             ignore: None,
@@ -236,7 +237,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::PartialConfiguratio
             line_ending: None,
             enabled: None,
             // js ones
-            bracket_same_line: Some(value.bracket_line),
+            bracket_same_line: Some(value.bracket_line.into()),
             arrow_parentheses: Some(value.arrow_parens.into()),
             semicolons: Some(semicolons),
             trailing_commas: Some(value.trailing_comma.into()),
@@ -337,7 +338,7 @@ impl TryFrom<Override> for biome_configuration::OverridePattern {
             }
         });
         let js_formatter = biome_configuration::PartialJavascriptFormatter {
-            bracket_same_line: options.bracket_line,
+            bracket_same_line: options.bracket_line.map(Into::into),
             arrow_parentheses: options.arrow_parens.map(|arrow_parens| arrow_parens.into()),
             semicolons,
             trailing_commas: options

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
-snapshot_kind: text
 ---
 # Emitted Messages
 
@@ -37,6 +36,9 @@ The configuration that is contained inside the file `biome.json`
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-same-line=<true|false>  Put the `>` of a multi-line HTML or JSX element at the end
+                              of the last line instead of being alone on the next line (does not
+                              apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
@@ -48,9 +50,6 @@ The configuration that is contained inside the file `biome.json`
                               or only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow
                               functions. Defaults to "always".
-        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX
-                              tags to the end of the last line, rather than being alone on the
-                              following line. Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its
                               super languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and
@@ -65,6 +64,9 @@ The configuration that is contained inside the file `biome.json`
                               double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
+        --javascript-bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline
+                              HTML/JSX tags to the end of the last line, rather than being alone on
+                              the following line. Defaults to false.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assists-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
-snapshot_kind: text
 ---
 # Emitted Messages
 
@@ -38,6 +37,9 @@ The configuration that is contained inside the file `biome.json`
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-same-line=<true|false>  Put the `>` of a multi-line HTML or JSX element at the end
+                              of the last line instead of being alone on the next line (does not
+                              apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
         --jsx-quote-style=<double|single>  The type of quotes used in JSX. Defaults to double.
@@ -49,9 +51,6 @@ The configuration that is contained inside the file `biome.json`
                               or only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow
                               functions. Defaults to "always".
-        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX
-                              tags to the end of the last line, rather than being alone on the
-                              following line. Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its
                               super languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and
@@ -66,6 +65,9 @@ The configuration that is contained inside the file `biome.json`
                               double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
+        --javascript-bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline
+                              HTML/JSX tags to the end of the last line, rather than being alone on
+                              the following line. Defaults to false.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assists-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -19,6 +19,9 @@ Generic options applied to all files
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTMLish languages. By
                               default auto.
+        --bracket-same-line=<true|false>  Put the `>` of a multi-line HTML or JSX element at the end
+                              of the last line instead of being alone on the next line (does not
+                              apply to self closing elements).
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
 
@@ -32,9 +35,6 @@ Formatting options specific to the JavaScript files
                               or only in for statements where it is necessary because of ASI.
         --arrow-parentheses=<always|as-needed>  Whether to add non-necessary parentheses to arrow
                               functions. Defaults to "always".
-        --bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline HTML/JSX
-                              tags to the end of the last line, rather than being alone on the
-                              following line. Defaults to false.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its
                               super languages) files.
         --javascript-formatter-indent-style=<tab|space>  The indent style applied to JavaScript (and
@@ -49,6 +49,9 @@ Formatting options specific to the JavaScript files
                               double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
+        --javascript-bracket-same-line=<true|false>  Whether to hug the closing bracket of multiline
+                              HTML/JSX tags to the end of the last line, rather than being alone on
+                              the following line. Defaults to false.
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
 

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
@@ -32,24 +32,25 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        8 │ + → → "lineEnding":·"lf",
        9 │ + → → "lineWidth":·80,
       10 │ + → → "attributePosition":·"auto",
-      11 │ + → → "bracketSpacing":·true
-      12 │ + → },
-      13 │ + → "linter":·{·"enabled":·true·},
-      14 │ + → "javascript":·{
-      15 │ + → → "formatter":·{
-      16 │ + → → → "jsxQuoteStyle":·"double",
-      17 │ + → → → "quoteProperties":·"asNeeded",
-      18 │ + → → → "trailingCommas":·"all",
-      19 │ + → → → "semicolons":·"always",
-      20 │ + → → → "arrowParentheses":·"always",
-      21 │ + → → → "bracketSameLine":·false,
+      11 │ + → → "bracketSameLine":·false,
+      12 │ + → → "bracketSpacing":·true
+      13 │ + → },
+      14 │ + → "linter":·{·"enabled":·true·},
+      15 │ + → "javascript":·{
+      16 │ + → → "formatter":·{
+      17 │ + → → → "jsxQuoteStyle":·"double",
+      18 │ + → → → "quoteProperties":·"asNeeded",
+      19 │ + → → → "trailingCommas":·"all",
+      20 │ + → → → "semicolons":·"always",
+      21 │ + → → → "arrowParentheses":·"always",
       22 │ + → → → "quoteStyle":·"single",
       23 │ + → → → "attributePosition":·"auto",
-      24 │ + → → → "bracketSpacing":·true
-      25 │ + → → }
-      26 │ + → }
-      27 │ + }
-      28 │ + 
+      24 │ + → → → "bracketSameLine":·false,
+      25 │ + → → → "bracketSpacing":·true
+      26 │ + → → }
+      27 │ + → }
+      28 │ + }
+      29 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
@@ -36,23 +36,24 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        8 │ + → → "lineEnding":·"lf",
        9 │ + → → "lineWidth":·80,
       10 │ + → → "attributePosition":·"auto",
-      11 │ + → → "bracketSpacing":·true
-      12 │ + → },
-      13 │ + → "javascript":·{
-      14 │ + → → "formatter":·{
-      15 │ + → → → "jsxQuoteStyle":·"double",
-      16 │ + → → → "quoteProperties":·"asNeeded",
-      17 │ + → → → "trailingCommas":·"all",
-      18 │ + → → → "semicolons":·"asNeeded",
-      19 │ + → → → "arrowParentheses":·"always",
-      20 │ + → → → "bracketSameLine":·false,
+      11 │ + → → "bracketSameLine":·false,
+      12 │ + → → "bracketSpacing":·true
+      13 │ + → },
+      14 │ + → "javascript":·{
+      15 │ + → → "formatter":·{
+      16 │ + → → → "jsxQuoteStyle":·"double",
+      17 │ + → → → "quoteProperties":·"asNeeded",
+      18 │ + → → → "trailingCommas":·"all",
+      19 │ + → → → "semicolons":·"asNeeded",
+      20 │ + → → → "arrowParentheses":·"always",
       21 │ + → → → "quoteStyle":·"single",
       22 │ + → → → "attributePosition":·"auto",
-      23 │ + → → → "bracketSpacing":·true
-      24 │ + → → }
-      25 │ + → }
-      26 │ + }
-      27 │ + 
+      23 │ + → → → "bracketSameLine":·false,
+      24 │ + → → → "bracketSpacing":·true
+      25 │ + → → }
+      26 │ + → }
+      27 │ + }
+      28 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true
   },
   "linter": { "enabled": true },
@@ -25,9 +26,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
@@ -32,24 +32,25 @@ biome.jsonc migrate ━━━━━━━━━━━━━━━━━━━━
        8 │ + → → "lineEnding":·"lf",
        9 │ + → → "lineWidth":·80,
       10 │ + → → "attributePosition":·"auto",
-      11 │ + → → "bracketSpacing":·true
-      12 │ + → },
-      13 │ + → "linter":·{·"enabled":·true·},
-      14 │ + → "javascript":·{
-      15 │ + → → "formatter":·{
-      16 │ + → → → "jsxQuoteStyle":·"double",
-      17 │ + → → → "quoteProperties":·"asNeeded",
-      18 │ + → → → "trailingCommas":·"all",
-      19 │ + → → → "semicolons":·"always",
-      20 │ + → → → "arrowParentheses":·"always",
-      21 │ + → → → "bracketSameLine":·false,
+      11 │ + → → "bracketSameLine":·false,
+      12 │ + → → "bracketSpacing":·true
+      13 │ + → },
+      14 │ + → "linter":·{·"enabled":·true·},
+      15 │ + → "javascript":·{
+      16 │ + → → "formatter":·{
+      17 │ + → → → "jsxQuoteStyle":·"double",
+      18 │ + → → → "quoteProperties":·"asNeeded",
+      19 │ + → → → "trailingCommas":·"all",
+      20 │ + → → → "semicolons":·"always",
+      21 │ + → → → "arrowParentheses":·"always",
       22 │ + → → → "quoteStyle":·"single",
       23 │ + → → → "attributePosition":·"auto",
-      24 │ + → → → "bracketSpacing":·true
-      25 │ + → → }
-      26 │ + → }
-      27 │ + }
-      28 │ + 
+      24 │ + → → → "bracketSameLine":·false,
+      25 │ + → → → "bracketSpacing":·true
+      26 │ + → → }
+      27 │ + → }
+      28 │ + }
+      29 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
@@ -43,39 +43,40 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        8 │ + → → "lineEnding":·"lf",
        9 │ + → → "lineWidth":·80,
       10 │ + → → "attributePosition":·"auto",
-      11 │ + → → "bracketSpacing":·true
-      12 │ + → },
-      13 │ + → "javascript":·{
-      14 │ + → → "formatter":·{
-      15 │ + → → → "jsxQuoteStyle":·"double",
-      16 │ + → → → "quoteProperties":·"asNeeded",
-      17 │ + → → → "trailingCommas":·"all",
-      18 │ + → → → "semicolons":·"asNeeded",
-      19 │ + → → → "arrowParentheses":·"always",
-      20 │ + → → → "bracketSameLine":·false,
+      11 │ + → → "bracketSameLine":·false,
+      12 │ + → → "bracketSpacing":·true
+      13 │ + → },
+      14 │ + → "javascript":·{
+      15 │ + → → "formatter":·{
+      16 │ + → → → "jsxQuoteStyle":·"double",
+      17 │ + → → → "quoteProperties":·"asNeeded",
+      18 │ + → → → "trailingCommas":·"all",
+      19 │ + → → → "semicolons":·"asNeeded",
+      20 │ + → → → "arrowParentheses":·"always",
       21 │ + → → → "quoteStyle":·"single",
       22 │ + → → → "attributePosition":·"auto",
-      23 │ + → → → "bracketSpacing":·true
-      24 │ + → → }
-      25 │ + → },
-      26 │ + → "overrides":·[
-      27 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
-      28 │ + → → {
-      29 │ + → → → "include":·["**/*.spec.js"],
-      30 │ + → → → "javascript":·{
-      31 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      32 │ + → → → }
-      33 │ + → → },
-      34 │ + → → {
-      35 │ + → → → "include":·["**/*.ts"],
-      36 │ + → → → "javascript":·{
-      37 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      38 │ + → → → },
-      39 │ + → → → "formatter":·{·"indentStyle":·"space"·}
-      40 │ + → → }
-      41 │ + → ]
-      42 │ + }
-      43 │ + 
+      23 │ + → → → "bracketSameLine":·false,
+      24 │ + → → → "bracketSpacing":·true
+      25 │ + → → }
+      26 │ + → },
+      27 │ + → "overrides":·[
+      28 │ + → → {·"include":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
+      29 │ + → → {
+      30 │ + → → → "include":·["**/*.spec.js"],
+      31 │ + → → → "javascript":·{
+      32 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      33 │ + → → → }
+      34 │ + → → },
+      35 │ + → → {
+      36 │ + → → → "include":·["**/*.ts"],
+      37 │ + → → → "javascript":·{
+      38 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      39 │ + → → → },
+      40 │ + → → → "formatter":·{·"indentStyle":·"space"·}
+      41 │ + → → }
+      42 │ + → ]
+      43 │ + }
+      44 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
@@ -45,25 +45,26 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        8 │ + → → "lineEnding":·"lf",
        9 │ + → → "lineWidth":·80,
       10 │ + → → "attributePosition":·"auto",
-      11 │ + → → "bracketSpacing":·true,
-      12 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
-      13 │ + → },
-      14 │ + → "linter":·{·"enabled":·true·},
-      15 │ + → "javascript":·{
-      16 │ + → → "formatter":·{
-      17 │ + → → → "jsxQuoteStyle":·"double",
-      18 │ + → → → "quoteProperties":·"asNeeded",
-      19 │ + → → → "trailingCommas":·"all",
-      20 │ + → → → "semicolons":·"always",
-      21 │ + → → → "arrowParentheses":·"always",
-      22 │ + → → → "bracketSameLine":·false,
+      11 │ + → → "bracketSameLine":·false,
+      12 │ + → → "bracketSpacing":·true,
+      13 │ + → → "ignore":·["dist/**",·"node_modules/**",·"generated/*.spec.js"]
+      14 │ + → },
+      15 │ + → "linter":·{·"enabled":·true·},
+      16 │ + → "javascript":·{
+      17 │ + → → "formatter":·{
+      18 │ + → → → "jsxQuoteStyle":·"double",
+      19 │ + → → → "quoteProperties":·"asNeeded",
+      20 │ + → → → "trailingCommas":·"all",
+      21 │ + → → → "semicolons":·"always",
+      22 │ + → → → "arrowParentheses":·"always",
       23 │ + → → → "quoteStyle":·"single",
       24 │ + → → → "attributePosition":·"auto",
-      25 │ + → → → "bracketSpacing":·true
-      26 │ + → → }
-      27 │ + → }
-      28 │ + }
-      29 │ + 
+      25 │ + → → → "bracketSameLine":·false,
+      26 │ + → → → "bracketSpacing":·true
+      27 │ + → → }
+      28 │ + → }
+      29 │ + }
+      30 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true
   },
   "linter": { "enabled": true },
@@ -25,9 +26,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true
   },
   "linter": { "enabled": true },
@@ -25,9 +26,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true
   },
   "linter": { "enabled": true },
@@ -25,9 +26,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true,
     "ignore": ["dist/**", "node_modules/**", "generated/*.spec.js"]
   },
@@ -26,9 +27,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -15,6 +15,7 @@ expression: content
     "lineEnding": "lf",
     "lineWidth": 80,
     "attributePosition": "auto",
+    "bracketSameLine": false,
     "bracketSpacing": true
   },
   "linter": { "enabled": true },
@@ -25,9 +26,9 @@ expression: content
       "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
+      "bracketSameLine": false,
       "bracketSpacing": true
     }
   }

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/with_formatter_configuration.snap
@@ -97,7 +97,7 @@ JavaScript Formatter:
   Semicolons:                   Always
   Arrow parentheses:            Always
   Bracket spacing:              unset
-  Bracket same line:            false
+  Bracket same line:            None
   Quote style:                  Double
   Indent style:                 Tab
   Indent width:                 2

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -1,6 +1,7 @@
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
-    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    AttributePosition, BracketSameLine, BracketSpacing, IndentStyle, IndentWidth, LineEnding,
+    LineWidth,
 };
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -45,6 +46,10 @@ pub struct FormatterConfiguration {
     #[partial(bpaf(long("attribute-position"), argument("multiline|auto"), optional))]
     pub attribute_position: AttributePosition,
 
+    /// Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+    #[partial(bpaf(long("bracket-same-line"), argument("true|false"), optional))]
+    pub bracket_same_line: BracketSameLine,
+
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
     pub bracket_spacing: BracketSpacing,
@@ -74,6 +79,7 @@ impl PartialFormatterConfiguration {
             line_ending: self.line_ending.unwrap_or_default(),
             line_width: self.line_width.unwrap_or_default(),
             attribute_position: self.attribute_position.unwrap_or_default(),
+            bracket_same_line: self.bracket_same_line.unwrap_or_default(),
             bracket_spacing: self.bracket_spacing.unwrap_or_default(),
             ignore: self.ignore.clone().unwrap_or_default(),
             include: self.include.clone().unwrap_or_default(),
@@ -92,6 +98,7 @@ impl Default for FormatterConfiguration {
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
             attribute_position: AttributePosition::default(),
+            bracket_same_line: BracketSameLine::default(),
             bracket_spacing: Default::default(),
             ignore: Default::default(),
             include: Default::default(),

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -1,6 +1,7 @@
 use biome_deserialize_macros::{Deserializable, Merge, Partial};
 use biome_formatter::{
-    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+    AttributePosition, BracketSameLine, BracketSpacing, IndentStyle, IndentWidth, LineEnding,
+    LineWidth, QuoteStyle,
 };
 use biome_js_formatter::context::{
     trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
@@ -33,10 +34,6 @@ pub struct JavascriptFormatter {
     /// Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
     #[partial(bpaf(long("arrow-parentheses"), argument("always|as-needed"), optional))]
     pub arrow_parentheses: ArrowParentheses,
-
-    /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
-    #[partial(bpaf(long("bracket-same-line"), argument("true|false"), optional))]
-    pub bracket_same_line: bool,
 
     /// Control the formatter for JavaScript (and its super languages) files.
     #[partial(bpaf(long("javascript-formatter-enabled"), argument("true|false"), optional))]
@@ -85,6 +82,10 @@ pub struct JavascriptFormatter {
     ))]
     pub attribute_position: Option<AttributePosition>,
 
+    /// Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+    #[partial(bpaf(long("javascript-bracket-same-line"), argument("true|false"), optional))]
+    pub bracket_same_line: Option<BracketSameLine>,
+
     // it's also a top-level configurable property.
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     #[partial(bpaf(long("bracket-spacing"), argument("true|false"), optional))]
@@ -101,7 +102,7 @@ impl PartialJavascriptFormatter {
             semicolons: self.semicolons.unwrap_or_default(),
             arrow_parentheses: self.arrow_parentheses.unwrap_or_default(),
             bracket_spacing: self.bracket_spacing,
-            bracket_same_line: self.bracket_same_line.unwrap_or_default(),
+            bracket_same_line: self.bracket_same_line,
             indent_style: self.indent_style,
             indent_width: self.indent_width,
             line_ending: self.line_ending,

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -9,7 +9,8 @@ use crate::{
 use biome_analyze::RuleDomain;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
-    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    AttributePosition, BracketSameLine, BracketSpacing, IndentStyle, IndentWidth, LineEnding,
+    LineWidth,
 };
 use bpaf::Bpaf;
 use rustc_hash::FxHashMap;
@@ -134,6 +135,11 @@ pub struct OverrideFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[bpaf(long("attribute-position"), argument("multiline|auto"), optional)]
     pub attribute_position: Option<AttributePosition>,
+
+    /// Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[bpaf(long("bracket-same-line"), argument("true|false"), optional, hide)]
+    pub bracket_same_line: Option<BracketSameLine>,
 
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/biome_configuration/tests/invalid/formatter_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/formatter_extraneous_field.json.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/biome_service/tests/spec_tests.rs
+source: crates/biome_configuration/tests/spec_tests.rs
 expression: formatter_extraneous_field.json
 ---
 formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -23,6 +23,7 @@ formatter_extraneous_field.json:3:3 deserialize ━━━━━━━━━━�
   - lineEnding
   - lineWidth
   - attributePosition
+  - bracketSameLine
   - bracketSpacing
   - ignore
   - include

--- a/crates/biome_configuration/tests/invalid/formatter_quote_style.json.snap
+++ b/crates/biome_configuration/tests/invalid/formatter_quote_style.json.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/biome_service/tests/spec_tests.rs
+source: crates/biome_configuration/tests/spec_tests.rs
 expression: formatter_quote_style.json
 ---
 formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -23,6 +23,7 @@ formatter_quote_style.json:3:9 deserialize ━━━━━━━━━━━━�
   - lineEnding
   - lineWidth
   - attributePosition
+  - bracketSameLine
   - bracketSpacing
   - ignore
   - include

--- a/crates/biome_css_formatter/src/context.rs
+++ b/crates/biome_css_formatter/src/context.rs
@@ -148,6 +148,10 @@ impl FormatOptions for CssFormatOptions {
         AttributePosition::default()
     }
 
+    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
+        biome_formatter::BracketSameLine::default()
+    }
+
     fn bracket_spacing(&self) -> BracketSpacing {
         BracketSpacing::default()
     }

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -2,8 +2,8 @@
 use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;
-use crate::prelude::*;
 use crate::{format, write, AttributePosition, BracketSpacing};
+use crate::{prelude::*, BracketSameLine};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions, TransformSourceMap,
@@ -202,6 +202,10 @@ impl FormatOptions for IrFormatOptions {
 
     fn attribute_position(&self) -> AttributePosition {
         AttributePosition::default()
+    }
+
+    fn bracket_same_line(&self) -> BracketSameLine {
+        BracketSameLine::default()
     }
 
     fn bracket_spacing(&self) -> BracketSpacing {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -641,6 +641,48 @@ impl FromStr for AttributePosition {
     }
 }
 
+/// Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+#[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct BracketSameLine(bool);
+
+impl BracketSameLine {
+    /// Return the boolean value for this [BracketSameLine]
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl From<bool> for BracketSameLine {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for BracketSameLine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", self.value())
+    }
+}
+
+impl FromStr for BracketSameLine {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match bool::from_str(s) {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for BracketSameLine. Supported values are 'true' and 'false'.",
+            ),
+        }
+    }
+}
+
 /// Context object storing data relevant when formatting an object.
 pub trait FormatContext {
     type Options: FormatOptions;
@@ -672,6 +714,9 @@ pub trait FormatOptions {
 
     /// The attribute position.
     fn attribute_position(&self) -> AttributePosition;
+
+    /// Whether to put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+    fn bracket_same_line(&self) -> BracketSameLine;
 
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
     fn bracket_spacing(&self) -> BracketSpacing;
@@ -725,6 +770,7 @@ pub struct SimpleFormatOptions {
     pub line_width: LineWidth,
     pub line_ending: LineEnding,
     pub attribute_position: AttributePosition,
+    pub bracket_same_line: BracketSameLine,
     pub bracket_spacing: BracketSpacing,
 }
 
@@ -747,6 +793,10 @@ impl FormatOptions for SimpleFormatOptions {
 
     fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    fn bracket_same_line(&self) -> BracketSameLine {
+        self.bracket_same_line
     }
 
     fn bracket_spacing(&self) -> BracketSpacing {

--- a/crates/biome_graphql_formatter/src/context.rs
+++ b/crates/biome_graphql_formatter/src/context.rs
@@ -1,5 +1,7 @@
 use crate::GraphqlCommentStyle;
-use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth, QuoteStyle};
+use biome_formatter::{
+    prelude::*, AttributePosition, BracketSameLine, BracketSpacing, IndentWidth, QuoteStyle,
+};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -159,6 +161,10 @@ impl FormatOptions for GraphqlFormatOptions {
 
     fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    fn bracket_same_line(&self) -> BracketSameLine {
+        BracketSameLine::default()
     }
 
     fn bracket_spacing(&self) -> BracketSpacing {

--- a/crates/biome_grit_formatter/src/context.rs
+++ b/crates/biome_grit_formatter/src/context.rs
@@ -149,6 +149,10 @@ impl FormatOptions for GritFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
+        biome_formatter::BracketSameLine::default()
+    }
+
     fn bracket_spacing(&self) -> biome_formatter::BracketSpacing {
         BracketSpacing::default()
     }

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -15,6 +15,8 @@ biome_formatter              = { workspace = true }
 biome_html_syntax            = { workspace = true }
 biome_rowan                  = { workspace = true }
 biome_suppression            = { workspace = true }
+schemars                     = { workspace = true, optional = true }
+serde                        = { workspace = true, optional = true }
 
 [dev-dependencies]
 biome_formatter_test = { workspace = true }
@@ -25,6 +27,10 @@ biome_service        = { workspace = true, features = ["experimental-html"] }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
 tests_macros         = { workspace = true }
+
+[features]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde", "biome_rowan/serde"]
 
 [lints]
 workspace = true

--- a/crates/biome_html_formatter/src/context.rs
+++ b/crates/biome_html_formatter/src/context.rs
@@ -1,8 +1,9 @@
-use std::{fmt, rc::Rc};
+use std::{fmt, rc::Rc, str::FromStr};
 
 use biome_formatter::{
-    printer::PrinterOptions, AttributePosition, BracketSpacing, CstFormatContext, FormatContext,
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, TransformSourceMap,
+    printer::PrinterOptions, AttributePosition, BracketSameLine, BracketSpacing, CstFormatContext,
+    FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    TransformSourceMap,
 };
 use biome_html_syntax::{HtmlFileSource, HtmlLanguage};
 
@@ -24,6 +25,22 @@ pub struct HtmlFormatOptions {
 
     /// Attribute position style. By default auto.
     attribute_position: AttributePosition,
+
+    /// Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+    ///
+    /// See: <https://prettier.io/docs/en/options.html#bracket-line>
+    bracket_same_line: BracketSameLine,
+
+    /// Whether to consider whitespace as significant. Default is `strict`.
+    ///
+    /// Whitespace inside HTML elements can sometimes affect the rendering of the page.
+    /// See:
+    /// - <https://prettier.io/docs/en/options.html#html-whitespace-sensitivity>
+    /// - <https://prettier.io/blog/2018/11/07/1.15.0#whitespace-sensitive-formatting>
+    whitespace_sensitivity: WhitespaceSensitivity,
+
+    /// Whether to indent the content of `<script>` and `<style>` tags. Default is `false`.
+    indent_script_and_style: IndentScriptAndStyle,
 }
 
 impl HtmlFormatOptions {
@@ -58,6 +75,27 @@ impl HtmlFormatOptions {
         self
     }
 
+    pub fn with_bracket_same_line(mut self, bracket_same_line: BracketSameLine) -> Self {
+        self.bracket_same_line = bracket_same_line;
+        self
+    }
+
+    pub fn with_whitespace_sensitivity(
+        mut self,
+        whitespace_sensitivity: WhitespaceSensitivity,
+    ) -> Self {
+        self.whitespace_sensitivity = whitespace_sensitivity;
+        self
+    }
+
+    pub fn with_indent_script_and_style(
+        mut self,
+        indent_script_and_style: IndentScriptAndStyle,
+    ) -> Self {
+        self.indent_script_and_style = indent_script_and_style;
+        self
+    }
+
     pub fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -76,6 +114,18 @@ impl HtmlFormatOptions {
 
     pub fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    pub fn bracket_same_line(&self) -> BracketSameLine {
+        self.bracket_same_line
+    }
+
+    pub fn whitespace_sensitivity(&self) -> WhitespaceSensitivity {
+        self.whitespace_sensitivity
+    }
+
+    pub fn indent_script_and_style(&self) -> IndentScriptAndStyle {
+        self.indent_script_and_style
     }
 
     pub fn set_indent_style(&mut self, indent_style: IndentStyle) {
@@ -97,6 +147,18 @@ impl HtmlFormatOptions {
     pub fn set_attribute_position(&mut self, attribute_position: AttributePosition) {
         self.attribute_position = attribute_position;
     }
+
+    pub fn set_bracket_same_line(&mut self, bracket_same_line: BracketSameLine) {
+        self.bracket_same_line = bracket_same_line;
+    }
+
+    pub fn set_whitespace_sensitivity(&mut self, whitespace_sensitivity: WhitespaceSensitivity) {
+        self.whitespace_sensitivity = whitespace_sensitivity;
+    }
+
+    pub fn set_indent_script_and_style(&mut self, indent_script_and_style: IndentScriptAndStyle) {
+        self.indent_script_and_style = indent_script_and_style;
+    }
 }
 
 impl fmt::Display for HtmlFormatOptions {
@@ -105,7 +167,15 @@ impl fmt::Display for HtmlFormatOptions {
         writeln!(f, "Indent width: {}", self.indent_width.value())?;
         writeln!(f, "Line ending: {}", self.line_ending)?;
         writeln!(f, "Line width: {}", self.line_width.value())?;
-        writeln!(f, "Attribute Position: {}", self.attribute_position)
+        writeln!(f, "Attribute Position: {}", self.attribute_position)?;
+        writeln!(f, "Bracket same line: {}", self.bracket_same_line)?;
+        writeln!(f, "Whitespace sensitivity: {}", self.whitespace_sensitivity)?;
+        writeln!(
+            f,
+            "Indent script and style: {}",
+            self.indent_script_and_style.value()
+        )?;
+        Ok(())
     }
 }
 
@@ -130,12 +200,113 @@ impl FormatOptions for HtmlFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_same_line(&self) -> BracketSameLine {
+        self.bracket_same_line
+    }
+
     fn bracket_spacing(&self) -> biome_formatter::BracketSpacing {
         BracketSpacing::default()
     }
 
     fn as_print_options(&self) -> biome_formatter::prelude::PrinterOptions {
         PrinterOptions::from(self)
+    }
+}
+
+/// Whitespace sensitivity for HTML formatting.
+///
+/// The following two cases won't produce the same output:
+///
+/// |                |      html      |    output    |
+/// | -------------- | :------------: | :----------: |
+/// | with spaces    | `1<b> 2 </b>3` | 1<b> 2 </b>3 |
+/// | without spaces |  `1<b>2</b>3`  |  1<b>2</b>3  |
+///
+/// This happens because whitespace is significant in inline elements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum WhitespaceSensitivity {
+    /// Leading and trailing whitespace in content is considered significant for inline elements.
+    ///
+    /// The formatter should leave at least one whitespace character if whitespace is present.
+    /// Otherwise, if there is no whitespace, it should not add any after `>` or before `<`. In other words, if there's no whitespace, the text content should hug the tags.
+    ///
+    /// Example of text hugging the tags:
+    /// ```html
+    /// <b
+    ///     >content</b
+    /// >
+    /// ```
+    #[default]
+    Strict,
+    /// Whitespace is considered insignificant. The formatter is free to remove or add whitespace as it sees fit.
+    Ignore,
+}
+
+impl fmt::Display for WhitespaceSensitivity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Strict => std::write!(f, "strict"),
+            Self::Ignore => std::write!(f, "ignore"),
+        }
+    }
+}
+
+impl FromStr for WhitespaceSensitivity {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "strict" => Ok(Self::Strict),
+            "ignore" => Ok(Self::Ignore),
+            _ => Err("Value not supported for WhitespaceSensitivity. Supported values are 'strict' and 'ignore'."),
+        }
+    }
+}
+
+/// Whether to indent the content of `<script>` and `<style>` tags for HTML-ish templating languages (Vue, Svelte, etc.).
+///
+/// When true, the content of `<script>` and `<style>` tags will be indented one level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct IndentScriptAndStyle(bool);
+
+impl IndentScriptAndStyle {
+    pub fn new(value: bool) -> Self {
+        Self(value)
+    }
+
+    pub fn value(&self) -> bool {
+        self.0
+    }
+}
+
+impl From<bool> for IndentScriptAndStyle {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl FromStr for IndentScriptAndStyle {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match bool::from_str(s) {
+            Ok(value) => Ok(Self(value)),
+            Err(_) => Err(
+                "Value not supported for IndentScriptAndStyle. Supported values are 'true' and 'false'.",
+            ),
+        }
     }
 }
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/break.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/attributes/no-break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/no-break.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/attributes/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/self-closing.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/attributes/single-quotes.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/single-quotes.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/pre.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/pre.html.snap
@@ -34,6 +34,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case0.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case0.html.snap
@@ -27,6 +27,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case1.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case1.html.snap
@@ -29,6 +29,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case2.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case2.html.snap
@@ -27,6 +27,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case3.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case3.html.snap
@@ -27,6 +27,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case4.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case4.html.snap
@@ -24,6 +24,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/example.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/example.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/long-content.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/long-content.html.snap
@@ -22,6 +22,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/many-children.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/many-children.html.snap
@@ -25,6 +25,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
@@ -24,6 +24,9 @@ Indent width: 2
 Line ending: LF
 Line width: 80
 Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
 -----
 
 ```html

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -4,8 +4,9 @@ use crate::comments::{FormatJsLeadingComment, JsCommentStyle, JsComments};
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::printer::PrinterOptions;
 use biome_formatter::{
-    AttributePosition, BracketSpacing, CstFormatContext, FormatContext, FormatElement,
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle, TransformSourceMap,
+    AttributePosition, BracketSameLine, BracketSpacing, CstFormatContext, FormatContext,
+    FormatElement, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, QuoteStyle,
+    TransformSourceMap,
 };
 use biome_js_syntax::{AnyJsFunctionBody, JsFileSource, JsLanguage};
 use std::fmt;
@@ -376,6 +377,10 @@ impl FormatOptions for JsFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
+        self.bracket_same_line
+    }
+
     fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
     }
@@ -521,26 +526,5 @@ impl fmt::Display for ArrowParentheses {
             ArrowParentheses::AsNeeded => write!(f, "As needed"),
             ArrowParentheses::Always => write!(f, "Always"),
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Merge, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
-    serde(rename_all = "camelCase")
-)]
-pub struct BracketSameLine(bool);
-
-impl BracketSameLine {
-    /// Return the boolean value for this [BracketSameLine]
-    pub fn value(&self) -> bool {
-        self.0
-    }
-}
-
-impl From<bool> for BracketSameLine {
-    fn from(value: bool) -> Self {
-        Self(value)
     }
 }

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -185,6 +185,10 @@ impl FormatOptions for JsonFormatOptions {
         self.attribute_position
     }
 
+    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
+        biome_formatter::BracketSameLine::default()
+    }
+
     fn bracket_spacing(&self) -> BracketSpacing {
         BracketSpacing::default()
     }

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -34,7 +34,7 @@ biome_grit_formatter    = { workspace = true }
 biome_grit_parser       = { workspace = true }
 biome_grit_patterns     = { workspace = true }
 biome_grit_syntax       = { workspace = true }
-biome_html_formatter    = { workspace = true }
+biome_html_formatter    = { workspace = true, features = ["serde"] }
 biome_html_parser       = { workspace = true }
 biome_html_syntax       = { workspace = true }
 biome_js_analyze        = { workspace = true }
@@ -86,6 +86,8 @@ schema = [
   "biome_graphql_syntax/schema",
   "biome_grit_syntax/schema",
   "biome_grit_patterns/schema",
+  "biome_html_syntax/schema",
+  "biome_html_formatter/schema",
 ]
 
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -27,16 +27,14 @@ use biome_analyze::{
 use biome_configuration::javascript::JsxRuntime;
 use biome_diagnostics::Applicability;
 use biome_formatter::{
-    AttributePosition, BracketSpacing, FormatError, IndentStyle, IndentWidth, LineEnding,
-    LineWidth, Printed, QuoteStyle,
+    AttributePosition, BracketSameLine, BracketSpacing, FormatError, IndentStyle, IndentWidth,
+    LineEnding, LineWidth, Printed, QuoteStyle,
 };
 use biome_fs::BiomePath;
 use biome_js_analyze::utils::rename::{RenameError, RenameSymbolExtensions};
 use biome_js_analyze::{analyze, analyze_with_inspect_matcher, ControlFlowGraph};
 use biome_js_formatter::context::trailing_commas::TrailingCommas;
-use biome_js_formatter::context::{
-    ArrowParentheses, BracketSameLine, JsFormatOptions, QuoteProperties, Semicolons,
-};
+use biome_js_formatter::context::{ArrowParentheses, JsFormatOptions, QuoteProperties, Semicolons};
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
 use biome_js_semantic::{semantic_model, SemanticModelOptions};
@@ -173,6 +171,7 @@ impl ServiceLanguage for JsLanguage {
         .with_bracket_same_line(
             language
                 .and_then(|l| l.bracket_same_line)
+                .or(global.and_then(|g| g.bracket_same_line))
                 .unwrap_or_default(),
         )
         .with_attribute_position(

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -17,7 +17,8 @@ use biome_css_parser::CssParserOptions;
 use biome_css_syntax::CssLanguage;
 use biome_deserialize::Merge;
 use biome_formatter::{
-    AttributePosition, BracketSpacing, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    AttributePosition, BracketSameLine, BracketSpacing, IndentStyle, IndentWidth, LineEnding,
+    LineWidth,
 };
 use biome_fs::BiomePath;
 use biome_graphql_formatter::context::GraphqlFormatOptions;
@@ -477,6 +478,7 @@ pub struct FormatSettings {
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub attribute_position: Option<AttributePosition>,
+    pub bracket_same_line: Option<BracketSameLine>,
     pub bracket_spacing: Option<BracketSpacing>,
     /// List of ignore paths/files
     pub ignored_files: Matcher,
@@ -494,6 +496,7 @@ impl Default for FormatSettings {
             line_ending: Some(LineEnding::default()),
             line_width: Some(LineWidth::default()),
             attribute_position: Some(AttributePosition::default()),
+            bracket_same_line: Some(BracketSameLine::default()),
             bracket_spacing: Some(BracketSpacing::default()),
             ignored_files: Matcher::empty(),
             included_files: Matcher::empty(),
@@ -514,6 +517,7 @@ pub struct OverrideFormatSettings {
     pub line_ending: Option<LineEnding>,
     pub line_width: Option<LineWidth>,
     pub bracket_spacing: Option<BracketSpacing>,
+    pub bracket_same_line: Option<BracketSameLine>,
     pub attribute_position: Option<AttributePosition>,
 }
 
@@ -650,7 +654,7 @@ impl From<JavascriptConfiguration> for LanguageSettings<JsLanguage> {
         language_setting.formatter.trailing_commas = Some(formatter.trailing_commas);
         language_setting.formatter.semicolons = Some(formatter.semicolons);
         language_setting.formatter.arrow_parentheses = Some(formatter.arrow_parentheses);
-        language_setting.formatter.bracket_same_line = Some(formatter.bracket_same_line.into());
+        language_setting.formatter.bracket_same_line = formatter.bracket_same_line;
         language_setting.formatter.enabled = Some(formatter.enabled);
         language_setting.formatter.line_width = formatter.line_width;
         language_setting.formatter.bracket_spacing = formatter.bracket_spacing;
@@ -1446,6 +1450,7 @@ pub fn to_override_settings(
                 line_ending: formatter.line_ending,
                 line_width: formatter.line_width,
                 bracket_spacing: formatter.bracket_spacing,
+                bracket_same_line: formatter.bracket_same_line,
                 attribute_position: formatter.attribute_position,
             })
             .unwrap_or_default();
@@ -1614,6 +1619,7 @@ pub fn to_format_settings(
         line_width: Some(conf.line_width),
         format_with_errors: conf.format_with_errors,
         attribute_position: Some(conf.attribute_position),
+        bracket_same_line: Some(conf.bracket_same_line),
         bracket_spacing: Some(conf.bracket_spacing),
         ignored_files: Matcher::from_globs(
             working_directory.clone(),
@@ -1641,6 +1647,7 @@ impl TryFrom<OverrideFormatterConfiguration> for FormatSettings {
             line_ending: conf.line_ending,
             line_width: conf.line_width,
             attribute_position: Some(AttributePosition::default()),
+            bracket_same_line: conf.bracket_same_line,
             bracket_spacing: Some(BracketSpacing::default()),
             format_with_errors: conf.format_with_errors.unwrap_or_default(),
             ignored_files: Matcher::empty(),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -142,6 +142,10 @@ export interface PartialFormatterConfiguration {
 	 */
 	attributePosition?: AttributePosition;
 	/**
+	 * Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+	 */
+	bracketSameLine?: BracketSameLine;
+	/**
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
 	bracketSpacing?: BracketSpacing;
@@ -361,6 +365,10 @@ export interface PartialCssParser {
 	cssModules?: boolean;
 }
 export type AttributePosition = "auto" | "multiline";
+/**
+ * Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+ */
+export type BracketSameLine = boolean;
 export type BracketSpacing = boolean;
 export type IndentStyle = "tab" | "space";
 export type IndentWidth = number;
@@ -437,7 +445,7 @@ export interface PartialJavascriptFormatter {
 	/**
 	 * Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
 	 */
-	bracketSameLine?: boolean;
+	bracketSameLine?: BracketSameLine;
 	/**
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */
@@ -1948,6 +1956,10 @@ export interface OverrideFormatterConfiguration {
 	 * The attribute position style.
 	 */
 	attributePosition?: AttributePosition;
+	/**
+	 * Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+	 */
+	bracketSameLine?: BracketSameLine;
 	/**
 	 * Whether to insert spaces around brackets in object literals. Defaults to true.
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -396,6 +396,10 @@
 			"additionalProperties": false
 		},
 		"AttributePosition": { "type": "string", "enum": ["auto", "multiline"] },
+		"BracketSameLine": {
+			"description": "Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).",
+			"type": "boolean"
+		},
 		"BracketSpacing": { "type": "boolean" },
 		"Complexity": {
 			"description": "A list of rules that belong to this group",
@@ -1398,6 +1402,13 @@
 						{ "type": "null" }
 					]
 				},
+				"bracketSameLine": {
+					"description": "Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSameLine" },
+						{ "type": "null" }
+					]
+				},
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
 					"anyOf": [
@@ -1640,7 +1651,10 @@
 				},
 				"bracketSameLine": {
 					"description": "Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.",
-					"type": ["boolean", "null"]
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSameLine" },
+						{ "type": "null" }
+					]
 				},
 				"bracketSpacing": {
 					"description": "Whether to insert spaces around brackets in object literals. Defaults to true.",
@@ -2636,6 +2650,13 @@
 					"description": "The attribute position style.",
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
+						{ "type": "null" }
+					]
+				},
+				"bracketSameLine": {
+					"description": "Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSameLine" },
 						{ "type": "null" }
 					]
 				},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This does some of the more tedious plumbing for HTML related formatting options. The goal is to jsut get some of the boilerplate out of the way, and nail down names for the new options so that it doesn't clog up other PRs.

- Makes `bracketSameLine` global (as discussed for 2.0 in #4024)
- Adds HTML-specific settings/options `whitespaceSensitivity` and `indentScriptAndStyle`, but does not implement them

related: #4024

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

CI should pass.
