### PR TITLE
refactor: convert clippy allows to clippy expects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ unused_lifetimes                       = "warn"
 unused_macro_rules                     = "warn"
 
 [workspace.lints.clippy]
+allow_attributes        = "deny"
 cargo_common_metadata   = "allow"
 empty_docs              = "allow" # there are some false positives inside biome_wasm
 multiple_crate_versions = "allow"

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -24,7 +24,7 @@ impl<'a, R> RuleContext<'a, R>
 where
     R: Rule + Sized + 'static,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         query_result: &'a RuleQueryResult<R>,
         root: &'a RuleRoot<R>,

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -445,7 +445,7 @@ macro_rules! declare_lint_rule {
         // This is implemented by calling the `group_category!` macro from the
         // parent module (that should be declared by a call to `declare_group!`)
         // and providing it with the name of this rule as a string literal token
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! rule_category {
             () => { super::group_category!( $name ) };
         }
@@ -497,7 +497,7 @@ macro_rules! declare_syntax_rule {
         // This is implemented by calling the `group_category!` macro from the
         // parent module (that should be declared by a call to `declare_group!`)
         // and providing it with the name of this rule as a string literal token
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! rule_category {
             () => { super::group_category!( $name ) };
         }
@@ -564,7 +564,7 @@ macro_rules! declare_source_rule {
         );
 
         /// This macro returns the corresponding [ActionCategory] to use inside the [RuleAction]
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! rule_action_category {
             () => { ActionCategory::Source(SourceActionKind::Other(Cow::Borrowed(concat!($language, ".", $name) )))  };
         }
@@ -609,7 +609,7 @@ macro_rules! declare_lint_group {
         // name within this group.
         // This is implemented by calling the `category_concat!` macro with the
         // "lint" prefix, the name of this group, and the rule name argument
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! group_category {
             ( $rule_name:tt ) => { $crate::category_concat!( "lint", $name, $rule_name ) };
         }
@@ -646,7 +646,7 @@ macro_rules! declare_assists_group {
         // name within this group.
         // This is implemented by calling the `category_concat!` macro with the
         // "lint" prefix, the name of this group, and the rule name argument
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! group_category {
             ( $rule_name:tt ) => { $crate::category_concat!( "assists", $name, $rule_name ) };
         }
@@ -683,7 +683,7 @@ macro_rules! declare_syntax_group {
         // name within this group.
         // This is implemented by calling the `category_concat!` macro with the
         // "lint" prefix, the name of this group, and the rule name argument
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! group_category {
             ( $rule_name:tt ) => { $crate::category_concat!( "syntax", $name, $rule_name ) };
         }

--- a/crates/biome_analyze/src/services.rs
+++ b/crates/biome_analyze/src/services.rs
@@ -32,7 +32,7 @@ impl MissingServicesDiagnostic {
 }
 
 pub trait FromServices: Sized {
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     fn from_services(
         rule_key: &RuleKey,
         services: &ServiceBag,

--- a/crates/biome_aria_metadata/build.rs
+++ b/crates/biome_aria_metadata/build.rs
@@ -236,7 +236,6 @@ enum AriaAttributeType {
 
 #[derive(Debug, Default, biome_deserialize_macros::Merge, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct ValueDefinition {
     description: String,
     is_default: bool,

--- a/crates/biome_cli/src/service/mod.rs
+++ b/crates/biome_cli/src/service/mod.rs
@@ -422,7 +422,7 @@ struct JsonRpcRequest<P> {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct JsonRpcResponse {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     jsonrpc: Cow<'static, str>,
     id: u64,
     result: Option<Box<RawValue>>,
@@ -431,10 +431,10 @@ struct JsonRpcResponse {
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcError {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     code: i64,
     message: String,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     data: Option<Box<RawValue>>,
 }
 

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -180,14 +180,10 @@ const APPLY_ATTRIBUTE_POSITION_AFTER: &str = r#"<Foo
 </Foo>;
 "#;
 
-// Without this, Test (windows-latest) fails with: `warning: constant `DEFAULT_CONFIGURATION_BEFORE` is never used`
-#[allow(dead_code)]
 const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
     return { a, b }
   }"#;
 
-// Without this, Test (windows-latest) fails with: `warning: constant `DEFAULT_CONFIGURATION_AFTER` is never used`
-#[allow(dead_code)]
 const DEFAULT_CONFIGURATION_AFTER: &str = "function f() {
       return { a, b };
 }

--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -144,7 +144,7 @@ pub enum EditorconfigValue<T> {
 }
 
 // This is an `Into` because implementing `From` is not possible because you can't implement traits for a type you don't own.
-#[allow(clippy::from_over_into)]
+#[expect(clippy::from_over_into)]
 impl<T: Default> Into<Option<T>> for EditorconfigValue<T> {
     fn into(self) -> Option<T> {
         match self {

--- a/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
@@ -105,7 +105,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                         .and_then(|property_node| property_node.name().ok())
                     {
                         let prop = prop_node.text();
-                        #[allow(clippy::disallowed_methods)]
+                        #[expect(clippy::disallowed_methods)]
                         let prop_lowercase = prop.to_lowercase();
 
                         let prop_prefix = vender_prefix(&prop_lowercase);

--- a/crates/biome_css_analyze/tests/spec_tests.rs
+++ b/crates/biome_css_analyze/tests/spec_tests.rs
@@ -99,7 +99,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn analyze_and_snap(
     snapshot: &mut String,
     input_code: &str,

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_css_syntax::{
     CssSyntaxElement as SyntaxElement, CssSyntaxNode as SyntaxNode, CssSyntaxToken as SyntaxToken,
     *,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_css_syntax::{CssSyntaxKind, CssSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct CssSyntaxFactory;
 impl SyntaxFactory for CssSyntaxFactory {
     type Kind = CssSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_css_formatter/src/css/bogus/mod.rs
+++ b/crates/biome_css_formatter/src/css/bogus/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_at_rule;
 pub(crate) mod bogus_block;

--- a/crates/biome_css_formatter/src/generated.rs
+++ b/crates/biome_css_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, CssFormatContext, CssFormatter, FormatBogusNodeRule, FormatNodeRule, IntoFormat,
 };
@@ -18,7 +19,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssAtRule {
         crate::css::statements::at_rule::FormatCssAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::at_rule::FormatCssAtRule::default(),
@@ -31,7 +31,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssAtRule {
         crate::css::statements::at_rule::FormatCssAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::at_rule::FormatCssAtRule::default(),
@@ -58,7 +57,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssAttributeMatcher {
         crate::css::auxiliary::attribute_matcher::FormatCssAttributeMatcher,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::attribute_matcher::FormatCssAttributeMatcher::default(),
@@ -71,7 +69,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssAttributeMatcher {
         crate::css::auxiliary::attribute_matcher::FormatCssAttributeMatcher,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::attribute_matcher::FormatCssAttributeMatcher::default(),
@@ -98,7 +95,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssAttributeMatcherValue {
         crate::css::auxiliary::attribute_matcher_value::FormatCssAttributeMatcherValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::attribute_matcher_value::FormatCssAttributeMatcherValue::default(
@@ -112,7 +108,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssAttributeMatcherValue
         crate::css::auxiliary::attribute_matcher_value::FormatCssAttributeMatcherValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::attribute_matcher_value::FormatCssAttributeMatcherValue::default(
@@ -140,7 +135,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssAttributeName {
         crate::css::auxiliary::attribute_name::FormatCssAttributeName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::attribute_name::FormatCssAttributeName::default(),
@@ -153,7 +147,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssAttributeName {
         crate::css::auxiliary::attribute_name::FormatCssAttributeName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::attribute_name::FormatCssAttributeName::default(),
@@ -180,7 +173,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssAttributeSelector {
         crate::css::selectors::attribute_selector::FormatCssAttributeSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::attribute_selector::FormatCssAttributeSelector::default(),
@@ -193,7 +185,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssAttributeSelector {
         crate::css::selectors::attribute_selector::FormatCssAttributeSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::attribute_selector::FormatCssAttributeSelector::default(),
@@ -220,7 +211,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBinaryExpression {
         crate::css::auxiliary::binary_expression::FormatCssBinaryExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::binary_expression::FormatCssBinaryExpression::default(),
@@ -233,7 +223,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBinaryExpression {
         crate::css::auxiliary::binary_expression::FormatCssBinaryExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::binary_expression::FormatCssBinaryExpression::default(),
@@ -260,7 +249,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBracketedValue {
         crate::css::auxiliary::bracketed_value::FormatCssBracketedValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::bracketed_value::FormatCssBracketedValue::default(),
@@ -273,7 +261,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBracketedValue {
         crate::css::auxiliary::bracketed_value::FormatCssBracketedValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::bracketed_value::FormatCssBracketedValue::default(),
@@ -300,7 +287,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCharsetAtRule {
         crate::css::statements::charset_at_rule::FormatCssCharsetAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::charset_at_rule::FormatCssCharsetAtRule::default(),
@@ -313,7 +299,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCharsetAtRule {
         crate::css::statements::charset_at_rule::FormatCssCharsetAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::charset_at_rule::FormatCssCharsetAtRule::default(),
@@ -340,7 +325,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssClassSelector {
         crate::css::selectors::class_selector::FormatCssClassSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::class_selector::FormatCssClassSelector::default(),
@@ -353,7 +337,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssClassSelector {
         crate::css::selectors::class_selector::FormatCssClassSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::class_selector::FormatCssClassSelector::default(),
@@ -371,7 +354,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssColor {
     type Format<'a> =
         FormatRefWithRule<'a, biome_css_syntax::CssColor, crate::css::value::color::FormatCssColor>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::value::color::FormatCssColor::default())
     }
 }
@@ -379,7 +361,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssColor {
     type Format =
         FormatOwnedWithRule<biome_css_syntax::CssColor, crate::css::value::color::FormatCssColor>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::value::color::FormatCssColor::default())
     }
 }
@@ -403,7 +384,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssColorProfileAtRule {
         crate::css::statements::color_profile_at_rule::FormatCssColorProfileAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::color_profile_at_rule::FormatCssColorProfileAtRule::default(),
@@ -416,7 +396,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssColorProfileAtRule {
         crate::css::statements::color_profile_at_rule::FormatCssColorProfileAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::color_profile_at_rule::FormatCssColorProfileAtRule::default(),
@@ -443,7 +422,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComplexSelector {
         crate::css::selectors::complex_selector::FormatCssComplexSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::complex_selector::FormatCssComplexSelector::default(),
@@ -456,7 +434,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComplexSelector {
         crate::css::selectors::complex_selector::FormatCssComplexSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::complex_selector::FormatCssComplexSelector::default(),
@@ -483,7 +460,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComposesImportSpecifier
         crate::css::auxiliary::composes_import_specifier::FormatCssComposesImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: composes_import_specifier :: FormatCssComposesImportSpecifier :: default ())
     }
 }
@@ -493,7 +469,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComposesImportSpecifi
         crate::css::auxiliary::composes_import_specifier::FormatCssComposesImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: composes_import_specifier :: FormatCssComposesImportSpecifier :: default ())
     }
 }
@@ -517,7 +492,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComposesProperty {
         crate::css::properties::composes_property::FormatCssComposesProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::properties::composes_property::FormatCssComposesProperty::default(),
@@ -530,7 +504,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComposesProperty {
         crate::css::properties::composes_property::FormatCssComposesProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::properties::composes_property::FormatCssComposesProperty::default(),
@@ -557,7 +530,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComposesPropertyValue {
         crate::css::auxiliary::composes_property_value::FormatCssComposesPropertyValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::composes_property_value::FormatCssComposesPropertyValue::default(
@@ -571,7 +543,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComposesPropertyValue
         crate::css::auxiliary::composes_property_value::FormatCssComposesPropertyValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::composes_property_value::FormatCssComposesPropertyValue::default(
@@ -599,7 +570,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCompoundSelector {
         crate::css::selectors::compound_selector::FormatCssCompoundSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::compound_selector::FormatCssCompoundSelector::default(),
@@ -612,7 +582,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCompoundSelector {
         crate::css::selectors::compound_selector::FormatCssCompoundSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::compound_selector::FormatCssCompoundSelector::default(),
@@ -639,7 +608,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerAndQuery {
         crate::css::auxiliary::container_and_query::FormatCssContainerAndQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::container_and_query::FormatCssContainerAndQuery::default(),
@@ -652,7 +620,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerAndQuery {
         crate::css::auxiliary::container_and_query::FormatCssContainerAndQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::container_and_query::FormatCssContainerAndQuery::default(),
@@ -679,7 +646,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerAtRule {
         crate::css::statements::container_at_rule::FormatCssContainerAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::container_at_rule::FormatCssContainerAtRule::default(),
@@ -692,7 +658,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerAtRule {
         crate::css::statements::container_at_rule::FormatCssContainerAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::container_at_rule::FormatCssContainerAtRule::default(),
@@ -719,7 +684,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerNotQuery {
         crate::css::auxiliary::container_not_query::FormatCssContainerNotQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::container_not_query::FormatCssContainerNotQuery::default(),
@@ -732,7 +696,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerNotQuery {
         crate::css::auxiliary::container_not_query::FormatCssContainerNotQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::container_not_query::FormatCssContainerNotQuery::default(),
@@ -759,7 +722,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerOrQuery {
         crate::css::auxiliary::container_or_query::FormatCssContainerOrQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::container_or_query::FormatCssContainerOrQuery::default(),
@@ -772,7 +734,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerOrQuery {
         crate::css::auxiliary::container_or_query::FormatCssContainerOrQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::container_or_query::FormatCssContainerOrQuery::default(),
@@ -799,7 +760,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerQueryInParens 
         crate::css::auxiliary::container_query_in_parens::FormatCssContainerQueryInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_query_in_parens :: FormatCssContainerQueryInParens :: default ())
     }
 }
@@ -809,7 +769,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerQueryInParen
         crate::css::auxiliary::container_query_in_parens::FormatCssContainerQueryInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_query_in_parens :: FormatCssContainerQueryInParens :: default ())
     }
 }
@@ -817,14 +776,12 @@ impl FormatRule < biome_css_syntax :: CssContainerSizeFeatureInParens > for crat
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerSizeFeatureInParens {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssContainerSizeFeatureInParens , crate :: css :: auxiliary :: container_size_feature_in_parens :: FormatCssContainerSizeFeatureInParens > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_size_feature_in_parens :: FormatCssContainerSizeFeatureInParens :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerSizeFeatureInParens {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssContainerSizeFeatureInParens , crate :: css :: auxiliary :: container_size_feature_in_parens :: FormatCssContainerSizeFeatureInParens > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_size_feature_in_parens :: FormatCssContainerSizeFeatureInParens :: default ())
     }
 }
@@ -848,7 +805,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleAndQuery 
         crate::css::auxiliary::container_style_and_query::FormatCssContainerStyleAndQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_style_and_query :: FormatCssContainerStyleAndQuery :: default ())
     }
 }
@@ -858,7 +814,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleAndQuer
         crate::css::auxiliary::container_style_and_query::FormatCssContainerStyleAndQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_style_and_query :: FormatCssContainerStyleAndQuery :: default ())
     }
 }
@@ -882,7 +837,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleInParens 
         crate::css::auxiliary::container_style_in_parens::FormatCssContainerStyleInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_style_in_parens :: FormatCssContainerStyleInParens :: default ())
     }
 }
@@ -892,7 +846,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleInParen
         crate::css::auxiliary::container_style_in_parens::FormatCssContainerStyleInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_style_in_parens :: FormatCssContainerStyleInParens :: default ())
     }
 }
@@ -916,7 +869,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleNotQuery 
         crate::css::auxiliary::container_style_not_query::FormatCssContainerStyleNotQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_style_not_query :: FormatCssContainerStyleNotQuery :: default ())
     }
 }
@@ -926,7 +878,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleNotQuer
         crate::css::auxiliary::container_style_not_query::FormatCssContainerStyleNotQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_style_not_query :: FormatCssContainerStyleNotQuery :: default ())
     }
 }
@@ -950,7 +901,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleOrQuery {
         crate::css::auxiliary::container_style_or_query::FormatCssContainerStyleOrQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_style_or_query :: FormatCssContainerStyleOrQuery :: default ())
     }
 }
@@ -960,7 +910,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleOrQuery
         crate::css::auxiliary::container_style_or_query::FormatCssContainerStyleOrQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_style_or_query :: FormatCssContainerStyleOrQuery :: default ())
     }
 }
@@ -980,14 +929,12 @@ impl FormatRule<biome_css_syntax::CssContainerStyleQueryInParens>
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleQueryInParens {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssContainerStyleQueryInParens , crate :: css :: auxiliary :: container_style_query_in_parens :: FormatCssContainerStyleQueryInParens > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: container_style_query_in_parens :: FormatCssContainerStyleQueryInParens :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssContainerStyleQueryInParens {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssContainerStyleQueryInParens , crate :: css :: auxiliary :: container_style_query_in_parens :: FormatCssContainerStyleQueryInParens > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: container_style_query_in_parens :: FormatCssContainerStyleQueryInParens :: default ())
     }
 }
@@ -1011,7 +958,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCounterStyleAtRule {
         crate::css::statements::counter_style_at_rule::FormatCssCounterStyleAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::counter_style_at_rule::FormatCssCounterStyleAtRule::default(),
@@ -1024,7 +970,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCounterStyleAtRule {
         crate::css::statements::counter_style_at_rule::FormatCssCounterStyleAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::counter_style_at_rule::FormatCssCounterStyleAtRule::default(),
@@ -1051,7 +996,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCustomIdentifier {
         crate::css::value::custom_identifier::FormatCssCustomIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::custom_identifier::FormatCssCustomIdentifier::default(),
@@ -1064,7 +1008,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCustomIdentifier {
         crate::css::value::custom_identifier::FormatCssCustomIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::custom_identifier::FormatCssCustomIdentifier::default(),
@@ -1091,7 +1034,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDashedIdentifier {
         crate::css::value::dashed_identifier::FormatCssDashedIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::dashed_identifier::FormatCssDashedIdentifier::default(),
@@ -1104,7 +1046,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDashedIdentifier {
         crate::css::value::dashed_identifier::FormatCssDashedIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::dashed_identifier::FormatCssDashedIdentifier::default(),
@@ -1131,7 +1072,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclaration {
         crate::css::auxiliary::declaration::FormatCssDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::declaration::FormatCssDeclaration::default(),
@@ -1144,7 +1084,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclaration {
         crate::css::auxiliary::declaration::FormatCssDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::declaration::FormatCssDeclaration::default(),
@@ -1171,7 +1110,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationBlock {
         crate::css::auxiliary::declaration_block::FormatCssDeclarationBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::declaration_block::FormatCssDeclarationBlock::default(),
@@ -1184,7 +1122,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationBlock {
         crate::css::auxiliary::declaration_block::FormatCssDeclarationBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::declaration_block::FormatCssDeclarationBlock::default(),
@@ -1211,7 +1148,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationImportant {
         crate::css::auxiliary::declaration_important::FormatCssDeclarationImportant,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::declaration_important::FormatCssDeclarationImportant::default(),
@@ -1224,7 +1160,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationImportant 
         crate::css::auxiliary::declaration_important::FormatCssDeclarationImportant,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::declaration_important::FormatCssDeclarationImportant::default(),
@@ -1251,7 +1186,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrAtRuleBloc
         crate::css::auxiliary::declaration_or_at_rule_block::FormatCssDeclarationOrAtRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: declaration_or_at_rule_block :: FormatCssDeclarationOrAtRuleBlock :: default ())
     }
 }
@@ -1261,7 +1195,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrAtRuleBl
         crate::css::auxiliary::declaration_or_at_rule_block::FormatCssDeclarationOrAtRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: declaration_or_at_rule_block :: FormatCssDeclarationOrAtRuleBlock :: default ())
     }
 }
@@ -1285,7 +1218,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrRuleBlock 
         crate::css::auxiliary::declaration_or_rule_block::FormatCssDeclarationOrRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: declaration_or_rule_block :: FormatCssDeclarationOrRuleBlock :: default ())
     }
 }
@@ -1295,7 +1227,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrRuleBloc
         crate::css::auxiliary::declaration_or_rule_block::FormatCssDeclarationOrRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: declaration_or_rule_block :: FormatCssDeclarationOrRuleBlock :: default ())
     }
 }
@@ -1319,7 +1250,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationWithSemicolo
         crate::css::auxiliary::declaration_with_semicolon::FormatCssDeclarationWithSemicolon,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: declaration_with_semicolon :: FormatCssDeclarationWithSemicolon :: default ())
     }
 }
@@ -1329,7 +1259,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationWithSemico
         crate::css::auxiliary::declaration_with_semicolon::FormatCssDeclarationWithSemicolon,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: declaration_with_semicolon :: FormatCssDeclarationWithSemicolon :: default ())
     }
 }
@@ -1353,7 +1282,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDocumentAtRule {
         crate::css::statements::document_at_rule::FormatCssDocumentAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::document_at_rule::FormatCssDocumentAtRule::default(),
@@ -1366,7 +1294,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDocumentAtRule {
         crate::css::statements::document_at_rule::FormatCssDocumentAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::document_at_rule::FormatCssDocumentAtRule::default(),
@@ -1393,7 +1320,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDocumentCustomMatcher {
         crate::css::auxiliary::document_custom_matcher::FormatCssDocumentCustomMatcher,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::document_custom_matcher::FormatCssDocumentCustomMatcher::default(
@@ -1407,7 +1333,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDocumentCustomMatcher
         crate::css::auxiliary::document_custom_matcher::FormatCssDocumentCustomMatcher,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::document_custom_matcher::FormatCssDocumentCustomMatcher::default(
@@ -1435,7 +1360,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssEmptyDeclaration {
         crate::css::auxiliary::empty_declaration::FormatCssEmptyDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::empty_declaration::FormatCssEmptyDeclaration::default(),
@@ -1448,7 +1372,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssEmptyDeclaration {
         crate::css::auxiliary::empty_declaration::FormatCssEmptyDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::empty_declaration::FormatCssEmptyDeclaration::default(),
@@ -1475,7 +1398,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFaceAtRule {
         crate::css::statements::font_face_at_rule::FormatCssFontFaceAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::font_face_at_rule::FormatCssFontFaceAtRule::default(),
@@ -1488,7 +1410,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFaceAtRule {
         crate::css::statements::font_face_at_rule::FormatCssFontFaceAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::font_face_at_rule::FormatCssFontFaceAtRule::default(),
@@ -1515,7 +1436,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFamilyName {
         crate::css::auxiliary::font_family_name::FormatCssFontFamilyName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::font_family_name::FormatCssFontFamilyName::default(),
@@ -1528,7 +1448,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFamilyName {
         crate::css::auxiliary::font_family_name::FormatCssFontFamilyName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::font_family_name::FormatCssFontFamilyName::default(),
@@ -1555,7 +1474,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesAtRule
         crate::css::statements::font_feature_values_at_rule::FormatCssFontFeatureValuesAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: statements :: font_feature_values_at_rule :: FormatCssFontFeatureValuesAtRule :: default ())
     }
 }
@@ -1565,7 +1483,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesAtRu
         crate::css::statements::font_feature_values_at_rule::FormatCssFontFeatureValuesAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: statements :: font_feature_values_at_rule :: FormatCssFontFeatureValuesAtRule :: default ())
     }
 }
@@ -1589,7 +1506,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesBlock 
         crate::css::auxiliary::font_feature_values_block::FormatCssFontFeatureValuesBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: font_feature_values_block :: FormatCssFontFeatureValuesBlock :: default ())
     }
 }
@@ -1599,7 +1515,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesBloc
         crate::css::auxiliary::font_feature_values_block::FormatCssFontFeatureValuesBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: font_feature_values_block :: FormatCssFontFeatureValuesBlock :: default ())
     }
 }
@@ -1623,7 +1538,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesItem {
         crate::css::auxiliary::font_feature_values_item::FormatCssFontFeatureValuesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: font_feature_values_item :: FormatCssFontFeatureValuesItem :: default ())
     }
 }
@@ -1633,7 +1547,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesItem
         crate::css::auxiliary::font_feature_values_item::FormatCssFontFeatureValuesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: font_feature_values_item :: FormatCssFontFeatureValuesItem :: default ())
     }
 }
@@ -1657,7 +1570,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontPaletteValuesAtRule
         crate::css::statements::font_palette_values_at_rule::FormatCssFontPaletteValuesAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: statements :: font_palette_values_at_rule :: FormatCssFontPaletteValuesAtRule :: default ())
     }
 }
@@ -1667,7 +1579,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontPaletteValuesAtRu
         crate::css::statements::font_palette_values_at_rule::FormatCssFontPaletteValuesAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: statements :: font_palette_values_at_rule :: FormatCssFontPaletteValuesAtRule :: default ())
     }
 }
@@ -1687,7 +1598,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFunction {
         crate::css::auxiliary::function::FormatCssFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::function::FormatCssFunction::default(),
@@ -1700,7 +1610,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFunction {
         crate::css::auxiliary::function::FormatCssFunction,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::function::FormatCssFunction::default(),
@@ -1727,7 +1636,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssGenericDelimiter {
         crate::css::auxiliary::generic_delimiter::FormatCssGenericDelimiter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::generic_delimiter::FormatCssGenericDelimiter::default(),
@@ -1740,7 +1648,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssGenericDelimiter {
         crate::css::auxiliary::generic_delimiter::FormatCssGenericDelimiter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::generic_delimiter::FormatCssGenericDelimiter::default(),
@@ -1767,7 +1674,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssGenericProperty {
         crate::css::properties::generic_property::FormatCssGenericProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::properties::generic_property::FormatCssGenericProperty::default(),
@@ -1780,7 +1686,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssGenericProperty {
         crate::css::properties::generic_property::FormatCssGenericProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::properties::generic_property::FormatCssGenericProperty::default(),
@@ -1807,7 +1712,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssIdSelector {
         crate::css::selectors::id_selector::FormatCssIdSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::id_selector::FormatCssIdSelector::default(),
@@ -1820,7 +1724,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssIdSelector {
         crate::css::selectors::id_selector::FormatCssIdSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::id_selector::FormatCssIdSelector::default(),
@@ -1847,7 +1750,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssIdentifier {
         crate::css::value::identifier::FormatCssIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::identifier::FormatCssIdentifier::default(),
@@ -1860,7 +1762,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssIdentifier {
         crate::css::value::identifier::FormatCssIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::identifier::FormatCssIdentifier::default(),
@@ -1887,7 +1788,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssImportAnonymousLayer {
         crate::css::auxiliary::import_anonymous_layer::FormatCssImportAnonymousLayer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::import_anonymous_layer::FormatCssImportAnonymousLayer::default(),
@@ -1900,7 +1800,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssImportAnonymousLayer 
         crate::css::auxiliary::import_anonymous_layer::FormatCssImportAnonymousLayer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::import_anonymous_layer::FormatCssImportAnonymousLayer::default(),
@@ -1927,7 +1826,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssImportAtRule {
         crate::css::statements::import_at_rule::FormatCssImportAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::import_at_rule::FormatCssImportAtRule::default(),
@@ -1940,7 +1838,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssImportAtRule {
         crate::css::statements::import_at_rule::FormatCssImportAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::import_at_rule::FormatCssImportAtRule::default(),
@@ -1967,7 +1864,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssImportNamedLayer {
         crate::css::auxiliary::import_named_layer::FormatCssImportNamedLayer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::import_named_layer::FormatCssImportNamedLayer::default(),
@@ -1980,7 +1876,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssImportNamedLayer {
         crate::css::auxiliary::import_named_layer::FormatCssImportNamedLayer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::import_named_layer::FormatCssImportNamedLayer::default(),
@@ -2007,7 +1902,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssImportSupports {
         crate::css::auxiliary::import_supports::FormatCssImportSupports,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::import_supports::FormatCssImportSupports::default(),
@@ -2020,7 +1914,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssImportSupports {
         crate::css::auxiliary::import_supports::FormatCssImportSupports,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::import_supports::FormatCssImportSupports::default(),
@@ -2047,7 +1940,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesAtRule {
         crate::css::statements::keyframes_at_rule::FormatCssKeyframesAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::keyframes_at_rule::FormatCssKeyframesAtRule::default(),
@@ -2060,7 +1952,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesAtRule {
         crate::css::statements::keyframes_at_rule::FormatCssKeyframesAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::keyframes_at_rule::FormatCssKeyframesAtRule::default(),
@@ -2087,7 +1978,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesBlock {
         crate::css::auxiliary::keyframes_block::FormatCssKeyframesBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::keyframes_block::FormatCssKeyframesBlock::default(),
@@ -2100,7 +1990,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesBlock {
         crate::css::auxiliary::keyframes_block::FormatCssKeyframesBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::keyframes_block::FormatCssKeyframesBlock::default(),
@@ -2127,7 +2016,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesIdentSelector 
         crate::css::selectors::keyframes_ident_selector::FormatCssKeyframesIdentSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: keyframes_ident_selector :: FormatCssKeyframesIdentSelector :: default ())
     }
 }
@@ -2137,7 +2025,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesIdentSelecto
         crate::css::selectors::keyframes_ident_selector::FormatCssKeyframesIdentSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: keyframes_ident_selector :: FormatCssKeyframesIdentSelector :: default ())
     }
 }
@@ -2161,7 +2048,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesItem {
         crate::css::auxiliary::keyframes_item::FormatCssKeyframesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::keyframes_item::FormatCssKeyframesItem::default(),
@@ -2174,7 +2060,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesItem {
         crate::css::auxiliary::keyframes_item::FormatCssKeyframesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::keyframes_item::FormatCssKeyframesItem::default(),
@@ -2201,7 +2086,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesPercentageSele
         crate::css::selectors::keyframes_percentage_selector::FormatCssKeyframesPercentageSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: keyframes_percentage_selector :: FormatCssKeyframesPercentageSelector :: default ())
     }
 }
@@ -2211,7 +2095,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesPercentageSe
         crate::css::selectors::keyframes_percentage_selector::FormatCssKeyframesPercentageSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: keyframes_percentage_selector :: FormatCssKeyframesPercentageSelector :: default ())
     }
 }
@@ -2235,7 +2118,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopeFunction 
         crate::css::auxiliary::keyframes_scope_function::FormatCssKeyframesScopeFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: keyframes_scope_function :: FormatCssKeyframesScopeFunction :: default ())
     }
 }
@@ -2245,7 +2127,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopeFunctio
         crate::css::auxiliary::keyframes_scope_function::FormatCssKeyframesScopeFunction,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: keyframes_scope_function :: FormatCssKeyframesScopeFunction :: default ())
     }
 }
@@ -2269,7 +2150,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopePrefix {
         crate::css::auxiliary::keyframes_scope_prefix::FormatCssKeyframesScopePrefix,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::keyframes_scope_prefix::FormatCssKeyframesScopePrefix::default(),
@@ -2282,7 +2162,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopePrefix 
         crate::css::auxiliary::keyframes_scope_prefix::FormatCssKeyframesScopePrefix,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::keyframes_scope_prefix::FormatCssKeyframesScopePrefix::default(),
@@ -2309,7 +2188,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopedName {
         crate::css::auxiliary::keyframes_scoped_name::FormatCssKeyframesScopedName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::keyframes_scoped_name::FormatCssKeyframesScopedName::default(),
@@ -2322,7 +2200,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesScopedName {
         crate::css::auxiliary::keyframes_scoped_name::FormatCssKeyframesScopedName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::keyframes_scoped_name::FormatCssKeyframesScopedName::default(),
@@ -2349,7 +2226,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssLayerAtRule {
         crate::css::statements::layer_at_rule::FormatCssLayerAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::layer_at_rule::FormatCssLayerAtRule::default(),
@@ -2362,7 +2238,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssLayerAtRule {
         crate::css::statements::layer_at_rule::FormatCssLayerAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::layer_at_rule::FormatCssLayerAtRule::default(),
@@ -2389,7 +2264,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssLayerDeclaration {
         crate::css::auxiliary::layer_declaration::FormatCssLayerDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::layer_declaration::FormatCssLayerDeclaration::default(),
@@ -2402,7 +2276,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssLayerDeclaration {
         crate::css::auxiliary::layer_declaration::FormatCssLayerDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::layer_declaration::FormatCssLayerDeclaration::default(),
@@ -2429,7 +2302,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssLayerReference {
         crate::css::auxiliary::layer_reference::FormatCssLayerReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::layer_reference::FormatCssLayerReference::default(),
@@ -2442,7 +2314,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssLayerReference {
         crate::css::auxiliary::layer_reference::FormatCssLayerReference,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::layer_reference::FormatCssLayerReference::default(),
@@ -2453,14 +2324,12 @@ impl FormatRule < biome_css_syntax :: CssListOfComponentValuesExpression > for c
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssListOfComponentValuesExpression {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssListOfComponentValuesExpression , crate :: css :: auxiliary :: list_of_component_values_expression :: FormatCssListOfComponentValuesExpression > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: list_of_component_values_expression :: FormatCssListOfComponentValuesExpression :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssListOfComponentValuesExpression {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssListOfComponentValuesExpression , crate :: css :: auxiliary :: list_of_component_values_expression :: FormatCssListOfComponentValuesExpression > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: list_of_component_values_expression :: FormatCssListOfComponentValuesExpression :: default ())
     }
 }
@@ -2484,7 +2353,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMarginAtRule {
         crate::css::statements::margin_at_rule::FormatCssMarginAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::margin_at_rule::FormatCssMarginAtRule::default(),
@@ -2497,7 +2365,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMarginAtRule {
         crate::css::statements::margin_at_rule::FormatCssMarginAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::margin_at_rule::FormatCssMarginAtRule::default(),
@@ -2524,7 +2391,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaAndCondition {
         crate::css::auxiliary::media_and_condition::FormatCssMediaAndCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_and_condition::FormatCssMediaAndCondition::default(),
@@ -2537,7 +2403,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaAndCondition {
         crate::css::auxiliary::media_and_condition::FormatCssMediaAndCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_and_condition::FormatCssMediaAndCondition::default(),
@@ -2564,7 +2429,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaAndTypeQuery {
         crate::css::auxiliary::media_and_type_query::FormatCssMediaAndTypeQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_and_type_query::FormatCssMediaAndTypeQuery::default(),
@@ -2577,7 +2441,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaAndTypeQuery {
         crate::css::auxiliary::media_and_type_query::FormatCssMediaAndTypeQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_and_type_query::FormatCssMediaAndTypeQuery::default(),
@@ -2604,7 +2467,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaAtRule {
         crate::css::statements::media_at_rule::FormatCssMediaAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::media_at_rule::FormatCssMediaAtRule::default(),
@@ -2617,7 +2479,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaAtRule {
         crate::css::statements::media_at_rule::FormatCssMediaAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::media_at_rule::FormatCssMediaAtRule::default(),
@@ -2644,7 +2505,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaConditionInParens 
         crate::css::auxiliary::media_condition_in_parens::FormatCssMediaConditionInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: media_condition_in_parens :: FormatCssMediaConditionInParens :: default ())
     }
 }
@@ -2654,7 +2514,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaConditionInParen
         crate::css::auxiliary::media_condition_in_parens::FormatCssMediaConditionInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: media_condition_in_parens :: FormatCssMediaConditionInParens :: default ())
     }
 }
@@ -2678,7 +2537,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaConditionQuery {
         crate::css::auxiliary::media_condition_query::FormatCssMediaConditionQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_condition_query::FormatCssMediaConditionQuery::default(),
@@ -2691,7 +2549,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaConditionQuery {
         crate::css::auxiliary::media_condition_query::FormatCssMediaConditionQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_condition_query::FormatCssMediaConditionQuery::default(),
@@ -2718,7 +2575,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaFeatureInParens {
         crate::css::auxiliary::media_feature_in_parens::FormatCssMediaFeatureInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_feature_in_parens::FormatCssMediaFeatureInParens::default(
@@ -2732,7 +2588,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaFeatureInParens 
         crate::css::auxiliary::media_feature_in_parens::FormatCssMediaFeatureInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_feature_in_parens::FormatCssMediaFeatureInParens::default(
@@ -2760,7 +2615,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaNotCondition {
         crate::css::auxiliary::media_not_condition::FormatCssMediaNotCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_not_condition::FormatCssMediaNotCondition::default(),
@@ -2773,7 +2627,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaNotCondition {
         crate::css::auxiliary::media_not_condition::FormatCssMediaNotCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_not_condition::FormatCssMediaNotCondition::default(),
@@ -2800,7 +2653,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaOrCondition {
         crate::css::auxiliary::media_or_condition::FormatCssMediaOrCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_or_condition::FormatCssMediaOrCondition::default(),
@@ -2813,7 +2665,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaOrCondition {
         crate::css::auxiliary::media_or_condition::FormatCssMediaOrCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_or_condition::FormatCssMediaOrCondition::default(),
@@ -2836,7 +2687,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaType {
         crate::css::auxiliary::media_type::FormatCssMediaType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_type::FormatCssMediaType::default(),
@@ -2849,7 +2699,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaType {
         crate::css::auxiliary::media_type::FormatCssMediaType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_type::FormatCssMediaType::default(),
@@ -2876,7 +2725,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaTypeQuery {
         crate::css::auxiliary::media_type_query::FormatCssMediaTypeQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::media_type_query::FormatCssMediaTypeQuery::default(),
@@ -2889,7 +2737,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaTypeQuery {
         crate::css::auxiliary::media_type_query::FormatCssMediaTypeQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::media_type_query::FormatCssMediaTypeQuery::default(),
@@ -2916,7 +2763,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMetavariable {
         crate::css::auxiliary::metavariable::FormatCssMetavariable,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::metavariable::FormatCssMetavariable::default(),
@@ -2929,7 +2775,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMetavariable {
         crate::css::auxiliary::metavariable::FormatCssMetavariable,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::metavariable::FormatCssMetavariable::default(),
@@ -2956,7 +2801,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNamedNamespacePrefix {
         crate::css::auxiliary::named_namespace_prefix::FormatCssNamedNamespacePrefix,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::named_namespace_prefix::FormatCssNamedNamespacePrefix::default(),
@@ -2969,7 +2813,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNamedNamespacePrefix 
         crate::css::auxiliary::named_namespace_prefix::FormatCssNamedNamespacePrefix,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::named_namespace_prefix::FormatCssNamedNamespacePrefix::default(),
@@ -2992,7 +2835,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNamespace {
         crate::css::auxiliary::namespace::FormatCssNamespace,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::namespace::FormatCssNamespace::default(),
@@ -3005,7 +2847,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNamespace {
         crate::css::auxiliary::namespace::FormatCssNamespace,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::namespace::FormatCssNamespace::default(),
@@ -3032,7 +2873,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNamespaceAtRule {
         crate::css::statements::namespace_at_rule::FormatCssNamespaceAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::namespace_at_rule::FormatCssNamespaceAtRule::default(),
@@ -3045,7 +2885,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNamespaceAtRule {
         crate::css::statements::namespace_at_rule::FormatCssNamespaceAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::namespace_at_rule::FormatCssNamespaceAtRule::default(),
@@ -3072,7 +2911,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNestedQualifiedRule {
         crate::css::auxiliary::nested_qualified_rule::FormatCssNestedQualifiedRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::nested_qualified_rule::FormatCssNestedQualifiedRule::default(),
@@ -3085,7 +2923,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNestedQualifiedRule {
         crate::css::auxiliary::nested_qualified_rule::FormatCssNestedQualifiedRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::nested_qualified_rule::FormatCssNestedQualifiedRule::default(),
@@ -3112,7 +2949,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNestedSelector {
         crate::css::selectors::nested_selector::FormatCssNestedSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::nested_selector::FormatCssNestedSelector::default(),
@@ -3125,7 +2961,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNestedSelector {
         crate::css::selectors::nested_selector::FormatCssNestedSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::nested_selector::FormatCssNestedSelector::default(),
@@ -3148,7 +2983,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNthOffset {
         crate::css::auxiliary::nth_offset::FormatCssNthOffset,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::nth_offset::FormatCssNthOffset::default(),
@@ -3161,7 +2995,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNthOffset {
         crate::css::auxiliary::nth_offset::FormatCssNthOffset,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::nth_offset::FormatCssNthOffset::default(),
@@ -3182,7 +3015,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNumber {
         crate::css::value::number::FormatCssNumber,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::value::number::FormatCssNumber::default())
     }
 }
@@ -3192,7 +3024,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNumber {
         crate::css::value::number::FormatCssNumber,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::value::number::FormatCssNumber::default())
     }
 }
@@ -3216,7 +3047,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageAtRule {
         crate::css::statements::page_at_rule::FormatCssPageAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::page_at_rule::FormatCssPageAtRule::default(),
@@ -3229,7 +3059,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageAtRule {
         crate::css::statements::page_at_rule::FormatCssPageAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::page_at_rule::FormatCssPageAtRule::default(),
@@ -3256,7 +3085,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageAtRuleBlock {
         crate::css::auxiliary::page_at_rule_block::FormatCssPageAtRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::page_at_rule_block::FormatCssPageAtRuleBlock::default(),
@@ -3269,7 +3097,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageAtRuleBlock {
         crate::css::auxiliary::page_at_rule_block::FormatCssPageAtRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::page_at_rule_block::FormatCssPageAtRuleBlock::default(),
@@ -3296,7 +3123,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageSelector {
         crate::css::selectors::page_selector::FormatCssPageSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::page_selector::FormatCssPageSelector::default(),
@@ -3309,7 +3135,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageSelector {
         crate::css::selectors::page_selector::FormatCssPageSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::page_selector::FormatCssPageSelector::default(),
@@ -3336,7 +3161,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorPseudo {
         crate::css::pseudo::page_selector_pseudo::FormatCssPageSelectorPseudo,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::pseudo::page_selector_pseudo::FormatCssPageSelectorPseudo::default(),
@@ -3349,7 +3173,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorPseudo {
         crate::css::pseudo::page_selector_pseudo::FormatCssPageSelectorPseudo,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::pseudo::page_selector_pseudo::FormatCssPageSelectorPseudo::default(),
@@ -3372,7 +3195,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssParameter {
         crate::css::auxiliary::parameter::FormatCssParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::parameter::FormatCssParameter::default(),
@@ -3385,7 +3207,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssParameter {
         crate::css::auxiliary::parameter::FormatCssParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::parameter::FormatCssParameter::default(),
@@ -3412,7 +3233,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssParenthesizedExpression
         crate::css::auxiliary::parenthesized_expression::FormatCssParenthesizedExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: parenthesized_expression :: FormatCssParenthesizedExpression :: default ())
     }
 }
@@ -3422,7 +3242,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssParenthesizedExpressi
         crate::css::auxiliary::parenthesized_expression::FormatCssParenthesizedExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: parenthesized_expression :: FormatCssParenthesizedExpression :: default ())
     }
 }
@@ -3446,7 +3265,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPercentage {
         crate::css::value::percentage::FormatCssPercentage,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::percentage::FormatCssPercentage::default(),
@@ -3459,7 +3277,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPercentage {
         crate::css::value::percentage::FormatCssPercentage,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::percentage::FormatCssPercentage::default(),
@@ -3486,7 +3303,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPositionTryAtRule {
         crate::css::statements::position_try_at_rule::FormatCssPositionTryAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::position_try_at_rule::FormatCssPositionTryAtRule::default(),
@@ -3499,7 +3315,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPositionTryAtRule {
         crate::css::statements::position_try_at_rule::FormatCssPositionTryAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::position_try_at_rule::FormatCssPositionTryAtRule::default(),
@@ -3526,7 +3341,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPropertyAtRule {
         crate::css::statements::property_at_rule::FormatCssPropertyAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::property_at_rule::FormatCssPropertyAtRule::default(),
@@ -3539,7 +3353,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPropertyAtRule {
         crate::css::statements::property_at_rule::FormatCssPropertyAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::property_at_rule::FormatCssPropertyAtRule::default(),
@@ -3550,14 +3363,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoClassFunctionCompoundSelector > f
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionCompoundSelector {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoClassFunctionCompoundSelector , crate :: css :: selectors :: pseudo_class_function_compound_selector :: FormatCssPseudoClassFunctionCompoundSelector > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: pseudo_class_function_compound_selector :: FormatCssPseudoClassFunctionCompoundSelector :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionCompoundSelector {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoClassFunctionCompoundSelector , crate :: css :: selectors :: pseudo_class_function_compound_selector :: FormatCssPseudoClassFunctionCompoundSelector > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: pseudo_class_function_compound_selector :: FormatCssPseudoClassFunctionCompoundSelector :: default ())
     }
 }
@@ -3565,14 +3376,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoClassFunctionCompoundSelectorList
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionCompoundSelectorList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoClassFunctionCompoundSelectorList , crate :: css :: pseudo :: pseudo_class_function_compound_selector_list :: FormatCssPseudoClassFunctionCompoundSelectorList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_compound_selector_list :: FormatCssPseudoClassFunctionCompoundSelectorList :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionCompoundSelectorList {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoClassFunctionCompoundSelectorList , crate :: css :: pseudo :: pseudo_class_function_compound_selector_list :: FormatCssPseudoClassFunctionCompoundSelectorList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_compound_selector_list :: FormatCssPseudoClassFunctionCompoundSelectorList :: default ())
     }
 }
@@ -3592,14 +3401,12 @@ impl FormatRule<biome_css_syntax::CssPseudoClassFunctionIdentifier>
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionIdentifier {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoClassFunctionIdentifier , crate :: css :: pseudo :: pseudo_class_function_identifier :: FormatCssPseudoClassFunctionIdentifier > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_identifier :: FormatCssPseudoClassFunctionIdentifier :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionIdentifier {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoClassFunctionIdentifier , crate :: css :: pseudo :: pseudo_class_function_identifier :: FormatCssPseudoClassFunctionIdentifier > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_identifier :: FormatCssPseudoClassFunctionIdentifier :: default ())
     }
 }
@@ -3623,7 +3430,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionNth 
         crate::css::pseudo::pseudo_class_function_nth::FormatCssPseudoClassFunctionNth,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_function_nth::FormatCssPseudoClassFunctionNth::default(
@@ -3637,7 +3443,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionNt
         crate::css::pseudo::pseudo_class_function_nth::FormatCssPseudoClassFunctionNth,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_function_nth::FormatCssPseudoClassFunctionNth::default(
@@ -3649,14 +3454,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoClassFunctionRelativeSelectorList
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionRelativeSelectorList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoClassFunctionRelativeSelectorList , crate :: css :: pseudo :: pseudo_class_function_relative_selector_list :: FormatCssPseudoClassFunctionRelativeSelectorList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_relative_selector_list :: FormatCssPseudoClassFunctionRelativeSelectorList :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionRelativeSelectorList {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoClassFunctionRelativeSelectorList , crate :: css :: pseudo :: pseudo_class_function_relative_selector_list :: FormatCssPseudoClassFunctionRelativeSelectorList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_relative_selector_list :: FormatCssPseudoClassFunctionRelativeSelectorList :: default ())
     }
 }
@@ -3680,7 +3483,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionSele
         crate::css::selectors::pseudo_class_function_selector::FormatCssPseudoClassFunctionSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: pseudo_class_function_selector :: FormatCssPseudoClassFunctionSelector :: default ())
     }
 }
@@ -3690,7 +3492,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionSe
         crate::css::selectors::pseudo_class_function_selector::FormatCssPseudoClassFunctionSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: pseudo_class_function_selector :: FormatCssPseudoClassFunctionSelector :: default ())
     }
 }
@@ -3698,14 +3499,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoClassFunctionSelectorList > for c
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionSelectorList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoClassFunctionSelectorList , crate :: css :: pseudo :: pseudo_class_function_selector_list :: FormatCssPseudoClassFunctionSelectorList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_selector_list :: FormatCssPseudoClassFunctionSelectorList :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionSelectorList {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoClassFunctionSelectorList , crate :: css :: pseudo :: pseudo_class_function_selector_list :: FormatCssPseudoClassFunctionSelectorList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_selector_list :: FormatCssPseudoClassFunctionSelectorList :: default ())
     }
 }
@@ -3729,7 +3528,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionValu
         crate::css::pseudo::pseudo_class_function_value_list::FormatCssPseudoClassFunctionValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_value_list :: FormatCssPseudoClassFunctionValueList :: default ())
     }
 }
@@ -3739,7 +3537,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassFunctionVa
         crate::css::pseudo::pseudo_class_function_value_list::FormatCssPseudoClassFunctionValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_function_value_list :: FormatCssPseudoClassFunctionValueList :: default ())
     }
 }
@@ -3763,7 +3560,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassIdentifier {
         crate::css::pseudo::pseudo_class_identifier::FormatCssPseudoClassIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_identifier::FormatCssPseudoClassIdentifier::default(),
@@ -3776,7 +3572,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassIdentifier
         crate::css::pseudo::pseudo_class_identifier::FormatCssPseudoClassIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_identifier::FormatCssPseudoClassIdentifier::default(),
@@ -3803,7 +3598,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNth {
         crate::css::pseudo::pseudo_class_nth::FormatCssPseudoClassNth,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_nth::FormatCssPseudoClassNth::default(),
@@ -3816,7 +3610,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNth {
         crate::css::pseudo::pseudo_class_nth::FormatCssPseudoClassNth,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_nth::FormatCssPseudoClassNth::default(),
@@ -3843,7 +3636,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthIdentifie
         crate::css::pseudo::pseudo_class_nth_identifier::FormatCssPseudoClassNthIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_nth_identifier :: FormatCssPseudoClassNthIdentifier :: default ())
     }
 }
@@ -3853,7 +3645,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthIdentif
         crate::css::pseudo::pseudo_class_nth_identifier::FormatCssPseudoClassNthIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_class_nth_identifier :: FormatCssPseudoClassNthIdentifier :: default ())
     }
 }
@@ -3877,7 +3668,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthNumber {
         crate::css::pseudo::pseudo_class_nth_number::FormatCssPseudoClassNthNumber,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_nth_number::FormatCssPseudoClassNthNumber::default(),
@@ -3890,7 +3680,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthNumber 
         crate::css::pseudo::pseudo_class_nth_number::FormatCssPseudoClassNthNumber,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::pseudo::pseudo_class_nth_number::FormatCssPseudoClassNthNumber::default(),
@@ -3917,7 +3706,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthSelector 
         crate::css::selectors::pseudo_class_nth_selector::FormatCssPseudoClassNthSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: pseudo_class_nth_selector :: FormatCssPseudoClassNthSelector :: default ())
     }
 }
@@ -3927,7 +3715,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassNthSelecto
         crate::css::selectors::pseudo_class_nth_selector::FormatCssPseudoClassNthSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: pseudo_class_nth_selector :: FormatCssPseudoClassNthSelector :: default ())
     }
 }
@@ -3951,7 +3738,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassOfNthSelecto
         crate::css::selectors::pseudo_class_of_nth_selector::FormatCssPseudoClassOfNthSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: pseudo_class_of_nth_selector :: FormatCssPseudoClassOfNthSelector :: default ())
     }
 }
@@ -3961,7 +3747,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassOfNthSelec
         crate::css::selectors::pseudo_class_of_nth_selector::FormatCssPseudoClassOfNthSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: pseudo_class_of_nth_selector :: FormatCssPseudoClassOfNthSelector :: default ())
     }
 }
@@ -3985,7 +3770,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassSelector {
         crate::css::selectors::pseudo_class_selector::FormatCssPseudoClassSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::pseudo_class_selector::FormatCssPseudoClassSelector::default(),
@@ -3998,7 +3782,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoClassSelector {
         crate::css::selectors::pseudo_class_selector::FormatCssPseudoClassSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::pseudo_class_selector::FormatCssPseudoClassSelector::default(),
@@ -4009,14 +3792,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoElementFunctionIdentifier > for c
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementFunctionIdentifier {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoElementFunctionIdentifier , crate :: css :: pseudo :: pseudo_element_function_identifier :: FormatCssPseudoElementFunctionIdentifier > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_element_function_identifier :: FormatCssPseudoElementFunctionIdentifier :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementFunctionIdentifier {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoElementFunctionIdentifier , crate :: css :: pseudo :: pseudo_element_function_identifier :: FormatCssPseudoElementFunctionIdentifier > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_element_function_identifier :: FormatCssPseudoElementFunctionIdentifier :: default ())
     }
 }
@@ -4024,14 +3805,12 @@ impl FormatRule < biome_css_syntax :: CssPseudoElementFunctionSelector > for cra
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementFunctionSelector {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssPseudoElementFunctionSelector , crate :: css :: selectors :: pseudo_element_function_selector :: FormatCssPseudoElementFunctionSelector > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: pseudo_element_function_selector :: FormatCssPseudoElementFunctionSelector :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementFunctionSelector {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssPseudoElementFunctionSelector , crate :: css :: selectors :: pseudo_element_function_selector :: FormatCssPseudoElementFunctionSelector > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: pseudo_element_function_selector :: FormatCssPseudoElementFunctionSelector :: default ())
     }
 }
@@ -4055,7 +3834,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementIdentifier
         crate::css::pseudo::pseudo_element_identifier::FormatCssPseudoElementIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: pseudo :: pseudo_element_identifier :: FormatCssPseudoElementIdentifier :: default ())
     }
 }
@@ -4065,7 +3843,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementIdentifi
         crate::css::pseudo::pseudo_element_identifier::FormatCssPseudoElementIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: pseudo :: pseudo_element_identifier :: FormatCssPseudoElementIdentifier :: default ())
     }
 }
@@ -4089,7 +3866,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementSelector {
         crate::css::selectors::pseudo_element_selector::FormatCssPseudoElementSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::pseudo_element_selector::FormatCssPseudoElementSelector::default(
@@ -4103,7 +3879,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoElementSelector
         crate::css::selectors::pseudo_element_selector::FormatCssPseudoElementSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::pseudo_element_selector::FormatCssPseudoElementSelector::default(
@@ -4131,7 +3906,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQualifiedRule {
         crate::css::auxiliary::qualified_rule::FormatCssQualifiedRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::qualified_rule::FormatCssQualifiedRule::default(),
@@ -4144,7 +3918,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQualifiedRule {
         crate::css::auxiliary::qualified_rule::FormatCssQualifiedRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::qualified_rule::FormatCssQualifiedRule::default(),
@@ -4171,7 +3944,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureBoolean {
         crate::css::auxiliary::query_feature_boolean::FormatCssQueryFeatureBoolean,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::query_feature_boolean::FormatCssQueryFeatureBoolean::default(),
@@ -4184,7 +3956,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureBoolean {
         crate::css::auxiliary::query_feature_boolean::FormatCssQueryFeatureBoolean,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::query_feature_boolean::FormatCssQueryFeatureBoolean::default(),
@@ -4211,7 +3982,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeaturePlain {
         crate::css::auxiliary::query_feature_plain::FormatCssQueryFeaturePlain,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::query_feature_plain::FormatCssQueryFeaturePlain::default(),
@@ -4224,7 +3994,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeaturePlain {
         crate::css::auxiliary::query_feature_plain::FormatCssQueryFeaturePlain,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::query_feature_plain::FormatCssQueryFeaturePlain::default(),
@@ -4251,7 +4020,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRange {
         crate::css::auxiliary::query_feature_range::FormatCssQueryFeatureRange,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::query_feature_range::FormatCssQueryFeatureRange::default(),
@@ -4264,7 +4032,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRange {
         crate::css::auxiliary::query_feature_range::FormatCssQueryFeatureRange,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::query_feature_range::FormatCssQueryFeatureRange::default(),
@@ -4291,7 +4058,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRangeCompar
         crate::css::auxiliary::query_feature_range_comparison::FormatCssQueryFeatureRangeComparison,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: query_feature_range_comparison :: FormatCssQueryFeatureRangeComparison :: default ())
     }
 }
@@ -4301,7 +4067,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRangeComp
         crate::css::auxiliary::query_feature_range_comparison::FormatCssQueryFeatureRangeComparison,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: query_feature_range_comparison :: FormatCssQueryFeatureRangeComparison :: default ())
     }
 }
@@ -4325,7 +4090,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRangeInterv
         crate::css::auxiliary::query_feature_range_interval::FormatCssQueryFeatureRangeInterval,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: query_feature_range_interval :: FormatCssQueryFeatureRangeInterval :: default ())
     }
 }
@@ -4335,7 +4099,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureRangeInte
         crate::css::auxiliary::query_feature_range_interval::FormatCssQueryFeatureRangeInterval,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: query_feature_range_interval :: FormatCssQueryFeatureRangeInterval :: default ())
     }
 }
@@ -4359,7 +4122,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureReverseRang
         crate::css::auxiliary::query_feature_reverse_range::FormatCssQueryFeatureReverseRange,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: query_feature_reverse_range :: FormatCssQueryFeatureReverseRange :: default ())
     }
 }
@@ -4369,7 +4131,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssQueryFeatureReverseRa
         crate::css::auxiliary::query_feature_reverse_range::FormatCssQueryFeatureReverseRange,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: query_feature_reverse_range :: FormatCssQueryFeatureReverseRange :: default ())
     }
 }
@@ -4384,7 +4145,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRatio {
     type Format<'a> =
         FormatRefWithRule<'a, biome_css_syntax::CssRatio, crate::css::value::ratio::FormatCssRatio>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::value::ratio::FormatCssRatio::default())
     }
 }
@@ -4392,7 +4152,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRatio {
     type Format =
         FormatOwnedWithRule<biome_css_syntax::CssRatio, crate::css::value::ratio::FormatCssRatio>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::value::ratio::FormatCssRatio::default())
     }
 }
@@ -4416,7 +4175,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRegularDimension {
         crate::css::value::regular_dimension::FormatCssRegularDimension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::regular_dimension::FormatCssRegularDimension::default(),
@@ -4429,7 +4187,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRegularDimension {
         crate::css::value::regular_dimension::FormatCssRegularDimension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::regular_dimension::FormatCssRegularDimension::default(),
@@ -4456,7 +4213,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRelativeSelector {
         crate::css::selectors::relative_selector::FormatCssRelativeSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::relative_selector::FormatCssRelativeSelector::default(),
@@ -4469,7 +4225,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRelativeSelector {
         crate::css::selectors::relative_selector::FormatCssRelativeSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::relative_selector::FormatCssRelativeSelector::default(),
@@ -4490,7 +4245,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRoot {
         crate::css::auxiliary::root::FormatCssRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::auxiliary::root::FormatCssRoot::default())
     }
 }
@@ -4498,7 +4252,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRoot {
     type Format =
         FormatOwnedWithRule<biome_css_syntax::CssRoot, crate::css::auxiliary::root::FormatCssRoot>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::auxiliary::root::FormatCssRoot::default())
     }
 }
@@ -4518,7 +4271,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRuleBlock {
         crate::css::auxiliary::rule_block::FormatCssRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::rule_block::FormatCssRuleBlock::default(),
@@ -4531,7 +4283,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRuleBlock {
         crate::css::auxiliary::rule_block::FormatCssRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::rule_block::FormatCssRuleBlock::default(),
@@ -4558,7 +4309,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssScopeAtRule {
         crate::css::statements::scope_at_rule::FormatCssScopeAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::scope_at_rule::FormatCssScopeAtRule::default(),
@@ -4571,7 +4321,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssScopeAtRule {
         crate::css::statements::scope_at_rule::FormatCssScopeAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::scope_at_rule::FormatCssScopeAtRule::default(),
@@ -4594,7 +4343,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssScopeEdge {
         crate::css::auxiliary::scope_edge::FormatCssScopeEdge,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::scope_edge::FormatCssScopeEdge::default(),
@@ -4607,7 +4355,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssScopeEdge {
         crate::css::auxiliary::scope_edge::FormatCssScopeEdge,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::scope_edge::FormatCssScopeEdge::default(),
@@ -4634,7 +4381,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeEnd {
         crate::css::auxiliary::scope_range_end::FormatCssScopeRangeEnd,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::scope_range_end::FormatCssScopeRangeEnd::default(),
@@ -4647,7 +4393,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeEnd {
         crate::css::auxiliary::scope_range_end::FormatCssScopeRangeEnd,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::scope_range_end::FormatCssScopeRangeEnd::default(),
@@ -4674,7 +4419,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeInterval {
         crate::css::auxiliary::scope_range_interval::FormatCssScopeRangeInterval,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::scope_range_interval::FormatCssScopeRangeInterval::default(),
@@ -4687,7 +4431,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeInterval {
         crate::css::auxiliary::scope_range_interval::FormatCssScopeRangeInterval,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::scope_range_interval::FormatCssScopeRangeInterval::default(),
@@ -4714,7 +4457,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeStart {
         crate::css::auxiliary::scope_range_start::FormatCssScopeRangeStart,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::scope_range_start::FormatCssScopeRangeStart::default(),
@@ -4727,7 +4469,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssScopeRangeStart {
         crate::css::auxiliary::scope_range_start::FormatCssScopeRangeStart,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::scope_range_start::FormatCssScopeRangeStart::default(),
@@ -4754,7 +4495,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssStartingStyleAtRule {
         crate::css::statements::starting_style_at_rule::FormatCssStartingStyleAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::starting_style_at_rule::FormatCssStartingStyleAtRule::default(),
@@ -4767,7 +4507,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssStartingStyleAtRule {
         crate::css::statements::starting_style_at_rule::FormatCssStartingStyleAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::starting_style_at_rule::FormatCssStartingStyleAtRule::default(),
@@ -4788,7 +4527,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssString {
         crate::css::value::string::FormatCssString,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::value::string::FormatCssString::default())
     }
 }
@@ -4798,7 +4536,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssString {
         crate::css::value::string::FormatCssString,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::value::string::FormatCssString::default())
     }
 }
@@ -4822,7 +4559,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsAndCondition {
         crate::css::auxiliary::supports_and_condition::FormatCssSupportsAndCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::supports_and_condition::FormatCssSupportsAndCondition::default(),
@@ -4835,7 +4571,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsAndCondition 
         crate::css::auxiliary::supports_and_condition::FormatCssSupportsAndCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::supports_and_condition::FormatCssSupportsAndCondition::default(),
@@ -4862,7 +4597,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsAtRule {
         crate::css::statements::supports_at_rule::FormatCssSupportsAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::supports_at_rule::FormatCssSupportsAtRule::default(),
@@ -4875,7 +4609,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsAtRule {
         crate::css::statements::supports_at_rule::FormatCssSupportsAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::supports_at_rule::FormatCssSupportsAtRule::default(),
@@ -4902,7 +4635,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsConditionInPare
         crate::css::auxiliary::supports_condition_in_parens::FormatCssSupportsConditionInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: supports_condition_in_parens :: FormatCssSupportsConditionInParens :: default ())
     }
 }
@@ -4912,7 +4644,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsConditionInPa
         crate::css::auxiliary::supports_condition_in_parens::FormatCssSupportsConditionInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: supports_condition_in_parens :: FormatCssSupportsConditionInParens :: default ())
     }
 }
@@ -4936,7 +4667,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsFeatureDeclarat
         crate::css::auxiliary::supports_feature_declaration::FormatCssSupportsFeatureDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: supports_feature_declaration :: FormatCssSupportsFeatureDeclaration :: default ())
     }
 }
@@ -4946,7 +4676,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsFeatureDeclar
         crate::css::auxiliary::supports_feature_declaration::FormatCssSupportsFeatureDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: supports_feature_declaration :: FormatCssSupportsFeatureDeclaration :: default ())
     }
 }
@@ -4970,7 +4699,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsFeatureSelector
         crate::css::selectors::supports_feature_selector::FormatCssSupportsFeatureSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: selectors :: supports_feature_selector :: FormatCssSupportsFeatureSelector :: default ())
     }
 }
@@ -4980,7 +4708,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsFeatureSelect
         crate::css::selectors::supports_feature_selector::FormatCssSupportsFeatureSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: selectors :: supports_feature_selector :: FormatCssSupportsFeatureSelector :: default ())
     }
 }
@@ -5004,7 +4731,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsNotCondition {
         crate::css::auxiliary::supports_not_condition::FormatCssSupportsNotCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::supports_not_condition::FormatCssSupportsNotCondition::default(),
@@ -5017,7 +4743,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsNotCondition 
         crate::css::auxiliary::supports_not_condition::FormatCssSupportsNotCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::supports_not_condition::FormatCssSupportsNotCondition::default(),
@@ -5044,7 +4769,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSupportsOrCondition {
         crate::css::auxiliary::supports_or_condition::FormatCssSupportsOrCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::supports_or_condition::FormatCssSupportsOrCondition::default(),
@@ -5057,7 +4781,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSupportsOrCondition {
         crate::css::auxiliary::supports_or_condition::FormatCssSupportsOrCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::supports_or_condition::FormatCssSupportsOrCondition::default(),
@@ -5084,7 +4807,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssTypeSelector {
         crate::css::selectors::type_selector::FormatCssTypeSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::type_selector::FormatCssTypeSelector::default(),
@@ -5097,7 +4819,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssTypeSelector {
         crate::css::selectors::type_selector::FormatCssTypeSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::type_selector::FormatCssTypeSelector::default(),
@@ -5124,7 +4845,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnicodeCodepoint {
         crate::css::auxiliary::unicode_codepoint::FormatCssUnicodeCodepoint,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::unicode_codepoint::FormatCssUnicodeCodepoint::default(),
@@ -5137,7 +4857,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnicodeCodepoint {
         crate::css::auxiliary::unicode_codepoint::FormatCssUnicodeCodepoint,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::unicode_codepoint::FormatCssUnicodeCodepoint::default(),
@@ -5164,7 +4883,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRange {
         crate::css::auxiliary::unicode_range::FormatCssUnicodeRange,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::unicode_range::FormatCssUnicodeRange::default(),
@@ -5177,7 +4895,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRange {
         crate::css::auxiliary::unicode_range::FormatCssUnicodeRange,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::unicode_range::FormatCssUnicodeRange::default(),
@@ -5204,7 +4921,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRangeInterval {
         crate::css::auxiliary::unicode_range_interval::FormatCssUnicodeRangeInterval,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::unicode_range_interval::FormatCssUnicodeRangeInterval::default(),
@@ -5217,7 +4933,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRangeInterval 
         crate::css::auxiliary::unicode_range_interval::FormatCssUnicodeRangeInterval,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::unicode_range_interval::FormatCssUnicodeRangeInterval::default(),
@@ -5244,7 +4959,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRangeWildcard {
         crate::css::auxiliary::unicode_range_wildcard::FormatCssUnicodeRangeWildcard,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::unicode_range_wildcard::FormatCssUnicodeRangeWildcard::default(),
@@ -5257,7 +4971,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnicodeRangeWildcard 
         crate::css::auxiliary::unicode_range_wildcard::FormatCssUnicodeRangeWildcard,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::unicode_range_wildcard::FormatCssUnicodeRangeWildcard::default(),
@@ -5284,7 +4997,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUniversalNamespacePrefi
         crate::css::auxiliary::universal_namespace_prefix::FormatCssUniversalNamespacePrefix,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: universal_namespace_prefix :: FormatCssUniversalNamespacePrefix :: default ())
     }
 }
@@ -5294,7 +5006,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUniversalNamespacePre
         crate::css::auxiliary::universal_namespace_prefix::FormatCssUniversalNamespacePrefix,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: universal_namespace_prefix :: FormatCssUniversalNamespacePrefix :: default ())
     }
 }
@@ -5318,7 +5029,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUniversalSelector {
         crate::css::selectors::universal_selector::FormatCssUniversalSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::selectors::universal_selector::FormatCssUniversalSelector::default(),
@@ -5331,7 +5041,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUniversalSelector {
         crate::css::selectors::universal_selector::FormatCssUniversalSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::selectors::universal_selector::FormatCssUniversalSelector::default(),
@@ -5358,7 +5067,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnknownBlockAtRule {
         crate::css::statements::unknown_block_at_rule::FormatCssUnknownBlockAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::unknown_block_at_rule::FormatCssUnknownBlockAtRule::default(),
@@ -5371,7 +5079,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnknownBlockAtRule {
         crate::css::statements::unknown_block_at_rule::FormatCssUnknownBlockAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::unknown_block_at_rule::FormatCssUnknownBlockAtRule::default(),
@@ -5398,7 +5105,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnknownDimension {
         crate::css::value::unknown_dimension::FormatCssUnknownDimension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::unknown_dimension::FormatCssUnknownDimension::default(),
@@ -5411,7 +5117,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnknownDimension {
         crate::css::value::unknown_dimension::FormatCssUnknownDimension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::unknown_dimension::FormatCssUnknownDimension::default(),
@@ -5438,7 +5143,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnknownValueAtRule {
         crate::css::statements::unknown_value_at_rule::FormatCssUnknownValueAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::unknown_value_at_rule::FormatCssUnknownValueAtRule::default(),
@@ -5451,7 +5155,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnknownValueAtRule {
         crate::css::statements::unknown_value_at_rule::FormatCssUnknownValueAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::unknown_value_at_rule::FormatCssUnknownValueAtRule::default(),
@@ -5478,7 +5181,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUrlFunction {
         crate::css::auxiliary::url_function::FormatCssUrlFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::auxiliary::url_function::FormatCssUrlFunction::default(),
@@ -5491,7 +5193,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUrlFunction {
         crate::css::auxiliary::url_function::FormatCssUrlFunction,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::auxiliary::url_function::FormatCssUrlFunction::default(),
@@ -5518,7 +5219,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUrlValueRaw {
         crate::css::value::url_value_raw::FormatCssUrlValueRaw,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::value::url_value_raw::FormatCssUrlValueRaw::default(),
@@ -5531,7 +5231,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUrlValueRaw {
         crate::css::value::url_value_raw::FormatCssUrlValueRaw,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::value::url_value_raw::FormatCssUrlValueRaw::default(),
@@ -5558,7 +5257,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRule {
         crate::css::statements::value_at_rule::FormatCssValueAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::value_at_rule::FormatCssValueAtRule::default(),
@@ -5571,7 +5269,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRule {
         crate::css::statements::value_at_rule::FormatCssValueAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::value_at_rule::FormatCssValueAtRule::default(),
@@ -5582,14 +5279,12 @@ impl FormatRule < biome_css_syntax :: CssValueAtRuleDeclarationClause > for crat
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleDeclarationClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssValueAtRuleDeclarationClause , crate :: css :: auxiliary :: value_at_rule_declaration_clause :: FormatCssValueAtRuleDeclarationClause > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_declaration_clause :: FormatCssValueAtRuleDeclarationClause :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleDeclarationClause {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssValueAtRuleDeclarationClause , crate :: css :: auxiliary :: value_at_rule_declaration_clause :: FormatCssValueAtRuleDeclarationClause > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_declaration_clause :: FormatCssValueAtRuleDeclarationClause :: default ())
     }
 }
@@ -5613,7 +5308,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleGenericPrope
         crate::css::properties::value_at_rule_generic_property::FormatCssValueAtRuleGenericProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: properties :: value_at_rule_generic_property :: FormatCssValueAtRuleGenericProperty :: default ())
     }
 }
@@ -5623,7 +5317,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleGenericPro
         crate::css::properties::value_at_rule_generic_property::FormatCssValueAtRuleGenericProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: properties :: value_at_rule_generic_property :: FormatCssValueAtRuleGenericProperty :: default ())
     }
 }
@@ -5647,7 +5340,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportClause
         crate::css::auxiliary::value_at_rule_import_clause::FormatCssValueAtRuleImportClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_import_clause :: FormatCssValueAtRuleImportClause :: default ())
     }
 }
@@ -5657,7 +5349,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportClau
         crate::css::auxiliary::value_at_rule_import_clause::FormatCssValueAtRuleImportClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_import_clause :: FormatCssValueAtRuleImportClause :: default ())
     }
 }
@@ -5681,7 +5372,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportSpecif
         crate::css::auxiliary::value_at_rule_import_specifier::FormatCssValueAtRuleImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_import_specifier :: FormatCssValueAtRuleImportSpecifier :: default ())
     }
 }
@@ -5691,7 +5381,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportSpec
         crate::css::auxiliary::value_at_rule_import_specifier::FormatCssValueAtRuleImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_import_specifier :: FormatCssValueAtRuleImportSpecifier :: default ())
     }
 }
@@ -5699,14 +5388,12 @@ impl FormatRule < biome_css_syntax :: CssValueAtRuleNamedImportSpecifier > for c
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleNamedImportSpecifier {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssValueAtRuleNamedImportSpecifier , crate :: css :: auxiliary :: value_at_rule_named_import_specifier :: FormatCssValueAtRuleNamedImportSpecifier > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_named_import_specifier :: FormatCssValueAtRuleNamedImportSpecifier :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleNamedImportSpecifier {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssValueAtRuleNamedImportSpecifier , crate :: css :: auxiliary :: value_at_rule_named_import_specifier :: FormatCssValueAtRuleNamedImportSpecifier > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: auxiliary :: value_at_rule_named_import_specifier :: FormatCssValueAtRuleNamedImportSpecifier :: default ())
     }
 }
@@ -5730,7 +5417,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssViewTransitionAtRule {
         crate::css::statements::view_transition_at_rule::FormatCssViewTransitionAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::statements::view_transition_at_rule::FormatCssViewTransitionAtRule::default(
@@ -5744,7 +5430,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssViewTransitionAtRule 
         crate::css::statements::view_transition_at_rule::FormatCssViewTransitionAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::statements::view_transition_at_rule::FormatCssViewTransitionAtRule::default(
@@ -5759,7 +5444,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBracketedValueList {
         crate::css::lists::bracketed_value_list::FormatCssBracketedValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::bracketed_value_list::FormatCssBracketedValueList::default(),
@@ -5772,7 +5456,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBracketedValueList {
         crate::css::lists::bracketed_value_list::FormatCssBracketedValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::bracketed_value_list::FormatCssBracketedValueList::default(),
@@ -5786,7 +5469,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComponentValueList {
         crate::css::lists::component_value_list::FormatCssComponentValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::component_value_list::FormatCssComponentValueList::default(),
@@ -5799,7 +5481,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComponentValueList {
         crate::css::lists::component_value_list::FormatCssComponentValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::component_value_list::FormatCssComponentValueList::default(),
@@ -5813,7 +5494,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssComposesClassList {
         crate::css::lists::composes_class_list::FormatCssComposesClassList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::composes_class_list::FormatCssComposesClassList::default(),
@@ -5826,7 +5506,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssComposesClassList {
         crate::css::lists::composes_class_list::FormatCssComposesClassList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::composes_class_list::FormatCssComposesClassList::default(),
@@ -5840,7 +5519,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCompoundSelectorList {
         crate::css::lists::compound_selector_list::FormatCssCompoundSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::compound_selector_list::FormatCssCompoundSelectorList::default(),
@@ -5853,7 +5531,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCompoundSelectorList 
         crate::css::lists::compound_selector_list::FormatCssCompoundSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::compound_selector_list::FormatCssCompoundSelectorList::default(),
@@ -5867,7 +5544,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssCustomIdentifierList {
         crate::css::lists::custom_identifier_list::FormatCssCustomIdentifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::custom_identifier_list::FormatCssCustomIdentifierList::default(),
@@ -5880,7 +5556,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssCustomIdentifierList 
         crate::css::lists::custom_identifier_list::FormatCssCustomIdentifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::custom_identifier_list::FormatCssCustomIdentifierList::default(),
@@ -5894,7 +5569,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationList {
         crate::css::lists::declaration_list::FormatCssDeclarationList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::declaration_list::FormatCssDeclarationList::default(),
@@ -5907,7 +5581,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationList {
         crate::css::lists::declaration_list::FormatCssDeclarationList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::declaration_list::FormatCssDeclarationList::default(),
@@ -5921,7 +5594,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrAtRuleList
         crate::css::lists::declaration_or_at_rule_list::FormatCssDeclarationOrAtRuleList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: lists :: declaration_or_at_rule_list :: FormatCssDeclarationOrAtRuleList :: default ())
     }
 }
@@ -5931,7 +5603,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrAtRuleLi
         crate::css::lists::declaration_or_at_rule_list::FormatCssDeclarationOrAtRuleList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: lists :: declaration_or_at_rule_list :: FormatCssDeclarationOrAtRuleList :: default ())
     }
 }
@@ -5942,7 +5613,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrRuleList {
         crate::css::lists::declaration_or_rule_list::FormatCssDeclarationOrRuleList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::declaration_or_rule_list::FormatCssDeclarationOrRuleList::default(),
@@ -5955,7 +5625,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDeclarationOrRuleList
         crate::css::lists::declaration_or_rule_list::FormatCssDeclarationOrRuleList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::declaration_or_rule_list::FormatCssDeclarationOrRuleList::default(),
@@ -5969,7 +5638,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssDocumentMatcherList {
         crate::css::lists::document_matcher_list::FormatCssDocumentMatcherList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::document_matcher_list::FormatCssDocumentMatcherList::default(),
@@ -5982,7 +5650,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssDocumentMatcherList {
         crate::css::lists::document_matcher_list::FormatCssDocumentMatcherList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::document_matcher_list::FormatCssDocumentMatcherList::default(),
@@ -5996,7 +5663,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFamilyNameList {
         crate::css::lists::font_family_name_list::FormatCssFontFamilyNameList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::font_family_name_list::FormatCssFontFamilyNameList::default(),
@@ -6009,7 +5675,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFamilyNameList {
         crate::css::lists::font_family_name_list::FormatCssFontFamilyNameList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::font_family_name_list::FormatCssFontFamilyNameList::default(),
@@ -6023,7 +5688,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesItemLi
         crate::css::lists::font_feature_values_item_list::FormatCssFontFeatureValuesItemList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: lists :: font_feature_values_item_list :: FormatCssFontFeatureValuesItemList :: default ())
     }
 }
@@ -6033,7 +5697,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssFontFeatureValuesItem
         crate::css::lists::font_feature_values_item_list::FormatCssFontFeatureValuesItemList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: lists :: font_feature_values_item_list :: FormatCssFontFeatureValuesItemList :: default ())
     }
 }
@@ -6044,7 +5707,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssGenericComponentValueLi
         crate::css::lists::generic_component_value_list::FormatCssGenericComponentValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: lists :: generic_component_value_list :: FormatCssGenericComponentValueList :: default ())
     }
 }
@@ -6054,7 +5716,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssGenericComponentValue
         crate::css::lists::generic_component_value_list::FormatCssGenericComponentValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: lists :: generic_component_value_list :: FormatCssGenericComponentValueList :: default ())
     }
 }
@@ -6065,7 +5726,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesItemList {
         crate::css::lists::keyframes_item_list::FormatCssKeyframesItemList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::keyframes_item_list::FormatCssKeyframesItemList::default(),
@@ -6078,7 +5738,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesItemList {
         crate::css::lists::keyframes_item_list::FormatCssKeyframesItemList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::keyframes_item_list::FormatCssKeyframesItemList::default(),
@@ -6092,7 +5751,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssKeyframesSelectorList {
         crate::css::lists::keyframes_selector_list::FormatCssKeyframesSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::keyframes_selector_list::FormatCssKeyframesSelectorList::default(),
@@ -6105,7 +5763,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssKeyframesSelectorList
         crate::css::lists::keyframes_selector_list::FormatCssKeyframesSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::keyframes_selector_list::FormatCssKeyframesSelectorList::default(),
@@ -6119,7 +5776,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssLayerNameList {
         crate::css::lists::layer_name_list::FormatCssLayerNameList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::layer_name_list::FormatCssLayerNameList::default(),
@@ -6132,7 +5788,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssLayerNameList {
         crate::css::lists::layer_name_list::FormatCssLayerNameList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::layer_name_list::FormatCssLayerNameList::default(),
@@ -6146,7 +5801,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssLayerReferenceList {
         crate::css::lists::layer_reference_list::FormatCssLayerReferenceList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::layer_reference_list::FormatCssLayerReferenceList::default(),
@@ -6159,7 +5813,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssLayerReferenceList {
         crate::css::lists::layer_reference_list::FormatCssLayerReferenceList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::layer_reference_list::FormatCssLayerReferenceList::default(),
@@ -6173,7 +5826,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssMediaQueryList {
         crate::css::lists::media_query_list::FormatCssMediaQueryList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::media_query_list::FormatCssMediaQueryList::default(),
@@ -6186,7 +5838,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssMediaQueryList {
         crate::css::lists::media_query_list::FormatCssMediaQueryList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::media_query_list::FormatCssMediaQueryList::default(),
@@ -6200,7 +5851,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssNestedSelectorList {
         crate::css::lists::nested_selector_list::FormatCssNestedSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::nested_selector_list::FormatCssNestedSelectorList::default(),
@@ -6213,7 +5863,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssNestedSelectorList {
         crate::css::lists::nested_selector_list::FormatCssNestedSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::nested_selector_list::FormatCssNestedSelectorList::default(),
@@ -6227,7 +5876,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageAtRuleItemList {
         crate::css::lists::page_at_rule_item_list::FormatCssPageAtRuleItemList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::page_at_rule_item_list::FormatCssPageAtRuleItemList::default(),
@@ -6240,7 +5888,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageAtRuleItemList {
         crate::css::lists::page_at_rule_item_list::FormatCssPageAtRuleItemList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::page_at_rule_item_list::FormatCssPageAtRuleItemList::default(),
@@ -6254,7 +5901,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorList {
         crate::css::lists::page_selector_list::FormatCssPageSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::page_selector_list::FormatCssPageSelectorList::default(),
@@ -6267,7 +5913,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorList {
         crate::css::lists::page_selector_list::FormatCssPageSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::page_selector_list::FormatCssPageSelectorList::default(),
@@ -6281,7 +5926,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorPseudoList 
         crate::css::lists::page_selector_pseudo_list::FormatCssPageSelectorPseudoList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::page_selector_pseudo_list::FormatCssPageSelectorPseudoList::default(
@@ -6295,7 +5939,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPageSelectorPseudoLis
         crate::css::lists::page_selector_pseudo_list::FormatCssPageSelectorPseudoList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::page_selector_pseudo_list::FormatCssPageSelectorPseudoList::default(
@@ -6310,7 +5953,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssParameterList {
         crate::css::lists::parameter_list::FormatCssParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::parameter_list::FormatCssParameterList::default(),
@@ -6323,7 +5965,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssParameterList {
         crate::css::lists::parameter_list::FormatCssParameterList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::parameter_list::FormatCssParameterList::default(),
@@ -6337,7 +5978,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssPseudoValueList {
         crate::css::lists::pseudo_value_list::FormatCssPseudoValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::pseudo_value_list::FormatCssPseudoValueList::default(),
@@ -6350,7 +5990,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssPseudoValueList {
         crate::css::lists::pseudo_value_list::FormatCssPseudoValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::pseudo_value_list::FormatCssPseudoValueList::default(),
@@ -6364,7 +6003,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRelativeSelectorList {
         crate::css::lists::relative_selector_list::FormatCssRelativeSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::relative_selector_list::FormatCssRelativeSelectorList::default(),
@@ -6377,7 +6015,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRelativeSelectorList 
         crate::css::lists::relative_selector_list::FormatCssRelativeSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::relative_selector_list::FormatCssRelativeSelectorList::default(),
@@ -6391,7 +6028,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssRuleList {
         crate::css::lists::rule_list::FormatCssRuleList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::rule_list::FormatCssRuleList::default(),
@@ -6404,7 +6040,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssRuleList {
         crate::css::lists::rule_list::FormatCssRuleList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::rule_list::FormatCssRuleList::default(),
@@ -6418,7 +6053,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSelectorList {
         crate::css::lists::selector_list::FormatCssSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::selector_list::FormatCssSelectorList::default(),
@@ -6431,7 +6065,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSelectorList {
         crate::css::lists::selector_list::FormatCssSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::selector_list::FormatCssSelectorList::default(),
@@ -6445,7 +6078,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssSubSelectorList {
         crate::css::lists::sub_selector_list::FormatCssSubSelectorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::sub_selector_list::FormatCssSubSelectorList::default(),
@@ -6458,7 +6090,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssSubSelectorList {
         crate::css::lists::sub_selector_list::FormatCssSubSelectorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::sub_selector_list::FormatCssSubSelectorList::default(),
@@ -6472,7 +6103,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUrlModifierList {
         crate::css::lists::url_modifier_list::FormatCssUrlModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::lists::url_modifier_list::FormatCssUrlModifierList::default(),
@@ -6485,7 +6115,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUrlModifierList {
         crate::css::lists::url_modifier_list::FormatCssUrlModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::lists::url_modifier_list::FormatCssUrlModifierList::default(),
@@ -6495,14 +6124,12 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUrlModifierList {
 impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportSpecifierList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: CssValueAtRuleImportSpecifierList , crate :: css :: lists :: value_at_rule_import_specifier_list :: FormatCssValueAtRuleImportSpecifierList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: lists :: value_at_rule_import_specifier_list :: FormatCssValueAtRuleImportSpecifierList :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleImportSpecifierList {
     type Format = FormatOwnedWithRule < biome_css_syntax :: CssValueAtRuleImportSpecifierList , crate :: css :: lists :: value_at_rule_import_specifier_list :: FormatCssValueAtRuleImportSpecifierList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: lists :: value_at_rule_import_specifier_list :: FormatCssValueAtRuleImportSpecifierList :: default ())
     }
 }
@@ -6513,7 +6140,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRulePropertyList
         crate::css::lists::value_at_rule_property_list::FormatCssValueAtRulePropertyList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: lists :: value_at_rule_property_list :: FormatCssValueAtRulePropertyList :: default ())
     }
 }
@@ -6523,7 +6149,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRulePropertyLi
         crate::css::lists::value_at_rule_property_list::FormatCssValueAtRulePropertyList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: lists :: value_at_rule_property_list :: FormatCssValueAtRulePropertyList :: default ())
     }
 }
@@ -6538,7 +6163,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogus {
     type Format<'a> =
         FormatRefWithRule<'a, biome_css_syntax::CssBogus, crate::css::bogus::bogus::FormatCssBogus>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::bogus::bogus::FormatCssBogus::default())
     }
 }
@@ -6546,7 +6170,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogus {
     type Format =
         FormatOwnedWithRule<biome_css_syntax::CssBogus, crate::css::bogus::bogus::FormatCssBogus>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::bogus::bogus::FormatCssBogus::default())
     }
 }
@@ -6570,7 +6193,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusAtRule {
         crate::css::bogus::bogus_at_rule::FormatCssBogusAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_at_rule::FormatCssBogusAtRule::default(),
@@ -6583,7 +6205,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusAtRule {
         crate::css::bogus::bogus_at_rule::FormatCssBogusAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_at_rule::FormatCssBogusAtRule::default(),
@@ -6610,7 +6231,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusBlock {
         crate::css::bogus::bogus_block::FormatCssBogusBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_block::FormatCssBogusBlock::default(),
@@ -6623,7 +6243,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusBlock {
         crate::css::bogus::bogus_block::FormatCssBogusBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_block::FormatCssBogusBlock::default(),
@@ -6650,7 +6269,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusCustomIdentifier {
         crate::css::bogus::bogus_custom_identifier::FormatCssBogusCustomIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_custom_identifier::FormatCssBogusCustomIdentifier::default(),
@@ -6663,7 +6281,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusCustomIdentifier
         crate::css::bogus::bogus_custom_identifier::FormatCssBogusCustomIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_custom_identifier::FormatCssBogusCustomIdentifier::default(),
@@ -6690,7 +6307,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusDeclarationItem {
         crate::css::bogus::bogus_declaration_item::FormatCssBogusDeclarationItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_declaration_item::FormatCssBogusDeclarationItem::default(),
@@ -6703,7 +6319,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusDeclarationItem 
         crate::css::bogus::bogus_declaration_item::FormatCssBogusDeclarationItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_declaration_item::FormatCssBogusDeclarationItem::default(),
@@ -6730,7 +6345,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusDocumentMatcher {
         crate::css::bogus::bogus_document_matcher::FormatCssBogusDocumentMatcher,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_document_matcher::FormatCssBogusDocumentMatcher::default(),
@@ -6743,7 +6357,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusDocumentMatcher 
         crate::css::bogus::bogus_document_matcher::FormatCssBogusDocumentMatcher,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_document_matcher::FormatCssBogusDocumentMatcher::default(),
@@ -6770,7 +6383,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusFontFamilyName {
         crate::css::bogus::bogus_font_family_name::FormatCssBogusFontFamilyName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_font_family_name::FormatCssBogusFontFamilyName::default(),
@@ -6783,7 +6395,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusFontFamilyName {
         crate::css::bogus::bogus_font_family_name::FormatCssBogusFontFamilyName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_font_family_name::FormatCssBogusFontFamilyName::default(),
@@ -6810,7 +6421,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusFontFeatureValuesI
         crate::css::bogus::bogus_font_feature_values_item::FormatCssBogusFontFeatureValuesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: bogus :: bogus_font_feature_values_item :: FormatCssBogusFontFeatureValuesItem :: default ())
     }
 }
@@ -6820,7 +6430,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusFontFeatureValue
         crate::css::bogus::bogus_font_feature_values_item::FormatCssBogusFontFeatureValuesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: bogus :: bogus_font_feature_values_item :: FormatCssBogusFontFeatureValuesItem :: default ())
     }
 }
@@ -6844,7 +6453,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusKeyframesItem {
         crate::css::bogus::bogus_keyframes_item::FormatCssBogusKeyframesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_keyframes_item::FormatCssBogusKeyframesItem::default(),
@@ -6857,7 +6465,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusKeyframesItem {
         crate::css::bogus::bogus_keyframes_item::FormatCssBogusKeyframesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_keyframes_item::FormatCssBogusKeyframesItem::default(),
@@ -6884,7 +6491,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusKeyframesName {
         crate::css::bogus::bogus_keyframes_name::FormatCssBogusKeyframesName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_keyframes_name::FormatCssBogusKeyframesName::default(),
@@ -6897,7 +6503,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusKeyframesName {
         crate::css::bogus::bogus_keyframes_name::FormatCssBogusKeyframesName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_keyframes_name::FormatCssBogusKeyframesName::default(),
@@ -6924,7 +6529,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusLayer {
         crate::css::bogus::bogus_layer::FormatCssBogusLayer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_layer::FormatCssBogusLayer::default(),
@@ -6937,7 +6541,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusLayer {
         crate::css::bogus::bogus_layer::FormatCssBogusLayer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_layer::FormatCssBogusLayer::default(),
@@ -6964,7 +6567,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusMediaQuery {
         crate::css::bogus::bogus_media_query::FormatCssBogusMediaQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_media_query::FormatCssBogusMediaQuery::default(),
@@ -6977,7 +6579,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusMediaQuery {
         crate::css::bogus::bogus_media_query::FormatCssBogusMediaQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_media_query::FormatCssBogusMediaQuery::default(),
@@ -7004,7 +6605,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusPageSelectorPseudo
         crate::css::bogus::bogus_page_selector_pseudo::FormatCssBogusPageSelectorPseudo,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: bogus :: bogus_page_selector_pseudo :: FormatCssBogusPageSelectorPseudo :: default ())
     }
 }
@@ -7014,7 +6614,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusPageSelectorPseu
         crate::css::bogus::bogus_page_selector_pseudo::FormatCssBogusPageSelectorPseudo,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: bogus :: bogus_page_selector_pseudo :: FormatCssBogusPageSelectorPseudo :: default ())
     }
 }
@@ -7038,7 +6637,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusParameter {
         crate::css::bogus::bogus_parameter::FormatCssBogusParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_parameter::FormatCssBogusParameter::default(),
@@ -7051,7 +6649,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusParameter {
         crate::css::bogus::bogus_parameter::FormatCssBogusParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_parameter::FormatCssBogusParameter::default(),
@@ -7078,7 +6675,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusProperty {
         crate::css::bogus::bogus_property::FormatCssBogusProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_property::FormatCssBogusProperty::default(),
@@ -7091,7 +6687,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusProperty {
         crate::css::bogus::bogus_property::FormatCssBogusProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_property::FormatCssBogusProperty::default(),
@@ -7118,7 +6713,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusPropertyValue {
         crate::css::bogus::bogus_property_value::FormatCssBogusPropertyValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_property_value::FormatCssBogusPropertyValue::default(),
@@ -7131,7 +6725,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusPropertyValue {
         crate::css::bogus::bogus_property_value::FormatCssBogusPropertyValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_property_value::FormatCssBogusPropertyValue::default(),
@@ -7158,7 +6751,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusPseudoClass {
         crate::css::bogus::bogus_pseudo_class::FormatCssBogusPseudoClass,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_pseudo_class::FormatCssBogusPseudoClass::default(),
@@ -7171,7 +6763,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusPseudoClass {
         crate::css::bogus::bogus_pseudo_class::FormatCssBogusPseudoClass,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_pseudo_class::FormatCssBogusPseudoClass::default(),
@@ -7198,7 +6789,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusPseudoElement {
         crate::css::bogus::bogus_pseudo_element::FormatCssBogusPseudoElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_pseudo_element::FormatCssBogusPseudoElement::default(),
@@ -7211,7 +6801,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusPseudoElement {
         crate::css::bogus::bogus_pseudo_element::FormatCssBogusPseudoElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_pseudo_element::FormatCssBogusPseudoElement::default(),
@@ -7234,7 +6823,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusRule {
         crate::css::bogus::bogus_rule::FormatCssBogusRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_rule::FormatCssBogusRule::default(),
@@ -7247,7 +6835,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusRule {
         crate::css::bogus::bogus_rule::FormatCssBogusRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_rule::FormatCssBogusRule::default(),
@@ -7274,7 +6861,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusScopeRange {
         crate::css::bogus::bogus_scope_range::FormatCssBogusScopeRange,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_scope_range::FormatCssBogusScopeRange::default(),
@@ -7287,7 +6873,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusScopeRange {
         crate::css::bogus::bogus_scope_range::FormatCssBogusScopeRange,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_scope_range::FormatCssBogusScopeRange::default(),
@@ -7314,7 +6899,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusSelector {
         crate::css::bogus::bogus_selector::FormatCssBogusSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_selector::FormatCssBogusSelector::default(),
@@ -7327,7 +6911,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusSelector {
         crate::css::bogus::bogus_selector::FormatCssBogusSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_selector::FormatCssBogusSelector::default(),
@@ -7354,7 +6937,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusSubSelector {
         crate::css::bogus::bogus_sub_selector::FormatCssBogusSubSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_sub_selector::FormatCssBogusSubSelector::default(),
@@ -7367,7 +6949,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusSubSelector {
         crate::css::bogus::bogus_sub_selector::FormatCssBogusSubSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_sub_selector::FormatCssBogusSubSelector::default(),
@@ -7394,7 +6975,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusUnicodeRangeValue 
         crate::css::bogus::bogus_unicode_range_value::FormatCssBogusUnicodeRangeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_unicode_range_value::FormatCssBogusUnicodeRangeValue::default(
@@ -7408,7 +6988,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusUnicodeRangeValu
         crate::css::bogus::bogus_unicode_range_value::FormatCssBogusUnicodeRangeValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_unicode_range_value::FormatCssBogusUnicodeRangeValue::default(
@@ -7436,7 +7015,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssBogusUrlModifier {
         crate::css::bogus::bogus_url_modifier::FormatCssBogusUrlModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::bogus::bogus_url_modifier::FormatCssBogusUrlModifier::default(),
@@ -7449,7 +7027,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssBogusUrlModifier {
         crate::css::bogus::bogus_url_modifier::FormatCssBogusUrlModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::bogus::bogus_url_modifier::FormatCssBogusUrlModifier::default(),
@@ -7476,7 +7053,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssUnknownAtRuleComponentL
         crate::css::bogus::unknown_at_rule_component_list::FormatCssUnknownAtRuleComponentList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: bogus :: unknown_at_rule_component_list :: FormatCssUnknownAtRuleComponentList :: default ())
     }
 }
@@ -7486,7 +7062,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssUnknownAtRuleComponen
         crate::css::bogus::unknown_at_rule_component_list::FormatCssUnknownAtRuleComponentList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: bogus :: unknown_at_rule_component_list :: FormatCssUnknownAtRuleComponentList :: default ())
     }
 }
@@ -7510,7 +7085,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleGenericValue
         crate::css::bogus::value_at_rule_generic_value::FormatCssValueAtRuleGenericValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: bogus :: value_at_rule_generic_value :: FormatCssValueAtRuleGenericValue :: default ())
     }
 }
@@ -7520,7 +7094,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::CssValueAtRuleGenericVal
         crate::css::bogus::value_at_rule_generic_value::FormatCssValueAtRuleGenericValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: bogus :: value_at_rule_generic_value :: FormatCssValueAtRuleGenericValue :: default ())
     }
 }
@@ -7531,7 +7104,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssAtRule {
         crate::css::any::at_rule::FormatAnyCssAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::at_rule::FormatAnyCssAtRule::default(),
@@ -7544,7 +7116,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssAtRule {
         crate::css::any::at_rule::FormatAnyCssAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::at_rule::FormatAnyCssAtRule::default(),
@@ -7558,7 +7129,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssAttributeMatcherValu
         crate::css::any::attribute_matcher_value::FormatAnyCssAttributeMatcherValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::attribute_matcher_value::FormatAnyCssAttributeMatcherValue::default(),
@@ -7571,7 +7141,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssAttributeMatcherVa
         crate::css::any::attribute_matcher_value::FormatAnyCssAttributeMatcherValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::attribute_matcher_value::FormatAnyCssAttributeMatcherValue::default(),
@@ -7585,7 +7154,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssComposesImportSource
         crate::css::any::composes_import_source::FormatAnyCssComposesImportSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::composes_import_source::FormatAnyCssComposesImportSource::default(),
@@ -7598,7 +7166,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssComposesImportSour
         crate::css::any::composes_import_source::FormatAnyCssComposesImportSource,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::composes_import_source::FormatAnyCssComposesImportSource::default(),
@@ -7612,7 +7179,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssCompoundSelector {
         crate::css::any::compound_selector::FormatAnyCssCompoundSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::compound_selector::FormatAnyCssCompoundSelector::default(),
@@ -7625,7 +7191,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssCompoundSelector {
         crate::css::any::compound_selector::FormatAnyCssCompoundSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::compound_selector::FormatAnyCssCompoundSelector::default(),
@@ -7639,7 +7204,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssConditionalBlock {
         crate::css::any::conditional_block::FormatAnyCssConditionalBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::conditional_block::FormatAnyCssConditionalBlock::default(),
@@ -7652,7 +7216,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssConditionalBlock {
         crate::css::any::conditional_block::FormatAnyCssConditionalBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::conditional_block::FormatAnyCssConditionalBlock::default(),
@@ -7666,7 +7229,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerAndCombinab
         crate::css::any::container_and_combinable_query::FormatAnyCssContainerAndCombinableQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: container_and_combinable_query :: FormatAnyCssContainerAndCombinableQuery :: default ())
     }
 }
@@ -7676,7 +7238,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerAndCombin
         crate::css::any::container_and_combinable_query::FormatAnyCssContainerAndCombinableQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: container_and_combinable_query :: FormatAnyCssContainerAndCombinableQuery :: default ())
     }
 }
@@ -7687,7 +7248,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerOrCombinabl
         crate::css::any::container_or_combinable_query::FormatAnyCssContainerOrCombinableQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: container_or_combinable_query :: FormatAnyCssContainerOrCombinableQuery :: default ())
     }
 }
@@ -7697,7 +7257,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerOrCombina
         crate::css::any::container_or_combinable_query::FormatAnyCssContainerOrCombinableQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: container_or_combinable_query :: FormatAnyCssContainerOrCombinableQuery :: default ())
     }
 }
@@ -7708,7 +7267,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerQuery {
         crate::css::any::container_query::FormatAnyCssContainerQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::container_query::FormatAnyCssContainerQuery::default(),
@@ -7721,7 +7279,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerQuery {
         crate::css::any::container_query::FormatAnyCssContainerQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::container_query::FormatAnyCssContainerQuery::default(),
@@ -7735,7 +7292,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerQueryInPare
         crate::css::any::container_query_in_parens::FormatAnyCssContainerQueryInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::container_query_in_parens::FormatAnyCssContainerQueryInParens::default(
@@ -7749,7 +7305,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerQueryInPa
         crate::css::any::container_query_in_parens::FormatAnyCssContainerQueryInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::container_query_in_parens::FormatAnyCssContainerQueryInParens::default(
@@ -7760,14 +7315,12 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerQueryInPa
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleAndCombinableQuery {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: AnyCssContainerStyleAndCombinableQuery , crate :: css :: any :: container_style_and_combinable_query :: FormatAnyCssContainerStyleAndCombinableQuery > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: container_style_and_combinable_query :: FormatAnyCssContainerStyleAndCombinableQuery :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleAndCombinableQuery {
     type Format = FormatOwnedWithRule < biome_css_syntax :: AnyCssContainerStyleAndCombinableQuery , crate :: css :: any :: container_style_and_combinable_query :: FormatAnyCssContainerStyleAndCombinableQuery > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: container_style_and_combinable_query :: FormatAnyCssContainerStyleAndCombinableQuery :: default ())
     }
 }
@@ -7778,7 +7331,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleInPare
         crate::css::any::container_style_in_parens::FormatAnyCssContainerStyleInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::container_style_in_parens::FormatAnyCssContainerStyleInParens::default(
@@ -7792,7 +7344,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleInPa
         crate::css::any::container_style_in_parens::FormatAnyCssContainerStyleInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::container_style_in_parens::FormatAnyCssContainerStyleInParens::default(
@@ -7803,14 +7354,12 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleInPa
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleOrCombinableQuery {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: AnyCssContainerStyleOrCombinableQuery , crate :: css :: any :: container_style_or_combinable_query :: FormatAnyCssContainerStyleOrCombinableQuery > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: container_style_or_combinable_query :: FormatAnyCssContainerStyleOrCombinableQuery :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleOrCombinableQuery {
     type Format = FormatOwnedWithRule < biome_css_syntax :: AnyCssContainerStyleOrCombinableQuery , crate :: css :: any :: container_style_or_combinable_query :: FormatAnyCssContainerStyleOrCombinableQuery > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: container_style_or_combinable_query :: FormatAnyCssContainerStyleOrCombinableQuery :: default ())
     }
 }
@@ -7821,7 +7370,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleQuery 
         crate::css::any::container_style_query::FormatAnyCssContainerStyleQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::container_style_query::FormatAnyCssContainerStyleQuery::default(),
@@ -7834,7 +7382,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssContainerStyleQuer
         crate::css::any::container_style_query::FormatAnyCssContainerStyleQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::container_style_query::FormatAnyCssContainerStyleQuery::default(),
@@ -7848,7 +7395,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssCustomIdentifier {
         crate::css::any::custom_identifier::FormatAnyCssCustomIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::custom_identifier::FormatAnyCssCustomIdentifier::default(),
@@ -7861,7 +7407,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssCustomIdentifier {
         crate::css::any::custom_identifier::FormatAnyCssCustomIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::custom_identifier::FormatAnyCssCustomIdentifier::default(),
@@ -7875,7 +7420,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationBlock {
         crate::css::any::declaration_block::FormatAnyCssDeclarationBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::declaration_block::FormatAnyCssDeclarationBlock::default(),
@@ -7888,7 +7432,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationBlock {
         crate::css::any::declaration_block::FormatAnyCssDeclarationBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::declaration_block::FormatAnyCssDeclarationBlock::default(),
@@ -7902,7 +7445,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationName {
         crate::css::any::declaration_name::FormatAnyCssDeclarationName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::declaration_name::FormatAnyCssDeclarationName::default(),
@@ -7915,7 +7457,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationName {
         crate::css::any::declaration_name::FormatAnyCssDeclarationName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::declaration_name::FormatAnyCssDeclarationName::default(),
@@ -7929,7 +7470,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrAtRule 
         crate::css::any::declaration_or_at_rule::FormatAnyCssDeclarationOrAtRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::declaration_or_at_rule::FormatAnyCssDeclarationOrAtRule::default(),
@@ -7942,7 +7482,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrAtRul
         crate::css::any::declaration_or_at_rule::FormatAnyCssDeclarationOrAtRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::declaration_or_at_rule::FormatAnyCssDeclarationOrAtRule::default(),
@@ -7956,7 +7495,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrAtRuleB
         crate::css::any::declaration_or_at_rule_block::FormatAnyCssDeclarationOrAtRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: declaration_or_at_rule_block :: FormatAnyCssDeclarationOrAtRuleBlock :: default ())
     }
 }
@@ -7966,7 +7504,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrAtRul
         crate::css::any::declaration_or_at_rule_block::FormatAnyCssDeclarationOrAtRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: declaration_or_at_rule_block :: FormatAnyCssDeclarationOrAtRuleBlock :: default ())
     }
 }
@@ -7977,7 +7514,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrRule {
         crate::css::any::declaration_or_rule::FormatAnyCssDeclarationOrRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::declaration_or_rule::FormatAnyCssDeclarationOrRule::default(),
@@ -7990,7 +7526,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrRule 
         crate::css::any::declaration_or_rule::FormatAnyCssDeclarationOrRule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::declaration_or_rule::FormatAnyCssDeclarationOrRule::default(),
@@ -8004,7 +7539,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrRuleBlo
         crate::css::any::declaration_or_rule_block::FormatAnyCssDeclarationOrRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::declaration_or_rule_block::FormatAnyCssDeclarationOrRuleBlock::default(
@@ -8018,7 +7552,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDeclarationOrRuleB
         crate::css::any::declaration_or_rule_block::FormatAnyCssDeclarationOrRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::declaration_or_rule_block::FormatAnyCssDeclarationOrRuleBlock::default(
@@ -8033,7 +7566,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDimension {
         crate::css::any::dimension::FormatAnyCssDimension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::dimension::FormatAnyCssDimension::default(),
@@ -8046,7 +7578,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDimension {
         crate::css::any::dimension::FormatAnyCssDimension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::dimension::FormatAnyCssDimension::default(),
@@ -8060,7 +7591,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssDocumentMatcher {
         crate::css::any::document_matcher::FormatAnyCssDocumentMatcher,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::document_matcher::FormatAnyCssDocumentMatcher::default(),
@@ -8073,7 +7603,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssDocumentMatcher {
         crate::css::any::document_matcher::FormatAnyCssDocumentMatcher,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::document_matcher::FormatAnyCssDocumentMatcher::default(),
@@ -8087,7 +7616,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssExpression {
         crate::css::any::expression::FormatAnyCssExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::expression::FormatAnyCssExpression::default(),
@@ -8100,7 +7628,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssExpression {
         crate::css::any::expression::FormatAnyCssExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::expression::FormatAnyCssExpression::default(),
@@ -8114,7 +7641,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFamilyName {
         crate::css::any::font_family_name::FormatAnyCssFontFamilyName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::font_family_name::FormatAnyCssFontFamilyName::default(),
@@ -8127,7 +7653,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFamilyName {
         crate::css::any::font_family_name::FormatAnyCssFontFamilyName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::font_family_name::FormatAnyCssFontFamilyName::default(),
@@ -8141,7 +7666,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFeatureValuesBlo
         crate::css::any::font_feature_values_block::FormatAnyCssFontFeatureValuesBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::font_feature_values_block::FormatAnyCssFontFeatureValuesBlock::default(
@@ -8155,7 +7679,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFeatureValuesB
         crate::css::any::font_feature_values_block::FormatAnyCssFontFeatureValuesBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::font_feature_values_block::FormatAnyCssFontFeatureValuesBlock::default(
@@ -8170,7 +7693,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFeatureValuesIte
         crate::css::any::font_feature_values_item::FormatAnyCssFontFeatureValuesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::font_feature_values_item::FormatAnyCssFontFeatureValuesItem::default(),
@@ -8183,7 +7705,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssFontFeatureValuesI
         crate::css::any::font_feature_values_item::FormatAnyCssFontFeatureValuesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::font_feature_values_item::FormatAnyCssFontFeatureValuesItem::default(),
@@ -8197,7 +7718,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssFunction {
         crate::css::any::function::FormatAnyCssFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::function::FormatAnyCssFunction::default(),
@@ -8210,7 +7730,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssFunction {
         crate::css::any::function::FormatAnyCssFunction,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::function::FormatAnyCssFunction::default(),
@@ -8224,7 +7743,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssGenericComponentValu
         crate::css::any::generic_component_value::FormatAnyCssGenericComponentValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::generic_component_value::FormatAnyCssGenericComponentValue::default(),
@@ -8237,7 +7755,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssGenericComponentVa
         crate::css::any::generic_component_value::FormatAnyCssGenericComponentValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::generic_component_value::FormatAnyCssGenericComponentValue::default(),
@@ -8251,7 +7768,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssImportLayer {
         crate::css::any::import_layer::FormatAnyCssImportLayer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::import_layer::FormatAnyCssImportLayer::default(),
@@ -8264,7 +7780,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssImportLayer {
         crate::css::any::import_layer::FormatAnyCssImportLayer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::import_layer::FormatAnyCssImportLayer::default(),
@@ -8278,7 +7793,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssImportSupportsCondit
         crate::css::any::import_supports_condition::FormatAnyCssImportSupportsCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: import_supports_condition :: FormatAnyCssImportSupportsCondition :: default ())
     }
 }
@@ -8288,7 +7802,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssImportSupportsCond
         crate::css::any::import_supports_condition::FormatAnyCssImportSupportsCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: import_supports_condition :: FormatAnyCssImportSupportsCondition :: default ())
     }
 }
@@ -8299,7 +7812,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssImportUrl {
         crate::css::any::import_url::FormatAnyCssImportUrl,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::import_url::FormatAnyCssImportUrl::default(),
@@ -8312,7 +7824,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssImportUrl {
         crate::css::any::import_url::FormatAnyCssImportUrl,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::import_url::FormatAnyCssImportUrl::default(),
@@ -8326,7 +7837,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesBlock {
         crate::css::any::keyframes_block::FormatAnyCssKeyframesBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_block::FormatAnyCssKeyframesBlock::default(),
@@ -8339,7 +7849,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesBlock {
         crate::css::any::keyframes_block::FormatAnyCssKeyframesBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_block::FormatAnyCssKeyframesBlock::default(),
@@ -8353,7 +7862,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesIdentifier 
         crate::css::any::keyframes_identifier::FormatAnyCssKeyframesIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_identifier::FormatAnyCssKeyframesIdentifier::default(),
@@ -8366,7 +7874,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesIdentifie
         crate::css::any::keyframes_identifier::FormatAnyCssKeyframesIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_identifier::FormatAnyCssKeyframesIdentifier::default(),
@@ -8380,7 +7887,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesItem {
         crate::css::any::keyframes_item::FormatAnyCssKeyframesItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_item::FormatAnyCssKeyframesItem::default(),
@@ -8393,7 +7899,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesItem {
         crate::css::any::keyframes_item::FormatAnyCssKeyframesItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_item::FormatAnyCssKeyframesItem::default(),
@@ -8407,7 +7912,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesName {
         crate::css::any::keyframes_name::FormatAnyCssKeyframesName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_name::FormatAnyCssKeyframesName::default(),
@@ -8420,7 +7924,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesName {
         crate::css::any::keyframes_name::FormatAnyCssKeyframesName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_name::FormatAnyCssKeyframesName::default(),
@@ -8434,7 +7937,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesScope {
         crate::css::any::keyframes_scope::FormatAnyCssKeyframesScope,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_scope::FormatAnyCssKeyframesScope::default(),
@@ -8447,7 +7949,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesScope {
         crate::css::any::keyframes_scope::FormatAnyCssKeyframesScope,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_scope::FormatAnyCssKeyframesScope::default(),
@@ -8461,7 +7962,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesSelector {
         crate::css::any::keyframes_selector::FormatAnyCssKeyframesSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::keyframes_selector::FormatAnyCssKeyframesSelector::default(),
@@ -8474,7 +7974,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssKeyframesSelector 
         crate::css::any::keyframes_selector::FormatAnyCssKeyframesSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::keyframes_selector::FormatAnyCssKeyframesSelector::default(),
@@ -8488,7 +7987,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssLayer {
         crate::css::any::layer::FormatAnyCssLayer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::any::layer::FormatAnyCssLayer::default())
     }
 }
@@ -8498,7 +7996,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssLayer {
         crate::css::any::layer::FormatAnyCssLayer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::any::layer::FormatAnyCssLayer::default())
     }
 }
@@ -8509,7 +8006,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaAndCombinableCo
         crate::css::any::media_and_combinable_condition::FormatAnyCssMediaAndCombinableCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: media_and_combinable_condition :: FormatAnyCssMediaAndCombinableCondition :: default ())
     }
 }
@@ -8519,7 +8015,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaAndCombinable
         crate::css::any::media_and_combinable_condition::FormatAnyCssMediaAndCombinableCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: media_and_combinable_condition :: FormatAnyCssMediaAndCombinableCondition :: default ())
     }
 }
@@ -8530,7 +8025,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaCondition {
         crate::css::any::media_condition::FormatAnyCssMediaCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::media_condition::FormatAnyCssMediaCondition::default(),
@@ -8543,7 +8037,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaCondition {
         crate::css::any::media_condition::FormatAnyCssMediaCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::media_condition::FormatAnyCssMediaCondition::default(),
@@ -8557,7 +8050,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaInParens {
         crate::css::any::media_in_parens::FormatAnyCssMediaInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::media_in_parens::FormatAnyCssMediaInParens::default(),
@@ -8570,7 +8062,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaInParens {
         crate::css::any::media_in_parens::FormatAnyCssMediaInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::media_in_parens::FormatAnyCssMediaInParens::default(),
@@ -8584,7 +8075,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaOrCombinableCon
         crate::css::any::media_or_combinable_condition::FormatAnyCssMediaOrCombinableCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: media_or_combinable_condition :: FormatAnyCssMediaOrCombinableCondition :: default ())
     }
 }
@@ -8594,7 +8084,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaOrCombinableC
         crate::css::any::media_or_combinable_condition::FormatAnyCssMediaOrCombinableCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: media_or_combinable_condition :: FormatAnyCssMediaOrCombinableCondition :: default ())
     }
 }
@@ -8605,7 +8094,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaQuery {
         crate::css::any::media_query::FormatAnyCssMediaQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::media_query::FormatAnyCssMediaQuery::default(),
@@ -8618,7 +8106,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaQuery {
         crate::css::any::media_query::FormatAnyCssMediaQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::media_query::FormatAnyCssMediaQuery::default(),
@@ -8632,7 +8119,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeCondition {
         crate::css::any::media_type_condition::FormatAnyCssMediaTypeCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::media_type_condition::FormatAnyCssMediaTypeCondition::default(),
@@ -8645,7 +8131,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeCondition
         crate::css::any::media_type_condition::FormatAnyCssMediaTypeCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::media_type_condition::FormatAnyCssMediaTypeCondition::default(),
@@ -8659,7 +8144,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeQuery {
         crate::css::any::media_type_query::FormatAnyCssMediaTypeQuery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::media_type_query::FormatAnyCssMediaTypeQuery::default(),
@@ -8672,7 +8156,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssMediaTypeQuery {
         crate::css::any::media_type_query::FormatAnyCssMediaTypeQuery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::media_type_query::FormatAnyCssMediaTypeQuery::default(),
@@ -8686,7 +8169,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssNamespacePrefix {
         crate::css::any::namespace_prefix::FormatAnyCssNamespacePrefix,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::namespace_prefix::FormatAnyCssNamespacePrefix::default(),
@@ -8699,7 +8181,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssNamespacePrefix {
         crate::css::any::namespace_prefix::FormatAnyCssNamespacePrefix,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::namespace_prefix::FormatAnyCssNamespacePrefix::default(),
@@ -8713,7 +8194,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssNamespaceUrl {
         crate::css::any::namespace_url::FormatAnyCssNamespaceUrl,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::namespace_url::FormatAnyCssNamespaceUrl::default(),
@@ -8726,7 +8206,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssNamespaceUrl {
         crate::css::any::namespace_url::FormatAnyCssNamespaceUrl,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::namespace_url::FormatAnyCssNamespaceUrl::default(),
@@ -8740,7 +8219,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPageAtRuleBlock {
         crate::css::any::page_at_rule_block::FormatAnyCssPageAtRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::page_at_rule_block::FormatAnyCssPageAtRuleBlock::default(),
@@ -8753,7 +8231,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPageAtRuleBlock {
         crate::css::any::page_at_rule_block::FormatAnyCssPageAtRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::page_at_rule_block::FormatAnyCssPageAtRuleBlock::default(),
@@ -8767,7 +8244,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPageAtRuleItem {
         crate::css::any::page_at_rule_item::FormatAnyCssPageAtRuleItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::page_at_rule_item::FormatAnyCssPageAtRuleItem::default(),
@@ -8780,7 +8256,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPageAtRuleItem {
         crate::css::any::page_at_rule_item::FormatAnyCssPageAtRuleItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::page_at_rule_item::FormatAnyCssPageAtRuleItem::default(),
@@ -8794,7 +8269,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPageSelector {
         crate::css::any::page_selector::FormatAnyCssPageSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::page_selector::FormatAnyCssPageSelector::default(),
@@ -8807,7 +8281,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPageSelector {
         crate::css::any::page_selector::FormatAnyCssPageSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::page_selector::FormatAnyCssPageSelector::default(),
@@ -8821,7 +8294,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPageSelectorPseudo {
         crate::css::any::page_selector_pseudo::FormatAnyCssPageSelectorPseudo,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::page_selector_pseudo::FormatAnyCssPageSelectorPseudo::default(),
@@ -8834,7 +8306,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPageSelectorPseudo
         crate::css::any::page_selector_pseudo::FormatAnyCssPageSelectorPseudo,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::page_selector_pseudo::FormatAnyCssPageSelectorPseudo::default(),
@@ -8848,7 +8319,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssProperty {
         crate::css::any::property::FormatAnyCssProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::property::FormatAnyCssProperty::default(),
@@ -8861,7 +8331,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssProperty {
         crate::css::any::property::FormatAnyCssProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::property::FormatAnyCssProperty::default(),
@@ -8875,7 +8344,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClass {
         crate::css::any::pseudo_class::FormatAnyCssPseudoClass,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::pseudo_class::FormatAnyCssPseudoClass::default(),
@@ -8888,7 +8356,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClass {
         crate::css::any::pseudo_class::FormatAnyCssPseudoClass,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::pseudo_class::FormatAnyCssPseudoClass::default(),
@@ -8902,7 +8369,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClassNth {
         crate::css::any::pseudo_class_nth::FormatAnyCssPseudoClassNth,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::pseudo_class_nth::FormatAnyCssPseudoClassNth::default(),
@@ -8915,7 +8381,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClassNth {
         crate::css::any::pseudo_class_nth::FormatAnyCssPseudoClassNth,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::pseudo_class_nth::FormatAnyCssPseudoClassNth::default(),
@@ -8929,7 +8394,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClassNthSelect
         crate::css::any::pseudo_class_nth_selector::FormatAnyCssPseudoClassNthSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::pseudo_class_nth_selector::FormatAnyCssPseudoClassNthSelector::default(
@@ -8943,7 +8407,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoClassNthSele
         crate::css::any::pseudo_class_nth_selector::FormatAnyCssPseudoClassNthSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::pseudo_class_nth_selector::FormatAnyCssPseudoClassNthSelector::default(
@@ -8958,7 +8421,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoElement {
         crate::css::any::pseudo_element::FormatAnyCssPseudoElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::pseudo_element::FormatAnyCssPseudoElement::default(),
@@ -8971,7 +8433,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoElement {
         crate::css::any::pseudo_element::FormatAnyCssPseudoElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::pseudo_element::FormatAnyCssPseudoElement::default(),
@@ -8985,7 +8446,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoValue {
         crate::css::any::pseudo_value::FormatAnyCssPseudoValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::pseudo_value::FormatAnyCssPseudoValue::default(),
@@ -8998,7 +8458,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssPseudoValue {
         crate::css::any::pseudo_value::FormatAnyCssPseudoValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::pseudo_value::FormatAnyCssPseudoValue::default(),
@@ -9012,7 +8471,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssQueryFeature {
         crate::css::any::query_feature::FormatAnyCssQueryFeature,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::query_feature::FormatAnyCssQueryFeature::default(),
@@ -9025,7 +8483,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssQueryFeature {
         crate::css::any::query_feature::FormatAnyCssQueryFeature,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::query_feature::FormatAnyCssQueryFeature::default(),
@@ -9039,7 +8496,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssQueryFeatureValue {
         crate::css::any::query_feature_value::FormatAnyCssQueryFeatureValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::query_feature_value::FormatAnyCssQueryFeatureValue::default(),
@@ -9052,7 +8508,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssQueryFeatureValue 
         crate::css::any::query_feature_value::FormatAnyCssQueryFeatureValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::query_feature_value::FormatAnyCssQueryFeatureValue::default(),
@@ -9066,7 +8521,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssRelativeSelector {
         crate::css::any::relative_selector::FormatAnyCssRelativeSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::relative_selector::FormatAnyCssRelativeSelector::default(),
@@ -9079,7 +8533,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssRelativeSelector {
         crate::css::any::relative_selector::FormatAnyCssRelativeSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::relative_selector::FormatAnyCssRelativeSelector::default(),
@@ -9093,7 +8546,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssRule {
         crate::css::any::rule::FormatAnyCssRule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::any::rule::FormatAnyCssRule::default())
     }
 }
@@ -9101,7 +8553,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssRule {
     type Format =
         FormatOwnedWithRule<biome_css_syntax::AnyCssRule, crate::css::any::rule::FormatAnyCssRule>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::any::rule::FormatAnyCssRule::default())
     }
 }
@@ -9112,7 +8563,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssRuleBlock {
         crate::css::any::rule_block::FormatAnyCssRuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::rule_block::FormatAnyCssRuleBlock::default(),
@@ -9125,7 +8575,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssRuleBlock {
         crate::css::any::rule_block::FormatAnyCssRuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::rule_block::FormatAnyCssRuleBlock::default(),
@@ -9139,7 +8588,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssScopeRange {
         crate::css::any::scope_range::FormatAnyCssScopeRange,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::scope_range::FormatAnyCssScopeRange::default(),
@@ -9152,7 +8600,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssScopeRange {
         crate::css::any::scope_range::FormatAnyCssScopeRange,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::scope_range::FormatAnyCssScopeRange::default(),
@@ -9166,7 +8613,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSelector {
         crate::css::any::selector::FormatAnyCssSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::selector::FormatAnyCssSelector::default(),
@@ -9179,7 +8625,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSelector {
         crate::css::any::selector::FormatAnyCssSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::selector::FormatAnyCssSelector::default(),
@@ -9193,7 +8638,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSimpleSelector {
         crate::css::any::simple_selector::FormatAnyCssSimpleSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::simple_selector::FormatAnyCssSimpleSelector::default(),
@@ -9206,7 +8650,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSimpleSelector {
         crate::css::any::simple_selector::FormatAnyCssSimpleSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::simple_selector::FormatAnyCssSimpleSelector::default(),
@@ -9220,7 +8663,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssStartingStyleBlock {
         crate::css::any::starting_style_block::FormatAnyCssStartingStyleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::starting_style_block::FormatAnyCssStartingStyleBlock::default(),
@@ -9233,7 +8675,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssStartingStyleBlock
         crate::css::any::starting_style_block::FormatAnyCssStartingStyleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::starting_style_block::FormatAnyCssStartingStyleBlock::default(),
@@ -9247,7 +8688,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSubSelector {
         crate::css::any::sub_selector::FormatAnyCssSubSelector,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::sub_selector::FormatAnyCssSubSelector::default(),
@@ -9260,7 +8700,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSubSelector {
         crate::css::any::sub_selector::FormatAnyCssSubSelector,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::sub_selector::FormatAnyCssSubSelector::default(),
@@ -9270,14 +8709,12 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSubSelector {
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsAndCombinableCondition {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: AnyCssSupportsAndCombinableCondition , crate :: css :: any :: supports_and_combinable_condition :: FormatAnyCssSupportsAndCombinableCondition > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: supports_and_combinable_condition :: FormatAnyCssSupportsAndCombinableCondition :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsAndCombinableCondition {
     type Format = FormatOwnedWithRule < biome_css_syntax :: AnyCssSupportsAndCombinableCondition , crate :: css :: any :: supports_and_combinable_condition :: FormatAnyCssSupportsAndCombinableCondition > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: supports_and_combinable_condition :: FormatAnyCssSupportsAndCombinableCondition :: default ())
     }
 }
@@ -9288,7 +8725,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsCondition {
         crate::css::any::supports_condition::FormatAnyCssSupportsCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::supports_condition::FormatAnyCssSupportsCondition::default(),
@@ -9301,7 +8737,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsCondition 
         crate::css::any::supports_condition::FormatAnyCssSupportsCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::supports_condition::FormatAnyCssSupportsCondition::default(),
@@ -9315,7 +8750,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsInParens {
         crate::css::any::supports_in_parens::FormatAnyCssSupportsInParens,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::supports_in_parens::FormatAnyCssSupportsInParens::default(),
@@ -9328,7 +8762,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsInParens {
         crate::css::any::supports_in_parens::FormatAnyCssSupportsInParens,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::supports_in_parens::FormatAnyCssSupportsInParens::default(),
@@ -9338,14 +8771,12 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsInParens {
 impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsOrCombinableCondition {
     type Format < 'a > = FormatRefWithRule < 'a , biome_css_syntax :: AnyCssSupportsOrCombinableCondition , crate :: css :: any :: supports_or_combinable_condition :: FormatAnyCssSupportsOrCombinableCondition > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: supports_or_combinable_condition :: FormatAnyCssSupportsOrCombinableCondition :: default ())
     }
 }
 impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssSupportsOrCombinableCondition {
     type Format = FormatOwnedWithRule < biome_css_syntax :: AnyCssSupportsOrCombinableCondition , crate :: css :: any :: supports_or_combinable_condition :: FormatAnyCssSupportsOrCombinableCondition > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: supports_or_combinable_condition :: FormatAnyCssSupportsOrCombinableCondition :: default ())
     }
 }
@@ -9356,7 +8787,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssUnicodeValue {
         crate::css::any::unicode_value::FormatAnyCssUnicodeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::unicode_value::FormatAnyCssUnicodeValue::default(),
@@ -9369,7 +8799,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssUnicodeValue {
         crate::css::any::unicode_value::FormatAnyCssUnicodeValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::unicode_value::FormatAnyCssUnicodeValue::default(),
@@ -9383,7 +8812,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssUrlModifier {
         crate::css::any::url_modifier::FormatAnyCssUrlModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::url_modifier::FormatAnyCssUrlModifier::default(),
@@ -9396,7 +8824,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssUrlModifier {
         crate::css::any::url_modifier::FormatAnyCssUrlModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::url_modifier::FormatAnyCssUrlModifier::default(),
@@ -9410,7 +8837,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssUrlValue {
         crate::css::any::url_value::FormatAnyCssUrlValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::url_value::FormatAnyCssUrlValue::default(),
@@ -9423,7 +8849,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssUrlValue {
         crate::css::any::url_value::FormatAnyCssUrlValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::url_value::FormatAnyCssUrlValue::default(),
@@ -9437,7 +8862,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssValue {
         crate::css::any::value::FormatAnyCssValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::css::any::value::FormatAnyCssValue::default())
     }
 }
@@ -9447,7 +8871,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssValue {
         crate::css::any::value::FormatAnyCssValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::css::any::value::FormatAnyCssValue::default())
     }
 }
@@ -9458,7 +8881,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleClause {
         crate::css::any::value_at_rule_clause::FormatAnyCssValueAtRuleClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::value_at_rule_clause::FormatAnyCssValueAtRuleClause::default(),
@@ -9471,7 +8893,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleClause 
         crate::css::any::value_at_rule_clause::FormatAnyCssValueAtRuleClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::value_at_rule_clause::FormatAnyCssValueAtRuleClause::default(),
@@ -9485,7 +8906,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleImportSou
         crate::css::any::value_at_rule_import_source::FormatAnyCssValueAtRuleImportSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: value_at_rule_import_source :: FormatAnyCssValueAtRuleImportSource :: default ())
     }
 }
@@ -9495,7 +8915,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleImportS
         crate::css::any::value_at_rule_import_source::FormatAnyCssValueAtRuleImportSource,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: value_at_rule_import_source :: FormatAnyCssValueAtRuleImportSource :: default ())
     }
 }
@@ -9506,7 +8925,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleImportSpe
         crate::css::any::value_at_rule_import_specifier::FormatAnyCssValueAtRuleImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: css :: any :: value_at_rule_import_specifier :: FormatAnyCssValueAtRuleImportSpecifier :: default ())
     }
 }
@@ -9516,7 +8934,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleImportS
         crate::css::any::value_at_rule_import_specifier::FormatAnyCssValueAtRuleImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: css :: any :: value_at_rule_import_specifier :: FormatAnyCssValueAtRuleImportSpecifier :: default ())
     }
 }
@@ -9527,7 +8944,6 @@ impl AsFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRuleProperty 
         crate::css::any::value_at_rule_property::FormatAnyCssValueAtRuleProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::css::any::value_at_rule_property::FormatAnyCssValueAtRuleProperty::default(),
@@ -9540,7 +8956,6 @@ impl IntoFormat<CssFormatContext> for biome_css_syntax::AnyCssValueAtRulePropert
         crate::css::any::value_at_rule_property::FormatAnyCssValueAtRuleProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::css::any::value_at_rule_property::FormatAnyCssValueAtRuleProperty::default(),

--- a/crates/biome_css_formatter/src/prelude.rs
+++ b/crates/biome_css_formatter/src/prelude.rs
@@ -1,14 +1,12 @@
 //! This module provides important and useful traits to help to format tokens and nodes
 //! when implementing the [crate::FormatNodeRule] trait.
+#![allow(unused_imports)]
 
-#[allow(unused_imports)]
+pub(crate) use crate::separated::FormatAstSeparatedListExtension;
 pub(crate) use crate::{
     AsFormat, CssFormatContext, CssFormatter, FormatNodeRule, FormattedIterExt as _, IntoFormat,
 };
 pub(crate) use biome_formatter::prelude::*;
-#[allow(unused_imports)]
 pub(crate) use biome_rowan::{
     AstNode as _, AstNodeList as _, AstNodeSlotMap as _, AstSeparatedList as _,
 };
-
-pub(crate) use crate::separated::FormatAstSeparatedListExtension;

--- a/crates/biome_css_formatter/src/separated.rs
+++ b/crates/biome_css_formatter/src/separated.rs
@@ -101,7 +101,7 @@ type CssFormatSeparatedIterWithOptions<Node, Options> = FormatSeparatedIter<
 >;
 
 /// AST Separated list formatting extension methods with options
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) trait FormatAstSeparatedListWithOptionsExtension<O>:
     AstSeparatedList<Language = CssLanguage>
 {

--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -55,7 +55,7 @@ impl LexContext for CssLexContext {
 /// Context in which the [CssLexContext]'s current should be re-lexed.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CssReLexContext {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Regular,
     /// See [CssLexContext::UnicodeRange]
     UnicodeRange,

--- a/crates/biome_css_parser/src/lexer/tests.rs
+++ b/crates/biome_css_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut, unused_variables)]
 
 use super::{CssLexer, TextSize};
 use crate::lexer::CssLexContext;
@@ -88,11 +88,7 @@ fn losslessness(string: String) -> bool {
     });
     let token_ranges = receiver
         .recv_timeout(Duration::from_secs(2))
-        .unwrap_or_else(|_| {
-            panic!(
-                "Lexer is infinitely recursing with this code: ->{string}<-"
-            )
-        });
+        .unwrap_or_else(|_| panic!("Lexer is infinitely recursing with this code: ->{string}<-"));
 
     let mut new_str = String::with_capacity(string.len());
     let mut idx = TextSize::from(0);

--- a/crates/biome_css_parser/src/syntax/mod.rs
+++ b/crates/biome_css_parser/src/syntax/mod.rs
@@ -586,7 +586,6 @@ impl ParseRecovery for BracketedValueListRecovery {
 /// preserved. If parsing fails, this function rewinds the parser back to
 /// where it was before attempting the parse and the `Err` value is returned.
 #[must_use = "The result of try_parse contains information about whether the parse succeeded and should not be ignored"]
-#[allow(dead_code)]
 pub(crate) fn try_parse<T, E>(
     p: &mut CssParser,
     func: impl FnOnce(&mut CssParser) -> Result<T, E>,

--- a/crates/biome_css_parser/src/syntax/value/dimension.rs
+++ b/crates/biome_css_parser/src/syntax/value/dimension.rs
@@ -178,54 +178,54 @@ fn is_nth_at_flex_unit(p: &mut CssParser, n: usize) -> bool {
     p.nth_at_ts(n, FLEX_UNIT_SET)
 }
 
-// TODO: In the future, remove the `#[allow(dead_code)]` as these get used.
+// TODO: In the future, remove the `#[expect(dead_code)]` as these get used.
 
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Length value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_length_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_length_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Length value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_container_lengths_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_container_lengths_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become an Angle value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_angle_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_angle_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Time value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_time_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_time_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Frequency value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_frequency_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_frequency_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Resolution value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_resolution_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_resolution_unit(p, 1)
 }
 /// Returns true if the parser is currently at the start of a RegularDimension
 /// that will become a Flex value
 #[inline]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn is_at_flex_dimension(p: &mut CssParser) -> bool {
     is_at_regular_dimension(p) && is_nth_at_flex_unit(p, 1)
 }

--- a/crates/biome_css_parser/src/token_source.rs
+++ b/crates/biome_css_parser/src/token_source.rs
@@ -15,7 +15,6 @@ pub(crate) struct CssTokenSource<'src> {
     pub(super) trivia_list: Vec<Trivia>,
 }
 
-#[allow(dead_code)]
 pub(crate) type CssTokenSourceCheckpoint = TokenSourceCheckpoint<CssSyntaxKind>;
 
 impl<'src> CssTokenSource<'src> {
@@ -68,7 +67,6 @@ impl<'src> CssTokenSource<'src> {
     }
 
     /// Creates a checkpoint to which it can later return using [Self::rewind].
-    #[allow(dead_code)]
     pub fn checkpoint(&self) -> CssTokenSourceCheckpoint {
         CssTokenSourceCheckpoint {
             trivia_len: self.trivia_list.len() as u32,

--- a/crates/biome_css_parser/tests/spec_tests.rs
+++ b/crates/biome_css_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_css_syntax/src/file_source.rs
+++ b/crates/biome_css_syntax/src/file_source.rs
@@ -7,8 +7,6 @@ use std::{ffi::OsStr, path::Path};
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct CssFileSource {
-    // Unused until we potentially support postcss/less/sass
-    #[allow(unused)]
     variant: CssVariant,
 }
 

--- a/crates/biome_css_syntax/src/generated/kind.rs
+++ b/crates/biome_css_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -489,72 +488,109 @@ pub enum CssSyntaxKind {
 use self::CssSyntaxKind::*;
 impl CssSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            SEMICOLON | COMMA | L_PAREN | R_PAREN | L_CURLY | R_CURLY | L_BRACK | R_BRACK
-            | L_ANGLE | R_ANGLE | TILDE | HASH | AMP | PIPE | PIPE2 | PLUS | STAR | SLASH
-            | CARET | PERCENT | DOT | COLON | COLON2 | EQ | BANG | NEQ | MINUS | LTEQ | GTEQ
-            | PLUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ | AT | DOLLAR_EQ
-            | TILDE_EQ | CDC | CDO | UNICODE => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            SEMICOLON
+                | COMMA
+                | L_PAREN
+                | R_PAREN
+                | L_CURLY
+                | R_CURLY
+                | L_BRACK
+                | R_BRACK
+                | L_ANGLE
+                | R_ANGLE
+                | TILDE
+                | HASH
+                | AMP
+                | PIPE
+                | PIPE2
+                | PLUS
+                | STAR
+                | SLASH
+                | CARET
+                | PERCENT
+                | DOT
+                | COLON
+                | COLON2
+                | EQ
+                | BANG
+                | NEQ
+                | MINUS
+                | LTEQ
+                | GTEQ
+                | PLUSEQ
+                | PIPEEQ
+                | AMPEQ
+                | CARETEQ
+                | SLASHEQ
+                | STAREQ
+                | PERCENTEQ
+                | AT
+                | DOLLAR_EQ
+                | TILDE_EQ
+                | CDC
+                | CDO
+                | UNICODE
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
+        matches!(
+            self,
             CSS_STRING_LITERAL
-            | CSS_NUMBER_LITERAL
-            | CSS_DASHED_IDENTIFIER
-            | CSS_CUSTOM_IDENTIFIER
-            | CSS_SPACE_LITERAL
-            | CSS_URL_VALUE_RAW_LITERAL
-            | CSS_COLOR_LITERAL
-            | CSS_DIMENSION_VALUE
-            | CSS_PERCENTAGE_VALUE
-            | CSS_UNICODE_CODEPOINT_LITERAL
-            | CSS_UNICODE_RANGE_WILDCARD_LITERAL => true,
-            _ => false,
-        }
+                | CSS_NUMBER_LITERAL
+                | CSS_DASHED_IDENTIFIER
+                | CSS_CUSTOM_IDENTIFIER
+                | CSS_SPACE_LITERAL
+                | CSS_URL_VALUE_RAW_LITERAL
+                | CSS_COLOR_LITERAL
+                | CSS_DIMENSION_VALUE
+                | CSS_PERCENTAGE_VALUE
+                | CSS_UNICODE_CODEPOINT_LITERAL
+                | CSS_UNICODE_RANGE_WILDCARD_LITERAL
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
+        matches!(
+            self,
             CSS_RULE_LIST
-            | CSS_SELECTOR_LIST
-            | CSS_DECLARATION_OR_RULE_LIST
-            | CSS_DECLARATION_OR_AT_RULE_LIST
-            | CSS_ATTRIBUTE_LIST
-            | CSS_DECLARATION_LIST
-            | CSS_COMPONENT_VALUE_LIST
-            | CSS_GENERIC_COMPONENT_VALUE_LIST
-            | CSS_COMPOSES_CLASS_LIST
-            | CSS_PARAMETER_LIST
-            | CSS_ANY_SELECTOR_LIST
-            | CSS_SUB_SELECTOR_LIST
-            | CSS_NESTED_SELECTOR_LIST
-            | CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST
-            | CSS_PSEUDO_CLASS_FUNCTION_COMPOUND_SELECTOR_LIST
-            | CSS_COMPOUND_SELECTOR_LIST
-            | CSS_PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST
-            | CSS_RELATIVE_SELECTOR_LIST
-            | CSS_PSEUDO_CLASS_FUNCTION_VALUE_LIST
-            | CSS_PSEUDO_VALUE_LIST
-            | CSS_URL_MODIFIER_LIST
-            | CSS_BRACKETED_VALUE_LIST
-            | CSS_FONT_FAMILY_NAME_LIST
-            | CSS_CUSTOM_IDENTIFIER_LIST
-            | CSS_FONT_FEATURE_VALUES_ITEM_LIST
-            | CSS_MEDIA_QUERY_LIST
-            | CSS_KEYFRAMES_ITEM_LIST
-            | CSS_KEYFRAMES_SELECTOR_LIST
-            | CSS_PAGE_SELECTOR_LIST
-            | CSS_PAGE_SELECTOR_PSEUDO_LIST
-            | CSS_PAGE_AT_RULE_ITEM_LIST
-            | CSS_LAYER_REFERENCE_LIST
-            | CSS_LAYER_NAME_LIST
-            | CSS_DOCUMENT_MATCHER_LIST
-            | CSS_VALUE_AT_RULE_PROPERTY_LIST
-            | CSS_VALUE_AT_RULE_IMPORT_SPECIFIER_LIST
-            | CSS_UNKNOWN_AT_RULE_COMPONENT_LIST => true,
-            _ => false,
-        }
+                | CSS_SELECTOR_LIST
+                | CSS_DECLARATION_OR_RULE_LIST
+                | CSS_DECLARATION_OR_AT_RULE_LIST
+                | CSS_ATTRIBUTE_LIST
+                | CSS_DECLARATION_LIST
+                | CSS_COMPONENT_VALUE_LIST
+                | CSS_GENERIC_COMPONENT_VALUE_LIST
+                | CSS_COMPOSES_CLASS_LIST
+                | CSS_PARAMETER_LIST
+                | CSS_ANY_SELECTOR_LIST
+                | CSS_SUB_SELECTOR_LIST
+                | CSS_NESTED_SELECTOR_LIST
+                | CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST
+                | CSS_PSEUDO_CLASS_FUNCTION_COMPOUND_SELECTOR_LIST
+                | CSS_COMPOUND_SELECTOR_LIST
+                | CSS_PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST
+                | CSS_RELATIVE_SELECTOR_LIST
+                | CSS_PSEUDO_CLASS_FUNCTION_VALUE_LIST
+                | CSS_PSEUDO_VALUE_LIST
+                | CSS_URL_MODIFIER_LIST
+                | CSS_BRACKETED_VALUE_LIST
+                | CSS_FONT_FAMILY_NAME_LIST
+                | CSS_CUSTOM_IDENTIFIER_LIST
+                | CSS_FONT_FEATURE_VALUES_ITEM_LIST
+                | CSS_MEDIA_QUERY_LIST
+                | CSS_KEYFRAMES_ITEM_LIST
+                | CSS_KEYFRAMES_SELECTOR_LIST
+                | CSS_PAGE_SELECTOR_LIST
+                | CSS_PAGE_SELECTOR_PSEUDO_LIST
+                | CSS_PAGE_AT_RULE_ITEM_LIST
+                | CSS_LAYER_REFERENCE_LIST
+                | CSS_LAYER_NAME_LIST
+                | CSS_DOCUMENT_MATCHER_LIST
+                | CSS_VALUE_AT_RULE_PROPERTY_LIST
+                | CSS_VALUE_AT_RULE_IMPORT_SPECIFIER_LIST
+                | CSS_UNKNOWN_AT_RULE_COMPONENT_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<CssSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     CssLanguage as Language, CssSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     CssSyntaxKind::{self as SyntaxKind, *},
     CssSyntaxList as SyntaxList, CssSyntaxNode as SyntaxNode, CssSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct CssAtRule {

--- a/crates/biome_diagnostics/src/display/backtrace.rs
+++ b/crates/biome_diagnostics/src/display/backtrace.rs
@@ -209,7 +209,7 @@ thread_local! {
 /// On the main thread:
 /// ```
 /// # use biome_diagnostics::set_bottom_frame;
-/// # #[allow(clippy::needless_doctest_main)]
+/// # #[expect(clippy::needless_doctest_main)]
 /// pub fn main() {
 ///     set_bottom_frame(main as usize);
 ///

--- a/crates/biome_formatter/src/buffer.rs
+++ b/crates/biome_formatter/src/buffer.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::mutable_key_type)]
+#![expect(clippy::mutable_key_type)]
 use super::{write, Arguments, FormatElement};
 use crate::format_element::Interned;
 use crate::prelude::tag::Condition;

--- a/crates/biome_formatter/src/comments/builder.rs
+++ b/crates/biome_formatter/src/comments/builder.rs
@@ -555,7 +555,7 @@ impl<'a> SourceParentheses<'a> {
             SourceParentheses::Empty => None,
             SourceParentheses::SourceMap { next, tail, .. } => {
                 while let Some(range) = next {
-                    #[allow(clippy::comparison_chain)]
+                    #[expect(clippy::comparison_chain)]
                     if range.transformed == offset {
                         // A deleted range can contain multiple tokens. See if there's any `)` in the deleted
                         // range and compute its source range.

--- a/crates/biome_formatter/src/comments/map.rs
+++ b/crates/biome_formatter/src/comments/map.rs
@@ -248,7 +248,6 @@ impl<K: std::hash::Hash + Eq, V> CommentsMap<K, V> {
     }
 
     /// Returns an iterator over the parts of all keys.
-    #[allow(unused)]
     pub fn all_parts(&self) -> impl Iterator<Item = &V> {
         self.index
             .values()

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::mutable_key_type)]
+#![expect(clippy::mutable_key_type)]
 use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;

--- a/crates/biome_formatter/src/group_id.rs
+++ b/crates/biome_formatter/src/group_id.rs
@@ -8,7 +8,6 @@ pub struct DebugGroupId {
 }
 
 impl DebugGroupId {
-    #[allow(unused)]
     fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
         Self {
             value,
@@ -34,7 +33,7 @@ pub struct ReleaseGroupId {
 
 impl ReleaseGroupId {
     /// Creates a new unique group id with the given debug name (only stored in debug builds)
-    #[allow(unused)]
+    #[expect(unused)]
     fn new(value: NonZeroU32, _: &'static str) -> Self {
         Self { value }
     }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -1614,9 +1614,9 @@ pub fn format_range<Language: FormatLanguage>(
         // nodes and iterating along the two paths at once to find the first
         // divergence (the ancestors have to be collected into vectors first
         // since the ancestor iterator isn't double ended)
-        #[allow(clippy::needless_collect)]
+        #[expect(clippy::needless_collect)]
         let start_to_root: Vec<_> = result_start_node.ancestors().collect();
-        #[allow(clippy::needless_collect)]
+        #[expect(clippy::needless_collect)]
         let end_to_root: Vec<_> = result_end_node.ancestors().collect();
 
         start_to_root
@@ -1889,7 +1889,7 @@ impl<Context> FormatState<Context> {
 
     /// Tracks the given token as formatted
     #[inline]
-    pub fn track_token<L: Language>(&mut self, #[allow(unused_variables)] token: &SyntaxToken<L>) {
+    pub fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>) {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 self.printed_tokens.track_token(token);
@@ -1923,10 +1923,7 @@ impl<Context> FormatState<Context> {
 
     /// Asserts in debug builds that all tokens have been printed.
     #[inline]
-    pub fn assert_formatted_all_tokens<L: Language>(
-        &self,
-        #[allow(unused_variables)] root: &SyntaxNode<L>,
-    ) {
+    pub fn assert_formatted_all_tokens<L: Language>(&self, root: &SyntaxNode<L>) {
         cfg_if::cfg_if! {
             if #[cfg(debug_assertions)] {
                 self.printed_tokens.assert_all_tracked(root);

--- a/crates/biome_formatter/src/macros.rs
+++ b/crates/biome_formatter/src/macros.rs
@@ -329,7 +329,7 @@ macro_rules! format {
 #[macro_export]
 macro_rules! best_fitting {
     ($least_expanded:expr, $($tail:expr),+ $(,)?) => {{
-        #[allow(clippy::macro_metavars_in_unsafe)]
+        #[expect(clippy::macro_metavars_in_unsafe)]
         unsafe {
             $crate::BestFitting::from_arguments_unchecked($crate::format_args!($least_expanded, $($tail),+))
         }

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -112,17 +112,17 @@ impl PrinterOptions {
         self.indent_width
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) const fn line_ending(&self) -> LineEnding {
         self.line_ending
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn bracket_spacing(&self) -> BracketSpacing {
         self.bracket_spacing
     }

--- a/crates/biome_formatter/src/separated.rs
+++ b/crates/biome_formatter/src/separated.rs
@@ -157,7 +157,6 @@ where
         self
     }
 
-    #[allow(unused)]
     pub fn with_group_id(mut self, group_id: Option<GroupId>) -> Self {
         self.options.group_id = group_id;
         self

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -241,7 +241,6 @@ struct AliasPath {
 }
 
 impl AliasPath {
-    #[allow(dead_code)]
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -249,24 +248,22 @@ impl AliasPath {
         }
     }
 
-    #[allow(dead_code)]
     pub fn add_prefix(&mut self, prefix: impl Into<PathBuf>) {
         self.prefix.push(prefix.into());
     }
 }
 
-#[allow(dead_code)]
 pub struct Aliases {
     aliases: Vec<AliasPath>,
 }
 
 impl Aliases {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn new() -> Self {
         Self { aliases: vec![] }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn with_alias<'a>(
         mut self,
         name: impl Into<String>,
@@ -280,7 +277,7 @@ impl Aliases {
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn get_paths_by_name(&self, name: &str) -> Option<&[PathBuf]> {
         self.aliases
             .iter()

--- a/crates/biome_graphql_analyze/tests/spec_tests.rs
+++ b/crates/biome_graphql_analyze/tests/spec_tests.rs
@@ -88,7 +88,6 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn analyze_and_snap(
     snapshot: &mut String,
     input_code: &str,

--- a/crates/biome_graphql_factory/src/generated.rs
+++ b/crates/biome_graphql_factory/src/generated.rs
@@ -1,7 +1,6 @@
 #[rustfmt::skip]
 pub(super) mod syntax_factory;
 #[rustfmt::skip]
-#[allow(unused)]
 pub(crate) mod node_factory;
 
 pub use syntax_factory::GraphqlSyntaxFactory;

--- a/crates/biome_graphql_factory/src/generated/node_factory.rs
+++ b/crates/biome_graphql_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_graphql_syntax::{
     GraphqlSyntaxElement as SyntaxElement, GraphqlSyntaxNode as SyntaxNode,
     GraphqlSyntaxToken as SyntaxToken, *,

--- a/crates/biome_graphql_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_graphql_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_graphql_syntax::{GraphqlSyntaxKind, GraphqlSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct GraphqlSyntaxFactory;
 impl SyntaxFactory for GraphqlSyntaxFactory {
     type Kind = GraphqlSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_graphql_formatter/src/generated.rs
+++ b/crates/biome_graphql_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, FormatBogusNodeRule, FormatNodeRule, GraphqlFormatContext, GraphqlFormatter,
     IntoFormat,
@@ -25,7 +26,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlAlias {
         crate::graphql::auxiliary::alias::FormatGraphqlAlias,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::alias::FormatGraphqlAlias::default(),
@@ -38,7 +38,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlAlias {
         crate::graphql::auxiliary::alias::FormatGraphqlAlias,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::alias::FormatGraphqlAlias::default(),
@@ -65,7 +64,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgument {
         crate::graphql::auxiliary::argument::FormatGraphqlArgument,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::argument::FormatGraphqlArgument::default(),
@@ -78,7 +76,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgument 
         crate::graphql::auxiliary::argument::FormatGraphqlArgument,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::argument::FormatGraphqlArgument::default(),
@@ -105,7 +102,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArguments {
         crate::graphql::auxiliary::arguments::FormatGraphqlArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::arguments::FormatGraphqlArguments::default(),
@@ -118,7 +114,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArguments
         crate::graphql::auxiliary::arguments::FormatGraphqlArguments,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::arguments::FormatGraphqlArguments::default(),
@@ -145,7 +140,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgumentsDe
         crate::graphql::definitions::arguments_definition::FormatGraphqlArgumentsDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: arguments_definition :: FormatGraphqlArgumentsDefinition :: default ())
     }
 }
@@ -155,7 +149,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArguments
         crate::graphql::definitions::arguments_definition::FormatGraphqlArgumentsDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: arguments_definition :: FormatGraphqlArgumentsDefinition :: default ())
     }
 }
@@ -179,7 +172,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBooleanValu
         crate::graphql::value::boolean_value::FormatGraphqlBooleanValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::boolean_value::FormatGraphqlBooleanValue::default(),
@@ -192,7 +184,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBooleanVa
         crate::graphql::value::boolean_value::FormatGraphqlBooleanValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::boolean_value::FormatGraphqlBooleanValue::default(),
@@ -219,7 +210,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDefaultValu
         crate::graphql::value::default_value::FormatGraphqlDefaultValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::default_value::FormatGraphqlDefaultValue::default(),
@@ -232,7 +222,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDefaultVa
         crate::graphql::value::default_value::FormatGraphqlDefaultValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::default_value::FormatGraphqlDefaultValue::default(),
@@ -259,7 +248,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDescription
         crate::graphql::auxiliary::description::FormatGraphqlDescription,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::description::FormatGraphqlDescription::default(),
@@ -272,7 +260,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDescripti
         crate::graphql::auxiliary::description::FormatGraphqlDescription,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::description::FormatGraphqlDescription::default(),
@@ -299,7 +286,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective {
         crate::graphql::auxiliary::directive::FormatGraphqlDirective,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::directive::FormatGraphqlDirective::default(),
@@ -312,7 +298,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective
         crate::graphql::auxiliary::directive::FormatGraphqlDirective,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::directive::FormatGraphqlDirective::default(),
@@ -339,7 +324,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirectiveDe
         crate::graphql::definitions::directive_definition::FormatGraphqlDirectiveDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: directive_definition :: FormatGraphqlDirectiveDefinition :: default ())
     }
 }
@@ -349,7 +333,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective
         crate::graphql::definitions::directive_definition::FormatGraphqlDirectiveDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: directive_definition :: FormatGraphqlDirectiveDefinition :: default ())
     }
 }
@@ -373,7 +356,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirectiveLo
         crate::graphql::auxiliary::directive_location::FormatGraphqlDirectiveLocation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::directive_location::FormatGraphqlDirectiveLocation::default(
@@ -387,7 +369,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective
         crate::graphql::auxiliary::directive_location::FormatGraphqlDirectiveLocation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::directive_location::FormatGraphqlDirectiveLocation::default(
@@ -415,7 +396,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumTypeDef
         crate::graphql::definitions::enum_type_definition::FormatGraphqlEnumTypeDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: enum_type_definition :: FormatGraphqlEnumTypeDefinition :: default ())
     }
 }
@@ -425,7 +405,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumTypeD
         crate::graphql::definitions::enum_type_definition::FormatGraphqlEnumTypeDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: enum_type_definition :: FormatGraphqlEnumTypeDefinition :: default ())
     }
 }
@@ -449,7 +428,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumTypeExt
         crate::graphql::extensions::enum_type_extension::FormatGraphqlEnumTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: enum_type_extension :: FormatGraphqlEnumTypeExtension :: default ())
     }
 }
@@ -459,7 +437,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumTypeE
         crate::graphql::extensions::enum_type_extension::FormatGraphqlEnumTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: enum_type_extension :: FormatGraphqlEnumTypeExtension :: default ())
     }
 }
@@ -483,7 +460,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValue {
         crate::graphql::value::enum_value::FormatGraphqlEnumValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::enum_value::FormatGraphqlEnumValue::default(),
@@ -496,7 +472,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValue
         crate::graphql::value::enum_value::FormatGraphqlEnumValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::enum_value::FormatGraphqlEnumValue::default(),
@@ -523,7 +498,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValueDe
         crate::graphql::definitions::enum_value_definition::FormatGraphqlEnumValueDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: enum_value_definition :: FormatGraphqlEnumValueDefinition :: default ())
     }
 }
@@ -533,7 +507,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValue
         crate::graphql::definitions::enum_value_definition::FormatGraphqlEnumValueDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: enum_value_definition :: FormatGraphqlEnumValueDefinition :: default ())
     }
 }
@@ -557,7 +530,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValuesD
         crate::graphql::definitions::enum_values_definition::FormatGraphqlEnumValuesDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: enum_values_definition :: FormatGraphqlEnumValuesDefinition :: default ())
     }
 }
@@ -567,7 +539,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValue
         crate::graphql::definitions::enum_values_definition::FormatGraphqlEnumValuesDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: enum_values_definition :: FormatGraphqlEnumValuesDefinition :: default ())
     }
 }
@@ -591,7 +562,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlField {
         crate::graphql::auxiliary::field::FormatGraphqlField,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::field::FormatGraphqlField::default(),
@@ -604,7 +574,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlField {
         crate::graphql::auxiliary::field::FormatGraphqlField,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::field::FormatGraphqlField::default(),
@@ -631,7 +600,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldDefini
         crate::graphql::definitions::field_definition::FormatGraphqlFieldDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::definitions::field_definition::FormatGraphqlFieldDefinition::default(),
@@ -644,7 +612,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldDefi
         crate::graphql::definitions::field_definition::FormatGraphqlFieldDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::definitions::field_definition::FormatGraphqlFieldDefinition::default(),
@@ -671,7 +638,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldsDefin
         crate::graphql::definitions::fields_definition::FormatGraphqlFieldsDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::definitions::fields_definition::FormatGraphqlFieldsDefinition::default(
@@ -685,7 +651,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldsDef
         crate::graphql::definitions::fields_definition::FormatGraphqlFieldsDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::definitions::fields_definition::FormatGraphqlFieldsDefinition::default(
@@ -713,7 +678,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFloatValue 
         crate::graphql::value::float_value::FormatGraphqlFloatValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::float_value::FormatGraphqlFloatValue::default(),
@@ -726,7 +690,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFloatValu
         crate::graphql::value::float_value::FormatGraphqlFloatValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::float_value::FormatGraphqlFloatValue::default(),
@@ -753,7 +716,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFragmentDef
         crate::graphql::definitions::fragment_definition::FormatGraphqlFragmentDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: fragment_definition :: FormatGraphqlFragmentDefinition :: default ())
     }
 }
@@ -763,7 +725,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFragmentD
         crate::graphql::definitions::fragment_definition::FormatGraphqlFragmentDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: fragment_definition :: FormatGraphqlFragmentDefinition :: default ())
     }
 }
@@ -787,7 +748,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFragmentSpr
         crate::graphql::auxiliary::fragment_spread::FormatGraphqlFragmentSpread,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::fragment_spread::FormatGraphqlFragmentSpread::default(),
@@ -800,7 +760,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFragmentS
         crate::graphql::auxiliary::fragment_spread::FormatGraphqlFragmentSpread,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::fragment_spread::FormatGraphqlFragmentSpread::default(),
@@ -827,7 +786,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlImplementsI
         crate::graphql::auxiliary::implements_interfaces::FormatGraphqlImplementsInterfaces,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: auxiliary :: implements_interfaces :: FormatGraphqlImplementsInterfaces :: default ())
     }
 }
@@ -837,7 +795,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlImplement
         crate::graphql::auxiliary::implements_interfaces::FormatGraphqlImplementsInterfaces,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: auxiliary :: implements_interfaces :: FormatGraphqlImplementsInterfaces :: default ())
     }
 }
@@ -861,7 +818,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInlineFragm
         crate::graphql::auxiliary::inline_fragment::FormatGraphqlInlineFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::inline_fragment::FormatGraphqlInlineFragment::default(),
@@ -874,7 +830,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInlineFra
         crate::graphql::auxiliary::inline_fragment::FormatGraphqlInlineFragment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::inline_fragment::FormatGraphqlInlineFragment::default(),
@@ -901,7 +856,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputFields
         crate::graphql::definitions::input_fields_definition::FormatGraphqlInputFieldsDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: input_fields_definition :: FormatGraphqlInputFieldsDefinition :: default ())
     }
 }
@@ -911,7 +865,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputFiel
         crate::graphql::definitions::input_fields_definition::FormatGraphqlInputFieldsDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: input_fields_definition :: FormatGraphqlInputFieldsDefinition :: default ())
     }
 }
@@ -919,14 +872,12 @@ impl FormatRule < biome_graphql_syntax :: GraphqlInputObjectTypeDefinition > for
 impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputObjectTypeDefinition {
     type Format < 'a > = FormatRefWithRule < 'a , biome_graphql_syntax :: GraphqlInputObjectTypeDefinition , crate :: graphql :: definitions :: input_object_type_definition :: FormatGraphqlInputObjectTypeDefinition > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: input_object_type_definition :: FormatGraphqlInputObjectTypeDefinition :: default ())
     }
 }
 impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputObjectTypeDefinition {
     type Format = FormatOwnedWithRule < biome_graphql_syntax :: GraphqlInputObjectTypeDefinition , crate :: graphql :: definitions :: input_object_type_definition :: FormatGraphqlInputObjectTypeDefinition > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: input_object_type_definition :: FormatGraphqlInputObjectTypeDefinition :: default ())
     }
 }
@@ -934,14 +885,12 @@ impl FormatRule < biome_graphql_syntax :: GraphqlInputObjectTypeExtension > for 
 impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputObjectTypeExtension {
     type Format < 'a > = FormatRefWithRule < 'a , biome_graphql_syntax :: GraphqlInputObjectTypeExtension , crate :: graphql :: extensions :: input_object_type_extension :: FormatGraphqlInputObjectTypeExtension > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: input_object_type_extension :: FormatGraphqlInputObjectTypeExtension :: default ())
     }
 }
 impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputObjectTypeExtension {
     type Format = FormatOwnedWithRule < biome_graphql_syntax :: GraphqlInputObjectTypeExtension , crate :: graphql :: extensions :: input_object_type_extension :: FormatGraphqlInputObjectTypeExtension > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: input_object_type_extension :: FormatGraphqlInputObjectTypeExtension :: default ())
     }
 }
@@ -965,7 +914,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputValueD
         crate::graphql::definitions::input_value_definition::FormatGraphqlInputValueDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: input_value_definition :: FormatGraphqlInputValueDefinition :: default ())
     }
 }
@@ -975,7 +923,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputValu
         crate::graphql::definitions::input_value_definition::FormatGraphqlInputValueDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: input_value_definition :: FormatGraphqlInputValueDefinition :: default ())
     }
 }
@@ -999,7 +946,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlIntValue {
         crate::graphql::value::int_value::FormatGraphqlIntValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::int_value::FormatGraphqlIntValue::default(),
@@ -1012,7 +958,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlIntValue 
         crate::graphql::value::int_value::FormatGraphqlIntValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::int_value::FormatGraphqlIntValue::default(),
@@ -1035,14 +980,12 @@ impl FormatRule<biome_graphql_syntax::GraphqlInterfaceTypeDefinition>
 impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInterfaceTypeDefinition {
     type Format < 'a > = FormatRefWithRule < 'a , biome_graphql_syntax :: GraphqlInterfaceTypeDefinition , crate :: graphql :: definitions :: interface_type_definition :: FormatGraphqlInterfaceTypeDefinition > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: interface_type_definition :: FormatGraphqlInterfaceTypeDefinition :: default ())
     }
 }
 impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInterfaceTypeDefinition {
     type Format = FormatOwnedWithRule < biome_graphql_syntax :: GraphqlInterfaceTypeDefinition , crate :: graphql :: definitions :: interface_type_definition :: FormatGraphqlInterfaceTypeDefinition > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: interface_type_definition :: FormatGraphqlInterfaceTypeDefinition :: default ())
     }
 }
@@ -1066,7 +1009,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInterfaceTy
         crate::graphql::extensions::interface_type_extension::FormatGraphqlInterfaceTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: interface_type_extension :: FormatGraphqlInterfaceTypeExtension :: default ())
     }
 }
@@ -1076,7 +1018,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInterface
         crate::graphql::extensions::interface_type_extension::FormatGraphqlInterfaceTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: interface_type_extension :: FormatGraphqlInterfaceTypeExtension :: default ())
     }
 }
@@ -1100,7 +1041,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListType {
         crate::graphql::auxiliary::list_type::FormatGraphqlListType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::list_type::FormatGraphqlListType::default(),
@@ -1113,7 +1053,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListType 
         crate::graphql::auxiliary::list_type::FormatGraphqlListType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::list_type::FormatGraphqlListType::default(),
@@ -1140,7 +1079,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListValue {
         crate::graphql::value::list_value::FormatGraphqlListValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::list_value::FormatGraphqlListValue::default(),
@@ -1153,7 +1091,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListValue
         crate::graphql::value::list_value::FormatGraphqlListValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::list_value::FormatGraphqlListValue::default(),
@@ -1180,7 +1117,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlLiteralName
         crate::graphql::auxiliary::literal_name::FormatGraphqlLiteralName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::literal_name::FormatGraphqlLiteralName::default(),
@@ -1193,7 +1129,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlLiteralNa
         crate::graphql::auxiliary::literal_name::FormatGraphqlLiteralName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::literal_name::FormatGraphqlLiteralName::default(),
@@ -1220,7 +1155,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNameBinding
         crate::graphql::auxiliary::name_binding::FormatGraphqlNameBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::name_binding::FormatGraphqlNameBinding::default(),
@@ -1233,7 +1167,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNameBindi
         crate::graphql::auxiliary::name_binding::FormatGraphqlNameBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::name_binding::FormatGraphqlNameBinding::default(),
@@ -1260,7 +1193,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNameReferen
         crate::graphql::auxiliary::name_reference::FormatGraphqlNameReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::name_reference::FormatGraphqlNameReference::default(),
@@ -1273,7 +1205,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNameRefer
         crate::graphql::auxiliary::name_reference::FormatGraphqlNameReference,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::name_reference::FormatGraphqlNameReference::default(),
@@ -1300,7 +1231,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNonNullType
         crate::graphql::auxiliary::non_null_type::FormatGraphqlNonNullType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::non_null_type::FormatGraphqlNonNullType::default(),
@@ -1313,7 +1243,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNonNullTy
         crate::graphql::auxiliary::non_null_type::FormatGraphqlNonNullType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::non_null_type::FormatGraphqlNonNullType::default(),
@@ -1340,7 +1269,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNullValue {
         crate::graphql::value::null_value::FormatGraphqlNullValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::null_value::FormatGraphqlNullValue::default(),
@@ -1353,7 +1281,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlNullValue
         crate::graphql::value::null_value::FormatGraphqlNullValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::null_value::FormatGraphqlNullValue::default(),
@@ -1380,7 +1307,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectField
         crate::graphql::auxiliary::object_field::FormatGraphqlObjectField,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::object_field::FormatGraphqlObjectField::default(),
@@ -1393,7 +1319,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectFie
         crate::graphql::auxiliary::object_field::FormatGraphqlObjectField,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::object_field::FormatGraphqlObjectField::default(),
@@ -1420,7 +1345,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectTypeD
         crate::graphql::definitions::object_type_definition::FormatGraphqlObjectTypeDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: object_type_definition :: FormatGraphqlObjectTypeDefinition :: default ())
     }
 }
@@ -1430,7 +1354,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectTyp
         crate::graphql::definitions::object_type_definition::FormatGraphqlObjectTypeDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: object_type_definition :: FormatGraphqlObjectTypeDefinition :: default ())
     }
 }
@@ -1454,7 +1377,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectTypeE
         crate::graphql::extensions::object_type_extension::FormatGraphqlObjectTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: object_type_extension :: FormatGraphqlObjectTypeExtension :: default ())
     }
 }
@@ -1464,7 +1386,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectTyp
         crate::graphql::extensions::object_type_extension::FormatGraphqlObjectTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: object_type_extension :: FormatGraphqlObjectTypeExtension :: default ())
     }
 }
@@ -1488,7 +1409,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectValue
         crate::graphql::value::object_value::FormatGraphqlObjectValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::object_value::FormatGraphqlObjectValue::default(),
@@ -1501,7 +1421,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectVal
         crate::graphql::value::object_value::FormatGraphqlObjectValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::object_value::FormatGraphqlObjectValue::default(),
@@ -1528,7 +1447,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlOperationDe
         crate::graphql::definitions::operation_definition::FormatGraphqlOperationDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: operation_definition :: FormatGraphqlOperationDefinition :: default ())
     }
 }
@@ -1538,7 +1456,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlOperation
         crate::graphql::definitions::operation_definition::FormatGraphqlOperationDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: operation_definition :: FormatGraphqlOperationDefinition :: default ())
     }
 }
@@ -1562,7 +1479,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlOperationTy
         crate::graphql::auxiliary::operation_type::FormatGraphqlOperationType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::operation_type::FormatGraphqlOperationType::default(),
@@ -1575,7 +1491,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlOperation
         crate::graphql::auxiliary::operation_type::FormatGraphqlOperationType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::operation_type::FormatGraphqlOperationType::default(),
@@ -1602,7 +1517,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRoot {
         crate::graphql::auxiliary::root::FormatGraphqlRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::root::FormatGraphqlRoot::default(),
@@ -1615,7 +1529,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRoot {
         crate::graphql::auxiliary::root::FormatGraphqlRoot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::root::FormatGraphqlRoot::default(),
@@ -1626,14 +1539,12 @@ impl FormatRule < biome_graphql_syntax :: GraphqlRootOperationTypeDefinition > f
 impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRootOperationTypeDefinition {
     type Format < 'a > = FormatRefWithRule < 'a , biome_graphql_syntax :: GraphqlRootOperationTypeDefinition , crate :: graphql :: definitions :: root_operation_type_definition :: FormatGraphqlRootOperationTypeDefinition > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: root_operation_type_definition :: FormatGraphqlRootOperationTypeDefinition :: default ())
     }
 }
 impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRootOperationTypeDefinition {
     type Format = FormatOwnedWithRule < biome_graphql_syntax :: GraphqlRootOperationTypeDefinition , crate :: graphql :: definitions :: root_operation_type_definition :: FormatGraphqlRootOperationTypeDefinition > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: root_operation_type_definition :: FormatGraphqlRootOperationTypeDefinition :: default ())
     }
 }
@@ -1657,7 +1568,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRootOperati
         crate::graphql::auxiliary::root_operation_types::FormatGraphqlRootOperationTypes,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: auxiliary :: root_operation_types :: FormatGraphqlRootOperationTypes :: default ())
     }
 }
@@ -1667,7 +1577,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlRootOpera
         crate::graphql::auxiliary::root_operation_types::FormatGraphqlRootOperationTypes,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: auxiliary :: root_operation_types :: FormatGraphqlRootOperationTypes :: default ())
     }
 }
@@ -1691,7 +1600,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlScalarTypeD
         crate::graphql::definitions::scalar_type_definition::FormatGraphqlScalarTypeDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: scalar_type_definition :: FormatGraphqlScalarTypeDefinition :: default ())
     }
 }
@@ -1701,7 +1609,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlScalarTyp
         crate::graphql::definitions::scalar_type_definition::FormatGraphqlScalarTypeDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: scalar_type_definition :: FormatGraphqlScalarTypeDefinition :: default ())
     }
 }
@@ -1725,7 +1632,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlScalarTypeE
         crate::graphql::extensions::scalar_type_extension::FormatGraphqlScalarTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: scalar_type_extension :: FormatGraphqlScalarTypeExtension :: default ())
     }
 }
@@ -1735,7 +1641,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlScalarTyp
         crate::graphql::extensions::scalar_type_extension::FormatGraphqlScalarTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: scalar_type_extension :: FormatGraphqlScalarTypeExtension :: default ())
     }
 }
@@ -1759,7 +1664,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSchemaDefin
         crate::graphql::definitions::schema_definition::FormatGraphqlSchemaDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::definitions::schema_definition::FormatGraphqlSchemaDefinition::default(
@@ -1773,7 +1677,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSchemaDef
         crate::graphql::definitions::schema_definition::FormatGraphqlSchemaDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::definitions::schema_definition::FormatGraphqlSchemaDefinition::default(
@@ -1801,7 +1704,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSchemaExten
         crate::graphql::extensions::schema_extension::FormatGraphqlSchemaExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::extensions::schema_extension::FormatGraphqlSchemaExtension::default(),
@@ -1814,7 +1716,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSchemaExt
         crate::graphql::extensions::schema_extension::FormatGraphqlSchemaExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::extensions::schema_extension::FormatGraphqlSchemaExtension::default(),
@@ -1841,7 +1742,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSelectionSe
         crate::graphql::auxiliary::selection_set::FormatGraphqlSelectionSet,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::selection_set::FormatGraphqlSelectionSet::default(),
@@ -1854,7 +1754,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSelection
         crate::graphql::auxiliary::selection_set::FormatGraphqlSelectionSet,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::selection_set::FormatGraphqlSelectionSet::default(),
@@ -1881,7 +1780,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlStringValue
         crate::graphql::value::string_value::FormatGraphqlStringValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::value::string_value::FormatGraphqlStringValue::default(),
@@ -1894,7 +1792,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlStringVal
         crate::graphql::value::string_value::FormatGraphqlStringValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::value::string_value::FormatGraphqlStringValue::default(),
@@ -1921,7 +1818,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlTypeConditi
         crate::graphql::auxiliary::type_condition::FormatGraphqlTypeCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::type_condition::FormatGraphqlTypeCondition::default(),
@@ -1934,7 +1830,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlTypeCondi
         crate::graphql::auxiliary::type_condition::FormatGraphqlTypeCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::type_condition::FormatGraphqlTypeCondition::default(),
@@ -1961,7 +1856,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionMember
         crate::graphql::auxiliary::union_member_types::FormatGraphqlUnionMemberTypes,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::union_member_types::FormatGraphqlUnionMemberTypes::default(),
@@ -1974,7 +1868,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionMemb
         crate::graphql::auxiliary::union_member_types::FormatGraphqlUnionMemberTypes,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::union_member_types::FormatGraphqlUnionMemberTypes::default(),
@@ -2001,7 +1894,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionTypeDe
         crate::graphql::definitions::union_type_definition::FormatGraphqlUnionTypeDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: union_type_definition :: FormatGraphqlUnionTypeDefinition :: default ())
     }
 }
@@ -2011,7 +1903,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionType
         crate::graphql::definitions::union_type_definition::FormatGraphqlUnionTypeDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: union_type_definition :: FormatGraphqlUnionTypeDefinition :: default ())
     }
 }
@@ -2035,7 +1926,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionTypeEx
         crate::graphql::extensions::union_type_extension::FormatGraphqlUnionTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: extensions :: union_type_extension :: FormatGraphqlUnionTypeExtension :: default ())
     }
 }
@@ -2045,7 +1935,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionType
         crate::graphql::extensions::union_type_extension::FormatGraphqlUnionTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: extensions :: union_type_extension :: FormatGraphqlUnionTypeExtension :: default ())
     }
 }
@@ -2069,7 +1958,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableBin
         crate::graphql::auxiliary::variable_binding::FormatGraphqlVariableBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::variable_binding::FormatGraphqlVariableBinding::default(),
@@ -2082,7 +1970,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableB
         crate::graphql::auxiliary::variable_binding::FormatGraphqlVariableBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::variable_binding::FormatGraphqlVariableBinding::default(),
@@ -2109,7 +1996,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableDef
         crate::graphql::definitions::variable_definition::FormatGraphqlVariableDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: definitions :: variable_definition :: FormatGraphqlVariableDefinition :: default ())
     }
 }
@@ -2119,7 +2005,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableD
         crate::graphql::definitions::variable_definition::FormatGraphqlVariableDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: definitions :: variable_definition :: FormatGraphqlVariableDefinition :: default ())
     }
 }
@@ -2143,7 +2028,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableDef
         crate::graphql::auxiliary::variable_definitions::FormatGraphqlVariableDefinitions,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: auxiliary :: variable_definitions :: FormatGraphqlVariableDefinitions :: default ())
     }
 }
@@ -2153,7 +2037,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableD
         crate::graphql::auxiliary::variable_definitions::FormatGraphqlVariableDefinitions,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: auxiliary :: variable_definitions :: FormatGraphqlVariableDefinitions :: default ())
     }
 }
@@ -2177,7 +2060,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableRef
         crate::graphql::auxiliary::variable_reference::FormatGraphqlVariableReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::auxiliary::variable_reference::FormatGraphqlVariableReference::default(
@@ -2191,7 +2073,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableR
         crate::graphql::auxiliary::variable_reference::FormatGraphqlVariableReference,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::auxiliary::variable_reference::FormatGraphqlVariableReference::default(
@@ -2206,7 +2087,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgumentDef
         crate::graphql::lists::argument_definition_list::FormatGraphqlArgumentDefinitionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: argument_definition_list :: FormatGraphqlArgumentDefinitionList :: default ())
     }
 }
@@ -2216,7 +2096,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgumentD
         crate::graphql::lists::argument_definition_list::FormatGraphqlArgumentDefinitionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: argument_definition_list :: FormatGraphqlArgumentDefinitionList :: default ())
     }
 }
@@ -2227,7 +2106,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgumentLis
         crate::graphql::lists::argument_list::FormatGraphqlArgumentList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::argument_list::FormatGraphqlArgumentList::default(),
@@ -2240,7 +2118,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlArgumentL
         crate::graphql::lists::argument_list::FormatGraphqlArgumentList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::argument_list::FormatGraphqlArgumentList::default(),
@@ -2254,7 +2131,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDefinitionL
         crate::graphql::lists::definition_list::FormatGraphqlDefinitionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::definition_list::FormatGraphqlDefinitionList::default(),
@@ -2267,7 +2143,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDefinitio
         crate::graphql::lists::definition_list::FormatGraphqlDefinitionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::definition_list::FormatGraphqlDefinitionList::default(),
@@ -2281,7 +2156,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirectiveLi
         crate::graphql::lists::directive_list::FormatGraphqlDirectiveList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::directive_list::FormatGraphqlDirectiveList::default(),
@@ -2294,7 +2168,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective
         crate::graphql::lists::directive_list::FormatGraphqlDirectiveList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::directive_list::FormatGraphqlDirectiveList::default(),
@@ -2308,7 +2181,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirectiveLo
         crate::graphql::lists::directive_location_list::FormatGraphqlDirectiveLocationList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: directive_location_list :: FormatGraphqlDirectiveLocationList :: default ())
     }
 }
@@ -2318,7 +2190,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlDirective
         crate::graphql::lists::directive_location_list::FormatGraphqlDirectiveLocationList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: directive_location_list :: FormatGraphqlDirectiveLocationList :: default ())
     }
 }
@@ -2329,7 +2200,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValueLi
         crate::graphql::lists::enum_value_list::FormatGraphqlEnumValueList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::enum_value_list::FormatGraphqlEnumValueList::default(),
@@ -2342,7 +2212,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlEnumValue
         crate::graphql::lists::enum_value_list::FormatGraphqlEnumValueList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::enum_value_list::FormatGraphqlEnumValueList::default(),
@@ -2356,7 +2225,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldDefini
         crate::graphql::lists::field_definition_list::FormatGraphqlFieldDefinitionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::field_definition_list::FormatGraphqlFieldDefinitionList::default(
@@ -2370,7 +2238,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlFieldDefi
         crate::graphql::lists::field_definition_list::FormatGraphqlFieldDefinitionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::field_definition_list::FormatGraphqlFieldDefinitionList::default(
@@ -2385,7 +2252,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlImplementsI
         crate::graphql::lists::implements_interface_list::FormatGraphqlImplementsInterfaceList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: implements_interface_list :: FormatGraphqlImplementsInterfaceList :: default ())
     }
 }
@@ -2395,7 +2261,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlImplement
         crate::graphql::lists::implements_interface_list::FormatGraphqlImplementsInterfaceList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: implements_interface_list :: FormatGraphqlImplementsInterfaceList :: default ())
     }
 }
@@ -2406,7 +2271,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputFieldL
         crate::graphql::lists::input_field_list::FormatGraphqlInputFieldList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::input_field_list::FormatGraphqlInputFieldList::default(),
@@ -2419,7 +2283,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlInputFiel
         crate::graphql::lists::input_field_list::FormatGraphqlInputFieldList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::input_field_list::FormatGraphqlInputFieldList::default(),
@@ -2433,7 +2296,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListValueEl
         crate::graphql::lists::list_value_element_list::FormatGraphqlListValueElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: list_value_element_list :: FormatGraphqlListValueElementList :: default ())
     }
 }
@@ -2443,7 +2305,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlListValue
         crate::graphql::lists::list_value_element_list::FormatGraphqlListValueElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: list_value_element_list :: FormatGraphqlListValueElementList :: default ())
     }
 }
@@ -2454,7 +2315,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectValue
         crate::graphql::lists::object_value_member_list::FormatGraphqlObjectValueMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: object_value_member_list :: FormatGraphqlObjectValueMemberList :: default ())
     }
 }
@@ -2464,7 +2324,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlObjectVal
         crate::graphql::lists::object_value_member_list::FormatGraphqlObjectValueMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: object_value_member_list :: FormatGraphqlObjectValueMemberList :: default ())
     }
 }
@@ -2473,7 +2332,6 @@ impl AsFormat<GraphqlFormatContext>
 {
     type Format < 'a > = FormatRefWithRule < 'a , biome_graphql_syntax :: GraphqlRootOperationTypeDefinitionList , crate :: graphql :: lists :: root_operation_type_definition_list :: FormatGraphqlRootOperationTypeDefinitionList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: root_operation_type_definition_list :: FormatGraphqlRootOperationTypeDefinitionList :: default ())
     }
 }
@@ -2482,7 +2340,6 @@ impl IntoFormat<GraphqlFormatContext>
 {
     type Format = FormatOwnedWithRule < biome_graphql_syntax :: GraphqlRootOperationTypeDefinitionList , crate :: graphql :: lists :: root_operation_type_definition_list :: FormatGraphqlRootOperationTypeDefinitionList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: root_operation_type_definition_list :: FormatGraphqlRootOperationTypeDefinitionList :: default ())
     }
 }
@@ -2493,7 +2350,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSelectionLi
         crate::graphql::lists::selection_list::FormatGraphqlSelectionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::lists::selection_list::FormatGraphqlSelectionList::default(),
@@ -2506,7 +2362,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlSelection
         crate::graphql::lists::selection_list::FormatGraphqlSelectionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::lists::selection_list::FormatGraphqlSelectionList::default(),
@@ -2520,7 +2375,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionMember
         crate::graphql::lists::union_member_type_list::FormatGraphqlUnionMemberTypeList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: union_member_type_list :: FormatGraphqlUnionMemberTypeList :: default ())
     }
 }
@@ -2530,7 +2384,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlUnionMemb
         crate::graphql::lists::union_member_type_list::FormatGraphqlUnionMemberTypeList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: union_member_type_list :: FormatGraphqlUnionMemberTypeList :: default ())
     }
 }
@@ -2541,7 +2394,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableDef
         crate::graphql::lists::variable_definition_list::FormatGraphqlVariableDefinitionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: graphql :: lists :: variable_definition_list :: FormatGraphqlVariableDefinitionList :: default ())
     }
 }
@@ -2551,7 +2403,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlVariableD
         crate::graphql::lists::variable_definition_list::FormatGraphqlVariableDefinitionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: graphql :: lists :: variable_definition_list :: FormatGraphqlVariableDefinitionList :: default ())
     }
 }
@@ -2575,7 +2426,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogus {
         crate::graphql::bogus::bogus::FormatGraphqlBogus,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::bogus::bogus::FormatGraphqlBogus::default(),
@@ -2588,7 +2438,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogus {
         crate::graphql::bogus::bogus::FormatGraphqlBogus,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::bogus::bogus::FormatGraphqlBogus::default(),
@@ -2615,7 +2464,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusDefini
         crate::graphql::bogus::bogus_definition::FormatGraphqlBogusDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::bogus::bogus_definition::FormatGraphqlBogusDefinition::default(),
@@ -2628,7 +2476,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusDefi
         crate::graphql::bogus::bogus_definition::FormatGraphqlBogusDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::bogus::bogus_definition::FormatGraphqlBogusDefinition::default(),
@@ -2655,7 +2502,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusSelect
         crate::graphql::bogus::bogus_selection::FormatGraphqlBogusSelection,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::bogus::bogus_selection::FormatGraphqlBogusSelection::default(),
@@ -2668,7 +2514,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusSele
         crate::graphql::bogus::bogus_selection::FormatGraphqlBogusSelection,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::bogus::bogus_selection::FormatGraphqlBogusSelection::default(),
@@ -2695,7 +2540,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusType {
         crate::graphql::bogus::bogus_type::FormatGraphqlBogusType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::bogus::bogus_type::FormatGraphqlBogusType::default(),
@@ -2708,7 +2552,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusType
         crate::graphql::bogus::bogus_type::FormatGraphqlBogusType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::bogus::bogus_type::FormatGraphqlBogusType::default(),
@@ -2735,7 +2578,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusValue 
         crate::graphql::bogus::bogus_value::FormatGraphqlBogusValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::bogus::bogus_value::FormatGraphqlBogusValue::default(),
@@ -2748,7 +2590,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::GraphqlBogusValu
         crate::graphql::bogus::bogus_value::FormatGraphqlBogusValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::bogus::bogus_value::FormatGraphqlBogusValue::default(),
@@ -2762,7 +2603,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlDefiniti
         crate::graphql::any::definition::FormatAnyGraphqlDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::definition::FormatAnyGraphqlDefinition::default(),
@@ -2775,7 +2615,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlDefini
         crate::graphql::any::definition::FormatAnyGraphqlDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::definition::FormatAnyGraphqlDefinition::default(),
@@ -2789,7 +2628,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlOperatio
         crate::graphql::any::operation_definition::FormatAnyGraphqlOperationDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::operation_definition::FormatAnyGraphqlOperationDefinition::default(
@@ -2803,7 +2641,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlOperat
         crate::graphql::any::operation_definition::FormatAnyGraphqlOperationDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::operation_definition::FormatAnyGraphqlOperationDefinition::default(
@@ -2818,7 +2655,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlPrimitiv
         crate::graphql::any::primitive_type::FormatAnyGraphqlPrimitiveType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::primitive_type::FormatAnyGraphqlPrimitiveType::default(),
@@ -2831,7 +2667,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlPrimit
         crate::graphql::any::primitive_type::FormatAnyGraphqlPrimitiveType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::primitive_type::FormatAnyGraphqlPrimitiveType::default(),
@@ -2845,7 +2680,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlSelectio
         crate::graphql::any::selection::FormatAnyGraphqlSelection,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::selection::FormatAnyGraphqlSelection::default(),
@@ -2858,7 +2692,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlSelect
         crate::graphql::any::selection::FormatAnyGraphqlSelection,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::selection::FormatAnyGraphqlSelection::default(),
@@ -2872,7 +2705,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlType {
         crate::graphql::any::ts_type::FormatAnyGraphqlType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::ts_type::FormatAnyGraphqlType::default(),
@@ -2885,7 +2717,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlType {
         crate::graphql::any::ts_type::FormatAnyGraphqlType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::ts_type::FormatAnyGraphqlType::default(),
@@ -2899,7 +2730,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlTypeDefi
         crate::graphql::any::type_definition::FormatAnyGraphqlTypeDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::type_definition::FormatAnyGraphqlTypeDefinition::default(),
@@ -2912,7 +2742,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlTypeDe
         crate::graphql::any::type_definition::FormatAnyGraphqlTypeDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::type_definition::FormatAnyGraphqlTypeDefinition::default(),
@@ -2926,7 +2755,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlTypeExte
         crate::graphql::any::type_extension::FormatAnyGraphqlTypeExtension,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::type_extension::FormatAnyGraphqlTypeExtension::default(),
@@ -2939,7 +2767,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlTypeEx
         crate::graphql::any::type_extension::FormatAnyGraphqlTypeExtension,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::type_extension::FormatAnyGraphqlTypeExtension::default(),
@@ -2953,7 +2780,6 @@ impl AsFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlValue {
         crate::graphql::any::value::FormatAnyGraphqlValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::graphql::any::value::FormatAnyGraphqlValue::default(),
@@ -2966,7 +2792,6 @@ impl IntoFormat<GraphqlFormatContext> for biome_graphql_syntax::AnyGraphqlValue 
         crate::graphql::any::value::FormatAnyGraphqlValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::graphql::any::value::FormatAnyGraphqlValue::default(),

--- a/crates/biome_graphql_formatter/src/graphql/bogus/mod.rs
+++ b/crates/biome_graphql_formatter/src/graphql/bogus/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_definition;
 pub(crate) mod bogus_selection;

--- a/crates/biome_graphql_formatter/src/prelude.rs
+++ b/crates/biome_graphql_formatter/src/prelude.rs
@@ -1,13 +1,12 @@
 //! This module provides important and useful traits to help to format tokens and nodes
 //! when implementing the [crate::FormatNodeRule] trait.
+#![allow(unused_imports)]
 
-#[allow(unused_imports)]
 pub(crate) use crate::{
     AsFormat, FormatNodeRule, FormattedIterExt as _, GraphqlFormatContext, GraphqlFormatter,
     IntoFormat,
 };
 pub(crate) use biome_formatter::prelude::*;
-#[allow(unused_imports)]
 pub(crate) use biome_rowan::{
     AstNode as _, AstNodeList as _, AstNodeSlotMap as _, AstSeparatedList as _,
 };

--- a/crates/biome_graphql_formatter/tests/prettier_tests.rs
+++ b/crates/biome_graphql_formatter/tests/prettier_tests.rs
@@ -8,7 +8,6 @@ mod language;
 
 tests_macros::gen_tests! {"tests/specs/prettier/{graphql}/**/*.{graphql}", crate::test_snapshot, ""}
 
-#[allow(dead_code)]
 fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     countme::enable(true);
 

--- a/crates/biome_graphql_parser/src/lexer/tests.rs
+++ b/crates/biome_graphql_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut, unused_variables)]
 
 use super::{GraphqlLexer, TextSize};
 use biome_graphql_syntax::GraphqlSyntaxKind::{self, EOF};

--- a/crates/biome_graphql_parser/tests/spec_tests.rs
+++ b/crates/biome_graphql_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_graphql_syntax/src/file_source.rs
+++ b/crates/biome_graphql_syntax/src/file_source.rs
@@ -8,7 +8,6 @@ use std::path::Path;
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct GraphqlFileSource {
-    #[allow(unused)]
     variant: GraphqlVariant,
 }
 

--- a/crates/biome_graphql_syntax/src/generated/kind.rs
+++ b/crates/biome_graphql_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -160,37 +159,48 @@ pub enum GraphqlSyntaxKind {
 use self::GraphqlSyntaxKind::*;
 impl GraphqlSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            BANG | DOLLAR | AMP | L_PAREN | R_PAREN | DOT3 | COLON | EQ | AT | L_BRACK
-            | R_BRACK | L_CURLY | PIPE | R_CURLY => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            BANG | DOLLAR
+                | AMP
+                | L_PAREN
+                | R_PAREN
+                | DOT3
+                | COLON
+                | EQ
+                | AT
+                | L_BRACK
+                | R_BRACK
+                | L_CURLY
+                | PIPE
+                | R_CURLY
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            GRAPHQL_STRING_LITERAL | GRAPHQL_FLOAT_LITERAL | GRAPHQL_INT_LITERAL => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            GRAPHQL_STRING_LITERAL | GRAPHQL_FLOAT_LITERAL | GRAPHQL_INT_LITERAL
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
+        matches!(
+            self,
             GRAPHQL_DEFINITION_LIST
-            | GRAPHQL_SELECTION_LIST
-            | GRAPHQL_ARGUMENT_LIST
-            | GRAPHQL_LIST_VALUE_ELEMENT_LIST
-            | GRAPHQL_OBJECT_VALUE_MEMBER_LIST
-            | GRAPHQL_VARIABLE_DEFINITION_LIST
-            | GRAPHQL_DIRECTIVE_LIST
-            | GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION_LIST
-            | GRAPHQL_IMPLEMENTS_INTERFACE_LIST
-            | GRAPHQL_FIELD_DEFINITION_LIST
-            | GRAPHQL_ARGUMENT_DEFINITION_LIST
-            | GRAPHQL_UNION_MEMBER_TYPE_LIST
-            | GRAPHQL_ENUM_VALUE_LIST
-            | GRAPHQL_INPUT_FIELD_LIST
-            | GRAPHQL_DIRECTIVE_LOCATION_LIST => true,
-            _ => false,
-        }
+                | GRAPHQL_SELECTION_LIST
+                | GRAPHQL_ARGUMENT_LIST
+                | GRAPHQL_LIST_VALUE_ELEMENT_LIST
+                | GRAPHQL_OBJECT_VALUE_MEMBER_LIST
+                | GRAPHQL_VARIABLE_DEFINITION_LIST
+                | GRAPHQL_DIRECTIVE_LIST
+                | GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION_LIST
+                | GRAPHQL_IMPLEMENTS_INTERFACE_LIST
+                | GRAPHQL_FIELD_DEFINITION_LIST
+                | GRAPHQL_ARGUMENT_DEFINITION_LIST
+                | GRAPHQL_UNION_MEMBER_TYPE_LIST
+                | GRAPHQL_ENUM_VALUE_LIST
+                | GRAPHQL_INPUT_FIELD_LIST
+                | GRAPHQL_DIRECTIVE_LOCATION_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<GraphqlSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_graphql_syntax/src/generated/nodes.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     GraphqlLanguage as Language, GraphqlSyntaxElement as SyntaxElement,
@@ -10,18 +10,15 @@ use crate::{
     GraphqlSyntaxList as SyntaxList, GraphqlSyntaxNode as SyntaxNode,
     GraphqlSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct GraphqlAlias {

--- a/crates/biome_grit_factory/src/generated.rs
+++ b/crates/biome_grit_factory/src/generated.rs
@@ -1,7 +1,7 @@
 #[rustfmt::skip]
 pub(super) mod syntax_factory;
 #[rustfmt::skip]
-#[allow(unused)]
+#[expect(unused)]
 pub(crate) mod node_factory;
 
 pub use syntax_factory::GritSyntaxFactory;

--- a/crates/biome_grit_factory/src/generated/node_factory.rs
+++ b/crates/biome_grit_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_grit_syntax::{
     GritSyntaxElement as SyntaxElement, GritSyntaxNode as SyntaxNode,
     GritSyntaxToken as SyntaxToken, *,

--- a/crates/biome_grit_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_grit_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_grit_syntax::{GritSyntaxKind, GritSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct GritSyntaxFactory;
 impl SyntaxFactory for GritSyntaxFactory {
     type Kind = GritSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_grit_formatter/src/context.rs
+++ b/crates/biome_grit_formatter/src/context.rs
@@ -9,7 +9,6 @@ use biome_grit_syntax::GritLanguage;
 use std::fmt::Display;
 use std::rc::Rc;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct GritFormatContext {
     options: GritFormatOptions,

--- a/crates/biome_grit_formatter/src/generated.rs
+++ b/crates/biome_grit_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, FormatBogusNodeRule, FormatNodeRule, GritFormatContext, GritFormatter, IntoFormat,
 };
@@ -24,7 +25,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritAddOperation {
         crate::grit::patterns::add_operation::FormatGritAddOperation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::add_operation::FormatGritAddOperation::default(),
@@ -37,7 +37,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritAddOperation {
         crate::grit::patterns::add_operation::FormatGritAddOperation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::add_operation::FormatGritAddOperation::default(),
@@ -64,7 +63,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritAnnotation {
         crate::grit::auxiliary::annotation::FormatGritAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::annotation::FormatGritAnnotation::default(),
@@ -77,7 +75,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritAnnotation {
         crate::grit::auxiliary::annotation::FormatGritAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::annotation::FormatGritAnnotation::default(),
@@ -104,7 +101,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritAssignmentAsPattern 
         crate::grit::patterns::assignment_as_pattern::FormatGritAssignmentAsPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::assignment_as_pattern::FormatGritAssignmentAsPattern::default(),
@@ -117,7 +113,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritAssignmentAsPatter
         crate::grit::patterns::assignment_as_pattern::FormatGritAssignmentAsPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::assignment_as_pattern::FormatGritAssignmentAsPattern::default(),
@@ -144,7 +139,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBacktickSnippetLiter
         crate::grit::value::backtick_snippet_literal::FormatGritBacktickSnippetLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::backtick_snippet_literal::FormatGritBacktickSnippetLiteral::default(
@@ -158,7 +152,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBacktickSnippetLit
         crate::grit::value::backtick_snippet_literal::FormatGritBacktickSnippetLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::backtick_snippet_literal::FormatGritBacktickSnippetLiteral::default(
@@ -186,7 +179,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBooleanLiteral {
         crate::grit::value::boolean_literal::FormatGritBooleanLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::boolean_literal::FormatGritBooleanLiteral::default(),
@@ -199,7 +191,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBooleanLiteral {
         crate::grit::value::boolean_literal::FormatGritBooleanLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::boolean_literal::FormatGritBooleanLiteral::default(),
@@ -226,7 +217,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBracketedPattern {
         crate::grit::patterns::bracketed_pattern::FormatGritBracketedPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::bracketed_pattern::FormatGritBracketedPattern::default(),
@@ -239,7 +229,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBracketedPattern {
         crate::grit::patterns::bracketed_pattern::FormatGritBracketedPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::bracketed_pattern::FormatGritBracketedPattern::default(),
@@ -266,7 +255,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBracketedPredicate {
         crate::grit::predicates::bracketed_predicate::FormatGritBracketedPredicate,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::bracketed_predicate::FormatGritBracketedPredicate::default(),
@@ -279,7 +267,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBracketedPredicate
         crate::grit::predicates::bracketed_predicate::FormatGritBracketedPredicate,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::bracketed_predicate::FormatGritBracketedPredicate::default(),
@@ -302,7 +289,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBubble {
         crate::grit::auxiliary::bubble::FormatGritBubble,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::bubble::FormatGritBubble::default(),
@@ -315,7 +301,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBubble {
         crate::grit::auxiliary::bubble::FormatGritBubble,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::bubble::FormatGritBubble::default(),
@@ -342,7 +327,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBubbleScope {
         crate::grit::auxiliary::bubble_scope::FormatGritBubbleScope,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::bubble_scope::FormatGritBubbleScope::default(),
@@ -355,7 +339,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBubbleScope {
         crate::grit::auxiliary::bubble_scope::FormatGritBubbleScope,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::bubble_scope::FormatGritBubbleScope::default(),
@@ -382,7 +365,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritCodeSnippet {
         crate::grit::value::code_snippet::FormatGritCodeSnippet,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::code_snippet::FormatGritCodeSnippet::default(),
@@ -395,7 +377,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritCodeSnippet {
         crate::grit::value::code_snippet::FormatGritCodeSnippet,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::code_snippet::FormatGritCodeSnippet::default(),
@@ -422,7 +403,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritCurlyPattern {
         crate::grit::patterns::curly_pattern::FormatGritCurlyPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::curly_pattern::FormatGritCurlyPattern::default(),
@@ -435,7 +415,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritCurlyPattern {
         crate::grit::patterns::curly_pattern::FormatGritCurlyPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::curly_pattern::FormatGritCurlyPattern::default(),
@@ -462,7 +441,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritDivOperation {
         crate::grit::patterns::div_operation::FormatGritDivOperation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::div_operation::FormatGritDivOperation::default(),
@@ -475,7 +453,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDivOperation {
         crate::grit::patterns::div_operation::FormatGritDivOperation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::div_operation::FormatGritDivOperation::default(),
@@ -496,7 +473,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritDot {
         crate::grit::auxiliary::dot::FormatGritDot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::grit::auxiliary::dot::FormatGritDot::default())
     }
 }
@@ -504,7 +480,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDot {
     type Format =
         FormatOwnedWithRule<biome_grit_syntax::GritDot, crate::grit::auxiliary::dot::FormatGritDot>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::grit::auxiliary::dot::FormatGritDot::default())
     }
 }
@@ -528,7 +503,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritDotdotdot {
         crate::grit::auxiliary::dotdotdot::FormatGritDotdotdot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::dotdotdot::FormatGritDotdotdot::default(),
@@ -541,7 +515,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDotdotdot {
         crate::grit::auxiliary::dotdotdot::FormatGritDotdotdot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::dotdotdot::FormatGritDotdotdot::default(),
@@ -568,7 +541,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritDoubleLiteral {
         crate::grit::value::double_literal::FormatGritDoubleLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::double_literal::FormatGritDoubleLiteral::default(),
@@ -581,7 +553,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDoubleLiteral {
         crate::grit::value::double_literal::FormatGritDoubleLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::double_literal::FormatGritDoubleLiteral::default(),
@@ -602,7 +573,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritEvery {
         crate::grit::auxiliary::every::FormatGritEvery,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::every::FormatGritEvery::default(),
@@ -615,7 +585,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritEvery {
         crate::grit::auxiliary::every::FormatGritEvery,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::every::FormatGritEvery::default(),
@@ -636,7 +605,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritFiles {
         crate::grit::auxiliary::files::FormatGritFiles,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::files::FormatGritFiles::default(),
@@ -649,7 +617,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritFiles {
         crate::grit::auxiliary::files::FormatGritFiles,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::files::FormatGritFiles::default(),
@@ -676,7 +643,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritFunctionDefinition {
         crate::grit::declarations::function_definition::FormatGritFunctionDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::declarations::function_definition::FormatGritFunctionDefinition::default(),
@@ -689,7 +655,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritFunctionDefinition
         crate::grit::declarations::function_definition::FormatGritFunctionDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::declarations::function_definition::FormatGritFunctionDefinition::default(),
@@ -716,7 +681,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritIntLiteral {
         crate::grit::value::int_literal::FormatGritIntLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::int_literal::FormatGritIntLiteral::default(),
@@ -729,7 +693,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritIntLiteral {
         crate::grit::value::int_literal::FormatGritIntLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::int_literal::FormatGritIntLiteral::default(),
@@ -756,7 +719,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageDeclaration 
         crate::grit::auxiliary::language_declaration::FormatGritLanguageDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::language_declaration::FormatGritLanguageDeclaration::default(),
@@ -769,7 +731,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageDeclaratio
         crate::grit::auxiliary::language_declaration::FormatGritLanguageDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::language_declaration::FormatGritLanguageDeclaration::default(),
@@ -796,7 +757,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavor {
         crate::grit::auxiliary::language_flavor::FormatGritLanguageFlavor,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::language_flavor::FormatGritLanguageFlavor::default(),
@@ -809,7 +769,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavor {
         crate::grit::auxiliary::language_flavor::FormatGritLanguageFlavor,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::language_flavor::FormatGritLanguageFlavor::default(),
@@ -836,7 +795,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavorKind {
         crate::grit::auxiliary::language_flavor_kind::FormatGritLanguageFlavorKind,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::language_flavor_kind::FormatGritLanguageFlavorKind::default(),
@@ -849,7 +807,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavorKind
         crate::grit::auxiliary::language_flavor_kind::FormatGritLanguageFlavorKind,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::language_flavor_kind::FormatGritLanguageFlavorKind::default(),
@@ -876,7 +833,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageName {
         crate::grit::auxiliary::language_name::FormatGritLanguageName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::language_name::FormatGritLanguageName::default(),
@@ -889,7 +845,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageName {
         crate::grit::auxiliary::language_name::FormatGritLanguageName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::language_name::FormatGritLanguageName::default(),
@@ -916,7 +871,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageSpecificSnip
         crate::grit::auxiliary::language_specific_snippet::FormatGritLanguageSpecificSnippet,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: auxiliary :: language_specific_snippet :: FormatGritLanguageSpecificSnippet :: default ())
     }
 }
@@ -926,7 +880,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageSpecificSn
         crate::grit::auxiliary::language_specific_snippet::FormatGritLanguageSpecificSnippet,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: auxiliary :: language_specific_snippet :: FormatGritLanguageSpecificSnippet :: default ())
     }
 }
@@ -944,7 +897,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLike {
         crate::grit::auxiliary::like::FormatGritLike,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::like::FormatGritLike::default(),
@@ -957,7 +909,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLike {
         crate::grit::auxiliary::like::FormatGritLike,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::like::FormatGritLike::default(),
@@ -984,7 +935,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLikeThreshold {
         crate::grit::auxiliary::like_threshold::FormatGritLikeThreshold,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::like_threshold::FormatGritLikeThreshold::default(),
@@ -997,7 +947,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLikeThreshold {
         crate::grit::auxiliary::like_threshold::FormatGritLikeThreshold,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::like_threshold::FormatGritLikeThreshold::default(),
@@ -1018,7 +967,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritList {
         crate::grit::auxiliary::list::FormatGritList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::list::FormatGritList::default(),
@@ -1031,7 +979,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritList {
         crate::grit::auxiliary::list::FormatGritList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::list::FormatGritList::default(),
@@ -1058,7 +1005,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritListAccessor {
         crate::grit::auxiliary::list_accessor::FormatGritListAccessor,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::list_accessor::FormatGritListAccessor::default(),
@@ -1071,7 +1017,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritListAccessor {
         crate::grit::auxiliary::list_accessor::FormatGritListAccessor,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::list_accessor::FormatGritListAccessor::default(),
@@ -1092,7 +1037,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritMap {
         crate::grit::auxiliary::map::FormatGritMap,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::grit::auxiliary::map::FormatGritMap::default())
     }
 }
@@ -1100,7 +1044,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritMap {
     type Format =
         FormatOwnedWithRule<biome_grit_syntax::GritMap, crate::grit::auxiliary::map::FormatGritMap>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::grit::auxiliary::map::FormatGritMap::default())
     }
 }
@@ -1124,7 +1067,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritMapAccessor {
         crate::grit::auxiliary::map_accessor::FormatGritMapAccessor,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::map_accessor::FormatGritMapAccessor::default(),
@@ -1137,7 +1079,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritMapAccessor {
         crate::grit::auxiliary::map_accessor::FormatGritMapAccessor,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::map_accessor::FormatGritMapAccessor::default(),
@@ -1164,7 +1105,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritMapElement {
         crate::grit::auxiliary::map_element::FormatGritMapElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::map_element::FormatGritMapElement::default(),
@@ -1177,7 +1117,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritMapElement {
         crate::grit::auxiliary::map_element::FormatGritMapElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::map_element::FormatGritMapElement::default(),
@@ -1204,7 +1143,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritModOperation {
         crate::grit::patterns::mod_operation::FormatGritModOperation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::mod_operation::FormatGritModOperation::default(),
@@ -1217,7 +1155,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritModOperation {
         crate::grit::patterns::mod_operation::FormatGritModOperation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::mod_operation::FormatGritModOperation::default(),
@@ -1244,7 +1181,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritMulOperation {
         crate::grit::patterns::mul_operation::FormatGritMulOperation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::mul_operation::FormatGritMulOperation::default(),
@@ -1257,7 +1193,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritMulOperation {
         crate::grit::patterns::mul_operation::FormatGritMulOperation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::mul_operation::FormatGritMulOperation::default(),
@@ -1278,7 +1213,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritName {
         crate::grit::auxiliary::name::FormatGritName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::name::FormatGritName::default(),
@@ -1291,7 +1225,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritName {
         crate::grit::auxiliary::name::FormatGritName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::name::FormatGritName::default(),
@@ -1318,7 +1251,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritNamedArg {
         crate::grit::auxiliary::named_arg::FormatGritNamedArg,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::named_arg::FormatGritNamedArg::default(),
@@ -1331,7 +1263,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritNamedArg {
         crate::grit::auxiliary::named_arg::FormatGritNamedArg,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::named_arg::FormatGritNamedArg::default(),
@@ -1358,7 +1289,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritNegativeIntLiteral {
         crate::grit::value::negative_int_literal::FormatGritNegativeIntLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::negative_int_literal::FormatGritNegativeIntLiteral::default(),
@@ -1371,7 +1301,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritNegativeIntLiteral
         crate::grit::value::negative_int_literal::FormatGritNegativeIntLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::negative_int_literal::FormatGritNegativeIntLiteral::default(),
@@ -1398,7 +1327,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritNodeLike {
         crate::grit::auxiliary::node_like::FormatGritNodeLike,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::node_like::FormatGritNodeLike::default(),
@@ -1411,7 +1339,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritNodeLike {
         crate::grit::auxiliary::node_like::FormatGritNodeLike,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::node_like::FormatGritNodeLike::default(),
@@ -1432,7 +1359,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritNot {
         crate::grit::auxiliary::not::FormatGritNot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::grit::auxiliary::not::FormatGritNot::default())
     }
 }
@@ -1440,7 +1366,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritNot {
     type Format =
         FormatOwnedWithRule<biome_grit_syntax::GritNot, crate::grit::auxiliary::not::FormatGritNot>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::grit::auxiliary::not::FormatGritNot::default())
     }
 }
@@ -1464,7 +1389,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternAccumulate {
         crate::grit::patterns::pattern_accumulate::FormatGritPatternAccumulate,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_accumulate::FormatGritPatternAccumulate::default(),
@@ -1477,7 +1401,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternAccumulate 
         crate::grit::patterns::pattern_accumulate::FormatGritPatternAccumulate,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_accumulate::FormatGritPatternAccumulate::default(),
@@ -1504,7 +1427,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternAfter {
         crate::grit::patterns::pattern_after::FormatGritPatternAfter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_after::FormatGritPatternAfter::default(),
@@ -1517,7 +1439,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternAfter {
         crate::grit::patterns::pattern_after::FormatGritPatternAfter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_after::FormatGritPatternAfter::default(),
@@ -1544,7 +1465,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternAnd {
         crate::grit::patterns::pattern_and::FormatGritPatternAnd,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_and::FormatGritPatternAnd::default(),
@@ -1557,7 +1477,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternAnd {
         crate::grit::patterns::pattern_and::FormatGritPatternAnd,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_and::FormatGritPatternAnd::default(),
@@ -1584,7 +1503,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternAny {
         crate::grit::patterns::pattern_any::FormatGritPatternAny,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_any::FormatGritPatternAny::default(),
@@ -1597,7 +1515,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternAny {
         crate::grit::patterns::pattern_any::FormatGritPatternAny,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_any::FormatGritPatternAny::default(),
@@ -1624,7 +1541,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternAs {
         crate::grit::patterns::pattern_as::FormatGritPatternAs,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_as::FormatGritPatternAs::default(),
@@ -1637,7 +1553,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternAs {
         crate::grit::patterns::pattern_as::FormatGritPatternAs,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_as::FormatGritPatternAs::default(),
@@ -1664,7 +1579,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternBefore {
         crate::grit::patterns::pattern_before::FormatGritPatternBefore,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_before::FormatGritPatternBefore::default(),
@@ -1677,7 +1591,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternBefore {
         crate::grit::patterns::pattern_before::FormatGritPatternBefore,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_before::FormatGritPatternBefore::default(),
@@ -1704,7 +1617,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternContains {
         crate::grit::patterns::pattern_contains::FormatGritPatternContains,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_contains::FormatGritPatternContains::default(),
@@ -1717,7 +1629,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternContains {
         crate::grit::patterns::pattern_contains::FormatGritPatternContains,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_contains::FormatGritPatternContains::default(),
@@ -1744,7 +1655,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternContainsUntil
         crate::grit::patterns::pattern_contains_until_clause::FormatGritPatternContainsUntilClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: patterns :: pattern_contains_until_clause :: FormatGritPatternContainsUntilClause :: default ())
     }
 }
@@ -1754,7 +1664,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternContainsUnt
         crate::grit::patterns::pattern_contains_until_clause::FormatGritPatternContainsUntilClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: patterns :: pattern_contains_until_clause :: FormatGritPatternContainsUntilClause :: default ())
     }
 }
@@ -1778,7 +1687,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternDefinition {
         crate::grit::patterns::pattern_definition::FormatGritPatternDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_definition::FormatGritPatternDefinition::default(),
@@ -1791,7 +1699,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternDefinition 
         crate::grit::patterns::pattern_definition::FormatGritPatternDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_definition::FormatGritPatternDefinition::default(),
@@ -1818,7 +1725,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternDefinitionBod
         crate::grit::patterns::pattern_definition_body::FormatGritPatternDefinitionBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: patterns :: pattern_definition_body :: FormatGritPatternDefinitionBody :: default ())
     }
 }
@@ -1828,7 +1734,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternDefinitionB
         crate::grit::patterns::pattern_definition_body::FormatGritPatternDefinitionBody,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: patterns :: pattern_definition_body :: FormatGritPatternDefinitionBody :: default ())
     }
 }
@@ -1852,7 +1757,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternElseClause {
         crate::grit::patterns::pattern_else_clause::FormatGritPatternElseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_else_clause::FormatGritPatternElseClause::default(),
@@ -1865,7 +1769,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternElseClause 
         crate::grit::patterns::pattern_else_clause::FormatGritPatternElseClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_else_clause::FormatGritPatternElseClause::default(),
@@ -1892,7 +1795,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternIfElse {
         crate::grit::patterns::pattern_if_else::FormatGritPatternIfElse,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_if_else::FormatGritPatternIfElse::default(),
@@ -1905,7 +1807,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternIfElse {
         crate::grit::patterns::pattern_if_else::FormatGritPatternIfElse,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_if_else::FormatGritPatternIfElse::default(),
@@ -1932,7 +1833,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternIncludes {
         crate::grit::patterns::pattern_includes::FormatGritPatternIncludes,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_includes::FormatGritPatternIncludes::default(),
@@ -1945,7 +1845,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternIncludes {
         crate::grit::patterns::pattern_includes::FormatGritPatternIncludes,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_includes::FormatGritPatternIncludes::default(),
@@ -1972,7 +1871,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternLimit {
         crate::grit::patterns::pattern_limit::FormatGritPatternLimit,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_limit::FormatGritPatternLimit::default(),
@@ -1985,7 +1883,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternLimit {
         crate::grit::patterns::pattern_limit::FormatGritPatternLimit,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_limit::FormatGritPatternLimit::default(),
@@ -2012,7 +1909,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternMaybe {
         crate::grit::patterns::pattern_maybe::FormatGritPatternMaybe,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_maybe::FormatGritPatternMaybe::default(),
@@ -2025,7 +1921,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternMaybe {
         crate::grit::patterns::pattern_maybe::FormatGritPatternMaybe,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_maybe::FormatGritPatternMaybe::default(),
@@ -2052,7 +1947,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternNot {
         crate::grit::patterns::pattern_not::FormatGritPatternNot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_not::FormatGritPatternNot::default(),
@@ -2065,7 +1959,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternNot {
         crate::grit::patterns::pattern_not::FormatGritPatternNot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_not::FormatGritPatternNot::default(),
@@ -2092,7 +1985,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternOr {
         crate::grit::patterns::pattern_or::FormatGritPatternOr,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_or::FormatGritPatternOr::default(),
@@ -2105,7 +1997,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternOr {
         crate::grit::patterns::pattern_or::FormatGritPatternOr,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_or::FormatGritPatternOr::default(),
@@ -2132,7 +2023,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternOrElse {
         crate::grit::patterns::pattern_or_else::FormatGritPatternOrElse,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_or_else::FormatGritPatternOrElse::default(),
@@ -2145,7 +2035,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternOrElse {
         crate::grit::patterns::pattern_or_else::FormatGritPatternOrElse,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_or_else::FormatGritPatternOrElse::default(),
@@ -2172,7 +2061,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternWhere {
         crate::grit::patterns::pattern_where::FormatGritPatternWhere,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_where::FormatGritPatternWhere::default(),
@@ -2185,7 +2073,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternWhere {
         crate::grit::patterns::pattern_where::FormatGritPatternWhere,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_where::FormatGritPatternWhere::default(),
@@ -2212,7 +2099,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAccumulate 
         crate::grit::predicates::predicate_accumulate::FormatGritPredicateAccumulate,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_accumulate::FormatGritPredicateAccumulate::default(),
@@ -2225,7 +2111,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAccumulat
         crate::grit::predicates::predicate_accumulate::FormatGritPredicateAccumulate,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_accumulate::FormatGritPredicateAccumulate::default(),
@@ -2252,7 +2137,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAnd {
         crate::grit::predicates::predicate_and::FormatGritPredicateAnd,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_and::FormatGritPredicateAnd::default(),
@@ -2265,7 +2149,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAnd {
         crate::grit::predicates::predicate_and::FormatGritPredicateAnd,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_and::FormatGritPredicateAnd::default(),
@@ -2292,7 +2175,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAny {
         crate::grit::predicates::predicate_any::FormatGritPredicateAny,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_any::FormatGritPredicateAny::default(),
@@ -2305,7 +2187,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAny {
         crate::grit::predicates::predicate_any::FormatGritPredicateAny,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_any::FormatGritPredicateAny::default(),
@@ -2332,7 +2213,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAssignment 
         crate::grit::predicates::predicate_assignment::FormatGritPredicateAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_assignment::FormatGritPredicateAssignment::default(),
@@ -2345,7 +2225,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateAssignmen
         crate::grit::predicates::predicate_assignment::FormatGritPredicateAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_assignment::FormatGritPredicateAssignment::default(),
@@ -2372,7 +2251,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateCall {
         crate::grit::predicates::predicate_call::FormatGritPredicateCall,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_call::FormatGritPredicateCall::default(),
@@ -2385,7 +2263,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateCall {
         crate::grit::predicates::predicate_call::FormatGritPredicateCall,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_call::FormatGritPredicateCall::default(),
@@ -2412,7 +2289,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateCurly {
         crate::grit::predicates::predicate_curly::FormatGritPredicateCurly,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_curly::FormatGritPredicateCurly::default(),
@@ -2425,7 +2301,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateCurly {
         crate::grit::predicates::predicate_curly::FormatGritPredicateCurly,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_curly::FormatGritPredicateCurly::default(),
@@ -2452,7 +2327,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateDefinition 
         crate::grit::predicates::predicate_definition::FormatGritPredicateDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_definition::FormatGritPredicateDefinition::default(),
@@ -2465,7 +2339,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateDefinitio
         crate::grit::predicates::predicate_definition::FormatGritPredicateDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_definition::FormatGritPredicateDefinition::default(),
@@ -2492,7 +2365,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateElseClause 
         crate::grit::predicates::predicate_else_clause::FormatGritPredicateElseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_else_clause::FormatGritPredicateElseClause::default(
@@ -2506,7 +2378,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateElseClaus
         crate::grit::predicates::predicate_else_clause::FormatGritPredicateElseClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_else_clause::FormatGritPredicateElseClause::default(
@@ -2534,7 +2405,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateEqual {
         crate::grit::predicates::predicate_equal::FormatGritPredicateEqual,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_equal::FormatGritPredicateEqual::default(),
@@ -2547,7 +2417,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateEqual {
         crate::grit::predicates::predicate_equal::FormatGritPredicateEqual,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_equal::FormatGritPredicateEqual::default(),
@@ -2574,7 +2443,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateGreater {
         crate::grit::predicates::predicate_greater::FormatGritPredicateGreater,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_greater::FormatGritPredicateGreater::default(),
@@ -2587,7 +2455,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateGreater {
         crate::grit::predicates::predicate_greater::FormatGritPredicateGreater,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_greater::FormatGritPredicateGreater::default(),
@@ -2614,7 +2481,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateGreaterEqua
         crate::grit::predicates::predicate_greater_equal::FormatGritPredicateGreaterEqual,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: predicates :: predicate_greater_equal :: FormatGritPredicateGreaterEqual :: default ())
     }
 }
@@ -2624,7 +2490,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateGreaterEq
         crate::grit::predicates::predicate_greater_equal::FormatGritPredicateGreaterEqual,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: predicates :: predicate_greater_equal :: FormatGritPredicateGreaterEqual :: default ())
     }
 }
@@ -2648,7 +2513,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateIfElse {
         crate::grit::predicates::predicate_if_else::FormatGritPredicateIfElse,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_if_else::FormatGritPredicateIfElse::default(),
@@ -2661,7 +2525,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateIfElse {
         crate::grit::predicates::predicate_if_else::FormatGritPredicateIfElse,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_if_else::FormatGritPredicateIfElse::default(),
@@ -2688,7 +2551,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateLess {
         crate::grit::predicates::predicate_less::FormatGritPredicateLess,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_less::FormatGritPredicateLess::default(),
@@ -2701,7 +2563,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateLess {
         crate::grit::predicates::predicate_less::FormatGritPredicateLess,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_less::FormatGritPredicateLess::default(),
@@ -2728,7 +2589,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateLessEqual {
         crate::grit::predicates::predicate_less_equal::FormatGritPredicateLessEqual,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_less_equal::FormatGritPredicateLessEqual::default(),
@@ -2741,7 +2601,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateLessEqual
         crate::grit::predicates::predicate_less_equal::FormatGritPredicateLessEqual,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_less_equal::FormatGritPredicateLessEqual::default(),
@@ -2768,7 +2627,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateMatch {
         crate::grit::predicates::predicate_match::FormatGritPredicateMatch,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_match::FormatGritPredicateMatch::default(),
@@ -2781,7 +2639,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateMatch {
         crate::grit::predicates::predicate_match::FormatGritPredicateMatch,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_match::FormatGritPredicateMatch::default(),
@@ -2808,7 +2665,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateMaybe {
         crate::grit::predicates::predicate_maybe::FormatGritPredicateMaybe,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_maybe::FormatGritPredicateMaybe::default(),
@@ -2821,7 +2677,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateMaybe {
         crate::grit::predicates::predicate_maybe::FormatGritPredicateMaybe,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_maybe::FormatGritPredicateMaybe::default(),
@@ -2848,7 +2703,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateNot {
         crate::grit::predicates::predicate_not::FormatGritPredicateNot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_not::FormatGritPredicateNot::default(),
@@ -2861,7 +2715,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateNot {
         crate::grit::predicates::predicate_not::FormatGritPredicateNot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_not::FormatGritPredicateNot::default(),
@@ -2888,7 +2741,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateNotEqual {
         crate::grit::predicates::predicate_not_equal::FormatGritPredicateNotEqual,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_not_equal::FormatGritPredicateNotEqual::default(),
@@ -2901,7 +2753,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateNotEqual 
         crate::grit::predicates::predicate_not_equal::FormatGritPredicateNotEqual,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_not_equal::FormatGritPredicateNotEqual::default(),
@@ -2928,7 +2779,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateOr {
         crate::grit::predicates::predicate_or::FormatGritPredicateOr,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_or::FormatGritPredicateOr::default(),
@@ -2941,7 +2791,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateOr {
         crate::grit::predicates::predicate_or::FormatGritPredicateOr,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_or::FormatGritPredicateOr::default(),
@@ -2968,7 +2817,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateReturn {
         crate::grit::predicates::predicate_return::FormatGritPredicateReturn,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_return::FormatGritPredicateReturn::default(),
@@ -2981,7 +2829,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateReturn {
         crate::grit::predicates::predicate_return::FormatGritPredicateReturn,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_return::FormatGritPredicateReturn::default(),
@@ -3008,7 +2855,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateRewrite {
         crate::grit::predicates::predicate_rewrite::FormatGritPredicateRewrite,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::predicates::predicate_rewrite::FormatGritPredicateRewrite::default(),
@@ -3021,7 +2867,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateRewrite {
         crate::grit::predicates::predicate_rewrite::FormatGritPredicateRewrite,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::predicates::predicate_rewrite::FormatGritPredicateRewrite::default(),
@@ -3048,7 +2893,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRawBacktickSnippetLi
         crate::grit::value::raw_backtick_snippet_literal::FormatGritRawBacktickSnippetLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: value :: raw_backtick_snippet_literal :: FormatGritRawBacktickSnippetLiteral :: default ())
     }
 }
@@ -3058,7 +2902,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRawBacktickSnippet
         crate::grit::value::raw_backtick_snippet_literal::FormatGritRawBacktickSnippetLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: value :: raw_backtick_snippet_literal :: FormatGritRawBacktickSnippetLiteral :: default ())
     }
 }
@@ -3082,7 +2925,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRegexLiteral {
         crate::grit::value::regex_literal::FormatGritRegexLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::regex_literal::FormatGritRegexLiteral::default(),
@@ -3095,7 +2937,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRegexLiteral {
         crate::grit::value::regex_literal::FormatGritRegexLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::regex_literal::FormatGritRegexLiteral::default(),
@@ -3122,7 +2963,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRegexPattern {
         crate::grit::patterns::regex_pattern::FormatGritRegexPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::regex_pattern::FormatGritRegexPattern::default(),
@@ -3135,7 +2975,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRegexPattern {
         crate::grit::patterns::regex_pattern::FormatGritRegexPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::regex_pattern::FormatGritRegexPattern::default(),
@@ -3162,7 +3001,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRegexPatternVariable
         crate::grit::patterns::regex_pattern_variables::FormatGritRegexPatternVariables,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: patterns :: regex_pattern_variables :: FormatGritRegexPatternVariables :: default ())
     }
 }
@@ -3172,7 +3010,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRegexPatternVariab
         crate::grit::patterns::regex_pattern_variables::FormatGritRegexPatternVariables,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: patterns :: regex_pattern_variables :: FormatGritRegexPatternVariables :: default ())
     }
 }
@@ -3196,7 +3033,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRewrite {
         crate::grit::auxiliary::rewrite::FormatGritRewrite,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::rewrite::FormatGritRewrite::default(),
@@ -3209,7 +3045,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRewrite {
         crate::grit::auxiliary::rewrite::FormatGritRewrite,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::rewrite::FormatGritRewrite::default(),
@@ -3230,7 +3065,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritRoot {
         crate::grit::auxiliary::root::FormatGritRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::root::FormatGritRoot::default(),
@@ -3243,7 +3077,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritRoot {
         crate::grit::auxiliary::root::FormatGritRoot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::root::FormatGritRoot::default(),
@@ -3270,7 +3103,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritSequential {
         crate::grit::auxiliary::sequential::FormatGritSequential,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::sequential::FormatGritSequential::default(),
@@ -3283,7 +3115,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritSequential {
         crate::grit::auxiliary::sequential::FormatGritSequential,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::sequential::FormatGritSequential::default(),
@@ -3310,7 +3141,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritSnippetRegexLiteral 
         crate::grit::value::snippet_regex_literal::FormatGritSnippetRegexLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::snippet_regex_literal::FormatGritSnippetRegexLiteral::default(),
@@ -3323,7 +3153,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritSnippetRegexLitera
         crate::grit::value::snippet_regex_literal::FormatGritSnippetRegexLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::snippet_regex_literal::FormatGritSnippetRegexLiteral::default(),
@@ -3344,7 +3173,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritSome {
         crate::grit::auxiliary::some::FormatGritSome,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::some::FormatGritSome::default(),
@@ -3357,7 +3185,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritSome {
         crate::grit::auxiliary::some::FormatGritSome,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::some::FormatGritSome::default(),
@@ -3384,7 +3211,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritStringLiteral {
         crate::grit::value::string_literal::FormatGritStringLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::string_literal::FormatGritStringLiteral::default(),
@@ -3397,7 +3223,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritStringLiteral {
         crate::grit::value::string_literal::FormatGritStringLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::string_literal::FormatGritStringLiteral::default(),
@@ -3424,7 +3249,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritSubOperation {
         crate::grit::patterns::sub_operation::FormatGritSubOperation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::sub_operation::FormatGritSubOperation::default(),
@@ -3437,7 +3261,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritSubOperation {
         crate::grit::patterns::sub_operation::FormatGritSubOperation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::sub_operation::FormatGritSubOperation::default(),
@@ -3464,7 +3287,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritUndefinedLiteral {
         crate::grit::value::undefined_literal::FormatGritUndefinedLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::value::undefined_literal::FormatGritUndefinedLiteral::default(),
@@ -3477,7 +3299,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritUndefinedLiteral {
         crate::grit::value::undefined_literal::FormatGritUndefinedLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::value::undefined_literal::FormatGritUndefinedLiteral::default(),
@@ -3504,7 +3325,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritUnderscore {
         crate::grit::auxiliary::underscore::FormatGritUnderscore,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::underscore::FormatGritUnderscore::default(),
@@ -3517,7 +3337,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritUnderscore {
         crate::grit::auxiliary::underscore::FormatGritUnderscore,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::underscore::FormatGritUnderscore::default(),
@@ -3544,7 +3363,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritVariable {
         crate::grit::auxiliary::variable::FormatGritVariable,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::variable::FormatGritVariable::default(),
@@ -3557,7 +3375,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritVariable {
         crate::grit::auxiliary::variable::FormatGritVariable,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::variable::FormatGritVariable::default(),
@@ -3584,7 +3401,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritVersion {
         crate::grit::auxiliary::version::FormatGritVersion,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::version::FormatGritVersion::default(),
@@ -3597,7 +3413,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritVersion {
         crate::grit::auxiliary::version::FormatGritVersion,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::version::FormatGritVersion::default(),
@@ -3620,7 +3435,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritWithin {
         crate::grit::auxiliary::within::FormatGritWithin,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::auxiliary::within::FormatGritWithin::default(),
@@ -3633,7 +3447,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritWithin {
         crate::grit::auxiliary::within::FormatGritWithin,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::auxiliary::within::FormatGritWithin::default(),
@@ -3647,7 +3460,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritDefinitionList {
         crate::grit::lists::definition_list::FormatGritDefinitionList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::definition_list::FormatGritDefinitionList::default(),
@@ -3660,7 +3472,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDefinitionList {
         crate::grit::lists::definition_list::FormatGritDefinitionList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::definition_list::FormatGritDefinitionList::default(),
@@ -3674,7 +3485,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavorList {
         crate::grit::lists::language_flavor_list::FormatGritLanguageFlavorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::language_flavor_list::FormatGritLanguageFlavorList::default(),
@@ -3687,7 +3497,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritLanguageFlavorList
         crate::grit::lists::language_flavor_list::FormatGritLanguageFlavorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::language_flavor_list::FormatGritLanguageFlavorList::default(),
@@ -3701,7 +3510,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritListPatternList {
         crate::grit::lists::list_pattern_list::FormatGritListPatternList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::list_pattern_list::FormatGritListPatternList::default(),
@@ -3714,7 +3522,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritListPatternList {
         crate::grit::lists::list_pattern_list::FormatGritListPatternList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::list_pattern_list::FormatGritListPatternList::default(),
@@ -3728,7 +3535,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritMapElementList {
         crate::grit::lists::map_element_list::FormatGritMapElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::map_element_list::FormatGritMapElementList::default(),
@@ -3741,7 +3547,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritMapElementList {
         crate::grit::lists::map_element_list::FormatGritMapElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::map_element_list::FormatGritMapElementList::default(),
@@ -3755,7 +3560,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritNamedArgList {
         crate::grit::lists::named_arg_list::FormatGritNamedArgList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::named_arg_list::FormatGritNamedArgList::default(),
@@ -3768,7 +3572,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritNamedArgList {
         crate::grit::lists::named_arg_list::FormatGritNamedArgList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::named_arg_list::FormatGritNamedArgList::default(),
@@ -3782,7 +3585,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternList {
         crate::grit::lists::pattern_list::FormatGritPatternList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::pattern_list::FormatGritPatternList::default(),
@@ -3795,7 +3597,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternList {
         crate::grit::lists::pattern_list::FormatGritPatternList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::pattern_list::FormatGritPatternList::default(),
@@ -3809,7 +3610,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPredicateList {
         crate::grit::lists::predicate_list::FormatGritPredicateList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::predicate_list::FormatGritPredicateList::default(),
@@ -3822,7 +3622,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPredicateList {
         crate::grit::lists::predicate_list::FormatGritPredicateList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::predicate_list::FormatGritPredicateList::default(),
@@ -3836,7 +3635,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritVariableList {
         crate::grit::lists::variable_list::FormatGritVariableList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::lists::variable_list::FormatGritVariableList::default(),
@@ -3849,7 +3647,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritVariableList {
         crate::grit::lists::variable_list::FormatGritVariableList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::lists::variable_list::FormatGritVariableList::default(),
@@ -3870,7 +3667,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogus {
         crate::grit::bogus::bogus::FormatGritBogus,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::grit::bogus::bogus::FormatGritBogus::default())
     }
 }
@@ -3880,7 +3676,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogus {
         crate::grit::bogus::bogus::FormatGritBogus,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::grit::bogus::bogus::FormatGritBogus::default())
     }
 }
@@ -3904,7 +3699,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusContainer {
         crate::grit::bogus::bogus_container::FormatGritBogusContainer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_container::FormatGritBogusContainer::default(),
@@ -3917,7 +3711,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusContainer {
         crate::grit::bogus::bogus_container::FormatGritBogusContainer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_container::FormatGritBogusContainer::default(),
@@ -3944,7 +3737,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusDefinition {
         crate::grit::bogus::bogus_definition::FormatGritBogusDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_definition::FormatGritBogusDefinition::default(),
@@ -3957,7 +3749,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusDefinition {
         crate::grit::bogus::bogus_definition::FormatGritBogusDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_definition::FormatGritBogusDefinition::default(),
@@ -3984,7 +3775,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageDeclara
         crate::grit::bogus::bogus_language_declaration::FormatGritBogusLanguageDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: bogus :: bogus_language_declaration :: FormatGritBogusLanguageDeclaration :: default ())
     }
 }
@@ -3994,7 +3784,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageDecla
         crate::grit::bogus::bogus_language_declaration::FormatGritBogusLanguageDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: bogus :: bogus_language_declaration :: FormatGritBogusLanguageDeclaration :: default ())
     }
 }
@@ -4018,7 +3807,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageFlavorK
         crate::grit::bogus::bogus_language_flavor_kind::FormatGritBogusLanguageFlavorKind,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: grit :: bogus :: bogus_language_flavor_kind :: FormatGritBogusLanguageFlavorKind :: default ())
     }
 }
@@ -4028,7 +3816,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageFlavo
         crate::grit::bogus::bogus_language_flavor_kind::FormatGritBogusLanguageFlavorKind,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: grit :: bogus :: bogus_language_flavor_kind :: FormatGritBogusLanguageFlavorKind :: default ())
     }
 }
@@ -4052,7 +3839,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusLiteral {
         crate::grit::bogus::bogus_literal::FormatGritBogusLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_literal::FormatGritBogusLiteral::default(),
@@ -4065,7 +3851,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusLiteral {
         crate::grit::bogus::bogus_literal::FormatGritBogusLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_literal::FormatGritBogusLiteral::default(),
@@ -4092,7 +3877,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusMapElement {
         crate::grit::bogus::bogus_map_element::FormatGritBogusMapElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_map_element::FormatGritBogusMapElement::default(),
@@ -4105,7 +3889,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusMapElement {
         crate::grit::bogus::bogus_map_element::FormatGritBogusMapElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_map_element::FormatGritBogusMapElement::default(),
@@ -4132,7 +3915,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusNamedArg {
         crate::grit::bogus::bogus_named_arg::FormatGritBogusNamedArg,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_named_arg::FormatGritBogusNamedArg::default(),
@@ -4145,7 +3927,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusNamedArg {
         crate::grit::bogus::bogus_named_arg::FormatGritBogusNamedArg,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_named_arg::FormatGritBogusNamedArg::default(),
@@ -4172,7 +3953,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusPattern {
         crate::grit::bogus::bogus_pattern::FormatGritBogusPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_pattern::FormatGritBogusPattern::default(),
@@ -4185,7 +3965,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusPattern {
         crate::grit::bogus::bogus_pattern::FormatGritBogusPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_pattern::FormatGritBogusPattern::default(),
@@ -4212,7 +3991,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusPredicate {
         crate::grit::bogus::bogus_predicate::FormatGritBogusPredicate,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_predicate::FormatGritBogusPredicate::default(),
@@ -4225,7 +4003,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusPredicate {
         crate::grit::bogus::bogus_predicate::FormatGritBogusPredicate,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_predicate::FormatGritBogusPredicate::default(),
@@ -4252,7 +4029,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusVersion {
         crate::grit::bogus::bogus_version::FormatGritBogusVersion,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::bogus::bogus_version::FormatGritBogusVersion::default(),
@@ -4265,7 +4041,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusVersion {
         crate::grit::bogus::bogus_version::FormatGritBogusVersion,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::bogus::bogus_version::FormatGritBogusVersion::default(),
@@ -4279,7 +4054,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritCodeSnippetSource
         crate::grit::any::code_snippet_source::FormatAnyGritCodeSnippetSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::code_snippet_source::FormatAnyGritCodeSnippetSource::default(),
@@ -4292,7 +4066,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritCodeSnippetSour
         crate::grit::any::code_snippet_source::FormatAnyGritCodeSnippetSource,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::code_snippet_source::FormatAnyGritCodeSnippetSource::default(),
@@ -4306,7 +4079,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritContainer {
         crate::grit::any::container::FormatAnyGritContainer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::container::FormatAnyGritContainer::default(),
@@ -4319,7 +4091,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritContainer {
         crate::grit::any::container::FormatAnyGritContainer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::container::FormatAnyGritContainer::default(),
@@ -4333,7 +4104,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritDefinition {
         crate::grit::any::definition::FormatAnyGritDefinition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::definition::FormatAnyGritDefinition::default(),
@@ -4346,7 +4116,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritDefinition {
         crate::grit::any::definition::FormatAnyGritDefinition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::definition::FormatAnyGritDefinition::default(),
@@ -4360,7 +4129,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageDeclarati
         crate::grit::any::language_declaration::FormatAnyGritLanguageDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::language_declaration::FormatAnyGritLanguageDeclaration::default(),
@@ -4373,7 +4141,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageDeclara
         crate::grit::any::language_declaration::FormatAnyGritLanguageDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::language_declaration::FormatAnyGritLanguageDeclaration::default(),
@@ -4387,7 +4154,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageFlavorKin
         crate::grit::any::language_flavor_kind::FormatAnyGritLanguageFlavorKind,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::language_flavor_kind::FormatAnyGritLanguageFlavorKind::default(),
@@ -4400,7 +4166,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageFlavorK
         crate::grit::any::language_flavor_kind::FormatAnyGritLanguageFlavorKind,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::language_flavor_kind::FormatAnyGritLanguageFlavorKind::default(),
@@ -4414,7 +4179,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritListAccessorSubje
         crate::grit::any::list_accessor_subject::FormatAnyGritListAccessorSubject,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::list_accessor_subject::FormatAnyGritListAccessorSubject::default(),
@@ -4427,7 +4191,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritListAccessorSub
         crate::grit::any::list_accessor_subject::FormatAnyGritListAccessorSubject,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::list_accessor_subject::FormatAnyGritListAccessorSubject::default(),
@@ -4441,7 +4204,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritListIndex {
         crate::grit::any::list_index::FormatAnyGritListIndex,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::list_index::FormatAnyGritListIndex::default(),
@@ -4454,7 +4216,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritListIndex {
         crate::grit::any::list_index::FormatAnyGritListIndex,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::list_index::FormatAnyGritListIndex::default(),
@@ -4468,7 +4229,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritListPattern {
         crate::grit::any::list_pattern::FormatAnyGritListPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::list_pattern::FormatAnyGritListPattern::default(),
@@ -4481,7 +4241,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritListPattern {
         crate::grit::any::list_pattern::FormatAnyGritListPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::list_pattern::FormatAnyGritListPattern::default(),
@@ -4495,7 +4254,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritLiteral {
         crate::grit::any::literal::FormatAnyGritLiteral,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::literal::FormatAnyGritLiteral::default(),
@@ -4508,7 +4266,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritLiteral {
         crate::grit::any::literal::FormatAnyGritLiteral,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::literal::FormatAnyGritLiteral::default(),
@@ -4522,7 +4279,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapAccessorSubjec
         crate::grit::any::map_accessor_subject::FormatAnyGritMapAccessorSubject,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::map_accessor_subject::FormatAnyGritMapAccessorSubject::default(),
@@ -4535,7 +4291,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapAccessorSubj
         crate::grit::any::map_accessor_subject::FormatAnyGritMapAccessorSubject,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::map_accessor_subject::FormatAnyGritMapAccessorSubject::default(),
@@ -4549,7 +4304,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapElement {
         crate::grit::any::map_element::FormatAnyGritMapElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::map_element::FormatAnyGritMapElement::default(),
@@ -4562,7 +4316,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapElement {
         crate::grit::any::map_element::FormatAnyGritMapElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::map_element::FormatAnyGritMapElement::default(),
@@ -4576,7 +4329,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapKey {
         crate::grit::any::map_key::FormatAnyGritMapKey,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::map_key::FormatAnyGritMapKey::default(),
@@ -4589,7 +4341,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritMapKey {
         crate::grit::any::map_key::FormatAnyGritMapKey,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::map_key::FormatAnyGritMapKey::default(),
@@ -4603,7 +4354,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritMaybeCurlyPattern
         crate::grit::any::maybe_curly_pattern::FormatAnyGritMaybeCurlyPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::maybe_curly_pattern::FormatAnyGritMaybeCurlyPattern::default(),
@@ -4616,7 +4366,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritMaybeCurlyPatte
         crate::grit::any::maybe_curly_pattern::FormatAnyGritMaybeCurlyPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::maybe_curly_pattern::FormatAnyGritMaybeCurlyPattern::default(),
@@ -4630,7 +4379,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritMaybeNamedArg {
         crate::grit::any::maybe_named_arg::FormatAnyGritMaybeNamedArg,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::maybe_named_arg::FormatAnyGritMaybeNamedArg::default(),
@@ -4643,7 +4391,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritMaybeNamedArg {
         crate::grit::any::maybe_named_arg::FormatAnyGritMaybeNamedArg,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::maybe_named_arg::FormatAnyGritMaybeNamedArg::default(),
@@ -4657,7 +4404,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritPattern {
         crate::grit::any::pattern::FormatAnyGritPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::pattern::FormatAnyGritPattern::default(),
@@ -4670,7 +4416,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritPattern {
         crate::grit::any::pattern::FormatAnyGritPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::pattern::FormatAnyGritPattern::default(),
@@ -4684,7 +4429,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritPredicate {
         crate::grit::any::predicate::FormatAnyGritPredicate,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::predicate::FormatAnyGritPredicate::default(),
@@ -4697,7 +4441,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritPredicate {
         crate::grit::any::predicate::FormatAnyGritPredicate,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::predicate::FormatAnyGritPredicate::default(),
@@ -4711,7 +4454,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritPredicateMatchSub
         crate::grit::any::predicate_match_subject::FormatAnyGritPredicateMatchSubject,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::predicate_match_subject::FormatAnyGritPredicateMatchSubject::default(
@@ -4725,7 +4467,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritPredicateMatchS
         crate::grit::any::predicate_match_subject::FormatAnyGritPredicateMatchSubject,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::predicate_match_subject::FormatAnyGritPredicateMatchSubject::default(
@@ -4740,7 +4481,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritRegex {
         crate::grit::any::regex::FormatAnyGritRegex,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::grit::any::regex::FormatAnyGritRegex::default())
     }
 }
@@ -4750,7 +4490,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritRegex {
         crate::grit::any::regex::FormatAnyGritRegex,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::grit::any::regex::FormatAnyGritRegex::default())
     }
 }
@@ -4761,7 +4500,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritVersion {
         crate::grit::any::version::FormatAnyGritVersion,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::any::version::FormatAnyGritVersion::default(),
@@ -4774,7 +4512,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritVersion {
         crate::grit::any::version::FormatAnyGritVersion,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::version::FormatAnyGritVersion::default(),

--- a/crates/biome_grit_formatter/src/grit/bogus/mod.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_container;
 pub(crate) mod bogus_definition;

--- a/crates/biome_grit_formatter/src/lib.rs
+++ b/crates/biome_grit_formatter/src/lib.rs
@@ -119,7 +119,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub struct GritFormatLanguage {
     options: GritFormatOptions,
@@ -227,7 +226,6 @@ where
 /// Used to convert this object into an object that can be formatted.
 ///
 /// The difference to [AsFormat] is that this trait takes ownership of `self`.
-#[allow(dead_code)]
 pub(crate) trait IntoFormat<Context> {
     type Format: biome_formatter::Format<Context>;
 
@@ -260,7 +258,7 @@ where
 }
 
 /// Formatting specific [Iterator] extensions
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) trait FormattedIterExt {
     /// Converts every item to an object that knows how to format it.
     fn formatted<Context>(self) -> FormattedIter<Self, Self::Item, Context>
@@ -277,7 +275,6 @@ pub(crate) trait FormattedIterExt {
 
 impl<I> FormattedIterExt for I where I: std::iter::Iterator {}
 
-#[allow(dead_code)]
 pub(crate) struct FormattedIter<Iter, Item, Context>
 where
     Iter: Iterator<Item = Item>,

--- a/crates/biome_grit_formatter/src/prelude.rs
+++ b/crates/biome_grit_formatter/src/prelude.rs
@@ -1,7 +1,7 @@
 //! This module provides important and useful traits to help to format tokens and nodes
 //! when implementing the [crate::FormatNodeRule] trait.
+#![allow(unused_imports)]
 
-#[allow(unused_imports)]
 pub(crate) use crate::{
     AsFormat, FormatNodeRule, FormattedIterExt as _, FormattedIterExt, GritFormatContext,
     GritFormatter, IntoFormat,

--- a/crates/biome_grit_parser/src/lexer/tests.rs
+++ b/crates/biome_grit_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut, unused_variables)]
 
 use super::{GritLexer, TextSize};
 use biome_grit_syntax::GritSyntaxKind::{self, *};
@@ -99,11 +99,7 @@ fn losslessness(string: String) -> bool {
     });
     let token_ranges = receiver
         .recv_timeout(Duration::from_secs(2))
-        .unwrap_or_else(|_| {
-            panic!(
-                "Lexer is infinitely recursing with this code: ->{string}<-"
-            )
-        });
+        .unwrap_or_else(|_| panic!("Lexer is infinitely recursing with this code: ->{string}<-"));
 
     let mut new_str = String::with_capacity(string.len());
     let mut idx = TextSize::from(0);

--- a/crates/biome_grit_parser/tests/spec_tests.rs
+++ b/crates/biome_grit_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_grit_patterns/src/grit_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language.rs
@@ -342,7 +342,7 @@ trait GritTargetLanguageImpl {
 }
 
 pub trait GritTargetParser: Parser<Tree = GritTargetTree> {
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     fn from_cached_parse_result(
         &self,
         parse: &AnyParse,

--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -338,7 +338,7 @@ impl<'a> GritAstNode for GritTargetNode<'a> {
         self.text_trimmed_range().to_code_range(self.text())
     }
 
-    #[allow(refining_impl_trait)]
+    #[expect(refining_impl_trait)]
     fn children(&self) -> impl Iterator<Item = Self> + Clone {
         ChildrenIterator::new(self)
     }

--- a/crates/biome_grit_patterns/src/variables.rs
+++ b/crates/biome_grit_patterns/src/variables.rs
@@ -16,7 +16,7 @@ impl VariableLocations {
         Self(locations)
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn compiled_vars(&self) -> Vec<VariableBinding> {
         let mut variables = Vec::new();
         for (i, scope) in self.0.iter().enumerate() {

--- a/crates/biome_grit_patterns/tests/spec_tests.rs
+++ b/crates/biome_grit_patterns/tests/spec_tests.rs
@@ -205,6 +205,6 @@ fn format_range(range: Range) -> String {
 
 #[derive(Debug, Default)]
 struct ErrorSnapshotResult {
-    #[allow(unused)]
+    #[expect(unused)]
     diagnostics: Vec<Box<dyn Diagnostic>>,
 }

--- a/crates/biome_grit_syntax/src/file_source.rs
+++ b/crates/biome_grit_syntax/src/file_source.rs
@@ -6,7 +6,6 @@ use std::{ffi::OsStr, path::Path};
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct GritFileSource {
-    #[allow(unused)]
     variant: GritVariant,
 }
 

--- a/crates/biome_grit_syntax/src/generated/kind.rs
+++ b/crates/biome_grit_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -217,35 +216,63 @@ pub enum GritSyntaxKind {
 use self::GritSyntaxKind::*;
 impl GritSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            DOT3 | DOLLAR_UNDERSCORE | MATCH | SEMICOLON | COMMA | L_PAREN | R_PAREN | L_CURLY
-            | R_CURLY | L_BRACK | R_BRACK | L_ANGLE | R_ANGLE | PLUS | STAR | SLASH | PERCENT
-            | DOT | COLON | EQ | EQ2 | FAT_ARROW | BANG | NEQ | MINUS | LTEQ | GTEQ | PLUSEQ
-            | BACKTICK => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            DOT3 | DOLLAR_UNDERSCORE
+                | MATCH
+                | SEMICOLON
+                | COMMA
+                | L_PAREN
+                | R_PAREN
+                | L_CURLY
+                | R_CURLY
+                | L_BRACK
+                | R_BRACK
+                | L_ANGLE
+                | R_ANGLE
+                | PLUS
+                | STAR
+                | SLASH
+                | PERCENT
+                | DOT
+                | COLON
+                | EQ
+                | EQ2
+                | FAT_ARROW
+                | BANG
+                | NEQ
+                | MINUS
+                | LTEQ
+                | GTEQ
+                | PLUSEQ
+                | BACKTICK
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            GRIT_INT | GRIT_NEGATIVE_INT | GRIT_DOUBLE | GRIT_STRING | GRIT_REGEX
-            | GRIT_SNIPPET_REGEX => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            GRIT_INT
+                | GRIT_NEGATIVE_INT
+                | GRIT_DOUBLE
+                | GRIT_STRING
+                | GRIT_REGEX
+                | GRIT_SNIPPET_REGEX
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
+        matches!(
+            self,
             GRIT_DEFINITION_LIST
-            | GRIT_LANGUAGE_FLAVOR_LIST
-            | GRIT_PATTERN_LIST
-            | GRIT_NAMED_ARG_LIST
-            | GRIT_MAP_ELEMENT_LIST
-            | GRIT_LIST
-            | GRIT_LIST_PATTERN_LIST
-            | GRIT_PATTERN_ARG_LIST
-            | GRIT_PREDICATE_LIST
-            | GRIT_VARIABLE_LIST => true,
-            _ => false,
-        }
+                | GRIT_LANGUAGE_FLAVOR_LIST
+                | GRIT_PATTERN_LIST
+                | GRIT_NAMED_ARG_LIST
+                | GRIT_MAP_ELEMENT_LIST
+                | GRIT_LIST
+                | GRIT_LIST_PATTERN_LIST
+                | GRIT_PATTERN_ARG_LIST
+                | GRIT_PREDICATE_LIST
+                | GRIT_VARIABLE_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<GritSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_grit_syntax/src/generated/nodes.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     GritLanguage as Language, GritSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     GritSyntaxKind::{self as SyntaxKind, *},
     GritSyntaxList as SyntaxList, GritSyntaxNode as SyntaxNode, GritSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct GritAddOperation {

--- a/crates/biome_html_factory/src/generated/node_factory.rs
+++ b/crates/biome_html_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_html_syntax::{
     HtmlSyntaxElement as SyntaxElement, HtmlSyntaxNode as SyntaxNode,
     HtmlSyntaxToken as SyntaxToken, *,

--- a/crates/biome_html_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_html_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_html_syntax::{HtmlSyntaxKind, HtmlSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct HtmlSyntaxFactory;
 impl SyntaxFactory for HtmlSyntaxFactory {
     type Kind = HtmlSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_html_formatter/src/generated.rs
+++ b/crates/biome_html_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, FormatBogusNodeRule, FormatNodeRule, HtmlFormatContext, HtmlFormatter, IntoFormat,
 };
@@ -24,7 +25,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttribute {
         crate::html::auxiliary::attribute::FormatHtmlAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::attribute::FormatHtmlAttribute::default(),
@@ -37,7 +37,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttribute {
         crate::html::auxiliary::attribute::FormatHtmlAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::attribute::FormatHtmlAttribute::default(),
@@ -64,7 +63,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttributeInitializer
         crate::html::auxiliary::attribute_initializer_clause::FormatHtmlAttributeInitializerClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: html :: auxiliary :: attribute_initializer_clause :: FormatHtmlAttributeInitializerClause :: default ())
     }
 }
@@ -74,7 +72,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttributeInitializ
         crate::html::auxiliary::attribute_initializer_clause::FormatHtmlAttributeInitializerClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: html :: auxiliary :: attribute_initializer_clause :: FormatHtmlAttributeInitializerClause :: default ())
     }
 }
@@ -98,7 +95,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlClosingElement {
         crate::html::auxiliary::closing_element::FormatHtmlClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::closing_element::FormatHtmlClosingElement::default(),
@@ -111,7 +107,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlClosingElement {
         crate::html::auxiliary::closing_element::FormatHtmlClosingElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::closing_element::FormatHtmlClosingElement::default(),
@@ -138,7 +133,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlComment {
         crate::html::auxiliary::comment::FormatHtmlComment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::comment::FormatHtmlComment::default(),
@@ -151,7 +145,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlComment {
         crate::html::auxiliary::comment::FormatHtmlComment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::comment::FormatHtmlComment::default(),
@@ -178,7 +171,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlContent {
         crate::html::auxiliary::content::FormatHtmlContent,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::content::FormatHtmlContent::default(),
@@ -191,7 +183,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlContent {
         crate::html::auxiliary::content::FormatHtmlContent,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::content::FormatHtmlContent::default(),
@@ -218,7 +209,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlDirective {
         crate::html::auxiliary::directive::FormatHtmlDirective,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::directive::FormatHtmlDirective::default(),
@@ -231,7 +221,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlDirective {
         crate::html::auxiliary::directive::FormatHtmlDirective,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::directive::FormatHtmlDirective::default(),
@@ -258,7 +247,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlElement {
         crate::html::auxiliary::element::FormatHtmlElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::element::FormatHtmlElement::default(),
@@ -271,7 +259,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlElement {
         crate::html::auxiliary::element::FormatHtmlElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::element::FormatHtmlElement::default(),
@@ -292,7 +279,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlName {
         crate::html::auxiliary::name::FormatHtmlName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::name::FormatHtmlName::default(),
@@ -305,7 +291,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlName {
         crate::html::auxiliary::name::FormatHtmlName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::name::FormatHtmlName::default(),
@@ -332,7 +317,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlOpeningElement {
         crate::html::auxiliary::opening_element::FormatHtmlOpeningElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::opening_element::FormatHtmlOpeningElement::default(),
@@ -345,7 +329,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlOpeningElement {
         crate::html::auxiliary::opening_element::FormatHtmlOpeningElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::opening_element::FormatHtmlOpeningElement::default(),
@@ -366,7 +349,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlRoot {
         crate::html::auxiliary::root::FormatHtmlRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::root::FormatHtmlRoot::default(),
@@ -379,7 +361,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlRoot {
         crate::html::auxiliary::root::FormatHtmlRoot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::root::FormatHtmlRoot::default(),
@@ -406,7 +387,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlSelfClosingElement {
         crate::html::auxiliary::self_closing_element::FormatHtmlSelfClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::self_closing_element::FormatHtmlSelfClosingElement::default(),
@@ -419,7 +399,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlSelfClosingElement
         crate::html::auxiliary::self_closing_element::FormatHtmlSelfClosingElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::self_closing_element::FormatHtmlSelfClosingElement::default(),
@@ -442,7 +421,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlString {
         crate::html::auxiliary::string::FormatHtmlString,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::auxiliary::string::FormatHtmlString::default(),
@@ -455,7 +433,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlString {
         crate::html::auxiliary::string::FormatHtmlString,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::auxiliary::string::FormatHtmlString::default(),
@@ -469,7 +446,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttributeList {
         crate::html::lists::attribute_list::FormatHtmlAttributeList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::lists::attribute_list::FormatHtmlAttributeList::default(),
@@ -482,7 +458,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlAttributeList {
         crate::html::lists::attribute_list::FormatHtmlAttributeList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::lists::attribute_list::FormatHtmlAttributeList::default(),
@@ -496,7 +471,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlElementList {
         crate::html::lists::element_list::FormatHtmlElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::lists::element_list::FormatHtmlElementList::default(),
@@ -509,7 +483,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlElementList {
         crate::html::lists::element_list::FormatHtmlElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::lists::element_list::FormatHtmlElementList::default(),
@@ -530,7 +503,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogus {
         crate::html::bogus::bogus::FormatHtmlBogus,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::html::bogus::bogus::FormatHtmlBogus::default())
     }
 }
@@ -540,7 +512,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogus {
         crate::html::bogus::bogus::FormatHtmlBogus,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::html::bogus::bogus::FormatHtmlBogus::default())
     }
 }
@@ -564,7 +535,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogusAttribute {
         crate::html::bogus::bogus_attribute::FormatHtmlBogusAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::bogus::bogus_attribute::FormatHtmlBogusAttribute::default(),
@@ -577,7 +547,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogusAttribute {
         crate::html::bogus::bogus_attribute::FormatHtmlBogusAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::bogus::bogus_attribute::FormatHtmlBogusAttribute::default(),
@@ -604,7 +573,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogusElement {
         crate::html::bogus::bogus_element::FormatHtmlBogusElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::bogus::bogus_element::FormatHtmlBogusElement::default(),
@@ -617,7 +585,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::HtmlBogusElement {
         crate::html::bogus::bogus_element::FormatHtmlBogusElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::bogus::bogus_element::FormatHtmlBogusElement::default(),
@@ -631,7 +598,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::AnyHtmlAttribute {
         crate::html::any::attribute::FormatAnyHtmlAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::any::attribute::FormatAnyHtmlAttribute::default(),
@@ -644,7 +610,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::AnyHtmlAttribute {
         crate::html::any::attribute::FormatAnyHtmlAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::any::attribute::FormatAnyHtmlAttribute::default(),
@@ -658,7 +623,6 @@ impl AsFormat<HtmlFormatContext> for biome_html_syntax::AnyHtmlElement {
         crate::html::any::element::FormatAnyHtmlElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::html::any::element::FormatAnyHtmlElement::default(),
@@ -671,7 +635,6 @@ impl IntoFormat<HtmlFormatContext> for biome_html_syntax::AnyHtmlElement {
         crate::html::any::element::FormatAnyHtmlElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::html::any::element::FormatAnyHtmlElement::default(),

--- a/crates/biome_html_formatter/src/html/bogus/mod.rs
+++ b/crates/biome_html_formatter/src/html/bogus/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_attribute;
 pub(crate) mod bogus_element;

--- a/crates/biome_html_formatter/src/prelude.rs
+++ b/crates/biome_html_formatter/src/prelude.rs
@@ -1,8 +1,6 @@
-#[allow(unused_imports)]
 pub(crate) use crate::{
     format_verbatim_node, format_verbatim_skipped, AsFormat, FormatNodeRule, FormatResult,
     FormatRule, FormattedIterExt, HtmlFormatContext, HtmlFormatter,
 };
 pub(crate) use biome_formatter::prelude::*;
-#[allow(unused_imports)]
 pub(crate) use biome_rowan::{AstNode, AstNodeList};

--- a/crates/biome_html_formatter/tests/language.rs
+++ b/crates/biome_html_formatter/tests/language.rs
@@ -11,7 +11,7 @@ use biome_service::{
 };
 
 pub struct HtmlTestFormatLanguage {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     source_type: HtmlFileSource,
 }
 

--- a/crates/biome_html_formatter/tests/prettier_tests.rs
+++ b/crates/biome_html_formatter/tests/prettier_tests.rs
@@ -9,7 +9,7 @@ mod language;
 
 tests_macros::gen_tests! {"tests/specs/prettier/**/*.html", crate::test_snapshot, ""}
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn test_snapshot(input: &'static str, _: &str, _: &str, _: &str) {
     countme::enable(true);
 

--- a/crates/biome_html_parser/src/lexer/tests.rs
+++ b/crates/biome_html_parser/src/lexer/tests.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
 
 use super::{HtmlLexer, TextSize};
 use crate::token_source::HtmlLexContext;

--- a/crates/biome_html_parser/tests/spec_tests.rs
+++ b/crates/biome_html_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_html_syntax/src/file_source.rs
+++ b/crates/biome_html_syntax/src/file_source.rs
@@ -7,7 +7,6 @@ use std::{ffi::OsStr, path::Path};
     Debug, Clone, Default, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct HtmlFileSource {
-    #[allow(unused)]
     variant: HtmlVariant,
 }
 

--- a/crates/biome_html_syntax/src/generated/kind.rs
+++ b/crates/biome_html_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -57,22 +56,16 @@ pub enum HtmlSyntaxKind {
 use self::HtmlSyntaxKind::*;
 impl HtmlSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            L_ANGLE | R_ANGLE | SLASH | EQ | BANG | MINUS | COMMENT_START | COMMENT_END => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            L_ANGLE | R_ANGLE | SLASH | EQ | BANG | MINUS | COMMENT_START | COMMENT_END
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            HTML_STRING_LITERAL | HTML_LITERAL => true,
-            _ => false,
-        }
+        matches!(self, HTML_STRING_LITERAL | HTML_LITERAL)
     }
     pub const fn is_list(self) -> bool {
-        match self {
-            HTML_ELEMENT_LIST | HTML_ATTRIBUTE_LIST => true,
-            _ => false,
-        }
+        matches!(self, HTML_ELEMENT_LIST | HTML_ATTRIBUTE_LIST)
     }
     pub fn from_keyword(ident: &str) -> Option<HtmlSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     HtmlLanguage as Language, HtmlSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     HtmlSyntaxKind::{self as SyntaxKind, *},
     HtmlSyntaxList as SyntaxList, HtmlSyntaxNode as SyntaxNode, HtmlSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct HtmlAttribute {

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable_super.rs
@@ -70,7 +70,6 @@ declare_lint_rule! {
     }
 }
 
-#[allow(clippy::enum_variant_names)]
 pub enum RuleState {
     /// The constructor may call `super` multiple times
     DuplicateSuper { first: TextRange, second: TextRange },

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -106,7 +106,7 @@ declare_lint_rule! {
     /// ## Caveats
     ///
     /// If you are using TypeScript, TypeScript version 5.0 and later is required, also make sure to enable
-    /// [expectImportingTsExtensions=true](https://typescriptlang.org/tsconfig#allowImportingTsExtensions) in your `tsconfig.json`.
+    /// [allowImportingTsExtensions=true](https://typescriptlang.org/tsconfig#allowImportingTsExtensions) in your `tsconfig.json`.
     ///
     /// Rule does not yet check filesystem for file type. It tries to guess which extension
     /// it should add based on the file extension of the current file and the import path.

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -106,7 +106,7 @@ declare_lint_rule! {
     /// ## Caveats
     ///
     /// If you are using TypeScript, TypeScript version 5.0 and later is required, also make sure to enable
-    /// [allowImportingTsExtensions=true](https://typescriptlang.org/tsconfig#allowImportingTsExtensions) in your `tsconfig.json`.
+    /// [expectImportingTsExtensions=true](https://typescriptlang.org/tsconfig#allowImportingTsExtensions) in your `tsconfig.json`.
     ///
     /// Rule does not yet check filesystem for file type. It tries to guess which extension
     /// it should add based on the file extension of the current file and the import path.

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/presets.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/presets.rs
@@ -8,7 +8,7 @@ use super::{
 
 #[derive(Default)]
 pub enum UseSortedClassesPreset {
-    #[allow(unused)]
+    #[expect(unused)]
     None,
     #[default]
     TailwindCSS,

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_config.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_config.rs
@@ -34,7 +34,6 @@ pub type VariantsConfig = &'static [&'static str];
 /// The sort config, containing the utility config and the variant config.
 pub struct SortConfig {
     pub utilities: &'static [UtilityLayer],
-    #[allow(dead_code)]
     pub variants: VariantsConfig,
     pub layer_index_map: HashMap<&'static str, usize>,
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_unsafe_negation.rs
@@ -135,6 +135,5 @@ impl Rule for NoUnsafeNegation {
 
 declare_node_union! {
     /// Enum for [JsInstanceofExpression] and [JsInExpression]
-    #[allow(dead_code)]
     pub JsInOrInstanceOfExpression  = JsInstanceofExpression  | JsInExpression
 }

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -91,7 +91,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn analyze_and_snap(
     snapshot: &mut String,
     input_code: &str,

--- a/crates/biome_js_factory/src/generated/node_factory.rs
+++ b/crates/biome_js_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_js_syntax::{
     JsSyntaxElement as SyntaxElement, JsSyntaxNode as SyntaxNode, JsSyntaxToken as SyntaxToken, *,
 };

--- a/crates/biome_js_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_js_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_js_syntax::{JsSyntaxKind, JsSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct JsSyntaxFactory;
 impl SyntaxFactory for JsSyntaxFactory {
     type Kind = JsSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_js_formatter/src/generated.rs
+++ b/crates/biome_js_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, FormatBogusNodeRule, FormatNodeRule, IntoFormat, JsFormatContext, JsFormatter,
 };
@@ -24,7 +25,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAccessorModifier {
         crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier::default(),
@@ -37,7 +37,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAccessorModifier {
         crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::accessor_modifier::FormatJsAccessorModifier::default(),
@@ -64,7 +63,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPattern {
         crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern :: FormatJsArrayAssignmentPattern :: default ())
     }
 }
@@ -74,7 +72,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPattern {
         crate::js::assignments::array_assignment_pattern::FormatJsArrayAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern :: FormatJsArrayAssignmentPattern :: default ())
     }
 }
@@ -82,14 +79,12 @@ impl FormatRule < biome_js_syntax :: JsArrayAssignmentPatternElement > for crate
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElement {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayAssignmentPatternElement , crate :: js :: assignments :: array_assignment_pattern_element :: FormatJsArrayAssignmentPatternElement > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_element :: FormatJsArrayAssignmentPatternElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElement {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayAssignmentPatternElement , crate :: js :: assignments :: array_assignment_pattern_element :: FormatJsArrayAssignmentPatternElement > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_element :: FormatJsArrayAssignmentPatternElement :: default ())
     }
 }
@@ -97,14 +92,12 @@ impl FormatRule < biome_js_syntax :: JsArrayAssignmentPatternRestElement > for c
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternRestElement {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayAssignmentPatternRestElement , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: array_assignment_pattern_rest_element :: FormatJsArrayAssignmentPatternRestElement :: default ())
     }
 }
@@ -128,7 +121,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPattern {
         crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern::default(),
@@ -141,7 +133,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPattern {
         crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::array_binding_pattern::FormatJsArrayBindingPattern::default(),
@@ -168,7 +159,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternElement
         crate::js::bindings::array_binding_pattern_element::FormatJsArrayBindingPatternElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_element :: FormatJsArrayBindingPatternElement :: default ())
     }
 }
@@ -178,7 +168,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternEleme
         crate::js::bindings::array_binding_pattern_element::FormatJsArrayBindingPatternElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_element :: FormatJsArrayBindingPatternElement :: default ())
     }
 }
@@ -186,14 +175,12 @@ impl FormatRule < biome_js_syntax :: JsArrayBindingPatternRestElement > for crat
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternRestElement {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternRestElement {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayBindingPatternRestElement , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: array_binding_pattern_rest_element :: FormatJsArrayBindingPatternRestElement :: default ())
     }
 }
@@ -217,7 +204,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayExpression {
         crate::js::expressions::array_expression::FormatJsArrayExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::array_expression::FormatJsArrayExpression::default(),
@@ -230,7 +216,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayExpression {
         crate::js::expressions::array_expression::FormatJsArrayExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::array_expression::FormatJsArrayExpression::default(),
@@ -253,7 +238,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayHole {
         crate::js::auxiliary::array_hole::FormatJsArrayHole,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::array_hole::FormatJsArrayHole::default(),
@@ -266,7 +250,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayHole {
         crate::js::auxiliary::array_hole::FormatJsArrayHole,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::array_hole::FormatJsArrayHole::default(),
@@ -293,7 +276,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrowFunctionExpression {
         crate::js::expressions::arrow_function_expression::FormatJsArrowFunctionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: arrow_function_expression :: FormatJsArrowFunctionExpression :: default ())
     }
 }
@@ -303,7 +285,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrowFunctionExpression 
         crate::js::expressions::arrow_function_expression::FormatJsArrowFunctionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: arrow_function_expression :: FormatJsArrowFunctionExpression :: default ())
     }
 }
@@ -327,7 +308,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAssignmentExpression {
         crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::assignment_expression::FormatJsAssignmentExpression::default(),
@@ -340,7 +320,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAssignmentExpression {
         crate::js::expressions::assignment_expression::FormatJsAssignmentExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::assignment_expression::FormatJsAssignmentExpression::default(),
@@ -367,7 +346,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsAwaitExpression {
         crate::js::expressions::await_expression::FormatJsAwaitExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::await_expression::FormatJsAwaitExpression::default(),
@@ -380,7 +358,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsAwaitExpression {
         crate::js::expressions::await_expression::FormatJsAwaitExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::await_expression::FormatJsAwaitExpression::default(),
@@ -407,7 +384,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBigintLiteralExpression {
         crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: bigint_literal_expression :: FormatJsBigintLiteralExpression :: default ())
     }
 }
@@ -417,7 +393,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBigintLiteralExpression 
         crate::js::expressions::bigint_literal_expression::FormatJsBigintLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: bigint_literal_expression :: FormatJsBigintLiteralExpression :: default ())
     }
 }
@@ -441,7 +416,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBinaryExpression {
         crate::js::expressions::binary_expression::FormatJsBinaryExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::binary_expression::FormatJsBinaryExpression::default(),
@@ -454,7 +428,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBinaryExpression {
         crate::js::expressions::binary_expression::FormatJsBinaryExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::binary_expression::FormatJsBinaryExpression::default(),
@@ -481,7 +454,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBlockStatement {
         crate::js::statements::block_statement::FormatJsBlockStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::block_statement::FormatJsBlockStatement::default(),
@@ -494,7 +466,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBlockStatement {
         crate::js::statements::block_statement::FormatJsBlockStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::block_statement::FormatJsBlockStatement::default(),
@@ -521,7 +492,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBooleanLiteralExpression {
         crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: boolean_literal_expression :: FormatJsBooleanLiteralExpression :: default ())
     }
 }
@@ -531,7 +501,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBooleanLiteralExpression
         crate::js::expressions::boolean_literal_expression::FormatJsBooleanLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: boolean_literal_expression :: FormatJsBooleanLiteralExpression :: default ())
     }
 }
@@ -555,7 +524,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBreakStatement {
         crate::js::statements::break_statement::FormatJsBreakStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::break_statement::FormatJsBreakStatement::default(),
@@ -568,7 +536,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBreakStatement {
         crate::js::statements::break_statement::FormatJsBreakStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::break_statement::FormatJsBreakStatement::default(),
@@ -595,7 +562,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallArguments {
         crate::js::expressions::call_arguments::FormatJsCallArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::call_arguments::FormatJsCallArguments::default(),
@@ -608,7 +574,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallArguments {
         crate::js::expressions::call_arguments::FormatJsCallArguments,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::call_arguments::FormatJsCallArguments::default(),
@@ -635,7 +600,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallExpression {
         crate::js::expressions::call_expression::FormatJsCallExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::call_expression::FormatJsCallExpression::default(),
@@ -648,7 +612,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallExpression {
         crate::js::expressions::call_expression::FormatJsCallExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::call_expression::FormatJsCallExpression::default(),
@@ -671,7 +634,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCaseClause {
         crate::js::auxiliary::case_clause::FormatJsCaseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::case_clause::FormatJsCaseClause::default(),
@@ -684,7 +646,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCaseClause {
         crate::js::auxiliary::case_clause::FormatJsCaseClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::case_clause::FormatJsCaseClause::default(),
@@ -707,7 +668,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCatchClause {
         crate::js::auxiliary::catch_clause::FormatJsCatchClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::catch_clause::FormatJsCatchClause::default(),
@@ -720,7 +680,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCatchClause {
         crate::js::auxiliary::catch_clause::FormatJsCatchClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::catch_clause::FormatJsCatchClause::default(),
@@ -747,7 +706,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCatchDeclaration {
         crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::declarations::catch_declaration::FormatJsCatchDeclaration::default(),
@@ -760,7 +718,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCatchDeclaration {
         crate::js::declarations::catch_declaration::FormatJsCatchDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::declarations::catch_declaration::FormatJsCatchDeclaration::default(),
@@ -787,7 +744,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassDeclaration {
         crate::js::declarations::class_declaration::FormatJsClassDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::declarations::class_declaration::FormatJsClassDeclaration::default(),
@@ -800,7 +756,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassDeclaration {
         crate::js::declarations::class_declaration::FormatJsClassDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::declarations::class_declaration::FormatJsClassDeclaration::default(),
@@ -811,14 +766,12 @@ impl FormatRule < biome_js_syntax :: JsClassExportDefaultDeclaration > for crate
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsClassExportDefaultDeclaration , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: declarations :: class_export_default_declaration :: FormatJsClassExportDefaultDeclaration :: default ())
     }
 }
@@ -842,7 +795,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassExpression {
         crate::js::expressions::class_expression::FormatJsClassExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::class_expression::FormatJsClassExpression::default(),
@@ -855,7 +807,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassExpression {
         crate::js::expressions::class_expression::FormatJsClassExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::class_expression::FormatJsClassExpression::default(),
@@ -882,7 +833,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberAssignment {
         crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: computed_member_assignment :: FormatJsComputedMemberAssignment :: default ())
     }
 }
@@ -892,7 +842,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberAssignment
         crate::js::assignments::computed_member_assignment::FormatJsComputedMemberAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: computed_member_assignment :: FormatJsComputedMemberAssignment :: default ())
     }
 }
@@ -916,7 +865,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberExpression {
         crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: computed_member_expression :: FormatJsComputedMemberExpression :: default ())
     }
 }
@@ -926,7 +874,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberExpression
         crate::js::expressions::computed_member_expression::FormatJsComputedMemberExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: computed_member_expression :: FormatJsComputedMemberExpression :: default ())
     }
 }
@@ -950,7 +897,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberName {
         crate::js::objects::computed_member_name::FormatJsComputedMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::computed_member_name::FormatJsComputedMemberName::default(),
@@ -963,7 +909,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsComputedMemberName {
         crate::js::objects::computed_member_name::FormatJsComputedMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::computed_member_name::FormatJsComputedMemberName::default(),
@@ -990,7 +935,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConditionalExpression {
         crate::js::expressions::conditional_expression::FormatJsConditionalExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::conditional_expression::FormatJsConditionalExpression::default(
@@ -1004,7 +948,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConditionalExpression {
         crate::js::expressions::conditional_expression::FormatJsConditionalExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::conditional_expression::FormatJsConditionalExpression::default(
@@ -1032,7 +975,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorClassMember {
         crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::constructor_class_member::FormatJsConstructorClassMember::default(),
@@ -1045,7 +987,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorClassMember {
         crate::js::classes::constructor_class_member::FormatJsConstructorClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::constructor_class_member::FormatJsConstructorClassMember::default(),
@@ -1072,7 +1013,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameters {
         crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::constructor_parameters::FormatJsConstructorParameters::default(),
@@ -1085,7 +1025,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameters {
         crate::js::bindings::constructor_parameters::FormatJsConstructorParameters,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::constructor_parameters::FormatJsConstructorParameters::default(),
@@ -1112,7 +1051,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsContinueStatement {
         crate::js::statements::continue_statement::FormatJsContinueStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::continue_statement::FormatJsContinueStatement::default(),
@@ -1125,7 +1063,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsContinueStatement {
         crate::js::statements::continue_statement::FormatJsContinueStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::continue_statement::FormatJsContinueStatement::default(),
@@ -1152,7 +1089,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDebuggerStatement {
         crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::debugger_statement::FormatJsDebuggerStatement::default(),
@@ -1165,7 +1101,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDebuggerStatement {
         crate::js::statements::debugger_statement::FormatJsDebuggerStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::debugger_statement::FormatJsDebuggerStatement::default(),
@@ -1188,7 +1123,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDecorator {
         crate::js::auxiliary::decorator::FormatJsDecorator,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::decorator::FormatJsDecorator::default(),
@@ -1201,7 +1135,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDecorator {
         crate::js::auxiliary::decorator::FormatJsDecorator,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::decorator::FormatJsDecorator::default(),
@@ -1228,7 +1161,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDefaultClause {
         crate::js::auxiliary::default_clause::FormatJsDefaultClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::default_clause::FormatJsDefaultClause::default(),
@@ -1241,7 +1173,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDefaultClause {
         crate::js::auxiliary::default_clause::FormatJsDefaultClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::default_clause::FormatJsDefaultClause::default(),
@@ -1268,7 +1199,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDefaultImportSpecifier {
         crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier::default(),
@@ -1281,7 +1211,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDefaultImportSpecifier {
         crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::default_import_specifier::FormatJsDefaultImportSpecifier::default(),
@@ -1304,7 +1233,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDirective {
         crate::js::auxiliary::directive::FormatJsDirective,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::directive::FormatJsDirective::default(),
@@ -1317,7 +1245,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDirective {
         crate::js::auxiliary::directive::FormatJsDirective,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::directive::FormatJsDirective::default(),
@@ -1344,7 +1271,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDoWhileStatement {
         crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::do_while_statement::FormatJsDoWhileStatement::default(),
@@ -1357,7 +1283,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDoWhileStatement {
         crate::js::statements::do_while_statement::FormatJsDoWhileStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::do_while_statement::FormatJsDoWhileStatement::default(),
@@ -1380,7 +1305,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsElseClause {
         crate::js::auxiliary::else_clause::FormatJsElseClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::else_clause::FormatJsElseClause::default(),
@@ -1393,7 +1317,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsElseClause {
         crate::js::auxiliary::else_clause::FormatJsElseClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::else_clause::FormatJsElseClause::default(),
@@ -1420,7 +1343,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsEmptyClassMember {
         crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::empty_class_member::FormatJsEmptyClassMember::default(),
@@ -1433,7 +1355,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsEmptyClassMember {
         crate::js::classes::empty_class_member::FormatJsEmptyClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::empty_class_member::FormatJsEmptyClassMember::default(),
@@ -1460,7 +1381,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsEmptyStatement {
         crate::js::statements::empty_statement::FormatJsEmptyStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::empty_statement::FormatJsEmptyStatement::default(),
@@ -1473,7 +1393,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsEmptyStatement {
         crate::js::statements::empty_statement::FormatJsEmptyStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::empty_statement::FormatJsEmptyStatement::default(),
@@ -1491,7 +1410,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExport {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::module::export::FormatJsExport::default())
     }
 }
@@ -1499,7 +1417,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExport {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsExport, crate::js::module::export::FormatJsExport>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::module::export::FormatJsExport::default())
     }
 }
@@ -1523,7 +1440,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportAsClause {
         crate::js::module::export_as_clause::FormatJsExportAsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::export_as_clause::FormatJsExportAsClause::default(),
@@ -1536,7 +1452,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportAsClause {
         crate::js::module::export_as_clause::FormatJsExportAsClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::export_as_clause::FormatJsExportAsClause::default(),
@@ -1559,14 +1474,12 @@ impl FormatRule<biome_js_syntax::JsExportDefaultDeclarationClause>
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultDeclarationClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultDeclarationClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsExportDefaultDeclarationClause , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_declaration_clause :: FormatJsExportDefaultDeclarationClause :: default ())
     }
 }
@@ -1590,7 +1503,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultExpressionCla
         crate::js::module::export_default_expression_clause::FormatJsExportDefaultExpressionClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause :: default ())
     }
 }
@@ -1600,7 +1512,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportDefaultExpressionC
         crate::js::module::export_default_expression_clause::FormatJsExportDefaultExpressionClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: export_default_expression_clause :: FormatJsExportDefaultExpressionClause :: default ())
     }
 }
@@ -1624,7 +1535,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportFromClause {
         crate::js::module::export_from_clause::FormatJsExportFromClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::export_from_clause::FormatJsExportFromClause::default(),
@@ -1637,7 +1547,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportFromClause {
         crate::js::module::export_from_clause::FormatJsExportFromClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::export_from_clause::FormatJsExportFromClause::default(),
@@ -1664,7 +1573,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedClause {
         crate::js::module::export_named_clause::FormatJsExportNamedClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::export_named_clause::FormatJsExportNamedClause::default(),
@@ -1677,7 +1585,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedClause {
         crate::js::module::export_named_clause::FormatJsExportNamedClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::export_named_clause::FormatJsExportNamedClause::default(),
@@ -1704,7 +1611,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromClause {
         crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause::default(),
@@ -1717,7 +1623,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromClause {
         crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::export_named_from_clause::FormatJsExportNamedFromClause::default(),
@@ -1744,7 +1649,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier {
         crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: export_named_from_specifier :: FormatJsExportNamedFromSpecifier :: default ())
     }
 }
@@ -1754,7 +1658,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier
         crate::js::module::export_named_from_specifier::FormatJsExportNamedFromSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: export_named_from_specifier :: FormatJsExportNamedFromSpecifier :: default ())
     }
 }
@@ -1778,7 +1681,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedShorthandSpecif
         crate::js::module::export_named_shorthand_specifier::FormatJsExportNamedShorthandSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier :: default ())
     }
 }
@@ -1788,7 +1690,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedShorthandSpec
         crate::js::module::export_named_shorthand_specifier::FormatJsExportNamedShorthandSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: export_named_shorthand_specifier :: FormatJsExportNamedShorthandSpecifier :: default ())
     }
 }
@@ -1812,7 +1713,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifier {
         crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier::default(),
@@ -1825,7 +1725,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifier {
         crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::export_named_specifier::FormatJsExportNamedSpecifier::default(),
@@ -1852,7 +1751,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExpressionSnipped {
         crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped::default(),
@@ -1865,7 +1763,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExpressionSnipped {
         crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::expression_snipped::FormatJsExpressionSnipped::default(),
@@ -1892,7 +1789,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExpressionStatement {
         crate::js::statements::expression_statement::FormatJsExpressionStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::expression_statement::FormatJsExpressionStatement::default(),
@@ -1905,7 +1801,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExpressionStatement {
         crate::js::statements::expression_statement::FormatJsExpressionStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::expression_statement::FormatJsExpressionStatement::default(),
@@ -1932,7 +1827,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExtendsClause {
         crate::js::classes::extends_clause::FormatJsExtendsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::extends_clause::FormatJsExtendsClause::default(),
@@ -1945,7 +1839,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExtendsClause {
         crate::js::classes::extends_clause::FormatJsExtendsClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::extends_clause::FormatJsExtendsClause::default(),
@@ -1972,7 +1865,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFinallyClause {
         crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::finally_clause::FormatJsFinallyClause::default(),
@@ -1985,7 +1877,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFinallyClause {
         crate::js::auxiliary::finally_clause::FormatJsFinallyClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::finally_clause::FormatJsFinallyClause::default(),
@@ -2012,7 +1903,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForInStatement {
         crate::js::statements::for_in_statement::FormatJsForInStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::for_in_statement::FormatJsForInStatement::default(),
@@ -2025,7 +1915,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForInStatement {
         crate::js::statements::for_in_statement::FormatJsForInStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::for_in_statement::FormatJsForInStatement::default(),
@@ -2052,7 +1941,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForOfStatement {
         crate::js::statements::for_of_statement::FormatJsForOfStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::for_of_statement::FormatJsForOfStatement::default(),
@@ -2065,7 +1953,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForOfStatement {
         crate::js::statements::for_of_statement::FormatJsForOfStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::for_of_statement::FormatJsForOfStatement::default(),
@@ -2088,7 +1975,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForStatement {
         crate::js::statements::for_statement::FormatJsForStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::for_statement::FormatJsForStatement::default(),
@@ -2101,7 +1987,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForStatement {
         crate::js::statements::for_statement::FormatJsForStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::for_statement::FormatJsForStatement::default(),
@@ -2128,7 +2013,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsForVariableDeclaration {
         crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: declarations :: for_variable_declaration :: FormatJsForVariableDeclaration :: default ())
     }
 }
@@ -2138,7 +2022,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsForVariableDeclaration {
         crate::js::declarations::for_variable_declaration::FormatJsForVariableDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: declarations :: for_variable_declaration :: FormatJsForVariableDeclaration :: default ())
     }
 }
@@ -2162,7 +2045,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFormalParameter {
         crate::js::bindings::formal_parameter::FormatJsFormalParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::formal_parameter::FormatJsFormalParameter::default(),
@@ -2175,7 +2057,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFormalParameter {
         crate::js::bindings::formal_parameter::FormatJsFormalParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::formal_parameter::FormatJsFormalParameter::default(),
@@ -2198,7 +2079,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionBody {
         crate::js::auxiliary::function_body::FormatJsFunctionBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::function_body::FormatJsFunctionBody::default(),
@@ -2211,7 +2091,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionBody {
         crate::js::auxiliary::function_body::FormatJsFunctionBody,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::function_body::FormatJsFunctionBody::default(),
@@ -2238,7 +2117,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionDeclaration {
         crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::declarations::function_declaration::FormatJsFunctionDeclaration::default(),
@@ -2251,7 +2129,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionDeclaration {
         crate::js::declarations::function_declaration::FormatJsFunctionDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::declarations::function_declaration::FormatJsFunctionDeclaration::default(),
@@ -2262,14 +2139,12 @@ impl FormatRule < biome_js_syntax :: JsFunctionExportDefaultDeclaration > for cr
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsFunctionExportDefaultDeclaration , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: declarations :: function_export_default_declaration :: FormatJsFunctionExportDefaultDeclaration :: default ())
     }
 }
@@ -2293,7 +2168,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsFunctionExpression {
         crate::js::expressions::function_expression::FormatJsFunctionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::function_expression::FormatJsFunctionExpression::default(),
@@ -2306,7 +2180,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsFunctionExpression {
         crate::js::expressions::function_expression::FormatJsFunctionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::function_expression::FormatJsFunctionExpression::default(),
@@ -2333,7 +2206,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsGetterClassMember {
         crate::js::classes::getter_class_member::FormatJsGetterClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::getter_class_member::FormatJsGetterClassMember::default(),
@@ -2346,7 +2218,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsGetterClassMember {
         crate::js::classes::getter_class_member::FormatJsGetterClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::getter_class_member::FormatJsGetterClassMember::default(),
@@ -2373,7 +2244,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsGetterObjectMember {
         crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::getter_object_member::FormatJsGetterObjectMember::default(),
@@ -2386,7 +2256,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsGetterObjectMember {
         crate::js::objects::getter_object_member::FormatJsGetterObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::getter_object_member::FormatJsGetterObjectMember::default(),
@@ -2413,7 +2282,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierAssignment {
         crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment::default(),
@@ -2426,7 +2294,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierAssignment {
         crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::assignments::identifier_assignment::FormatJsIdentifierAssignment::default(),
@@ -2453,7 +2320,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierBinding {
         crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::identifier_binding::FormatJsIdentifierBinding::default(),
@@ -2466,7 +2332,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierBinding {
         crate::js::bindings::identifier_binding::FormatJsIdentifierBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::identifier_binding::FormatJsIdentifierBinding::default(),
@@ -2493,7 +2358,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIdentifierExpression {
         crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::identifier_expression::FormatJsIdentifierExpression::default(),
@@ -2506,7 +2370,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIdentifierExpression {
         crate::js::expressions::identifier_expression::FormatJsIdentifierExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::identifier_expression::FormatJsIdentifierExpression::default(),
@@ -2529,7 +2392,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsIfStatement {
         crate::js::statements::if_statement::FormatJsIfStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::if_statement::FormatJsIfStatement::default(),
@@ -2542,7 +2404,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsIfStatement {
         crate::js::statements::if_statement::FormatJsIfStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::if_statement::FormatJsIfStatement::default(),
@@ -2560,7 +2421,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImport {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::module::import::FormatJsImport::default())
     }
 }
@@ -2568,7 +2428,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImport {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsImport, crate::js::module::import::FormatJsImport>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::module::import::FormatJsImport::default())
     }
 }
@@ -2592,7 +2451,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertion {
         crate::js::module::import_assertion::FormatJsImportAssertion,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_assertion::FormatJsImportAssertion::default(),
@@ -2605,7 +2463,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertion {
         crate::js::module::import_assertion::FormatJsImportAssertion,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_assertion::FormatJsImportAssertion::default(),
@@ -2632,7 +2489,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntry {
         crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry::default(),
@@ -2645,7 +2501,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntry {
         crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_assertion_entry::FormatJsImportAssertionEntry::default(),
@@ -2672,7 +2527,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportBareClause {
         crate::js::module::import_bare_clause::FormatJsImportBareClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_bare_clause::FormatJsImportBareClause::default(),
@@ -2685,7 +2539,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportBareClause {
         crate::js::module::import_bare_clause::FormatJsImportBareClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_bare_clause::FormatJsImportBareClause::default(),
@@ -2712,7 +2565,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportCallExpression {
         crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::import_call_expression::FormatJsImportCallExpression::default(),
@@ -2725,7 +2577,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportCallExpression {
         crate::js::expressions::import_call_expression::FormatJsImportCallExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::import_call_expression::FormatJsImportCallExpression::default(),
@@ -2752,7 +2603,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportCombinedClause {
         crate::js::module::import_combined_clause::FormatJsImportCombinedClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_combined_clause::FormatJsImportCombinedClause::default(),
@@ -2765,7 +2615,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportCombinedClause {
         crate::js::module::import_combined_clause::FormatJsImportCombinedClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_combined_clause::FormatJsImportCombinedClause::default(),
@@ -2792,7 +2641,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportDefaultClause {
         crate::js::module::import_default_clause::FormatJsImportDefaultClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_default_clause::FormatJsImportDefaultClause::default(),
@@ -2805,7 +2653,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportDefaultClause {
         crate::js::module::import_default_clause::FormatJsImportDefaultClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_default_clause::FormatJsImportDefaultClause::default(),
@@ -2832,7 +2679,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportMetaExpression {
         crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression::default(),
@@ -2845,7 +2691,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportMetaExpression {
         crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::import_meta_expression::FormatJsImportMetaExpression::default(),
@@ -2872,7 +2717,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportNamedClause {
         crate::js::module::import_named_clause::FormatJsImportNamedClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_named_clause::FormatJsImportNamedClause::default(),
@@ -2885,7 +2729,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportNamedClause {
         crate::js::module::import_named_clause::FormatJsImportNamedClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_named_clause::FormatJsImportNamedClause::default(),
@@ -2912,7 +2755,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportNamespaceClause {
         crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause::default(),
@@ -2925,7 +2767,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportNamespaceClause {
         crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::import_namespace_clause::FormatJsImportNamespaceClause::default(),
@@ -2948,7 +2789,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInExpression {
         crate::js::expressions::in_expression::FormatJsInExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::in_expression::FormatJsInExpression::default(),
@@ -2961,7 +2801,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInExpression {
         crate::js::expressions::in_expression::FormatJsInExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::in_expression::FormatJsInExpression::default(),
@@ -2988,7 +2827,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInitializerClause {
         crate::js::auxiliary::initializer_clause::FormatJsInitializerClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::initializer_clause::FormatJsInitializerClause::default(),
@@ -3001,7 +2839,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInitializerClause {
         crate::js::auxiliary::initializer_clause::FormatJsInitializerClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::initializer_clause::FormatJsInitializerClause::default(),
@@ -3028,7 +2865,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsInstanceofExpression {
         crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression::default(),
@@ -3041,7 +2877,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsInstanceofExpression {
         crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::instanceof_expression::FormatJsInstanceofExpression::default(),
@@ -3059,7 +2894,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLabel {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsLabel, crate::js::auxiliary::label::FormatJsLabel>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::auxiliary::label::FormatJsLabel::default())
     }
 }
@@ -3067,7 +2901,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLabel {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsLabel, crate::js::auxiliary::label::FormatJsLabel>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::auxiliary::label::FormatJsLabel::default())
     }
 }
@@ -3091,7 +2924,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLabeledStatement {
         crate::js::statements::labeled_statement::FormatJsLabeledStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::labeled_statement::FormatJsLabeledStatement::default(),
@@ -3104,7 +2936,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLabeledStatement {
         crate::js::statements::labeled_statement::FormatJsLabeledStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::labeled_statement::FormatJsLabeledStatement::default(),
@@ -3131,7 +2962,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLiteralExportName {
         crate::js::module::literal_export_name::FormatJsLiteralExportName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::literal_export_name::FormatJsLiteralExportName::default(),
@@ -3144,7 +2974,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLiteralExportName {
         crate::js::module::literal_export_name::FormatJsLiteralExportName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::literal_export_name::FormatJsLiteralExportName::default(),
@@ -3171,7 +3000,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLiteralMemberName {
         crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::literal_member_name::FormatJsLiteralMemberName::default(),
@@ -3184,7 +3012,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLiteralMemberName {
         crate::js::objects::literal_member_name::FormatJsLiteralMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::literal_member_name::FormatJsLiteralMemberName::default(),
@@ -3211,7 +3038,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsLogicalExpression {
         crate::js::expressions::logical_expression::FormatJsLogicalExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::logical_expression::FormatJsLogicalExpression::default(),
@@ -3224,7 +3050,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsLogicalExpression {
         crate::js::expressions::logical_expression::FormatJsLogicalExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::logical_expression::FormatJsLogicalExpression::default(),
@@ -3247,7 +3072,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMetavariable {
         crate::js::auxiliary::metavariable::FormatJsMetavariable,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::metavariable::FormatJsMetavariable::default(),
@@ -3260,7 +3084,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMetavariable {
         crate::js::auxiliary::metavariable::FormatJsMetavariable,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::metavariable::FormatJsMetavariable::default(),
@@ -3287,7 +3110,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodClassMember {
         crate::js::classes::method_class_member::FormatJsMethodClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::method_class_member::FormatJsMethodClassMember::default(),
@@ -3300,7 +3122,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodClassMember {
         crate::js::classes::method_class_member::FormatJsMethodClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::method_class_member::FormatJsMethodClassMember::default(),
@@ -3327,7 +3148,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodObjectMember {
         crate::js::objects::method_object_member::FormatJsMethodObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::method_object_member::FormatJsMethodObjectMember::default(),
@@ -3340,7 +3160,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodObjectMember {
         crate::js::objects::method_object_member::FormatJsMethodObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::method_object_member::FormatJsMethodObjectMember::default(),
@@ -3361,7 +3180,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModule {
         crate::js::auxiliary::module::FormatJsModule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::module::FormatJsModule::default(),
@@ -3374,7 +3192,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModule {
         crate::js::auxiliary::module::FormatJsModule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::module::FormatJsModule::default(),
@@ -3397,7 +3214,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModuleSource {
         crate::js::module::module_source::FormatJsModuleSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::module_source::FormatJsModuleSource::default(),
@@ -3410,7 +3226,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModuleSource {
         crate::js::module::module_source::FormatJsModuleSource,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::module_source::FormatJsModuleSource::default(),
@@ -3428,7 +3243,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::auxiliary::name::FormatJsName::default())
     }
 }
@@ -3436,7 +3250,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsName, crate::js::auxiliary::name::FormatJsName>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::auxiliary::name::FormatJsName::default())
     }
 }
@@ -3460,7 +3273,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifier {
         crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier::default(),
@@ -3473,7 +3285,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifier {
         crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::named_import_specifier::FormatJsNamedImportSpecifier::default(),
@@ -3500,7 +3311,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifiers {
         crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers::default(),
@@ -3513,7 +3323,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifiers {
         crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::module::named_import_specifiers::FormatJsNamedImportSpecifiers::default(),
@@ -3540,7 +3349,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamespaceImportSpecifier {
         crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: namespace_import_specifier :: FormatJsNamespaceImportSpecifier :: default ())
     }
 }
@@ -3550,7 +3358,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamespaceImportSpecifier
         crate::js::module::namespace_import_specifier::FormatJsNamespaceImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: namespace_import_specifier :: FormatJsNamespaceImportSpecifier :: default ())
     }
 }
@@ -3574,7 +3381,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNewExpression {
         crate::js::expressions::new_expression::FormatJsNewExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::new_expression::FormatJsNewExpression::default(),
@@ -3587,7 +3393,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNewExpression {
         crate::js::expressions::new_expression::FormatJsNewExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::new_expression::FormatJsNewExpression::default(),
@@ -3614,7 +3419,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNewTargetExpression {
         crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::new_target_expression::FormatJsNewTargetExpression::default(),
@@ -3627,7 +3431,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNewTargetExpression {
         crate::js::expressions::new_target_expression::FormatJsNewTargetExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::new_target_expression::FormatJsNewTargetExpression::default(),
@@ -3654,7 +3457,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNullLiteralExpression {
         crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression::default(
@@ -3668,7 +3470,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNullLiteralExpression {
         crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::null_literal_expression::FormatJsNullLiteralExpression::default(
@@ -3696,7 +3497,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNumberLiteralExpression {
         crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: number_literal_expression :: FormatJsNumberLiteralExpression :: default ())
     }
 }
@@ -3706,7 +3506,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNumberLiteralExpression 
         crate::js::expressions::number_literal_expression::FormatJsNumberLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: number_literal_expression :: FormatJsNumberLiteralExpression :: default ())
     }
 }
@@ -3730,7 +3529,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPattern {
         crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern :: FormatJsObjectAssignmentPattern :: default ())
     }
 }
@@ -3740,7 +3538,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPattern 
         crate::js::assignments::object_assignment_pattern::FormatJsObjectAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern :: FormatJsObjectAssignmentPattern :: default ())
     }
 }
@@ -3748,14 +3545,12 @@ impl FormatRule < biome_js_syntax :: JsObjectAssignmentPatternProperty > for cra
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternProperty , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_property :: FormatJsObjectAssignmentPatternProperty :: default ())
     }
 }
@@ -3779,7 +3574,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternRes
         crate::js::assignments::object_assignment_pattern_rest::FormatJsObjectAssignmentPatternRest,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest :: default ())
     }
 }
@@ -3789,7 +3583,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternR
         crate::js::assignments::object_assignment_pattern_rest::FormatJsObjectAssignmentPatternRest,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_rest :: FormatJsObjectAssignmentPatternRest :: default ())
     }
 }
@@ -3797,14 +3590,12 @@ impl FormatRule < biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty 
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternShorthandProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternShorthandProperty , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: object_assignment_pattern_shorthand_property :: FormatJsObjectAssignmentPatternShorthandProperty :: default ())
     }
 }
@@ -3828,7 +3619,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPattern {
         crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern::default(),
@@ -3841,7 +3631,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPattern {
         crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::object_binding_pattern::FormatJsObjectBindingPattern::default(),
@@ -3868,7 +3657,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternProper
         crate::js::bindings::object_binding_pattern_property::FormatJsObjectBindingPatternProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty :: default ())
     }
 }
@@ -3878,7 +3666,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternProp
         crate::js::bindings::object_binding_pattern_property::FormatJsObjectBindingPatternProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_property :: FormatJsObjectBindingPatternProperty :: default ())
     }
 }
@@ -3902,7 +3689,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternRest {
         crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_rest :: FormatJsObjectBindingPatternRest :: default ())
     }
 }
@@ -3912,7 +3698,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternRest
         crate::js::bindings::object_binding_pattern_rest::FormatJsObjectBindingPatternRest,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_rest :: FormatJsObjectBindingPatternRest :: default ())
     }
 }
@@ -3920,14 +3705,12 @@ impl FormatRule < biome_js_syntax :: JsObjectBindingPatternShorthandProperty > f
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternShorthandProperty {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectBindingPatternShorthandProperty , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bindings :: object_binding_pattern_shorthand_property :: FormatJsObjectBindingPatternShorthandProperty :: default ())
     }
 }
@@ -3951,7 +3734,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectExpression {
         crate::js::expressions::object_expression::FormatJsObjectExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::object_expression::FormatJsObjectExpression::default(),
@@ -3964,7 +3746,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectExpression {
         crate::js::expressions::object_expression::FormatJsObjectExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::object_expression::FormatJsObjectExpression::default(),
@@ -3987,7 +3768,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParameters {
         crate::js::bindings::parameters::FormatJsParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::parameters::FormatJsParameters::default(),
@@ -4000,7 +3780,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParameters {
         crate::js::bindings::parameters::FormatJsParameters,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::parameters::FormatJsParameters::default(),
@@ -4027,7 +3806,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedAssignment {
         crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: parenthesized_assignment :: FormatJsParenthesizedAssignment :: default ())
     }
 }
@@ -4037,7 +3815,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedAssignment 
         crate::js::assignments::parenthesized_assignment::FormatJsParenthesizedAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: parenthesized_assignment :: FormatJsParenthesizedAssignment :: default ())
     }
 }
@@ -4061,7 +3838,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedExpression {
         crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: parenthesized_expression :: FormatJsParenthesizedExpression :: default ())
     }
 }
@@ -4071,7 +3847,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParenthesizedExpression 
         crate::js::expressions::parenthesized_expression::FormatJsParenthesizedExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: parenthesized_expression :: FormatJsParenthesizedExpression :: default ())
     }
 }
@@ -4095,7 +3870,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPostUpdateExpression {
         crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression::default(),
@@ -4108,7 +3882,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPostUpdateExpression {
         crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::post_update_expression::FormatJsPostUpdateExpression::default(),
@@ -4135,7 +3908,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPreUpdateExpression {
         crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression::default(),
@@ -4148,7 +3920,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPreUpdateExpression {
         crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::pre_update_expression::FormatJsPreUpdateExpression::default(),
@@ -4175,7 +3946,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPrivateClassMemberName {
         crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName::default(
@@ -4189,7 +3959,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPrivateClassMemberName {
         crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::private_class_member_name::FormatJsPrivateClassMemberName::default(
@@ -4213,7 +3982,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPrivateName {
         crate::js::auxiliary::private_name::FormatJsPrivateName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::private_name::FormatJsPrivateName::default(),
@@ -4226,7 +3994,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPrivateName {
         crate::js::auxiliary::private_name::FormatJsPrivateName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::private_name::FormatJsPrivateName::default(),
@@ -4253,7 +4020,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyClassMember {
         crate::js::classes::property_class_member::FormatJsPropertyClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::property_class_member::FormatJsPropertyClassMember::default(),
@@ -4266,7 +4032,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyClassMember {
         crate::js::classes::property_class_member::FormatJsPropertyClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::property_class_member::FormatJsPropertyClassMember::default(),
@@ -4293,7 +4058,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyObjectMember {
         crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::property_object_member::FormatJsPropertyObjectMember::default(),
@@ -4306,7 +4070,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyObjectMember {
         crate::js::objects::property_object_member::FormatJsPropertyObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::property_object_member::FormatJsPropertyObjectMember::default(),
@@ -4333,7 +4096,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsReferenceIdentifier {
         crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier::default(),
@@ -4346,7 +4108,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsReferenceIdentifier {
         crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::reference_identifier::FormatJsReferenceIdentifier::default(),
@@ -4373,7 +4134,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsRegexLiteralExpression {
         crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: regex_literal_expression :: FormatJsRegexLiteralExpression :: default ())
     }
 }
@@ -4383,7 +4143,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsRegexLiteralExpression {
         crate::js::expressions::regex_literal_expression::FormatJsRegexLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: regex_literal_expression :: FormatJsRegexLiteralExpression :: default ())
     }
 }
@@ -4407,7 +4166,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsRestParameter {
         crate::js::bindings::rest_parameter::FormatJsRestParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bindings::rest_parameter::FormatJsRestParameter::default(),
@@ -4420,7 +4178,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsRestParameter {
         crate::js::bindings::rest_parameter::FormatJsRestParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bindings::rest_parameter::FormatJsRestParameter::default(),
@@ -4447,7 +4204,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsReturnStatement {
         crate::js::statements::return_statement::FormatJsReturnStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::return_statement::FormatJsReturnStatement::default(),
@@ -4460,7 +4216,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsReturnStatement {
         crate::js::statements::return_statement::FormatJsReturnStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::return_statement::FormatJsReturnStatement::default(),
@@ -4481,7 +4236,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsScript {
         crate::js::auxiliary::script::FormatJsScript,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::script::FormatJsScript::default(),
@@ -4494,7 +4248,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsScript {
         crate::js::auxiliary::script::FormatJsScript,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::script::FormatJsScript::default(),
@@ -4521,7 +4274,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSequenceExpression {
         crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::sequence_expression::FormatJsSequenceExpression::default(),
@@ -4534,7 +4286,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSequenceExpression {
         crate::js::expressions::sequence_expression::FormatJsSequenceExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::sequence_expression::FormatJsSequenceExpression::default(),
@@ -4561,7 +4312,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSetterClassMember {
         crate::js::classes::setter_class_member::FormatJsSetterClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::classes::setter_class_member::FormatJsSetterClassMember::default(),
@@ -4574,7 +4324,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSetterClassMember {
         crate::js::classes::setter_class_member::FormatJsSetterClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::classes::setter_class_member::FormatJsSetterClassMember::default(),
@@ -4601,7 +4350,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSetterObjectMember {
         crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::objects::setter_object_member::FormatJsSetterObjectMember::default(),
@@ -4614,7 +4362,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSetterObjectMember {
         crate::js::objects::setter_object_member::FormatJsSetterObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::objects::setter_object_member::FormatJsSetterObjectMember::default(),
@@ -4641,7 +4388,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsShorthandNamedImportSpecif
         crate::js::module::shorthand_named_import_specifier::FormatJsShorthandNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier :: default ())
     }
 }
@@ -4651,7 +4397,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandNamedImportSpec
         crate::js::module::shorthand_named_import_specifier::FormatJsShorthandNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: module :: shorthand_named_import_specifier :: FormatJsShorthandNamedImportSpecifier :: default ())
     }
 }
@@ -4675,7 +4420,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsShorthandPropertyObjectMem
         crate::js::objects::shorthand_property_object_member::FormatJsShorthandPropertyObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember :: default ())
     }
 }
@@ -4685,7 +4429,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsShorthandPropertyObjectM
         crate::js::objects::shorthand_property_object_member::FormatJsShorthandPropertyObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: objects :: shorthand_property_object_member :: FormatJsShorthandPropertyObjectMember :: default ())
     }
 }
@@ -4703,7 +4446,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSpread {
         crate::js::auxiliary::spread::FormatJsSpread,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::spread::FormatJsSpread::default(),
@@ -4716,7 +4458,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSpread {
         crate::js::auxiliary::spread::FormatJsSpread,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::spread::FormatJsSpread::default(),
@@ -4727,14 +4468,12 @@ impl FormatRule < biome_js_syntax :: JsStaticInitializationBlockClassMember > fo
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticInitializationBlockClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsStaticInitializationBlockClassMember , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: classes :: static_initialization_block_class_member :: FormatJsStaticInitializationBlockClassMember :: default ())
     }
 }
@@ -4758,7 +4497,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberAssignment {
         crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: assignments :: static_member_assignment :: FormatJsStaticMemberAssignment :: default ())
     }
 }
@@ -4768,7 +4506,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberAssignment {
         crate::js::assignments::static_member_assignment::FormatJsStaticMemberAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: assignments :: static_member_assignment :: FormatJsStaticMemberAssignment :: default ())
     }
 }
@@ -4792,7 +4529,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberExpression {
         crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: static_member_expression :: FormatJsStaticMemberExpression :: default ())
     }
 }
@@ -4802,7 +4538,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticMemberExpression {
         crate::js::expressions::static_member_expression::FormatJsStaticMemberExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: static_member_expression :: FormatJsStaticMemberExpression :: default ())
     }
 }
@@ -4826,7 +4561,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStaticModifier {
         crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::static_modifier::FormatJsStaticModifier::default(),
@@ -4839,7 +4573,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStaticModifier {
         crate::js::auxiliary::static_modifier::FormatJsStaticModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::static_modifier::FormatJsStaticModifier::default(),
@@ -4866,7 +4599,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStringLiteralExpression {
         crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: expressions :: string_literal_expression :: FormatJsStringLiteralExpression :: default ())
     }
 }
@@ -4876,7 +4608,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStringLiteralExpression 
         crate::js::expressions::string_literal_expression::FormatJsStringLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: expressions :: string_literal_expression :: FormatJsStringLiteralExpression :: default ())
     }
 }
@@ -4900,7 +4631,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSuperExpression {
         crate::js::expressions::super_expression::FormatJsSuperExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::super_expression::FormatJsSuperExpression::default(),
@@ -4913,7 +4643,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSuperExpression {
         crate::js::expressions::super_expression::FormatJsSuperExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::super_expression::FormatJsSuperExpression::default(),
@@ -4940,7 +4669,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSwitchStatement {
         crate::js::statements::switch_statement::FormatJsSwitchStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::switch_statement::FormatJsSwitchStatement::default(),
@@ -4953,7 +4681,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSwitchStatement {
         crate::js::statements::switch_statement::FormatJsSwitchStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::switch_statement::FormatJsSwitchStatement::default(),
@@ -4980,7 +4707,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateChunkElement {
         crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement::default(),
@@ -4993,7 +4719,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateChunkElement {
         crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::template_chunk_element::FormatJsTemplateChunkElement::default(),
@@ -5020,7 +4745,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateElement {
         crate::js::auxiliary::template_element::FormatJsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::template_element::FormatJsTemplateElement::default(),
@@ -5033,7 +4757,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateElement {
         crate::js::auxiliary::template_element::FormatJsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::template_element::FormatJsTemplateElement::default(),
@@ -5060,7 +4783,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateExpression {
         crate::js::expressions::template_expression::FormatJsTemplateExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::template_expression::FormatJsTemplateExpression::default(),
@@ -5073,7 +4795,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateExpression {
         crate::js::expressions::template_expression::FormatJsTemplateExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::template_expression::FormatJsTemplateExpression::default(),
@@ -5100,7 +4821,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsThisExpression {
         crate::js::expressions::this_expression::FormatJsThisExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::this_expression::FormatJsThisExpression::default(),
@@ -5113,7 +4833,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsThisExpression {
         crate::js::expressions::this_expression::FormatJsThisExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::this_expression::FormatJsThisExpression::default(),
@@ -5140,7 +4859,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsThrowStatement {
         crate::js::statements::throw_statement::FormatJsThrowStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::throw_statement::FormatJsThrowStatement::default(),
@@ -5153,7 +4871,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsThrowStatement {
         crate::js::statements::throw_statement::FormatJsThrowStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::throw_statement::FormatJsThrowStatement::default(),
@@ -5180,7 +4897,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTryFinallyStatement {
         crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement::default(),
@@ -5193,7 +4909,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTryFinallyStatement {
         crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::try_finally_statement::FormatJsTryFinallyStatement::default(),
@@ -5216,7 +4931,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTryStatement {
         crate::js::statements::try_statement::FormatJsTryStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::try_statement::FormatJsTryStatement::default(),
@@ -5229,7 +4943,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTryStatement {
         crate::js::statements::try_statement::FormatJsTryStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::try_statement::FormatJsTryStatement::default(),
@@ -5256,7 +4969,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsUnaryExpression {
         crate::js::expressions::unary_expression::FormatJsUnaryExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::unary_expression::FormatJsUnaryExpression::default(),
@@ -5269,7 +4981,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsUnaryExpression {
         crate::js::expressions::unary_expression::FormatJsUnaryExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::unary_expression::FormatJsUnaryExpression::default(),
@@ -5296,7 +5007,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaration {
         crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::declarations::variable_declaration::FormatJsVariableDeclaration::default(),
@@ -5309,7 +5019,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaration {
         crate::js::declarations::variable_declaration::FormatJsVariableDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::declarations::variable_declaration::FormatJsVariableDeclaration::default(),
@@ -5336,7 +5045,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarationClause 
         crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: auxiliary :: variable_declaration_clause :: FormatJsVariableDeclarationClause :: default ())
     }
 }
@@ -5346,7 +5054,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarationClaus
         crate::js::auxiliary::variable_declaration_clause::FormatJsVariableDeclarationClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: auxiliary :: variable_declaration_clause :: FormatJsVariableDeclarationClause :: default ())
     }
 }
@@ -5370,7 +5077,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarator {
         crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator::default(),
@@ -5383,7 +5089,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclarator {
         crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::auxiliary::variable_declarator::FormatJsVariableDeclarator::default(),
@@ -5410,7 +5115,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableStatement {
         crate::js::statements::variable_statement::FormatJsVariableStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::variable_statement::FormatJsVariableStatement::default(),
@@ -5423,7 +5127,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableStatement {
         crate::js::statements::variable_statement::FormatJsVariableStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::variable_statement::FormatJsVariableStatement::default(),
@@ -5450,7 +5153,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsWhileStatement {
         crate::js::statements::while_statement::FormatJsWhileStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::while_statement::FormatJsWhileStatement::default(),
@@ -5463,7 +5165,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsWhileStatement {
         crate::js::statements::while_statement::FormatJsWhileStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::while_statement::FormatJsWhileStatement::default(),
@@ -5490,7 +5191,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsWithStatement {
         crate::js::statements::with_statement::FormatJsWithStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::statements::with_statement::FormatJsWithStatement::default(),
@@ -5503,7 +5203,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsWithStatement {
         crate::js::statements::with_statement::FormatJsWithStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::statements::with_statement::FormatJsWithStatement::default(),
@@ -5530,7 +5229,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsYieldArgument {
         crate::js::expressions::yield_argument::FormatJsYieldArgument,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::yield_argument::FormatJsYieldArgument::default(),
@@ -5543,7 +5241,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsYieldArgument {
         crate::js::expressions::yield_argument::FormatJsYieldArgument,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::yield_argument::FormatJsYieldArgument::default(),
@@ -5570,7 +5267,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsYieldExpression {
         crate::js::expressions::yield_expression::FormatJsYieldExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::expressions::yield_expression::FormatJsYieldExpression::default(),
@@ -5583,7 +5279,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsYieldExpression {
         crate::js::expressions::yield_expression::FormatJsYieldExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::expressions::yield_expression::FormatJsYieldExpression::default(),
@@ -5606,7 +5301,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttribute {
         crate::jsx::attribute::attribute::FormatJsxAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::attribute::attribute::FormatJsxAttribute::default(),
@@ -5619,7 +5313,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttribute {
         crate::jsx::attribute::attribute::FormatJsxAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::attribute::attribute::FormatJsxAttribute::default(),
@@ -5646,7 +5339,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttributeInitializerClaus
         crate::jsx::attribute::attribute_initializer_clause::FormatJsxAttributeInitializerClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause :: default ())
     }
 }
@@ -5656,7 +5348,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttributeInitializerCla
         crate::jsx::attribute::attribute_initializer_clause::FormatJsxAttributeInitializerClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: jsx :: attribute :: attribute_initializer_clause :: FormatJsxAttributeInitializerClause :: default ())
     }
 }
@@ -5680,7 +5371,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxClosingElement {
         crate::jsx::tag::closing_element::FormatJsxClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::closing_element::FormatJsxClosingElement::default(),
@@ -5693,7 +5383,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxClosingElement {
         crate::jsx::tag::closing_element::FormatJsxClosingElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::closing_element::FormatJsxClosingElement::default(),
@@ -5720,7 +5409,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxClosingFragment {
         crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::closing_fragment::FormatJsxClosingFragment::default(),
@@ -5733,7 +5421,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxClosingFragment {
         crate::jsx::tag::closing_fragment::FormatJsxClosingFragment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::closing_fragment::FormatJsxClosingFragment::default(),
@@ -5754,7 +5441,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxElement {
         crate::jsx::tag::element::FormatJsxElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::tag::element::FormatJsxElement::default())
     }
 }
@@ -5764,7 +5450,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxElement {
         crate::jsx::tag::element::FormatJsxElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::tag::element::FormatJsxElement::default())
     }
 }
@@ -5788,7 +5473,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxExpressionAttributeValue 
         crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: jsx :: attribute :: expression_attribute_value :: FormatJsxExpressionAttributeValue :: default ())
     }
 }
@@ -5798,7 +5482,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxExpressionAttributeValu
         crate::jsx::attribute::expression_attribute_value::FormatJsxExpressionAttributeValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: jsx :: attribute :: expression_attribute_value :: FormatJsxExpressionAttributeValue :: default ())
     }
 }
@@ -5822,7 +5505,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxExpressionChild {
         crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild::default(),
@@ -5835,7 +5517,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxExpressionChild {
         crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::auxiliary::expression_child::FormatJsxExpressionChild::default(),
@@ -5856,7 +5537,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxFragment {
         crate::jsx::tag::fragment::FormatJsxFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::fragment::FormatJsxFragment::default(),
@@ -5869,7 +5549,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxFragment {
         crate::jsx::tag::fragment::FormatJsxFragment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::fragment::FormatJsxFragment::default(),
@@ -5892,7 +5571,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxMemberName {
         crate::jsx::objects::member_name::FormatJsxMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::objects::member_name::FormatJsxMemberName::default(),
@@ -5905,7 +5583,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxMemberName {
         crate::jsx::objects::member_name::FormatJsxMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::objects::member_name::FormatJsxMemberName::default(),
@@ -5923,7 +5600,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName::default())
     }
 }
@@ -5931,7 +5607,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsxName, crate::jsx::auxiliary::name::FormatJsxName>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::auxiliary::name::FormatJsxName::default())
     }
 }
@@ -5955,7 +5630,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxNamespaceName {
         crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName::default(),
@@ -5968,7 +5642,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxNamespaceName {
         crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::auxiliary::namespace_name::FormatJsxNamespaceName::default(),
@@ -5995,7 +5668,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxOpeningElement {
         crate::jsx::tag::opening_element::FormatJsxOpeningElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::opening_element::FormatJsxOpeningElement::default(),
@@ -6008,7 +5680,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxOpeningElement {
         crate::jsx::tag::opening_element::FormatJsxOpeningElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::opening_element::FormatJsxOpeningElement::default(),
@@ -6035,7 +5706,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxOpeningFragment {
         crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment::default(),
@@ -6048,7 +5718,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxOpeningFragment {
         crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::opening_fragment::FormatJsxOpeningFragment::default(),
@@ -6075,7 +5744,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxReferenceIdentifier {
         crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier::default(),
@@ -6088,7 +5756,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxReferenceIdentifier {
         crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::auxiliary::reference_identifier::FormatJsxReferenceIdentifier::default(),
@@ -6115,7 +5782,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSelfClosingElement {
         crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement::default(),
@@ -6128,7 +5794,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSelfClosingElement {
         crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::tag::self_closing_element::FormatJsxSelfClosingElement::default(),
@@ -6155,7 +5820,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSpreadAttribute {
         crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute::default(),
@@ -6168,7 +5832,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSpreadAttribute {
         crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::attribute::spread_attribute::FormatJsxSpreadAttribute::default(),
@@ -6191,7 +5854,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxSpreadChild {
         crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild::default(),
@@ -6204,7 +5866,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxSpreadChild {
         crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::auxiliary::spread_child::FormatJsxSpreadChild::default(),
@@ -6225,7 +5886,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxString {
         crate::jsx::auxiliary::string::FormatJsxString,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::auxiliary::string::FormatJsxString::default(),
@@ -6238,7 +5898,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxString {
         crate::jsx::auxiliary::string::FormatJsxString,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::auxiliary::string::FormatJsxString::default(),
@@ -6265,7 +5924,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxTagExpression {
         crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::expressions::tag_expression::FormatJsxTagExpression::default(),
@@ -6278,7 +5936,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxTagExpression {
         crate::jsx::expressions::tag_expression::FormatJsxTagExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::expressions::tag_expression::FormatJsxTagExpression::default(),
@@ -6296,7 +5953,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxText {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText::default())
     }
 }
@@ -6304,7 +5960,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxText {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsxText, crate::jsx::auxiliary::text::FormatJsxText>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::auxiliary::text::FormatJsxText::default())
     }
 }
@@ -6328,7 +5983,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAbstractModifier {
         crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier::default(),
@@ -6341,7 +5995,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAbstractModifier {
         crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::abstract_modifier::FormatTsAbstractModifier::default(),
@@ -6368,7 +6021,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAccessibilityModifier {
         crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier::default(),
@@ -6381,7 +6033,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAccessibilityModifier {
         crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::accessibility_modifier::FormatTsAccessibilityModifier::default(),
@@ -6402,7 +6053,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAnyType {
         crate::ts::types::any_type::FormatTsAnyType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType::default())
     }
 }
@@ -6412,7 +6062,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAnyType {
         crate::ts::types::any_type::FormatTsAnyType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::ts::types::any_type::FormatTsAnyType::default())
     }
 }
@@ -6430,7 +6079,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsArrayType {
         crate::ts::types::array_type::FormatTsArrayType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::array_type::FormatTsArrayType::default(),
@@ -6443,7 +6091,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsArrayType {
         crate::ts::types::array_type::FormatTsArrayType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::array_type::FormatTsArrayType::default(),
@@ -6466,7 +6113,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAsAssignment {
         crate::ts::assignments::as_assignment::FormatTsAsAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::assignments::as_assignment::FormatTsAsAssignment::default(),
@@ -6479,7 +6125,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAsAssignment {
         crate::ts::assignments::as_assignment::FormatTsAsAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::assignments::as_assignment::FormatTsAsAssignment::default(),
@@ -6502,7 +6147,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAsExpression {
         crate::ts::expressions::as_expression::FormatTsAsExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::expressions::as_expression::FormatTsAsExpression::default(),
@@ -6515,7 +6159,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAsExpression {
         crate::ts::expressions::as_expression::FormatTsAsExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::expressions::as_expression::FormatTsAsExpression::default(),
@@ -6542,7 +6185,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAssertsCondition {
         crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition::default(),
@@ -6555,7 +6197,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAssertsCondition {
         crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::asserts_condition::FormatTsAssertsCondition::default(),
@@ -6582,7 +6223,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsAssertsReturnType {
         crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::asserts_return_type::FormatTsAssertsReturnType::default(),
@@ -6595,7 +6235,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsAssertsReturnType {
         crate::ts::types::asserts_return_type::FormatTsAssertsReturnType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::asserts_return_type::FormatTsAssertsReturnType::default(),
@@ -6622,7 +6261,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBigintLiteralType {
         crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType::default(),
@@ -6635,7 +6273,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBigintLiteralType {
         crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::bigint_literal_type::FormatTsBigintLiteralType::default(),
@@ -6658,7 +6295,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBigintType {
         crate::ts::types::bigint_type::FormatTsBigintType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::bigint_type::FormatTsBigintType::default(),
@@ -6671,7 +6307,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBigintType {
         crate::ts::types::bigint_type::FormatTsBigintType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::bigint_type::FormatTsBigintType::default(),
@@ -6698,7 +6333,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBooleanLiteralType {
         crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType::default(),
@@ -6711,7 +6345,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBooleanLiteralType {
         crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::boolean_literal_type::FormatTsBooleanLiteralType::default(),
@@ -6734,7 +6367,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBooleanType {
         crate::ts::types::boolean_type::FormatTsBooleanType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::boolean_type::FormatTsBooleanType::default(),
@@ -6747,7 +6379,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBooleanType {
         crate::ts::types::boolean_type::FormatTsBooleanType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::boolean_type::FormatTsBooleanType::default(),
@@ -6774,7 +6405,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsCallSignatureTypeMember {
         crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: call_signature_type_member :: FormatTsCallSignatureTypeMember :: default ())
     }
 }
@@ -6784,7 +6414,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsCallSignatureTypeMember 
         crate::ts::auxiliary::call_signature_type_member::FormatTsCallSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: call_signature_type_member :: FormatTsCallSignatureTypeMember :: default ())
     }
 }
@@ -6808,7 +6437,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConditionalType {
         crate::ts::types::conditional_type::FormatTsConditionalType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::conditional_type::FormatTsConditionalType::default(),
@@ -6821,7 +6449,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConditionalType {
         crate::ts::types::conditional_type::FormatTsConditionalType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::conditional_type::FormatTsConditionalType::default(),
@@ -6848,7 +6475,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstModifier {
         crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::const_modifier::FormatTsConstModifier::default(),
@@ -6861,7 +6487,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstModifier {
         crate::ts::auxiliary::const_modifier::FormatTsConstModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::const_modifier::FormatTsConstModifier::default(),
@@ -6888,7 +6513,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructSignatureTypeMemb
         crate::ts::auxiliary::construct_signature_type_member::FormatTsConstructSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember :: default ())
     }
 }
@@ -6898,7 +6522,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructSignatureTypeMe
         crate::ts::auxiliary::construct_signature_type_member::FormatTsConstructSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: construct_signature_type_member :: FormatTsConstructSignatureTypeMember :: default ())
     }
 }
@@ -6906,14 +6529,12 @@ impl FormatRule < biome_js_syntax :: TsConstructorSignatureClassMember > for cra
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructorSignatureClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructorSignatureClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsConstructorSignatureClassMember , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: constructor_signature_class_member :: FormatTsConstructorSignatureClassMember :: default ())
     }
 }
@@ -6937,7 +6558,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsConstructorType {
         crate::ts::types::constructor_type::FormatTsConstructorType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::constructor_type::FormatTsConstructorType::default(),
@@ -6950,7 +6570,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsConstructorType {
         crate::ts::types::constructor_type::FormatTsConstructorType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::constructor_type::FormatTsConstructorType::default(),
@@ -6977,7 +6596,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclarationModule {
         crate::ts::auxiliary::declaration_module::FormatTsDeclarationModule,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::declaration_module::FormatTsDeclarationModule::default(),
@@ -6990,7 +6608,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclarationModule {
         crate::ts::auxiliary::declaration_module::FormatTsDeclarationModule,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::declaration_module::FormatTsDeclarationModule::default(),
@@ -7017,7 +6634,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionDeclaration
         crate::ts::declarations::declare_function_declaration::FormatTsDeclareFunctionDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration :: default ())
     }
 }
@@ -7027,7 +6643,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionDeclarati
         crate::ts::declarations::declare_function_declaration::FormatTsDeclareFunctionDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_declaration :: FormatTsDeclareFunctionDeclaration :: default ())
     }
 }
@@ -7035,14 +6650,12 @@ impl FormatRule < biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration >
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareFunctionExportDefaultDeclaration {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsDeclareFunctionExportDefaultDeclaration , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: declare_function_export_default_declaration :: FormatTsDeclareFunctionExportDefaultDeclaration :: default ())
     }
 }
@@ -7066,7 +6679,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareModifier {
         crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier::default(),
@@ -7079,7 +6691,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareModifier {
         crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::declare_modifier::FormatTsDeclareModifier::default(),
@@ -7106,7 +6717,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDeclareStatement {
         crate::ts::statements::declare_statement::FormatTsDeclareStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::statements::declare_statement::FormatTsDeclareStatement::default(),
@@ -7119,7 +6729,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDeclareStatement {
         crate::ts::statements::declare_statement::FormatTsDeclareStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::statements::declare_statement::FormatTsDeclareStatement::default(),
@@ -7146,7 +6755,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefaultTypeClause {
         crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause::default(),
@@ -7159,7 +6767,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefaultTypeClause {
         crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::default_type_clause::FormatTsDefaultTypeClause::default(),
@@ -7186,7 +6793,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefinitePropertyAnnotation
         crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_property_annotation :: FormatTsDefinitePropertyAnnotation :: default ())
     }
 }
@@ -7196,7 +6802,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefinitePropertyAnnotati
         crate::ts::auxiliary::definite_property_annotation::FormatTsDefinitePropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: definite_property_annotation :: FormatTsDefinitePropertyAnnotation :: default ())
     }
 }
@@ -7220,7 +6825,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsDefiniteVariableAnnotation
         crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: definite_variable_annotation :: FormatTsDefiniteVariableAnnotation :: default ())
     }
 }
@@ -7230,7 +6834,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsDefiniteVariableAnnotati
         crate::ts::auxiliary::definite_variable_annotation::FormatTsDefiniteVariableAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: definite_variable_annotation :: FormatTsDefiniteVariableAnnotation :: default ())
     }
 }
@@ -7238,14 +6841,12 @@ impl FormatRule < biome_js_syntax :: TsEmptyExternalModuleDeclarationBody > for 
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEmptyExternalModuleDeclarationBody {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsEmptyExternalModuleDeclarationBody , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: empty_external_module_declaration_body :: FormatTsEmptyExternalModuleDeclarationBody :: default ())
     }
 }
@@ -7269,7 +6870,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumDeclaration {
         crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration::default(),
@@ -7282,7 +6882,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumDeclaration {
         crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::declarations::enum_declaration::FormatTsEnumDeclaration::default(),
@@ -7305,7 +6904,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumMember {
         crate::ts::auxiliary::enum_member::FormatTsEnumMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::enum_member::FormatTsEnumMember::default(),
@@ -7318,7 +6916,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumMember {
         crate::ts::auxiliary::enum_member::FormatTsEnumMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::enum_member::FormatTsEnumMember::default(),
@@ -7345,7 +6942,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportAsNamespaceClause {
         crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause::default(
@@ -7359,7 +6955,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportAsNamespaceClause 
         crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::export_as_namespace_clause::FormatTsExportAsNamespaceClause::default(
@@ -7387,7 +6982,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportAssignmentClause {
         crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause::default(),
@@ -7400,7 +6994,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportAssignmentClause {
         crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::export_assignment_clause::FormatTsExportAssignmentClause::default(),
@@ -7427,7 +7020,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExportDeclareClause {
         crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::export_declare_clause::FormatTsExportDeclareClause::default(),
@@ -7440,7 +7032,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExportDeclareClause {
         crate::ts::module::export_declare_clause::FormatTsExportDeclareClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::export_declare_clause::FormatTsExportDeclareClause::default(),
@@ -7467,7 +7058,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExtendsClause {
         crate::ts::classes::extends_clause::FormatTsExtendsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::classes::extends_clause::FormatTsExtendsClause::default(),
@@ -7480,7 +7070,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExtendsClause {
         crate::ts::classes::extends_clause::FormatTsExtendsClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::classes::extends_clause::FormatTsExtendsClause::default(),
@@ -7507,7 +7096,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleDeclaration 
         crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: external_module_declaration :: FormatTsExternalModuleDeclaration :: default ())
     }
 }
@@ -7517,7 +7105,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleDeclaratio
         crate::ts::declarations::external_module_declaration::FormatTsExternalModuleDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: external_module_declaration :: FormatTsExternalModuleDeclaration :: default ())
     }
 }
@@ -7541,7 +7128,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleReference {
         crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: external_module_reference :: FormatTsExternalModuleReference :: default ())
     }
 }
@@ -7551,7 +7137,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsExternalModuleReference 
         crate::ts::auxiliary::external_module_reference::FormatTsExternalModuleReference,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: external_module_reference :: FormatTsExternalModuleReference :: default ())
     }
 }
@@ -7571,7 +7156,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsFunctionType {
         crate::ts::types::function_type::FormatTsFunctionType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::function_type::FormatTsFunctionType::default(),
@@ -7584,7 +7168,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsFunctionType {
         crate::ts::types::function_type::FormatTsFunctionType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::function_type::FormatTsFunctionType::default(),
@@ -7611,7 +7194,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureClassMember
         crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: getter_signature_class_member :: FormatTsGetterSignatureClassMember :: default ())
     }
 }
@@ -7621,7 +7203,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureClassMemb
         crate::ts::classes::getter_signature_class_member::FormatTsGetterSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: getter_signature_class_member :: FormatTsGetterSignatureClassMember :: default ())
     }
 }
@@ -7645,7 +7226,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureTypeMember 
         crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: getter_signature_type_member :: FormatTsGetterSignatureTypeMember :: default ())
     }
 }
@@ -7655,7 +7235,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGetterSignatureTypeMembe
         crate::ts::auxiliary::getter_signature_type_member::FormatTsGetterSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: getter_signature_type_member :: FormatTsGetterSignatureTypeMember :: default ())
     }
 }
@@ -7679,7 +7258,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsGlobalDeclaration {
         crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration::default(),
@@ -7692,7 +7270,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsGlobalDeclaration {
         crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::declarations::global_declaration::FormatTsGlobalDeclaration::default(),
@@ -7719,7 +7296,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIdentifierBinding {
         crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding::default(),
@@ -7732,7 +7308,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIdentifierBinding {
         crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::identifier_binding::FormatTsIdentifierBinding::default(),
@@ -7759,7 +7334,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImplementsClause {
         crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::implements_clause::FormatTsImplementsClause::default(),
@@ -7772,7 +7346,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImplementsClause {
         crate::ts::auxiliary::implements_clause::FormatTsImplementsClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::implements_clause::FormatTsImplementsClause::default(),
@@ -7799,7 +7372,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportEqualsDeclaration {
         crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: declarations :: import_equals_declaration :: FormatTsImportEqualsDeclaration :: default ())
     }
 }
@@ -7809,7 +7381,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportEqualsDeclaration 
         crate::ts::declarations::import_equals_declaration::FormatTsImportEqualsDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: declarations :: import_equals_declaration :: FormatTsImportEqualsDeclaration :: default ())
     }
 }
@@ -7829,7 +7400,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportType {
         crate::ts::module::import_type::FormatTsImportType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::import_type::FormatTsImportType::default(),
@@ -7842,7 +7412,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportType {
         crate::ts::module::import_type::FormatTsImportType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::import_type::FormatTsImportType::default(),
@@ -7869,7 +7438,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportTypeArguments {
         crate::ts::expressions::import_type_arguments::FormatTsImportTypeArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::expressions::import_type_arguments::FormatTsImportTypeArguments::default(),
@@ -7882,7 +7450,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportTypeArguments {
         crate::ts::expressions::import_type_arguments::FormatTsImportTypeArguments,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::expressions::import_type_arguments::FormatTsImportTypeArguments::default(),
@@ -7909,7 +7476,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportTypeAssertion {
         crate::ts::module::import_type_assertion::FormatTsImportTypeAssertion,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::import_type_assertion::FormatTsImportTypeAssertion::default(),
@@ -7922,7 +7488,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportTypeAssertion {
         crate::ts::module::import_type_assertion::FormatTsImportTypeAssertion,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::import_type_assertion::FormatTsImportTypeAssertion::default(),
@@ -7949,7 +7514,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportTypeAssertionBlock {
         crate::ts::module::import_type_assertion_block::FormatTsImportTypeAssertionBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: module :: import_type_assertion_block :: FormatTsImportTypeAssertionBlock :: default ())
     }
 }
@@ -7959,7 +7523,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportTypeAssertionBlock
         crate::ts::module::import_type_assertion_block::FormatTsImportTypeAssertionBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: module :: import_type_assertion_block :: FormatTsImportTypeAssertionBlock :: default ())
     }
 }
@@ -7983,7 +7546,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsImportTypeQualifier {
         crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier::default(),
@@ -7996,7 +7558,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsImportTypeQualifier {
         crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::module::import_type_qualifier::FormatTsImportTypeQualifier::default(),
@@ -8019,7 +7580,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInModifier {
         crate::ts::auxiliary::in_modifier::FormatTsInModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::in_modifier::FormatTsInModifier::default(),
@@ -8032,7 +7592,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInModifier {
         crate::ts::auxiliary::in_modifier::FormatTsInModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::in_modifier::FormatTsInModifier::default(),
@@ -8059,7 +7618,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureClassMember 
         crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: index_signature_class_member :: FormatTsIndexSignatureClassMember :: default ())
     }
 }
@@ -8069,7 +7627,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureClassMembe
         crate::ts::classes::index_signature_class_member::FormatTsIndexSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: index_signature_class_member :: FormatTsIndexSignatureClassMember :: default ())
     }
 }
@@ -8093,7 +7650,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureParameter {
         crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: bindings :: index_signature_parameter :: FormatTsIndexSignatureParameter :: default ())
     }
 }
@@ -8103,7 +7659,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureParameter 
         crate::ts::bindings::index_signature_parameter::FormatTsIndexSignatureParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: bindings :: index_signature_parameter :: FormatTsIndexSignatureParameter :: default ())
     }
 }
@@ -8127,7 +7682,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureTypeMember {
         crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: index_signature_type_member :: FormatTsIndexSignatureTypeMember :: default ())
     }
 }
@@ -8137,7 +7691,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureTypeMember
         crate::ts::auxiliary::index_signature_type_member::FormatTsIndexSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: index_signature_type_member :: FormatTsIndexSignatureTypeMember :: default ())
     }
 }
@@ -8161,7 +7714,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexedAccessType {
         crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::indexed_access_type::FormatTsIndexedAccessType::default(),
@@ -8174,7 +7726,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexedAccessType {
         crate::ts::types::indexed_access_type::FormatTsIndexedAccessType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::indexed_access_type::FormatTsIndexedAccessType::default(),
@@ -8195,7 +7746,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInferType {
         crate::ts::types::infer_type::FormatTsInferType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::infer_type::FormatTsInferType::default(),
@@ -8208,7 +7758,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInferType {
         crate::ts::types::infer_type::FormatTsInferType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::infer_type::FormatTsInferType::default(),
@@ -8219,14 +7768,12 @@ impl FormatRule < biome_js_syntax :: TsInitializedPropertySignatureClassMember >
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsInitializedPropertySignatureClassMember {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsInitializedPropertySignatureClassMember , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInitializedPropertySignatureClassMember {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsInitializedPropertySignatureClassMember , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: initialized_property_signature_class_member :: FormatTsInitializedPropertySignatureClassMember :: default ())
     }
 }
@@ -8250,7 +7797,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInstantiationExpression {
         crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: instantiation_expression :: FormatTsInstantiationExpression :: default ())
     }
 }
@@ -8260,7 +7806,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInstantiationExpression 
         crate::ts::expressions::instantiation_expression::FormatTsInstantiationExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: instantiation_expression :: FormatTsInstantiationExpression :: default ())
     }
 }
@@ -8284,7 +7829,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsInterfaceDeclaration {
         crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration::default(),
@@ -8297,7 +7841,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsInterfaceDeclaration {
         crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::declarations::interface_declaration::FormatTsInterfaceDeclaration::default(),
@@ -8324,7 +7867,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIntersectionType {
         crate::ts::types::intersection_type::FormatTsIntersectionType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::intersection_type::FormatTsIntersectionType::default(),
@@ -8337,7 +7879,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIntersectionType {
         crate::ts::types::intersection_type::FormatTsIntersectionType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::intersection_type::FormatTsIntersectionType::default(),
@@ -8364,7 +7905,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsLiteralEnumMemberName {
         crate::ts::objects::literal_enum_member_name::FormatTsLiteralEnumMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::objects::literal_enum_member_name::FormatTsLiteralEnumMemberName::default(),
@@ -8377,7 +7917,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsLiteralEnumMemberName {
         crate::ts::objects::literal_enum_member_name::FormatTsLiteralEnumMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::objects::literal_enum_member_name::FormatTsLiteralEnumMemberName::default(),
@@ -8400,7 +7939,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedType {
         crate::ts::types::mapped_type::FormatTsMappedType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::mapped_type::FormatTsMappedType::default(),
@@ -8413,7 +7951,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedType {
         crate::ts::types::mapped_type::FormatTsMappedType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::mapped_type::FormatTsMappedType::default(),
@@ -8440,7 +7977,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeAsClause {
         crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause::default(),
@@ -8453,7 +7989,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeAsClause {
         crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::mapped_type_as_clause::FormatTsMappedTypeAsClause::default(),
@@ -8464,14 +7999,12 @@ impl FormatRule < biome_js_syntax :: TsMappedTypeOptionalModifierClause > for cr
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeOptionalModifierClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsMappedTypeOptionalModifierClause , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_optional_modifier_clause :: FormatTsMappedTypeOptionalModifierClause :: default ())
     }
 }
@@ -8479,14 +8012,12 @@ impl FormatRule < biome_js_syntax :: TsMappedTypeReadonlyModifierClause > for cr
 impl AsFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMappedTypeReadonlyModifierClause {
     type Format = FormatOwnedWithRule < biome_js_syntax :: TsMappedTypeReadonlyModifierClause , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: mapped_type_readonly_modifier_clause :: FormatTsMappedTypeReadonlyModifierClause :: default ())
     }
 }
@@ -8510,7 +8041,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureClassMember
         crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: method_signature_class_member :: FormatTsMethodSignatureClassMember :: default ())
     }
 }
@@ -8520,7 +8050,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureClassMemb
         crate::ts::classes::method_signature_class_member::FormatTsMethodSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: method_signature_class_member :: FormatTsMethodSignatureClassMember :: default ())
     }
 }
@@ -8544,7 +8073,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureTypeMember 
         crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: method_signature_type_member :: FormatTsMethodSignatureTypeMember :: default ())
     }
 }
@@ -8554,7 +8082,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureTypeMembe
         crate::ts::auxiliary::method_signature_type_member::FormatTsMethodSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: method_signature_type_member :: FormatTsMethodSignatureTypeMember :: default ())
     }
 }
@@ -8574,7 +8101,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsModuleBlock {
         crate::ts::auxiliary::module_block::FormatTsModuleBlock,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::module_block::FormatTsModuleBlock::default(),
@@ -8587,7 +8113,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsModuleBlock {
         crate::ts::auxiliary::module_block::FormatTsModuleBlock,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::module_block::FormatTsModuleBlock::default(),
@@ -8614,7 +8139,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsModuleDeclaration {
         crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::declarations::module_declaration::FormatTsModuleDeclaration::default(),
@@ -8627,7 +8151,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsModuleDeclaration {
         crate::ts::declarations::module_declaration::FormatTsModuleDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::declarations::module_declaration::FormatTsModuleDeclaration::default(),
@@ -8654,7 +8177,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNamedTupleTypeElement {
         crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement::default(
@@ -8668,7 +8190,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNamedTupleTypeElement {
         crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::named_tuple_type_element::FormatTsNamedTupleTypeElement::default(
@@ -8690,7 +8211,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNeverType {
         crate::ts::types::never_type::FormatTsNeverType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::never_type::FormatTsNeverType::default(),
@@ -8703,7 +8223,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNeverType {
         crate::ts::types::never_type::FormatTsNeverType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::never_type::FormatTsNeverType::default(),
@@ -8730,7 +8249,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionAssignment
         crate::ts::assignments::non_null_assertion_assignment::FormatTsNonNullAssertionAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment :: default ())
     }
 }
@@ -8740,7 +8258,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionAssignme
         crate::ts::assignments::non_null_assertion_assignment::FormatTsNonNullAssertionAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: assignments :: non_null_assertion_assignment :: FormatTsNonNullAssertionAssignment :: default ())
     }
 }
@@ -8764,7 +8281,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionExpression
         crate::ts::expressions::non_null_assertion_expression::FormatTsNonNullAssertionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression :: default ())
     }
 }
@@ -8774,7 +8290,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonNullAssertionExpressi
         crate::ts::expressions::non_null_assertion_expression::FormatTsNonNullAssertionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: non_null_assertion_expression :: FormatTsNonNullAssertionExpression :: default ())
     }
 }
@@ -8798,7 +8313,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNonPrimitiveType {
         crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType::default(),
@@ -8811,7 +8325,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNonPrimitiveType {
         crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::non_primitive_type::FormatTsNonPrimitiveType::default(),
@@ -8838,7 +8351,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNullLiteralType {
         crate::ts::types::null_literal_type::FormatTsNullLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::null_literal_type::FormatTsNullLiteralType::default(),
@@ -8851,7 +8363,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNullLiteralType {
         crate::ts::types::null_literal_type::FormatTsNullLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::null_literal_type::FormatTsNullLiteralType::default(),
@@ -8878,7 +8389,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNumberLiteralType {
         crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::number_literal_type::FormatTsNumberLiteralType::default(),
@@ -8891,7 +8401,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNumberLiteralType {
         crate::ts::types::number_literal_type::FormatTsNumberLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::number_literal_type::FormatTsNumberLiteralType::default(),
@@ -8914,7 +8423,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsNumberType {
         crate::ts::types::number_type::FormatTsNumberType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::number_type::FormatTsNumberType::default(),
@@ -8927,7 +8435,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsNumberType {
         crate::ts::types::number_type::FormatTsNumberType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::number_type::FormatTsNumberType::default(),
@@ -8950,7 +8457,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsObjectType {
         crate::ts::types::object_type::FormatTsObjectType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::object_type::FormatTsObjectType::default(),
@@ -8963,7 +8469,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsObjectType {
         crate::ts::types::object_type::FormatTsObjectType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::object_type::FormatTsObjectType::default(),
@@ -8990,7 +8495,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOptionalPropertyAnnotation
         crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_property_annotation :: FormatTsOptionalPropertyAnnotation :: default ())
     }
 }
@@ -9000,7 +8504,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalPropertyAnnotati
         crate::ts::auxiliary::optional_property_annotation::FormatTsOptionalPropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: optional_property_annotation :: FormatTsOptionalPropertyAnnotation :: default ())
     }
 }
@@ -9024,7 +8527,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOptionalTupleTypeElement {
         crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: optional_tuple_type_element :: FormatTsOptionalTupleTypeElement :: default ())
     }
 }
@@ -9034,7 +8536,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOptionalTupleTypeElement
         crate::ts::auxiliary::optional_tuple_type_element::FormatTsOptionalTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: optional_tuple_type_element :: FormatTsOptionalTupleTypeElement :: default ())
     }
 }
@@ -9054,7 +8555,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOutModifier {
         crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::out_modifier::FormatTsOutModifier::default(),
@@ -9067,7 +8567,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOutModifier {
         crate::ts::auxiliary::out_modifier::FormatTsOutModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::out_modifier::FormatTsOutModifier::default(),
@@ -9094,7 +8593,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsOverrideModifier {
         crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier::default(),
@@ -9107,7 +8605,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsOverrideModifier {
         crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::override_modifier::FormatTsOverrideModifier::default(),
@@ -9134,7 +8631,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsParenthesizedType {
         crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::parenthesized_type::FormatTsParenthesizedType::default(),
@@ -9147,7 +8643,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsParenthesizedType {
         crate::ts::types::parenthesized_type::FormatTsParenthesizedType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::parenthesized_type::FormatTsParenthesizedType::default(),
@@ -9174,7 +8669,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPredicateReturnType {
         crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::predicate_return_type::FormatTsPredicateReturnType::default(),
@@ -9187,7 +8681,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPredicateReturnType {
         crate::ts::types::predicate_return_type::FormatTsPredicateReturnType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::predicate_return_type::FormatTsPredicateReturnType::default(),
@@ -9214,7 +8707,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameter {
         crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::property_parameter::FormatTsPropertyParameter::default(),
@@ -9227,7 +8719,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameter {
         crate::ts::bindings::property_parameter::FormatTsPropertyParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::property_parameter::FormatTsPropertyParameter::default(),
@@ -9254,7 +8745,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureClassMemb
         crate::ts::classes::property_signature_class_member::FormatTsPropertySignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember :: default ())
     }
 }
@@ -9264,7 +8754,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureClassMe
         crate::ts::classes::property_signature_class_member::FormatTsPropertySignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: property_signature_class_member :: FormatTsPropertySignatureClassMember :: default ())
     }
 }
@@ -9288,7 +8777,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureTypeMembe
         crate::ts::auxiliary::property_signature_type_member::FormatTsPropertySignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember :: default ())
     }
 }
@@ -9298,7 +8786,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureTypeMem
         crate::ts::auxiliary::property_signature_type_member::FormatTsPropertySignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: property_signature_type_member :: FormatTsPropertySignatureTypeMember :: default ())
     }
 }
@@ -9322,7 +8809,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsQualifiedModuleName {
         crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName::default(),
@@ -9335,7 +8821,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsQualifiedModuleName {
         crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::qualified_module_name::FormatTsQualifiedModuleName::default(),
@@ -9362,7 +8847,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsQualifiedName {
         crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::qualified_name::FormatTsQualifiedName::default(),
@@ -9375,7 +8859,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsQualifiedName {
         crate::ts::auxiliary::qualified_name::FormatTsQualifiedName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::qualified_name::FormatTsQualifiedName::default(),
@@ -9402,7 +8885,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReadonlyModifier {
         crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier::default(),
@@ -9415,7 +8897,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReadonlyModifier {
         crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::readonly_modifier::FormatTsReadonlyModifier::default(),
@@ -9442,7 +8923,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReferenceType {
         crate::ts::types::reference_type::FormatTsReferenceType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::reference_type::FormatTsReferenceType::default(),
@@ -9455,7 +8935,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReferenceType {
         crate::ts::types::reference_type::FormatTsReferenceType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::reference_type::FormatTsReferenceType::default(),
@@ -9482,7 +8961,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsRestTupleTypeElement {
         crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement::default(),
@@ -9495,7 +8973,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsRestTupleTypeElement {
         crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::rest_tuple_type_element::FormatTsRestTupleTypeElement::default(),
@@ -9522,7 +8999,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsReturnTypeAnnotation {
         crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation::default(),
@@ -9535,7 +9011,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsReturnTypeAnnotation {
         crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::return_type_annotation::FormatTsReturnTypeAnnotation::default(),
@@ -9562,7 +9037,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesAssignment {
         crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment::default(),
@@ -9575,7 +9049,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesAssignment {
         crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::assignments::satisfies_assignment::FormatTsSatisfiesAssignment::default(),
@@ -9602,7 +9075,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesExpression {
         crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression::default(),
@@ -9615,7 +9087,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSatisfiesExpression {
         crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::expressions::satisfies_expression::FormatTsSatisfiesExpression::default(),
@@ -9642,7 +9113,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureClassMember
         crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: classes :: setter_signature_class_member :: FormatTsSetterSignatureClassMember :: default ())
     }
 }
@@ -9652,7 +9122,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureClassMemb
         crate::ts::classes::setter_signature_class_member::FormatTsSetterSignatureClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: classes :: setter_signature_class_member :: FormatTsSetterSignatureClassMember :: default ())
     }
 }
@@ -9676,7 +9145,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureTypeMember 
         crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: auxiliary :: setter_signature_type_member :: FormatTsSetterSignatureTypeMember :: default ())
     }
 }
@@ -9686,7 +9154,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSetterSignatureTypeMembe
         crate::ts::auxiliary::setter_signature_type_member::FormatTsSetterSignatureTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: auxiliary :: setter_signature_type_member :: FormatTsSetterSignatureTypeMember :: default ())
     }
 }
@@ -9710,7 +9177,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsStringLiteralType {
         crate::ts::types::string_literal_type::FormatTsStringLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::string_literal_type::FormatTsStringLiteralType::default(),
@@ -9723,7 +9189,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsStringLiteralType {
         crate::ts::types::string_literal_type::FormatTsStringLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::string_literal_type::FormatTsStringLiteralType::default(),
@@ -9746,7 +9211,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsStringType {
         crate::ts::types::string_type::FormatTsStringType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::string_type::FormatTsStringType::default(),
@@ -9759,7 +9223,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsStringType {
         crate::ts::types::string_type::FormatTsStringType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::string_type::FormatTsStringType::default(),
@@ -9782,7 +9245,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsSymbolType {
         crate::ts::types::symbol_type::FormatTsSymbolType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::symbol_type::FormatTsSymbolType::default(),
@@ -9795,7 +9257,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsSymbolType {
         crate::ts::types::symbol_type::FormatTsSymbolType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::symbol_type::FormatTsSymbolType::default(),
@@ -9822,7 +9283,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateChunkElement {
         crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement::default(),
@@ -9835,7 +9295,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateChunkElement {
         crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::template_chunk_element::FormatTsTemplateChunkElement::default(),
@@ -9862,7 +9321,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateElement {
         crate::ts::auxiliary::template_element::FormatTsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::template_element::FormatTsTemplateElement::default(),
@@ -9875,7 +9333,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateElement {
         crate::ts::auxiliary::template_element::FormatTsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::template_element::FormatTsTemplateElement::default(),
@@ -9902,7 +9359,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateLiteralType {
         crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::template_literal_type::FormatTsTemplateLiteralType::default(),
@@ -9915,7 +9371,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateLiteralType {
         crate::ts::types::template_literal_type::FormatTsTemplateLiteralType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::template_literal_type::FormatTsTemplateLiteralType::default(),
@@ -9942,7 +9397,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsThisParameter {
         crate::ts::bindings::this_parameter::FormatTsThisParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::this_parameter::FormatTsThisParameter::default(),
@@ -9955,7 +9409,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsThisParameter {
         crate::ts::bindings::this_parameter::FormatTsThisParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::this_parameter::FormatTsThisParameter::default(),
@@ -9976,7 +9429,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsThisType {
         crate::ts::types::this_type::FormatTsThisType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::this_type::FormatTsThisType::default(),
@@ -9989,7 +9441,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsThisType {
         crate::ts::types::this_type::FormatTsThisType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::this_type::FormatTsThisType::default(),
@@ -10010,7 +9461,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTupleType {
         crate::ts::types::tuple_type::FormatTsTupleType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::tuple_type::FormatTsTupleType::default(),
@@ -10023,7 +9473,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTupleType {
         crate::ts::types::tuple_type::FormatTsTupleType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::tuple_type::FormatTsTupleType::default(),
@@ -10050,7 +9499,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAliasDeclaration {
         crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration::default(
@@ -10064,7 +9512,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAliasDeclaration {
         crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::declarations::type_alias_declaration::FormatTsTypeAliasDeclaration::default(
@@ -10092,7 +9539,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAnnotation {
         crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation::default(),
@@ -10105,7 +9551,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAnnotation {
         crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::type_annotation::FormatTsTypeAnnotation::default(),
@@ -10132,7 +9577,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeArguments {
         crate::ts::expressions::type_arguments::FormatTsTypeArguments,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::expressions::type_arguments::FormatTsTypeArguments::default(),
@@ -10145,7 +9589,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeArguments {
         crate::ts::expressions::type_arguments::FormatTsTypeArguments,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::expressions::type_arguments::FormatTsTypeArguments::default(),
@@ -10172,7 +9615,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionAssignment {
         crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: assignments :: type_assertion_assignment :: FormatTsTypeAssertionAssignment :: default ())
     }
 }
@@ -10182,7 +9624,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionAssignment 
         crate::ts::assignments::type_assertion_assignment::FormatTsTypeAssertionAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: assignments :: type_assertion_assignment :: FormatTsTypeAssertionAssignment :: default ())
     }
 }
@@ -10206,7 +9647,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionExpression {
         crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: expressions :: type_assertion_expression :: FormatTsTypeAssertionExpression :: default ())
     }
 }
@@ -10216,7 +9656,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeAssertionExpression 
         crate::ts::expressions::type_assertion_expression::FormatTsTypeAssertionExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: expressions :: type_assertion_expression :: FormatTsTypeAssertionExpression :: default ())
     }
 }
@@ -10240,7 +9679,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeConstraintClause {
         crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause::default(),
@@ -10253,7 +9691,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeConstraintClause {
         crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::type_constraint_clause::FormatTsTypeConstraintClause::default(),
@@ -10280,7 +9717,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeOperatorType {
         crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::type_operator_type::FormatTsTypeOperatorType::default(),
@@ -10293,7 +9729,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeOperatorType {
         crate::ts::types::type_operator_type::FormatTsTypeOperatorType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::type_operator_type::FormatTsTypeOperatorType::default(),
@@ -10320,7 +9755,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameter {
         crate::ts::bindings::type_parameter::FormatTsTypeParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::type_parameter::FormatTsTypeParameter::default(),
@@ -10333,7 +9767,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameter {
         crate::ts::bindings::type_parameter::FormatTsTypeParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::type_parameter::FormatTsTypeParameter::default(),
@@ -10360,7 +9793,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterName {
         crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName::default(),
@@ -10373,7 +9805,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterName {
         crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::auxiliary::type_parameter_name::FormatTsTypeParameterName::default(),
@@ -10400,7 +9831,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameters {
         crate::ts::bindings::type_parameters::FormatTsTypeParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bindings::type_parameters::FormatTsTypeParameters::default(),
@@ -10413,7 +9843,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameters {
         crate::ts::bindings::type_parameters::FormatTsTypeParameters,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bindings::type_parameters::FormatTsTypeParameters::default(),
@@ -10436,7 +9865,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeofType {
         crate::ts::types::typeof_type::FormatTsTypeofType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::typeof_type::FormatTsTypeofType::default(),
@@ -10449,7 +9877,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeofType {
         crate::ts::types::typeof_type::FormatTsTypeofType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::typeof_type::FormatTsTypeofType::default(),
@@ -10476,7 +9903,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUndefinedType {
         crate::ts::types::undefined_type::FormatTsUndefinedType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::undefined_type::FormatTsUndefinedType::default(),
@@ -10489,7 +9915,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUndefinedType {
         crate::ts::types::undefined_type::FormatTsUndefinedType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::undefined_type::FormatTsUndefinedType::default(),
@@ -10510,7 +9935,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnionType {
         crate::ts::types::union_type::FormatTsUnionType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::union_type::FormatTsUnionType::default(),
@@ -10523,7 +9947,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnionType {
         crate::ts::types::union_type::FormatTsUnionType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::union_type::FormatTsUnionType::default(),
@@ -10546,7 +9969,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnknownType {
         crate::ts::types::unknown_type::FormatTsUnknownType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::unknown_type::FormatTsUnknownType::default(),
@@ -10559,7 +9981,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnknownType {
         crate::ts::types::unknown_type::FormatTsUnknownType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::unknown_type::FormatTsUnknownType::default(),
@@ -10580,7 +10001,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
         crate::ts::types::void_type::FormatTsVoidType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::types::void_type::FormatTsVoidType::default(),
@@ -10593,7 +10013,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
         crate::ts::types::void_type::FormatTsVoidType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::types::void_type::FormatTsVoidType::default(),
@@ -10603,28 +10022,24 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsVoidType {
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayAssignmentPatternElementList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayAssignmentPatternElementList , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_assignment_pattern_element_list :: FormatJsArrayAssignmentPatternElementList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternElementList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayBindingPatternElementList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsArrayBindingPatternElementList , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: array_binding_pattern_element_list :: FormatJsArrayBindingPatternElementList :: default ())
     }
 }
@@ -10635,7 +10050,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsArrayElementList {
         crate::js::lists::array_element_list::FormatJsArrayElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::array_element_list::FormatJsArrayElementList::default(),
@@ -10648,7 +10062,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsArrayElementList {
         crate::js::lists::array_element_list::FormatJsArrayElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::array_element_list::FormatJsArrayElementList::default(),
@@ -10662,7 +10075,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsCallArgumentList {
         crate::js::lists::call_argument_list::FormatJsCallArgumentList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::call_argument_list::FormatJsCallArgumentList::default(),
@@ -10675,7 +10087,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsCallArgumentList {
         crate::js::lists::call_argument_list::FormatJsCallArgumentList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::call_argument_list::FormatJsCallArgumentList::default(),
@@ -10689,7 +10100,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsClassMemberList {
         crate::js::lists::class_member_list::FormatJsClassMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::class_member_list::FormatJsClassMemberList::default(),
@@ -10702,7 +10112,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsClassMemberList {
         crate::js::lists::class_member_list::FormatJsClassMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::class_member_list::FormatJsClassMemberList::default(),
@@ -10716,7 +10125,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorModifierList {
         crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList::default(),
@@ -10729,7 +10137,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorModifierList 
         crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::constructor_modifier_list::FormatJsConstructorModifierList::default(),
@@ -10743,7 +10150,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameterList {
         crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList::default(
@@ -10757,7 +10163,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsConstructorParameterList
         crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::constructor_parameter_list::FormatJsConstructorParameterList::default(
@@ -10772,7 +10177,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDecoratorList {
         crate::js::lists::decorator_list::FormatJsDecoratorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::decorator_list::FormatJsDecoratorList::default(),
@@ -10785,7 +10189,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDecoratorList {
         crate::js::lists::decorator_list::FormatJsDecoratorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::decorator_list::FormatJsDecoratorList::default(),
@@ -10799,7 +10202,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsDirectiveList {
         crate::js::lists::directive_list::FormatJsDirectiveList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::directive_list::FormatJsDirectiveList::default(),
@@ -10812,7 +10214,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsDirectiveList {
         crate::js::lists::directive_list::FormatJsDirectiveList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::directive_list::FormatJsDirectiveList::default(),
@@ -10826,7 +10227,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifierLi
         crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
@@ -10836,7 +10236,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedFromSpecifier
         crate::js::lists::export_named_from_specifier_list::FormatJsExportNamedFromSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_from_specifier_list :: FormatJsExportNamedFromSpecifierList :: default ())
     }
 }
@@ -10847,7 +10246,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList {
         crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
@@ -10857,7 +10255,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsExportNamedSpecifierList
         crate::js::lists::export_named_specifier_list::FormatJsExportNamedSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: export_named_specifier_list :: FormatJsExportNamedSpecifierList :: default ())
     }
 }
@@ -10868,7 +10265,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList {
         crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
@@ -10878,7 +10274,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsImportAssertionEntryList
         crate::js::lists::import_assertion_entry_list::FormatJsImportAssertionEntryList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: import_assertion_entry_list :: FormatJsImportAssertionEntryList :: default ())
     }
 }
@@ -10889,7 +10284,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsMethodModifierList {
         crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::method_modifier_list::FormatJsMethodModifierList::default(),
@@ -10902,7 +10296,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsMethodModifierList {
         crate::js::lists::method_modifier_list::FormatJsMethodModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::method_modifier_list::FormatJsMethodModifierList::default(),
@@ -10916,7 +10309,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsModuleItemList {
         crate::js::lists::module_item_list::FormatJsModuleItemList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::module_item_list::FormatJsModuleItemList::default(),
@@ -10929,7 +10321,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsModuleItemList {
         crate::js::lists::module_item_list::FormatJsModuleItemList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::module_item_list::FormatJsModuleItemList::default(),
@@ -10943,7 +10334,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifierList {
         crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
@@ -10953,35 +10343,30 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsNamedImportSpecifierList
         crate::js::lists::named_import_specifier_list::FormatJsNamedImportSpecifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: named_import_specifier_list :: FormatJsNamedImportSpecifierList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectAssignmentPatternPropertyList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectAssignmentPatternPropertyList , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_assignment_pattern_property_list :: FormatJsObjectAssignmentPatternPropertyList :: default ())
     }
 }
 impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format < 'a > = FormatRefWithRule < 'a , biome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
 impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectBindingPatternPropertyList {
     type Format = FormatOwnedWithRule < biome_js_syntax :: JsObjectBindingPatternPropertyList , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList > ;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: lists :: object_binding_pattern_property_list :: FormatJsObjectBindingPatternPropertyList :: default ())
     }
 }
@@ -10992,7 +10377,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsObjectMemberList {
         crate::js::lists::object_member_list::FormatJsObjectMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::object_member_list::FormatJsObjectMemberList::default(),
@@ -11005,7 +10389,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsObjectMemberList {
         crate::js::lists::object_member_list::FormatJsObjectMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::object_member_list::FormatJsObjectMemberList::default(),
@@ -11019,7 +10402,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsParameterList {
         crate::js::lists::parameter_list::FormatJsParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::parameter_list::FormatJsParameterList::default(),
@@ -11032,7 +10414,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsParameterList {
         crate::js::lists::parameter_list::FormatJsParameterList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::parameter_list::FormatJsParameterList::default(),
@@ -11046,7 +10427,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsPropertyModifierList {
         crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::property_modifier_list::FormatJsPropertyModifierList::default(),
@@ -11059,7 +10439,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsPropertyModifierList {
         crate::js::lists::property_modifier_list::FormatJsPropertyModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::property_modifier_list::FormatJsPropertyModifierList::default(),
@@ -11073,7 +10452,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsStatementList {
         crate::js::lists::statement_list::FormatJsStatementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::statement_list::FormatJsStatementList::default(),
@@ -11086,7 +10464,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsStatementList {
         crate::js::lists::statement_list::FormatJsStatementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::statement_list::FormatJsStatementList::default(),
@@ -11100,7 +10477,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsSwitchCaseList {
         crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::switch_case_list::FormatJsSwitchCaseList::default(),
@@ -11113,7 +10489,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsSwitchCaseList {
         crate::js::lists::switch_case_list::FormatJsSwitchCaseList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::switch_case_list::FormatJsSwitchCaseList::default(),
@@ -11127,7 +10502,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsTemplateElementList {
         crate::js::lists::template_element_list::FormatJsTemplateElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::template_element_list::FormatJsTemplateElementList::default(),
@@ -11140,7 +10514,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsTemplateElementList {
         crate::js::lists::template_element_list::FormatJsTemplateElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::template_element_list::FormatJsTemplateElementList::default(),
@@ -11154,7 +10527,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaratorList {
         crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList::default(),
@@ -11167,7 +10539,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsVariableDeclaratorList {
         crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::lists::variable_declarator_list::FormatJsVariableDeclaratorList::default(),
@@ -11181,7 +10552,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxAttributeList {
         crate::jsx::lists::attribute_list::FormatJsxAttributeList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::lists::attribute_list::FormatJsxAttributeList::default(),
@@ -11194,7 +10564,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxAttributeList {
         crate::jsx::lists::attribute_list::FormatJsxAttributeList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::lists::attribute_list::FormatJsxAttributeList::default(),
@@ -11208,7 +10577,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsxChildList {
         crate::jsx::lists::child_list::FormatJsxChildList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::lists::child_list::FormatJsxChildList::default(),
@@ -11221,7 +10589,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsxChildList {
         crate::jsx::lists::child_list::FormatJsxChildList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::lists::child_list::FormatJsxChildList::default(),
@@ -11235,7 +10602,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsEnumMemberList {
         crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::enum_member_list::FormatTsEnumMemberList::default(),
@@ -11248,7 +10614,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsEnumMemberList {
         crate::ts::lists::enum_member_list::FormatTsEnumMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::enum_member_list::FormatTsEnumMemberList::default(),
@@ -11262,7 +10627,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureModifierList
         crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
@@ -11272,7 +10636,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIndexSignatureModifierLi
         crate::ts::lists::index_signature_modifier_list::FormatTsIndexSignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: index_signature_modifier_list :: FormatTsIndexSignatureModifierList :: default ())
     }
 }
@@ -11283,7 +10646,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementLis
         crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
@@ -11293,7 +10655,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsIntersectionTypeElementL
         crate::ts::lists::intersection_type_element_list::FormatTsIntersectionTypeElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: intersection_type_element_list :: FormatTsIntersectionTypeElementList :: default ())
     }
 }
@@ -11304,7 +10665,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierLis
         crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
@@ -11314,7 +10674,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsMethodSignatureModifierL
         crate::ts::lists::method_signature_modifier_list::FormatTsMethodSignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: method_signature_modifier_list :: FormatTsMethodSignatureModifierList :: default ())
     }
 }
@@ -11325,7 +10684,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifierL
         crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
@@ -11335,7 +10693,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertyParameterModifie
         crate::ts::lists::property_parameter_modifier_list::FormatTsPropertyParameterModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_parameter_modifier_list :: FormatTsPropertyParameterModifierList :: default ())
     }
 }
@@ -11346,7 +10703,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifierL
         crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
@@ -11356,7 +10712,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsPropertySignatureModifie
         crate::ts::lists::property_signature_modifier_list::FormatTsPropertySignatureModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: property_signature_modifier_list :: FormatTsPropertySignatureModifierList :: default ())
     }
 }
@@ -11367,7 +10722,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTemplateElementList {
         crate::ts::lists::template_element_list::FormatTsTemplateElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::template_element_list::FormatTsTemplateElementList::default(),
@@ -11380,7 +10734,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTemplateElementList {
         crate::ts::lists::template_element_list::FormatTsTemplateElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::template_element_list::FormatTsTemplateElementList::default(),
@@ -11394,7 +10747,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTupleTypeElementList {
         crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList::default(),
@@ -11407,7 +10759,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTupleTypeElementList {
         crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::tuple_type_element_list::FormatTsTupleTypeElementList::default(),
@@ -11421,7 +10772,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeArgumentList {
         crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::type_argument_list::FormatTsTypeArgumentList::default(),
@@ -11434,7 +10784,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeArgumentList {
         crate::ts::lists::type_argument_list::FormatTsTypeArgumentList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::type_argument_list::FormatTsTypeArgumentList::default(),
@@ -11448,7 +10797,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeList {
         crate::ts::lists::type_list::FormatTsTypeList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::type_list::FormatTsTypeList::default(),
@@ -11461,7 +10809,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeList {
         crate::ts::lists::type_list::FormatTsTypeList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::type_list::FormatTsTypeList::default(),
@@ -11475,7 +10822,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeMemberList {
         crate::ts::lists::type_member_list::FormatTsTypeMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::type_member_list::FormatTsTypeMemberList::default(),
@@ -11488,7 +10834,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeMemberList {
         crate::ts::lists::type_member_list::FormatTsTypeMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::type_member_list::FormatTsTypeMemberList::default(),
@@ -11502,7 +10847,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterList {
         crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::type_parameter_list::FormatTsTypeParameterList::default(),
@@ -11515,7 +10859,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterList {
         crate::ts::lists::type_parameter_list::FormatTsTypeParameterList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::type_parameter_list::FormatTsTypeParameterList::default(),
@@ -11529,7 +10872,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterModifierList 
         crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: lists :: type_parameter_modifier_list :: FormatTsTypeParameterModifierList :: default ())
     }
 }
@@ -11539,7 +10881,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsTypeParameterModifierLis
         crate::ts::lists::type_parameter_modifier_list::FormatTsTypeParameterModifierList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: lists :: type_parameter_modifier_list :: FormatTsTypeParameterModifierList :: default ())
     }
 }
@@ -11550,7 +10891,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsUnionTypeVariantList {
         crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList::default(),
@@ -11563,7 +10903,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsUnionTypeVariantList {
         crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::lists::union_type_variant_list::FormatTsUnionTypeVariantList::default(),
@@ -11581,7 +10920,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogus {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::JsBogus, crate::js::bogus::bogus::FormatJsBogus>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus::default())
     }
 }
@@ -11589,7 +10927,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogus {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::JsBogus, crate::js::bogus::bogus::FormatJsBogus>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::bogus::bogus::FormatJsBogus::default())
     }
 }
@@ -11613,7 +10950,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusAssignment {
         crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_assignment::FormatJsBogusAssignment::default(),
@@ -11626,7 +10962,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusAssignment {
         crate::js::bogus::bogus_assignment::FormatJsBogusAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_assignment::FormatJsBogusAssignment::default(),
@@ -11649,7 +10984,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusBinding {
         crate::js::bogus::bogus_binding::FormatJsBogusBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_binding::FormatJsBogusBinding::default(),
@@ -11662,7 +10996,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusBinding {
         crate::js::bogus::bogus_binding::FormatJsBogusBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_binding::FormatJsBogusBinding::default(),
@@ -11689,7 +11022,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusExpression {
         crate::js::bogus::bogus_expression::FormatJsBogusExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_expression::FormatJsBogusExpression::default(),
@@ -11702,7 +11034,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusExpression {
         crate::js::bogus::bogus_expression::FormatJsBogusExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_expression::FormatJsBogusExpression::default(),
@@ -11729,7 +11060,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusImportAssertionEntry 
         crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bogus :: bogus_import_assertion_entry :: FormatJsBogusImportAssertionEntry :: default ())
     }
 }
@@ -11739,7 +11069,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusImportAssertionEntr
         crate::js::bogus::bogus_import_assertion_entry::FormatJsBogusImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bogus :: bogus_import_assertion_entry :: FormatJsBogusImportAssertionEntry :: default ())
     }
 }
@@ -11759,7 +11088,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusMember {
         crate::js::bogus::bogus_member::FormatJsBogusMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_member::FormatJsBogusMember::default(),
@@ -11772,7 +11100,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusMember {
         crate::js::bogus::bogus_member::FormatJsBogusMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_member::FormatJsBogusMember::default(),
@@ -11799,7 +11126,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusNamedImportSpecifier 
         crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: bogus :: bogus_named_import_specifier :: FormatJsBogusNamedImportSpecifier :: default ())
     }
 }
@@ -11809,7 +11135,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusNamedImportSpecifie
         crate::js::bogus::bogus_named_import_specifier::FormatJsBogusNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: bogus :: bogus_named_import_specifier :: FormatJsBogusNamedImportSpecifier :: default ())
     }
 }
@@ -11833,7 +11158,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusParameter {
         crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_parameter::FormatJsBogusParameter::default(),
@@ -11846,7 +11170,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusParameter {
         crate::js::bogus::bogus_parameter::FormatJsBogusParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_parameter::FormatJsBogusParameter::default(),
@@ -11873,7 +11196,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::JsBogusStatement {
         crate::js::bogus::bogus_statement::FormatJsBogusStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::bogus::bogus_statement::FormatJsBogusStatement::default(),
@@ -11886,7 +11208,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::JsBogusStatement {
         crate::js::bogus::bogus_statement::FormatJsBogusStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::bogus::bogus_statement::FormatJsBogusStatement::default(),
@@ -11907,7 +11228,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::TsBogusType {
         crate::ts::bogus::bogus_type::FormatTsBogusType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::bogus::bogus_type::FormatTsBogusType::default(),
@@ -11920,7 +11240,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::TsBogusType {
         crate::ts::bogus::bogus_type::FormatTsBogusType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::bogus::bogus_type::FormatTsBogusType::default(),
@@ -11934,7 +11253,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatternE
         crate::js::any::array_assignment_pattern_element::FormatAnyJsArrayAssignmentPatternElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement :: default ())
     }
 }
@@ -11944,7 +11262,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayAssignmentPatter
         crate::js::any::array_assignment_pattern_element::FormatAnyJsArrayAssignmentPatternElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: any :: array_assignment_pattern_element :: FormatAnyJsArrayAssignmentPatternElement :: default ())
     }
 }
@@ -11955,7 +11272,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternElem
         crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatAnyJsArrayBindingPatternElement :: default ())
     }
 }
@@ -11965,7 +11281,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayBindingPatternEl
         crate::js::any::array_binding_pattern_element::FormatAnyJsArrayBindingPatternElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: any :: array_binding_pattern_element :: FormatAnyJsArrayBindingPatternElement :: default ())
     }
 }
@@ -11976,7 +11291,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
         crate::js::any::array_element::FormatAnyJsArrayElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::array_element::FormatAnyJsArrayElement::default(),
@@ -11989,7 +11303,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrayElement {
         crate::js::any::array_element::FormatAnyJsArrayElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::array_element::FormatAnyJsArrayElement::default(),
@@ -12003,7 +11316,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsArrowFunctionParameters
         crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters::default(
@@ -12017,7 +11329,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsArrowFunctionParamete
         crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::arrow_function_parameters::FormatAnyJsArrowFunctionParameters::default(
@@ -12032,7 +11343,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
         crate::js::any::assignment::FormatAnyJsAssignment,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::assignment::FormatAnyJsAssignment::default(),
@@ -12045,7 +11355,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignment {
         crate::js::any::assignment::FormatAnyJsAssignment,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::assignment::FormatAnyJsAssignment::default(),
@@ -12059,7 +11368,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignmentPattern {
         crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern::default(),
@@ -12072,7 +11380,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsAssignmentPattern {
         crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::assignment_pattern::FormatAnyJsAssignmentPattern::default(),
@@ -12086,7 +11393,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsBinding {
         crate::js::any::binding::FormatAnyJsBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding::default())
     }
 }
@@ -12096,7 +11402,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsBinding {
         crate::js::any::binding::FormatAnyJsBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::any::binding::FormatAnyJsBinding::default())
     }
 }
@@ -12107,7 +11412,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsBindingPattern {
         crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::binding_pattern::FormatAnyJsBindingPattern::default(),
@@ -12120,7 +11424,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsBindingPattern {
         crate::js::any::binding_pattern::FormatAnyJsBindingPattern,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::binding_pattern::FormatAnyJsBindingPattern::default(),
@@ -12134,7 +11437,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
         crate::js::any::call_argument::FormatAnyJsCallArgument,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::call_argument::FormatAnyJsCallArgument::default(),
@@ -12147,7 +11449,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsCallArgument {
         crate::js::any::call_argument::FormatAnyJsCallArgument,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::call_argument::FormatAnyJsCallArgument::default(),
@@ -12158,7 +11459,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClass {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsClass, crate::js::any::class::FormatAnyJsClass>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::any::class::FormatAnyJsClass::default())
     }
 }
@@ -12166,7 +11466,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClass {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsClass, crate::js::any::class::FormatAnyJsClass>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::any::class::FormatAnyJsClass::default())
     }
 }
@@ -12177,7 +11476,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMember {
         crate::js::any::class_member::FormatAnyJsClassMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::class_member::FormatAnyJsClassMember::default(),
@@ -12190,7 +11488,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMember {
         crate::js::any::class_member::FormatAnyJsClassMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::class_member::FormatAnyJsClassMember::default(),
@@ -12204,7 +11501,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMemberName {
         crate::js::any::class_member_name::FormatAnyJsClassMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::class_member_name::FormatAnyJsClassMemberName::default(),
@@ -12217,7 +11513,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsClassMemberName {
         crate::js::any::class_member_name::FormatAnyJsClassMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::class_member_name::FormatAnyJsClassMemberName::default(),
@@ -12231,7 +11526,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsCombinedSpecifier {
         crate::js::any::combined_specifier::FormatAnyJsCombinedSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::combined_specifier::FormatAnyJsCombinedSpecifier::default(),
@@ -12244,7 +11538,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsCombinedSpecifier {
         crate::js::any::combined_specifier::FormatAnyJsCombinedSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::combined_specifier::FormatAnyJsCombinedSpecifier::default(),
@@ -12258,7 +11551,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsConstructorParameter {
         crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter::default(),
@@ -12271,7 +11563,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsConstructorParameter 
         crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::constructor_parameter::FormatAnyJsConstructorParameter::default(),
@@ -12285,7 +11576,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
         crate::js::any::declaration::FormatAnyJsDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::declaration::FormatAnyJsDeclaration::default(),
@@ -12298,7 +11588,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclaration {
         crate::js::any::declaration::FormatAnyJsDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::declaration::FormatAnyJsDeclaration::default(),
@@ -12312,7 +11601,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclarationClause {
         crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::declaration_clause::FormatAnyJsDeclarationClause::default(),
@@ -12325,7 +11613,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDeclarationClause {
         crate::js::any::declaration_clause::FormatAnyJsDeclarationClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::declaration_clause::FormatAnyJsDeclarationClause::default(),
@@ -12339,7 +11626,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
         crate::js::any::decorator::FormatAnyJsDecorator,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::decorator::FormatAnyJsDecorator::default(),
@@ -12352,7 +11638,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsDecorator {
         crate::js::any::decorator::FormatAnyJsDecorator,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::decorator::FormatAnyJsDecorator::default(),
@@ -12366,7 +11651,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportClause {
         crate::js::any::export_clause::FormatAnyJsExportClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::export_clause::FormatAnyJsExportClause::default(),
@@ -12379,7 +11663,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportClause {
         crate::js::any::export_clause::FormatAnyJsExportClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::export_clause::FormatAnyJsExportClause::default(),
@@ -12393,7 +11676,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclaratio
         crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatAnyJsExportDefaultDeclaration :: default ())
     }
 }
@@ -12403,7 +11685,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportDefaultDeclarat
         crate::js::any::export_default_declaration::FormatAnyJsExportDefaultDeclaration,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: any :: export_default_declaration :: FormatAnyJsExportDefaultDeclaration :: default ())
     }
 }
@@ -12414,7 +11695,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExportNamedSpecifier {
         crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier::default(),
@@ -12427,7 +11707,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExportNamedSpecifier 
         crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::export_named_specifier::FormatAnyJsExportNamedSpecifier::default(),
@@ -12441,7 +11720,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
         crate::js::any::expression::FormatAnyJsExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::expression::FormatAnyJsExpression::default(),
@@ -12454,7 +11732,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsExpression {
         crate::js::any::expression::FormatAnyJsExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::expression::FormatAnyJsExpression::default(),
@@ -12468,7 +11745,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsForInOrOfInitializer {
         crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer::default(),
@@ -12481,7 +11757,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsForInOrOfInitializer 
         crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::for_in_or_of_initializer::FormatAnyJsForInOrOfInitializer::default(),
@@ -12495,7 +11770,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsForInitializer {
         crate::js::any::for_initializer::FormatAnyJsForInitializer,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::for_initializer::FormatAnyJsForInitializer::default(),
@@ -12508,7 +11782,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsForInitializer {
         crate::js::any::for_initializer::FormatAnyJsForInitializer,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::for_initializer::FormatAnyJsForInitializer::default(),
@@ -12522,7 +11795,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFormalParameter {
         crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::formal_parameter::FormatAnyJsFormalParameter::default(),
@@ -12535,7 +11807,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFormalParameter {
         crate::js::any::formal_parameter::FormatAnyJsFormalParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::formal_parameter::FormatAnyJsFormalParameter::default(),
@@ -12549,7 +11820,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFunction {
         crate::js::any::function::FormatAnyJsFunction,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::function::FormatAnyJsFunction::default(),
@@ -12562,7 +11832,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunction {
         crate::js::any::function::FormatAnyJsFunction,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::function::FormatAnyJsFunction::default(),
@@ -12576,7 +11845,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsFunctionBody {
         crate::js::any::function_body::FormatAnyJsFunctionBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::function_body::FormatAnyJsFunctionBody::default(),
@@ -12589,7 +11857,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsFunctionBody {
         crate::js::any::function_body::FormatAnyJsFunctionBody,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::function_body::FormatAnyJsFunctionBody::default(),
@@ -12603,7 +11870,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsImportAssertionEntry {
         crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry::default(),
@@ -12616,7 +11882,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsImportAssertionEntry 
         crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::import_assertion_entry::FormatAnyJsImportAssertionEntry::default(),
@@ -12630,7 +11895,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
         crate::js::any::import_clause::FormatAnyJsImportClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::import_clause::FormatAnyJsImportClause::default(),
@@ -12643,7 +11907,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsImportClause {
         crate::js::any::import_clause::FormatAnyJsImportClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::import_clause::FormatAnyJsImportClause::default(),
@@ -12657,7 +11920,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
         crate::js::any::in_property::FormatAnyJsInProperty,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::in_property::FormatAnyJsInProperty::default(),
@@ -12670,7 +11932,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsInProperty {
         crate::js::any::in_property::FormatAnyJsInProperty,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::in_property::FormatAnyJsInProperty::default(),
@@ -12684,7 +11945,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsLiteralExpression {
         crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::literal_expression::FormatAnyJsLiteralExpression::default(),
@@ -12697,7 +11957,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsLiteralExpression {
         crate::js::any::literal_expression::FormatAnyJsLiteralExpression,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::literal_expression::FormatAnyJsLiteralExpression::default(),
@@ -12711,7 +11970,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsMethodModifier {
         crate::js::any::method_modifier::FormatAnyJsMethodModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::method_modifier::FormatAnyJsMethodModifier::default(),
@@ -12724,7 +11982,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsMethodModifier {
         crate::js::any::method_modifier::FormatAnyJsMethodModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::method_modifier::FormatAnyJsMethodModifier::default(),
@@ -12738,7 +11995,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleItem {
         crate::js::any::module_item::FormatAnyJsModuleItem,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::module_item::FormatAnyJsModuleItem::default(),
@@ -12751,7 +12007,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleItem {
         crate::js::any::module_item::FormatAnyJsModuleItem,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::module_item::FormatAnyJsModuleItem::default(),
@@ -12765,7 +12020,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleSource {
         crate::js::any::module_source::FormatAnyJsModuleSource,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::module_source::FormatAnyJsModuleSource::default(),
@@ -12778,7 +12032,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsModuleSource {
         crate::js::any::module_source::FormatAnyJsModuleSource,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::module_source::FormatAnyJsModuleSource::default(),
@@ -12789,7 +12042,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsName, crate::js::any::name::FormatAnyJsName>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::any::name::FormatAnyJsName::default())
     }
 }
@@ -12797,7 +12049,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsName, crate::js::any::name::FormatAnyJsName>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::any::name::FormatAnyJsName::default())
     }
 }
@@ -12808,7 +12059,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImportSpecifier {
         crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier::default(),
@@ -12821,7 +12071,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsNamedImportSpecifier 
         crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::named_import_specifier::FormatAnyJsNamedImportSpecifier::default(),
@@ -12835,7 +12084,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPattern
         crate::js::any::object_assignment_pattern_member::FormatAnyJsObjectAssignmentPatternMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember :: default ())
     }
 }
@@ -12845,7 +12093,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectAssignmentPatte
         crate::js::any::object_assignment_pattern_member::FormatAnyJsObjectAssignmentPatternMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: any :: object_assignment_pattern_member :: FormatAnyJsObjectAssignmentPatternMember :: default ())
     }
 }
@@ -12856,7 +12103,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternMem
         crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatAnyJsObjectBindingPatternMember :: default ())
     }
 }
@@ -12866,7 +12112,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectBindingPatternM
         crate::js::any::object_binding_pattern_member::FormatAnyJsObjectBindingPatternMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: js :: any :: object_binding_pattern_member :: FormatAnyJsObjectBindingPatternMember :: default ())
     }
 }
@@ -12877,7 +12122,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMember {
         crate::js::any::object_member::FormatAnyJsObjectMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::object_member::FormatAnyJsObjectMember::default(),
@@ -12890,7 +12134,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMember {
         crate::js::any::object_member::FormatAnyJsObjectMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::object_member::FormatAnyJsObjectMember::default(),
@@ -12904,7 +12147,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMemberName {
         crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::object_member_name::FormatAnyJsObjectMemberName::default(),
@@ -12917,7 +12159,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsObjectMemberName {
         crate::js::any::object_member_name::FormatAnyJsObjectMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::object_member_name::FormatAnyJsObjectMemberName::default(),
@@ -12931,7 +12172,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
         crate::js::any::parameter::FormatAnyJsParameter,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::parameter::FormatAnyJsParameter::default(),
@@ -12944,7 +12184,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsParameter {
         crate::js::any::parameter::FormatAnyJsParameter,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::parameter::FormatAnyJsParameter::default(),
@@ -12958,7 +12197,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsPropertyModifier {
         crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::property_modifier::FormatAnyJsPropertyModifier::default(),
@@ -12971,7 +12209,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsPropertyModifier {
         crate::js::any::property_modifier::FormatAnyJsPropertyModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::property_modifier::FormatAnyJsPropertyModifier::default(),
@@ -12982,7 +12219,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsRoot {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsRoot, crate::js::any::root::FormatAnyJsRoot>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::js::any::root::FormatAnyJsRoot::default())
     }
 }
@@ -12990,7 +12226,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsRoot {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsRoot, crate::js::any::root::FormatAnyJsRoot>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::js::any::root::FormatAnyJsRoot::default())
     }
 }
@@ -13001,7 +12236,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
         crate::js::any::statement::FormatAnyJsStatement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::statement::FormatAnyJsStatement::default(),
@@ -13014,7 +12248,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsStatement {
         crate::js::any::statement::FormatAnyJsStatement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::statement::FormatAnyJsStatement::default(),
@@ -13028,7 +12261,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsSwitchClause {
         crate::js::any::switch_clause::FormatAnyJsSwitchClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::switch_clause::FormatAnyJsSwitchClause::default(),
@@ -13041,7 +12273,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsSwitchClause {
         crate::js::any::switch_clause::FormatAnyJsSwitchClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::switch_clause::FormatAnyJsSwitchClause::default(),
@@ -13055,7 +12286,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsTemplateElement {
         crate::js::any::template_element::FormatAnyJsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::js::any::template_element::FormatAnyJsTemplateElement::default(),
@@ -13068,7 +12298,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsTemplateElement {
         crate::js::any::template_element::FormatAnyJsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::js::any::template_element::FormatAnyJsTemplateElement::default(),
@@ -13082,7 +12311,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
         crate::jsx::any::attribute::FormatAnyJsxAttribute,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::any::attribute::FormatAnyJsxAttribute::default(),
@@ -13095,7 +12323,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttribute {
         crate::jsx::any::attribute::FormatAnyJsxAttribute,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::any::attribute::FormatAnyJsxAttribute::default(),
@@ -13109,7 +12336,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeName {
         crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::any::attribute_name::FormatAnyJsxAttributeName::default(),
@@ -13122,7 +12348,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeName {
         crate::jsx::any::attribute_name::FormatAnyJsxAttributeName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::any::attribute_name::FormatAnyJsxAttributeName::default(),
@@ -13136,7 +12361,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeValue {
         crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue::default(),
@@ -13149,7 +12373,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxAttributeValue {
         crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::any::attribute_value::FormatAnyJsxAttributeValue::default(),
@@ -13163,7 +12386,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxChild {
         crate::jsx::any::child::FormatAnyJsxChild,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild::default())
     }
 }
@@ -13173,7 +12395,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxChild {
         crate::jsx::any::child::FormatAnyJsxChild,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::any::child::FormatAnyJsxChild::default())
     }
 }
@@ -13184,7 +12405,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
         crate::jsx::any::element_name::FormatAnyJsxElementName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::any::element_name::FormatAnyJsxElementName::default(),
@@ -13197,7 +12417,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxElementName {
         crate::jsx::any::element_name::FormatAnyJsxElementName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::any::element_name::FormatAnyJsxElementName::default(),
@@ -13208,7 +12427,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsxName, crate::jsx::any::name::FormatAnyJsxName>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName::default())
     }
 }
@@ -13216,7 +12434,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsxName, crate::jsx::any::name::FormatAnyJsxName>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::any::name::FormatAnyJsxName::default())
     }
 }
@@ -13227,7 +12444,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
         crate::jsx::any::object_name::FormatAnyJsxObjectName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::jsx::any::object_name::FormatAnyJsxObjectName::default(),
@@ -13240,7 +12456,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxObjectName {
         crate::jsx::any::object_name::FormatAnyJsxObjectName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::jsx::any::object_name::FormatAnyJsxObjectName::default(),
@@ -13251,7 +12466,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyJsxTag {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyJsxTag, crate::jsx::any::tag::FormatAnyJsxTag>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag::default())
     }
 }
@@ -13259,7 +12473,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyJsxTag {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyJsxTag, crate::jsx::any::tag::FormatAnyJsxTag>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::jsx::any::tag::FormatAnyJsxTag::default())
     }
 }
@@ -13270,7 +12483,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsEnumMemberName {
         crate::ts::any::enum_member_name::FormatAnyTsEnumMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::enum_member_name::FormatAnyTsEnumMemberName::default(),
@@ -13283,7 +12495,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsEnumMemberName {
         crate::ts::any::enum_member_name::FormatAnyTsEnumMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::enum_member_name::FormatAnyTsEnumMemberName::default(),
@@ -13297,7 +12508,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclarati
         crate::ts::any::external_module_declaration_body::FormatAnyTsExternalModuleDeclarationBody,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody :: default ())
     }
 }
@@ -13307,7 +12517,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsExternalModuleDeclara
         crate::ts::any::external_module_declaration_body::FormatAnyTsExternalModuleDeclarationBody,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: external_module_declaration_body :: FormatAnyTsExternalModuleDeclarationBody :: default ())
     }
 }
@@ -13318,7 +12527,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsIdentifierBinding {
         crate::ts::any::identifier_binding::FormatAnyTsIdentifierBinding,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::identifier_binding::FormatAnyTsIdentifierBinding::default(),
@@ -13331,7 +12539,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsIdentifierBinding {
         crate::ts::any::identifier_binding::FormatAnyTsIdentifierBinding,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::identifier_binding::FormatAnyTsIdentifierBinding::default(),
@@ -13345,7 +12552,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsIndexSignatureModifier 
         crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier::default(),
@@ -13358,7 +12564,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsIndexSignatureModifie
         crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::index_signature_modifier::FormatAnyTsIndexSignatureModifier::default(),
@@ -13372,7 +12577,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsMethodSignatureModifier
         crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier::default(
@@ -13386,7 +12590,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsMethodSignatureModifi
         crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::method_signature_modifier::FormatAnyTsMethodSignatureModifier::default(
@@ -13401,7 +12604,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleName {
         crate::ts::any::module_name::FormatAnyTsModuleName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::module_name::FormatAnyTsModuleName::default(),
@@ -13414,7 +12616,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleName {
         crate::ts::any::module_name::FormatAnyTsModuleName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::module_name::FormatAnyTsModuleName::default(),
@@ -13428,7 +12629,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleReference {
         crate::ts::any::module_reference::FormatAnyTsModuleReference,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::module_reference::FormatAnyTsModuleReference::default(),
@@ -13441,7 +12641,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsModuleReference {
         crate::ts::any::module_reference::FormatAnyTsModuleReference,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::module_reference::FormatAnyTsModuleReference::default(),
@@ -13452,7 +12651,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsName {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyTsName, crate::ts::any::name::FormatAnyTsName>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::ts::any::name::FormatAnyTsName::default())
     }
 }
@@ -13460,7 +12658,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsName {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyTsName, crate::ts::any::name::FormatAnyTsName>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::ts::any::name::FormatAnyTsName::default())
     }
 }
@@ -13471,7 +12668,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyAnnotation {
         crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation::default(),
@@ -13484,7 +12680,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyAnnotation {
         crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::property_annotation::FormatAnyTsPropertyAnnotation::default(),
@@ -13498,7 +12693,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyParameterModifi
         crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatAnyTsPropertyParameterModifier :: default ())
     }
 }
@@ -13508,7 +12702,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertyParameterModi
         crate::ts::any::property_parameter_modifier::FormatAnyTsPropertyParameterModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_parameter_modifier :: FormatAnyTsPropertyParameterModifier :: default ())
     }
 }
@@ -13519,7 +12712,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureAnnota
         crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatAnyTsPropertySignatureAnnotation :: default ())
     }
 }
@@ -13529,7 +12721,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureAnno
         crate::ts::any::property_signature_annotation::FormatAnyTsPropertySignatureAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_annotation :: FormatAnyTsPropertySignatureAnnotation :: default ())
     }
 }
@@ -13540,7 +12731,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModifi
         crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatAnyTsPropertySignatureModifier :: default ())
     }
 }
@@ -13550,7 +12740,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsPropertySignatureModi
         crate::ts::any::property_signature_modifier::FormatAnyTsPropertySignatureModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: property_signature_modifier :: FormatAnyTsPropertySignatureModifier :: default ())
     }
 }
@@ -13561,7 +12750,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
         crate::ts::any::return_type::FormatAnyTsReturnType,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::return_type::FormatAnyTsReturnType::default(),
@@ -13574,7 +12762,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsReturnType {
         crate::ts::any::return_type::FormatAnyTsReturnType,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::return_type::FormatAnyTsReturnType::default(),
@@ -13588,7 +12775,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTemplateElement {
         crate::ts::any::template_element::FormatAnyTsTemplateElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::template_element::FormatAnyTsTemplateElement::default(),
@@ -13601,7 +12787,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTemplateElement {
         crate::ts::any::template_element::FormatAnyTsTemplateElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::template_element::FormatAnyTsTemplateElement::default(),
@@ -13615,7 +12800,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTupleTypeElement {
         crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement::default(),
@@ -13628,7 +12812,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTupleTypeElement {
         crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::tuple_type_element::FormatAnyTsTupleTypeElement::default(),
@@ -13639,7 +12822,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsType {
     type Format<'a> =
         FormatRefWithRule<'a, biome_js_syntax::AnyTsType, crate::ts::any::ts_type::FormatAnyTsType>;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType::default())
     }
 }
@@ -13647,7 +12829,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsType {
     type Format =
         FormatOwnedWithRule<biome_js_syntax::AnyTsType, crate::ts::any::ts_type::FormatAnyTsType>;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::ts::any::ts_type::FormatAnyTsType::default())
     }
 }
@@ -13658,7 +12839,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeMember {
         crate::ts::any::type_member::FormatAnyTsTypeMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::type_member::FormatAnyTsTypeMember::default(),
@@ -13671,7 +12851,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeMember {
         crate::ts::any::type_member::FormatAnyTsTypeMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::type_member::FormatAnyTsTypeMember::default(),
@@ -13685,7 +12864,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeParameterModifier {
         crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier::default(),
@@ -13698,7 +12876,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypeParameterModifier
         crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::type_parameter_modifier::FormatAnyTsTypeParameterModifier::default(),
@@ -13712,7 +12889,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParameterN
         crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatAnyTsTypePredicateParameterName :: default ())
     }
 }
@@ -13722,7 +12898,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsTypePredicateParamete
         crate::ts::any::type_predicate_parameter_name::FormatAnyTsTypePredicateParameterName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule :: new (self , crate :: ts :: any :: type_predicate_parameter_name :: FormatAnyTsTypePredicateParameterName :: default ())
     }
 }
@@ -13733,7 +12908,6 @@ impl AsFormat<JsFormatContext> for biome_js_syntax::AnyTsVariableAnnotation {
         crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation::default(),
@@ -13746,7 +12920,6 @@ impl IntoFormat<JsFormatContext> for biome_js_syntax::AnyTsVariableAnnotation {
         crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::ts::any::variable_annotation::FormatAnyTsVariableAnnotation::default(),

--- a/crates/biome_js_formatter/src/js/bogus/mod.rs
+++ b/crates/biome_js_formatter/src/js/bogus/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_assignment;
 pub(crate) mod bogus_binding;

--- a/crates/biome_js_formatter/src/jsx/attribute/mod.rs
+++ b/crates/biome_js_formatter/src/jsx/attribute/mod.rs
@@ -1,6 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod attribute;
 pub(crate) mod attribute_initializer_clause;
 pub(crate) mod expression_attribute_value;

--- a/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
+++ b/crates/biome_js_formatter/src/utils/format_binary_like_expression.rs
@@ -237,7 +237,6 @@ enum BinaryLeftOrRightSide {
 }
 
 impl BinaryLeftOrRightSide {
-    #[allow(unused)]
     fn is_jsx(&self) -> bool {
         match self {
             BinaryLeftOrRightSide::Left { parent, .. } => matches!(

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -13,8 +13,6 @@
 //! `>>` and `>>>` are not emitted as single tokens, they are emitted as multiple `>` tokens. This is because of
 //! TypeScript parsing and productions such as `T<U<N>>`
 
-#![allow(clippy::or_fun_call)]
-
 mod tests;
 
 use std::ops::{BitOr, BitOrAssign};
@@ -1448,7 +1446,6 @@ impl<'src> JsLexer<'src> {
         )
     }
     #[inline]
-    #[allow(clippy::many_single_char_names)]
     fn read_regex(&mut self) -> JsSyntaxKind {
         #[derive(Copy, Clone)]
         #[bitflags]

--- a/crates/biome_js_parser/src/lexer/tests.rs
+++ b/crates/biome_js_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut, unused_variables)]
 
 use super::{JsLexContext, JsLexer, TextRange, TextSize};
 use crate::span::Span;

--- a/crates/biome_js_parser/src/lib.rs
+++ b/crates/biome_js_parser/src/lib.rs
@@ -85,7 +85,6 @@ pub(crate) use state::{JsParserState, StrictMode};
 use std::fmt::Debug;
 
 pub enum JsSyntaxFeature {
-    #[allow(unused)]
     #[doc(alias = "LooseMode")]
     SloppyMode,
     StrictMode,

--- a/crates/biome_js_parser/src/parser/single_token_parse_recovery.rs
+++ b/crates/biome_js_parser/src/parser/single_token_parse_recovery.rs
@@ -20,7 +20,7 @@ pub(crate) struct SingleTokenParseRecovery {
     bogus_node_kind: JsSyntaxKind,
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl SingleTokenParseRecovery {
     pub fn new(recovery: TokenSet<JsSyntaxKind>, bogus_node_kind: JsSyntaxKind) -> Self {
         Self {

--- a/crates/biome_js_parser/src/syntax/object.rs
+++ b/crates/biome_js_parser/src/syntax/object.rs
@@ -1,4 +1,4 @@
-#[allow(deprecated)]
+#[expect(deprecated)]
 use crate::parser::single_token_parse_recovery::SingleTokenParseRecovery;
 use crate::parser::ParsedSyntax::{Absent, Present};
 use crate::parser::{ParsedSyntax, RecoveryResult};
@@ -231,7 +231,7 @@ fn parse_object_member(p: &mut JsParser) -> ParsedSyntax {
                 // test_err js object_expr_non_ident_literal_prop
                 // let d = {5}
 
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 SingleTokenParseRecovery::new(token_set![T![:], T![,]], JS_BOGUS).recover(p);
 
                 if p.eat(T![:]) {

--- a/crates/biome_js_parser/tests/spec_tests.rs
+++ b/crates/biome_js_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_js_syntax/src/generated/kind.rs
+++ b/crates/biome_js_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -523,68 +522,124 @@ pub enum JsSyntaxKind {
 use self::JsSyntaxKind::*;
 impl JsSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            SEMICOLON | COMMA | L_PAREN | R_PAREN | L_CURLY | R_CURLY | L_BRACK | R_BRACK
-            | L_ANGLE | R_ANGLE | TILDE | QUESTION | QUESTION2 | QUESTIONDOT | AMP | PIPE
-            | PLUS | PLUS2 | STAR | STAR2 | SLASH | CARET | PERCENT | DOT | DOT3 | COLON | EQ
-            | EQ2 | EQ3 | FAT_ARROW | BANG | NEQ | NEQ2 | MINUS | MINUS2 | LTEQ | GTEQ | PLUSEQ
-            | MINUSEQ | PIPEEQ | AMPEQ | CARETEQ | SLASHEQ | STAREQ | PERCENTEQ | AMP2 | PIPE2
-            | SHL | SHR | USHR | SHLEQ | SHREQ | USHREQ | AMP2EQ | PIPE2EQ | STAR2EQ
-            | QUESTION2EQ | AT | BACKTICK => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            SEMICOLON
+                | COMMA
+                | L_PAREN
+                | R_PAREN
+                | L_CURLY
+                | R_CURLY
+                | L_BRACK
+                | R_BRACK
+                | L_ANGLE
+                | R_ANGLE
+                | TILDE
+                | QUESTION
+                | QUESTION2
+                | QUESTIONDOT
+                | AMP
+                | PIPE
+                | PLUS
+                | PLUS2
+                | STAR
+                | STAR2
+                | SLASH
+                | CARET
+                | PERCENT
+                | DOT
+                | DOT3
+                | COLON
+                | EQ
+                | EQ2
+                | EQ3
+                | FAT_ARROW
+                | BANG
+                | NEQ
+                | NEQ2
+                | MINUS
+                | MINUS2
+                | LTEQ
+                | GTEQ
+                | PLUSEQ
+                | MINUSEQ
+                | PIPEEQ
+                | AMPEQ
+                | CARETEQ
+                | SLASHEQ
+                | STAREQ
+                | PERCENTEQ
+                | AMP2
+                | PIPE2
+                | SHL
+                | SHR
+                | USHR
+                | SHLEQ
+                | SHREQ
+                | USHREQ
+                | AMP2EQ
+                | PIPE2EQ
+                | STAR2EQ
+                | QUESTION2EQ
+                | AT
+                | BACKTICK
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            JS_NUMBER_LITERAL | JS_BIGINT_LITERAL | JS_STRING_LITERAL | JS_REGEX_LITERAL
-            | JSX_TEXT_LITERAL | JSX_STRING_LITERAL => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            JS_NUMBER_LITERAL
+                | JS_BIGINT_LITERAL
+                | JS_STRING_LITERAL
+                | JS_REGEX_LITERAL
+                | JSX_TEXT_LITERAL
+                | JSX_STRING_LITERAL
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
+        matches!(
+            self,
             JS_MODULE_ITEM_LIST
-            | JS_DIRECTIVE_LIST
-            | JS_STATEMENT_LIST
-            | JS_VARIABLE_DECLARATOR_LIST
-            | JS_SWITCH_CASE_LIST
-            | JS_PARAMETER_LIST
-            | TS_PROPERTY_PARAMETER_MODIFIER_LIST
-            | JS_ARRAY_ELEMENT_LIST
-            | JS_OBJECT_MEMBER_LIST
-            | JS_CALL_ARGUMENT_LIST
-            | JS_TEMPLATE_ELEMENT_LIST
-            | JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
-            | JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
-            | JS_CLASS_MEMBER_LIST
-            | JS_CONSTRUCTOR_MODIFIER_LIST
-            | JS_CONSTRUCTOR_PARAMETER_LIST
-            | JS_PROPERTY_MODIFIER_LIST
-            | JS_METHOD_MODIFIER_LIST
-            | JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST
-            | JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST
-            | JS_NAMED_IMPORT_SPECIFIER_LIST
-            | JS_IMPORT_ASSERTION_ENTRY_LIST
-            | JS_EXPORT_NAMED_SPECIFIER_LIST
-            | JS_EXPORT_NAMED_FROM_SPECIFIER_LIST
-            | JS_DECORATOR_LIST
-            | TS_UNION_TYPE_VARIANT_LIST
-            | TS_INTERSECTION_TYPE_ELEMENT_LIST
-            | TS_TYPE_MEMBER_LIST
-            | TS_TUPLE_TYPE_ELEMENT_LIST
-            | TS_TYPE_PARAMETER_LIST
-            | TS_TYPE_PARAMETER_MODIFIER_LIST
-            | TS_TEMPLATE_ELEMENT_LIST
-            | TS_TYPE_ARGUMENT_LIST
-            | TS_TYPE_LIST
-            | TS_ENUM_MEMBER_LIST
-            | TS_PROPERTY_SIGNATURE_MODIFIER_LIST
-            | TS_METHOD_SIGNATURE_MODIFIER_LIST
-            | TS_INDEX_SIGNATURE_MODIFIER_LIST
-            | JSX_ATTRIBUTE_LIST
-            | JSX_CHILD_LIST => true,
-            _ => false,
-        }
+                | JS_DIRECTIVE_LIST
+                | JS_STATEMENT_LIST
+                | JS_VARIABLE_DECLARATOR_LIST
+                | JS_SWITCH_CASE_LIST
+                | JS_PARAMETER_LIST
+                | TS_PROPERTY_PARAMETER_MODIFIER_LIST
+                | JS_ARRAY_ELEMENT_LIST
+                | JS_OBJECT_MEMBER_LIST
+                | JS_CALL_ARGUMENT_LIST
+                | JS_TEMPLATE_ELEMENT_LIST
+                | JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST
+                | JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST
+                | JS_CLASS_MEMBER_LIST
+                | JS_CONSTRUCTOR_MODIFIER_LIST
+                | JS_CONSTRUCTOR_PARAMETER_LIST
+                | JS_PROPERTY_MODIFIER_LIST
+                | JS_METHOD_MODIFIER_LIST
+                | JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST
+                | JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST
+                | JS_NAMED_IMPORT_SPECIFIER_LIST
+                | JS_IMPORT_ASSERTION_ENTRY_LIST
+                | JS_EXPORT_NAMED_SPECIFIER_LIST
+                | JS_EXPORT_NAMED_FROM_SPECIFIER_LIST
+                | JS_DECORATOR_LIST
+                | TS_UNION_TYPE_VARIANT_LIST
+                | TS_INTERSECTION_TYPE_ELEMENT_LIST
+                | TS_TYPE_MEMBER_LIST
+                | TS_TUPLE_TYPE_ELEMENT_LIST
+                | TS_TYPE_PARAMETER_LIST
+                | TS_TYPE_PARAMETER_MODIFIER_LIST
+                | TS_TEMPLATE_ELEMENT_LIST
+                | TS_TYPE_ARGUMENT_LIST
+                | TS_TYPE_LIST
+                | TS_ENUM_MEMBER_LIST
+                | TS_PROPERTY_SIGNATURE_MODIFIER_LIST
+                | TS_METHOD_SIGNATURE_MODIFIER_LIST
+                | TS_INDEX_SIGNATURE_MODIFIER_LIST
+                | JSX_ATTRIBUTE_LIST
+                | JSX_CHILD_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<JsSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     JsLanguage as Language, JsSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     JsSyntaxKind::{self as SyntaxKind, *},
     JsSyntaxList as SyntaxList, JsSyntaxNode as SyntaxNode, JsSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsAccessorModifier {

--- a/crates/biome_js_syntax/src/lib.rs
+++ b/crates/biome_js_syntax/src/lib.rs
@@ -185,7 +185,6 @@ impl TryFrom<JsSyntaxKind> for TriviaPieceKind {
 }
 
 /// See: [MDN Operator precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table)
-#[allow(dead_code)]
 #[derive(Debug, Eq, Ord, PartialOrd, PartialEq, Copy, Clone, Hash)]
 pub enum OperatorPrecedence {
     Comma = 0,
@@ -221,7 +220,6 @@ impl OperatorPrecedence {
     }
 
     /// Returns the operator with the highest precedence
-    #[allow(dead_code)]
     pub fn highest() -> Self {
         OperatorPrecedence::Primary
     }

--- a/crates/biome_js_transform/tests/spec_tests.rs
+++ b/crates/biome_js_transform/tests/spec_tests.rs
@@ -87,7 +87,6 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn analyze_and_snap(
     snapshot: &mut String,
     input_code: &str,

--- a/crates/biome_json_factory/src/generated/node_factory.rs
+++ b/crates/biome_json_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_json_syntax::{
     JsonSyntaxElement as SyntaxElement, JsonSyntaxNode as SyntaxNode,
     JsonSyntaxToken as SyntaxToken, *,

--- a/crates/biome_json_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_json_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_json_syntax::{JsonSyntaxKind, JsonSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct JsonSyntaxFactory;
 impl SyntaxFactory for JsonSyntaxFactory {
     type Kind = JsonSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_json_formatter/src/generated.rs
+++ b/crates/biome_json_formatter/src/generated.rs
@@ -1,5 +1,6 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
+#![expect(clippy::default_constructed_unit_structs)]
 use crate::{
     AsFormat, FormatBogusNodeRule, FormatNodeRule, IntoFormat, JsonFormatContext, JsonFormatter,
 };
@@ -24,7 +25,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonArrayValue {
         crate::json::value::array_value::FormatJsonArrayValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::array_value::FormatJsonArrayValue::default(),
@@ -37,7 +37,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonArrayValue {
         crate::json::value::array_value::FormatJsonArrayValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::array_value::FormatJsonArrayValue::default(),
@@ -64,7 +63,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBooleanValue {
         crate::json::value::boolean_value::FormatJsonBooleanValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::boolean_value::FormatJsonBooleanValue::default(),
@@ -77,7 +75,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBooleanValue {
         crate::json::value::boolean_value::FormatJsonBooleanValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::boolean_value::FormatJsonBooleanValue::default(),
@@ -100,7 +97,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMember {
         crate::json::auxiliary::member::FormatJsonMember,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::auxiliary::member::FormatJsonMember::default(),
@@ -113,7 +109,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMember {
         crate::json::auxiliary::member::FormatJsonMember,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::auxiliary::member::FormatJsonMember::default(),
@@ -140,7 +135,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMemberName {
         crate::json::auxiliary::member_name::FormatJsonMemberName,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::auxiliary::member_name::FormatJsonMemberName::default(),
@@ -153,7 +147,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMemberName {
         crate::json::auxiliary::member_name::FormatJsonMemberName,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::auxiliary::member_name::FormatJsonMemberName::default(),
@@ -180,7 +173,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonNullValue {
         crate::json::value::null_value::FormatJsonNullValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::null_value::FormatJsonNullValue::default(),
@@ -193,7 +185,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonNullValue {
         crate::json::value::null_value::FormatJsonNullValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::null_value::FormatJsonNullValue::default(),
@@ -220,7 +211,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonNumberValue {
         crate::json::value::number_value::FormatJsonNumberValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::number_value::FormatJsonNumberValue::default(),
@@ -233,7 +223,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonNumberValue {
         crate::json::value::number_value::FormatJsonNumberValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::number_value::FormatJsonNumberValue::default(),
@@ -260,7 +249,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonObjectValue {
         crate::json::value::object_value::FormatJsonObjectValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::object_value::FormatJsonObjectValue::default(),
@@ -273,7 +261,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonObjectValue {
         crate::json::value::object_value::FormatJsonObjectValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::object_value::FormatJsonObjectValue::default(),
@@ -294,7 +281,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonRoot {
         crate::json::auxiliary::root::FormatJsonRoot,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::auxiliary::root::FormatJsonRoot::default(),
@@ -307,7 +293,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonRoot {
         crate::json::auxiliary::root::FormatJsonRoot,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::auxiliary::root::FormatJsonRoot::default(),
@@ -334,7 +319,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonStringValue {
         crate::json::value::string_value::FormatJsonStringValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::value::string_value::FormatJsonStringValue::default(),
@@ -347,7 +331,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonStringValue {
         crate::json::value::string_value::FormatJsonStringValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::value::string_value::FormatJsonStringValue::default(),
@@ -361,7 +344,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonArrayElementList {
         crate::json::lists::array_element_list::FormatJsonArrayElementList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
@@ -374,7 +356,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonArrayElementList {
         crate::json::lists::array_element_list::FormatJsonArrayElementList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::lists::array_element_list::FormatJsonArrayElementList::default(),
@@ -388,7 +369,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonMemberList {
         crate::json::lists::member_list::FormatJsonMemberList,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::lists::member_list::FormatJsonMemberList::default(),
@@ -401,7 +381,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonMemberList {
         crate::json::lists::member_list::FormatJsonMemberList,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::lists::member_list::FormatJsonMemberList::default(),
@@ -422,7 +401,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBogus {
         crate::json::bogus::bogus::FormatJsonBogus,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus::default())
     }
 }
@@ -432,7 +410,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogus {
         crate::json::bogus::bogus::FormatJsonBogus,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::json::bogus::bogus::FormatJsonBogus::default())
     }
 }
@@ -456,7 +433,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::JsonBogusValue {
         crate::json::bogus::bogus_value::FormatJsonBogusValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::json::bogus::bogus_value::FormatJsonBogusValue::default(),
@@ -469,7 +445,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::JsonBogusValue {
         crate::json::bogus::bogus_value::FormatJsonBogusValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::json::bogus::bogus_value::FormatJsonBogusValue::default(),
@@ -483,7 +458,6 @@ impl AsFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
         crate::json::any::value::FormatAnyJsonValue,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(self, crate::json::any::value::FormatAnyJsonValue::default())
     }
 }
@@ -493,7 +467,6 @@ impl IntoFormat<JsonFormatContext> for biome_json_syntax::AnyJsonValue {
         crate::json::any::value::FormatAnyJsonValue,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(self, crate::json::any::value::FormatAnyJsonValue::default())
     }
 }

--- a/crates/biome_json_formatter/src/json/bogus/mod.rs
+++ b/crates/biome_json_formatter/src/json/bogus/mod.rs
@@ -1,5 +1,5 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub(crate) mod bogus;
 pub(crate) mod bogus_value;

--- a/crates/biome_json_formatter/src/lib.rs
+++ b/crates/biome_json_formatter/src/lib.rs
@@ -77,8 +77,6 @@ where
 /// Used to convert this object into an object that can be formatted.
 ///
 /// The difference to [AsFormat] is that this trait takes ownership of `self`.
-// False positive
-#[allow(dead_code)]
 pub(crate) trait IntoFormat<Context> {
     type Format: biome_formatter::Format<Context>;
 
@@ -112,7 +110,7 @@ where
 
 /// Formatting specific [Iterator] extensions
 // False positive
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) trait FormattedIterExt {
     /// Converts every item to an object that knows how to format it.
     fn formatted<Context>(self) -> FormattedIter<Self, Self::Item, Context>
@@ -129,8 +127,6 @@ pub(crate) trait FormattedIterExt {
 
 impl<I> FormattedIterExt for I where I: std::iter::Iterator {}
 
-// False positive
-#[allow(dead_code)]
 pub(crate) struct FormattedIter<Iter, Item, Context>
 where
     Iter: Iterator<Item = Item>,

--- a/crates/biome_json_formatter/src/prelude.rs
+++ b/crates/biome_json_formatter/src/prelude.rs
@@ -1,10 +1,9 @@
 //! This module provides important and useful traits to help to format tokens and nodes
 //! when implementing the [crate::FormatNodeRule] trait.
 
-#[allow(unused_imports)]
+#![allow(unused_imports)]
 pub(crate) use crate::{
     AsFormat, FormatNodeRule, FormattedIterExt as _, IntoFormat, JsonFormatContext, JsonFormatter,
 };
 pub(crate) use biome_formatter::prelude::*;
-#[allow(unused_imports)]
 pub(crate) use biome_rowan::{AstNode as _, AstNodeList as _, AstSeparatedList as _};

--- a/crates/biome_json_parser/src/lexer/tests.rs
+++ b/crates/biome_json_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut)]
 
 use super::{Lexer, TextSize};
 use biome_json_syntax::JsonSyntaxKind::{self, EOF};
@@ -76,11 +76,7 @@ fn losslessness(string: String) -> bool {
     });
     let token_ranges = receiver
         .recv_timeout(Duration::from_secs(2))
-        .unwrap_or_else(|_| {
-            panic!(
-                "Lexer is infinitely recursing with this code: ->{string}<-"
-            )
-        });
+        .unwrap_or_else(|_| panic!("Lexer is infinitely recursing with this code: ->{string}<-"));
 
     let mut new_str = String::with_capacity(string.len());
     let mut idx = TextSize::from(0);

--- a/crates/biome_json_parser/tests/spec_tests.rs
+++ b/crates/biome_json_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_json_syntax/src/generated/kind.rs
+++ b/crates/biome_json_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -52,22 +51,16 @@ pub enum JsonSyntaxKind {
 use self::JsonSyntaxKind::*;
 impl JsonSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            COLON | COMMA | L_PAREN | R_PAREN | L_CURLY | R_CURLY | L_BRACK | R_BRACK => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            COLON | COMMA | L_PAREN | R_PAREN | L_CURLY | R_CURLY | L_BRACK | R_BRACK
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            JSON_STRING_LITERAL | JSON_NUMBER_LITERAL => true,
-            _ => false,
-        }
+        matches!(self, JSON_STRING_LITERAL | JSON_NUMBER_LITERAL)
     }
     pub const fn is_list(self) -> bool {
-        match self {
-            JSON_MEMBER_LIST | JSON_ARRAY_ELEMENT_LIST => true,
-            _ => false,
-        }
+        matches!(self, JSON_MEMBER_LIST | JSON_ARRAY_ELEMENT_LIST)
     }
     pub fn from_keyword(ident: &str) -> Option<JsonSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_json_syntax/src/generated/nodes.rs
+++ b/crates/biome_json_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     JsonLanguage as Language, JsonSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     JsonSyntaxKind::{self as SyntaxKind, *},
     JsonSyntaxList as SyntaxList, JsonSyntaxNode as SyntaxNode, JsonSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct JsonArrayValue {

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -240,7 +240,7 @@ impl LSPServer {
 #[tower_lsp::async_trait]
 impl LanguageServer for LSPServer {
     // The `root_path` field is deprecated, but we still read it so we can print a warning about it
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     #[tracing::instrument(
         level = "trace",
         skip_all,

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -91,7 +91,6 @@ struct InitializeParams {
     client_capabilities: lsp_types::ClientCapabilities,
     client_information: Option<ClientInformation>,
     root_uri: Option<Url>,
-    #[allow(unused)]
     workspace_folders: Option<Vec<WorkspaceFolder>>,
 }
 

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -163,7 +163,7 @@ impl Server {
 
     /// Basic implementation of the `initialize` request for tests
     // The `root_path` field is deprecated, but we still need to specify it
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     async fn initialize(&mut self) -> Result<()> {
         let _res: InitializeResult = self
             .request(
@@ -191,7 +191,7 @@ impl Server {
     ///
     /// Hence, the two roots will be `/workspace/test_one` and `/workspace/test_two`
     // The `root_path` field is deprecated, but we still need to specify it
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     async fn initialize_workspaces(&mut self) -> Result<()> {
         let _res: InitializeResult = self
             .request(

--- a/crates/biome_markdown_factory/src/generated/node_factory.rs
+++ b/crates/biome_markdown_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_markdown_syntax::{
     MarkdownSyntaxElement as SyntaxElement, MarkdownSyntaxNode as SyntaxNode,
     MarkdownSyntaxToken as SyntaxToken, *,

--- a/crates/biome_markdown_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_markdown_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_markdown_syntax::{MarkdownSyntaxKind, MarkdownSyntaxKind::*, T, *};
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
@@ -8,7 +9,6 @@ use biome_rowan::{
 pub struct MarkdownSyntaxFactory;
 impl SyntaxFactory for MarkdownSyntaxFactory {
     type Kind = MarkdownSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_markdown_parser/src/lexer/mod.rs
+++ b/crates/biome_markdown_parser/src/lexer/mod.rs
@@ -28,7 +28,7 @@ impl LexContext for MarkdownLexContext {
 /// Context in which the [MarkdownLexContext]'s current should be re-lexed.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MarkdownReLexContext {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Regular,
     // UnicodeRange,
 }
@@ -190,7 +190,7 @@ impl<'src> MarkdownLexer<'src> {
     }
 
     /// Bumps the current byte and creates a lexed token of the passed in kind
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn eat_byte(&mut self, tok: MarkdownSyntaxKind) -> MarkdownSyntaxKind {
         self.advance(1);
         tok

--- a/crates/biome_markdown_parser/src/lexer/tests.rs
+++ b/crates/biome_markdown_parser/src/lexer/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![allow(unused_mut, unused_variables, unused_assignments)]
+#![expect(unused_mut, unused_variables)]
 
 use super::{MarkdownLexer, TextSize};
 use crate::lexer::MarkdownLexContext;

--- a/crates/biome_markdown_parser/src/parser.rs
+++ b/crates/biome_markdown_parser/src/parser.rs
@@ -19,7 +19,7 @@ impl<'source> MarkdownParser<'source> {
             source: MarkdownTokenSource::from_str(source),
         }
     }
-    #[allow(dead_code)]
+
     pub fn checkpoint(&self) -> MarkdownParserCheckpoint {
         MarkdownParserCheckpoint {
             context: self.context.checkpoint(),
@@ -31,7 +31,6 @@ impl<'source> MarkdownParser<'source> {
         self.source.before_whitespace_count()
     }
 
-    #[allow(dead_code)]
     pub fn rewind(&mut self, checkpoint: MarkdownParserCheckpoint) {
         let MarkdownParserCheckpoint { context, source } = checkpoint;
 
@@ -76,7 +75,6 @@ impl<'source> Parser for MarkdownParser<'source> {
     }
 }
 
-#[allow(dead_code)]
 pub struct MarkdownParserCheckpoint {
     pub(super) context: ParserContextCheckpoint,
     pub(super) source: MarkdownTokenSourceCheckpoint,

--- a/crates/biome_markdown_parser/src/token_source.rs
+++ b/crates/biome_markdown_parser/src/token_source.rs
@@ -14,7 +14,6 @@ pub(crate) struct MarkdownTokenSource<'source> {
     pub(super) trivia_list: Vec<Trivia>,
 }
 
-#[allow(dead_code)]
 pub(crate) type MarkdownTokenSourceCheckpoint = TokenSourceCheckpoint<MarkdownSyntaxKind>;
 
 impl<'source> MarkdownTokenSource<'source> {
@@ -86,13 +85,12 @@ impl<'source> MarkdownTokenSource<'source> {
         })
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn re_lex(&mut self, mode: MarkdownReLexContext) -> MarkdownSyntaxKind {
         self.lexer.re_lex(mode)
     }
 
     /// Creates a checkpoint to which it can later return using [Self::rewind].
-    #[allow(dead_code)]
     pub fn checkpoint(&self) -> MarkdownTokenSourceCheckpoint {
         MarkdownTokenSourceCheckpoint {
             trivia_len: self.trivia_list.len() as u32,
@@ -101,7 +99,6 @@ impl<'source> MarkdownTokenSource<'source> {
     }
 
     /// Restores the token source to a previous state
-    #[allow(dead_code)]
     pub fn rewind(&mut self, checkpoint: MarkdownTokenSourceCheckpoint) {
         assert!(self.trivia_list.len() >= checkpoint.trivia_len as usize);
         self.trivia_list.truncate(checkpoint.trivia_len as usize);

--- a/crates/biome_markdown_parser/tests/spec_tests.rs
+++ b/crates/biome_markdown_parser/tests/spec_tests.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 mod spec_test;
 
 mod ok {

--- a/crates/biome_markdown_syntax/src/generated/kind.rs
+++ b/crates/biome_markdown_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -76,33 +75,43 @@ pub enum MarkdownSyntaxKind {
 use self::MarkdownSyntaxKind::*;
 impl MarkdownSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            L_ANGLE | R_ANGLE | L_PAREN | R_PAREN | L_BRACK | R_BRACK | SLASH | EQ | BANG
-            | MINUS | STAR | BACKTICK | TILDE | WHITESPACE3 | UNDERSCORE | HASH => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            L_ANGLE
+                | R_ANGLE
+                | L_PAREN
+                | R_PAREN
+                | L_BRACK
+                | R_BRACK
+                | SLASH
+                | EQ
+                | BANG
+                | MINUS
+                | STAR
+                | BACKTICK
+                | TILDE
+                | WHITESPACE3
+                | UNDERSCORE
+                | HASH
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
+        matches!(
+            self,
             MD_HARD_LINE_LITERAL
-            | MD_SOFT_BREAK_LITERAL
-            | MD_TEXTUAL_LITERAL
-            | MD_STRING_LITERAL
-            | MD_INDENT_CHUNK_LITERAL
-            | MD_THEMATIC_BREAK_LITERAL
-            | MD_ERROR_LITERAL => true,
-            _ => false,
-        }
+                | MD_SOFT_BREAK_LITERAL
+                | MD_TEXTUAL_LITERAL
+                | MD_STRING_LITERAL
+                | MD_INDENT_CHUNK_LITERAL
+                | MD_THEMATIC_BREAK_LITERAL
+                | MD_ERROR_LITERAL
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
-            MD_BLOCK_LIST
-            | MD_HASH_LIST
-            | MD_BULLET_LIST
-            | MD_ORDER_LIST
-            | MD_PARAGRAPH_ITEM_LIST => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            MD_BLOCK_LIST | MD_HASH_LIST | MD_BULLET_LIST | MD_ORDER_LIST | MD_PARAGRAPH_ITEM_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<MarkdownSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_markdown_syntax/src/generated/nodes.rs
+++ b/crates/biome_markdown_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     MarkdownLanguage as Language, MarkdownSyntaxElement as SyntaxElement,
@@ -10,18 +10,15 @@ use crate::{
     MarkdownSyntaxList as SyntaxList, MarkdownSyntaxNode as SyntaxNode,
     MarkdownSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MdBulletListItem {

--- a/crates/biome_migrate/src/macros.rs
+++ b/crates/biome_migrate/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! declare_migration {
         // This is implemented by calling the `group_category!` macro from the
         // parent module (that should be declared by a call to `declare_group!`)
         // and providing it with the name of this rule as a string literal token
-        #[allow(unused_macros)]
+        #[expect(unused_macros)]
         macro_rules! rule_category {
             () => { super::group_category!( $name ) };
         }

--- a/crates/biome_parser/src/parsed_syntax.rs
+++ b/crates/biome_parser/src/parsed_syntax.rs
@@ -104,7 +104,6 @@ impl ParsedSyntax {
     }
 
     /// Returns the contained [ParsedSyntax::Present] value or passed default
-    #[allow(unused)]
     #[inline]
     pub fn unwrap_or(self, default: CompletedMarker) -> CompletedMarker {
         match self {
@@ -115,7 +114,6 @@ impl ParsedSyntax {
 
     /// Returns the contained [ParsedSyntax::Present] value or computes it from a clojure.
     #[inline]
-    #[allow(unused)]
     pub fn unwrap_or_else<F>(self, default: F) -> CompletedMarker
     where
         F: FnOnce() -> CompletedMarker,

--- a/crates/biome_project/src/license/generated.rs
+++ b/crates/biome_project/src/license/generated.rs
@@ -2,29 +2,29 @@
 
 #[derive(Debug)]
 pub struct LicenseList {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) license_list_version: &'static str,
     pub(crate) license_list: &'static [&'static Licence],
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) release_date: &'static str,
 }
 #[derive(Debug)]
 pub struct Licence {
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) reference: &'static str,
     pub(crate) is_deprecated_license_id: bool,
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) details_url: &'static str,
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) reference_number: u16,
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) name: &'static str,
     pub(crate) license_id: &'static str,
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) see_also: &'static [&'static str],
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) is_osi_approved: bool,
-    #[allow(unused)]
+    #[expect(unused)]
     pub(crate) is_fsf_libre: bool,
 }
 pub const LICENSE_LIST: LicenseList = LicenseList {

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -232,7 +232,6 @@ impl ops::Deref for GreenNode {
     fn deref(&self) -> &GreenNodeData {
         unsafe {
             let repr: &Repr = &self.ptr;
-            #[allow(invalid_reference_casting)]
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenNodeData>(repr)
         }

--- a/crates/biome_rowan/src/green/token.rs
+++ b/crates/biome_rowan/src/green/token.rs
@@ -192,7 +192,6 @@ impl ops::Deref for GreenToken {
     fn deref(&self) -> &GreenTokenData {
         unsafe {
             let repr: &Repr = &self.ptr;
-            #[allow(invalid_reference_casting)]
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenTokenData>(repr)
         }

--- a/crates/biome_rowan/src/green/trivia.rs
+++ b/crates/biome_rowan/src/green/trivia.rs
@@ -23,7 +23,7 @@ pub(crate) struct GreenTriviaData {
 }
 
 impl GreenTriviaData {
-    #[allow(unused)]
+    #[expect(unused)]
     #[inline]
     pub fn header(&self) -> &GreenTriviaHead {
         &self.data.header

--- a/crates/biome_rowan/src/lib.rs
+++ b/crates/biome_rowan/src/lib.rs
@@ -8,21 +8,21 @@ future_incompatible,
 )]
 #![deny(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![allow(clippy::map_unwrap_or, clippy::mem_forget)]
+#![expect(clippy::map_unwrap_or, clippy::mem_forget)]
 
 #[doc(hidden)]
 pub mod macros;
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub mod cursor;
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 mod green;
 
 pub mod syntax;
 mod syntax_node_text;
 mod utility_types;
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 mod arc;
 mod ast;
 mod cow_mut;

--- a/crates/biome_rowan/src/macros.rs
+++ b/crates/biome_rowan/src/macros.rs
@@ -65,7 +65,7 @@ macro_rules! declare_node_union {
 
     ( $( #[$attr:meta] )* $vis:vis $name:ident = $( $variant:ident )|* ) => {
         $( #[$attr] )*
-        #[allow(clippy::enum_variant_names)]
+        #[expect(clippy::enum_variant_names)]
         #[derive(Clone, PartialEq, Eq, Hash)]
         $vis enum $name {
             $( $variant($variant), )*

--- a/crates/biome_rowan/src/raw_language.rs
+++ b/crates/biome_rowan/src/raw_language.rs
@@ -17,7 +17,7 @@ impl Language for RawLanguage {
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u16)]
-#[allow(bad_style)]
+#[expect(bad_style)]
 pub enum RawLanguageKind {
     ROOT = 0,
     EXPRESSION_LIST = 1,
@@ -57,7 +57,7 @@ impl SyntaxKind for RawLanguageKind {
         RawSyntaxKind(*self as u16)
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn from_raw(raw: RawSyntaxKind) -> Self {
         assert!(raw.0 < RawLanguageKind::__LAST as u16);
 

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -556,7 +556,6 @@ pub(crate) trait ExtensionHandler {
 pub(crate) struct Features {
     js: JsFileHandler,
     json: JsonFileHandler,
-    #[allow(unused)]
     css: CssFileHandler,
     astro: AstroFileHandler,
     vue: VueFileHandler,

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -70,8 +70,6 @@ pub enum WorkspaceRef<'app> {
 impl<'app> Deref for WorkspaceRef<'app> {
     type Target = dyn Workspace + 'app;
 
-    // False positive
-    #[allow(clippy::explicit_auto_deref)]
     fn deref(&self) -> &Self::Target {
         match self {
             WorkspaceRef::Owned(inner) => &**inner,

--- a/crates/biome_service/src/matcher/pattern.rs
+++ b/crates/biome_service/src/matcher/pattern.rs
@@ -12,7 +12,7 @@ use std::{fmt, path};
 
 /// A pattern parsing error.
 #[derive(Debug)]
-#[allow(missing_copy_implementations)]
+#[expect(missing_copy_implementations)]
 pub struct PatternError {
     /// The approximate character index of where the error occurred.
     pub pos: usize,
@@ -558,7 +558,6 @@ fn chars_eq(a: char, b: char, case_sensitive: bool) -> bool {
 }
 
 /// Configuration options to modify the behaviour of `Pattern::matches_with(..)`.
-#[allow(missing_copy_implementations)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct MatchOptions {
     /// Whether or not patterns should be matched in a case-sensitive manner.

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1471,7 +1471,7 @@ impl OverrideSettingPattern {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     // NOTE: Currently not used because the rule options are typed using TypeId and Any, which isn't thread safe.
     // TODO: Find a way to cache this
     fn analyzer_rules_mut(&self, _analyzer_rules: &mut AnalyzerRules) {}

--- a/crates/biome_string_case/src/lib.rs
+++ b/crates/biome_string_case/src/lib.rs
@@ -626,7 +626,7 @@ impl StrLikeExtension for str {
     fn to_ascii_lowercase_cow(&self) -> Cow<Self> {
         let has_ascii_uppercase = self.bytes().any(|b| b.is_ascii_uppercase());
         if has_ascii_uppercase {
-            #[allow(clippy::disallowed_methods)]
+            #[expect(clippy::disallowed_methods)]
             Cow::Owned(self.to_ascii_lowercase())
         } else {
             Cow::Borrowed(self)
@@ -642,7 +642,7 @@ impl StrOnlyExtension for str {
     fn to_lowercase_cow(&self) -> Cow<Self> {
         let has_uppercase = self.chars().any(char::is_uppercase);
         if has_uppercase {
-            #[allow(clippy::disallowed_methods)]
+            #[expect(clippy::disallowed_methods)]
             Cow::Owned(self.to_lowercase())
         } else {
             Cow::Borrowed(self)
@@ -657,7 +657,7 @@ impl StrLikeExtension for std::ffi::OsStr {
             .iter()
             .any(|b| b.is_ascii_uppercase());
         if has_ascii_uppercase {
-            #[allow(clippy::disallowed_methods)]
+            #[expect(clippy::disallowed_methods)]
             Cow::Owned(self.to_ascii_lowercase())
         } else {
             Cow::Borrowed(self)

--- a/crates/biome_syntax_codegen/src/ast.rs
+++ b/crates/biome_syntax_codegen/src/ast.rs
@@ -552,7 +552,7 @@ pub struct AstListSeparatorConfiguration {
 
 #[derive(Debug)]
 pub struct AstNodeSrc {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub documentation: Vec<String>,
     pub name: String,
     // pub traits: Vec<String>,
@@ -586,7 +586,7 @@ pub enum Field {
 
 #[derive(Debug, Clone)]
 pub struct AstEnumSrc {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub documentation: Vec<String>,
     pub name: String,
     // pub traits: Vec<String>,
@@ -628,7 +628,7 @@ impl Field {
             }
         }
     }
-    #[allow(dead_code)]
+
     pub fn ty(&self) -> proc_macro2::Ident {
         match self {
             Field::Token { .. } => format_ident!("SyntaxToken"),

--- a/crates/biome_syntax_codegen/src/generate_node_factory.rs
+++ b/crates/biome_syntax_codegen/src/generate_node_factory.rs
@@ -212,8 +212,8 @@ where
     });
 
     let output = quote! {
-        #![allow(clippy::redundant_closure)]
-        #![allow(clippy::too_many_arguments)]
+        #![expect(clippy::redundant_closure)]
+        #![expect(clippy::too_many_arguments)]
         use #syntax_crate::{*, #syntax_token as SyntaxToken, #syntax_node as SyntaxNode, #syntax_element as SyntaxElement};
         use biome_rowan::AstNode;
 

--- a/crates/biome_syntax_codegen/src/generate_nodes.rs
+++ b/crates/biome_syntax_codegen/src/generate_nodes.rs
@@ -199,7 +199,6 @@ where
 
                     /// Construct the `slot_map` for this node by checking the `kind` of
                     /// each child of `syntax` against the defined grammar for the node.
-                    #[allow(clippy::explicit_counter_loop)]
                     pub fn build_slot_map(syntax: &SyntaxNode) -> #slot_map_type {
                         #slot_map_builder_impl
                     }
@@ -891,13 +890,15 @@ where
         #![allow(clippy::enum_variant_names)]
         // sometimes we generate comparison of simple tokens
         #![allow(clippy::match_like_matches_macro)]
+        #![allow(clippy::explicit_counter_loop)]
+        #![allow(dead_code)]
+        #![allow(unused)]
         use crate::{
             macros::map_syntax_node,
             #language as Language, #syntax_element as SyntaxElement, #syntax_element_children as SyntaxElementChildren,
             #syntax_kind::{self as SyntaxKind, *},
             #syntax_list as SyntaxList, #syntax_node as SyntaxNode, #syntax_token as SyntaxToken,
         };
-        #[allow(unused)]
         use biome_rowan::{
             AstNodeList, AstNodeListIterator,  AstNodeSlotMap, AstSeparatedList, AstSeparatedListNodesIterator
         };
@@ -907,7 +908,6 @@ where
 
         /// Sentinel value indicating a missing element in a dynamic node, where
         /// the slots are not statically known.
-        #[allow(dead_code)]
         pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 
         #(#node_defs)*

--- a/crates/biome_syntax_codegen/src/generate_syntax_factory.rs
+++ b/crates/biome_syntax_codegen/src/generate_syntax_factory.rs
@@ -165,7 +165,7 @@ where
         impl SyntaxFactory for #factory_kind {
             type Kind = #syntax_kind;
 
-            #[allow(unused_mut)]
+            #[expect(unused_mut)]
             fn make_syntax(
                 kind: Self::Kind,
                 children: ParsedChildren<Self::Kind>,

--- a/crates/biome_syntax_codegen/src/generate_syntax_kinds.rs
+++ b/crates/biome_syntax_codegen/src/generate_syntax_kinds.rs
@@ -108,8 +108,8 @@ where
     };
 
     let ast = quote! {
-        #![allow(clippy::all)]
-        #![allow(bad_style, missing_docs, unreachable_pub)]
+        #![expect(clippy::all)]
+        #![expect(bad_style, missing_docs, unreachable_pub)]
         /// The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`.
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
         #[repr(u16)]

--- a/crates/biome_text_size/src/serde_impls.rs
+++ b/crates/biome_text_size/src/serde_impls.rs
@@ -31,7 +31,7 @@ impl Serialize for TextRange {
 }
 
 impl<'de> Deserialize<'de> for TextRange {
-    #[allow(clippy::nonminimal_bool)]
+    #[expect(clippy::nonminimal_bool)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/biome_wasm/build.rs
+++ b/crates/biome_wasm/build.rs
@@ -1,7 +1,3 @@
-use std::{env, fs, io, path::PathBuf};
-
-use quote::{format_ident, quote};
-
 use biome_js_factory::syntax::JsFileSource;
 use biome_js_factory::{
     make,
@@ -10,6 +6,8 @@ use biome_js_factory::{
 use biome_js_formatter::{context::JsFormatOptions, format_node};
 use biome_rowan::AstNode;
 use biome_service::workspace_types::{generate_type, methods, ModuleQueue};
+use quote::{format_ident, quote};
+use std::{env, fs, io, path::PathBuf};
 
 fn main() -> io::Result<()> {
     let methods = methods();
@@ -74,10 +72,17 @@ fn main() -> io::Result<()> {
     // Generate wasm-bindgen extern type imports for all the types defined in the TS code
     let types = queue.visited().iter().map(|name| {
         let ident = format_ident!("I{name}");
-        quote! {
-            #[wasm_bindgen(typescript_type = #name)]
-            #[allow(non_camel_case_types)]
-            pub type #ident;
+        if name.contains('_') {
+            quote! {
+                #[wasm_bindgen(typescript_type = #name)]
+                #[expect(non_camel_case_types)]
+                pub type #ident;
+            }
+        } else {
+            quote! {
+                #[wasm_bindgen(typescript_type = #name)]
+                pub type #ident;
+            }
         }
     });
 

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -29,7 +29,6 @@ pub struct Workspace {
 #[wasm_bindgen]
 impl Workspace {
     #[wasm_bindgen(constructor)]
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Workspace {
         Workspace {
             inner: workspace::server(),
@@ -208,6 +207,12 @@ impl Workspace {
         to_value(&result)
             .map(IRenameResult::from)
             .map_err(into_error)
+    }
+}
+
+impl Default for Workspace {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/biome_yaml_factory/src/generated/node_factory.rs
+++ b/crates/biome_yaml_factory/src/generated/node_factory.rs
@@ -1,7 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
 #![allow(clippy::redundant_closure)]
-#![allow(clippy::too_many_arguments)]
 use biome_rowan::AstNode;
 use biome_yaml_syntax::{
     YamlSyntaxElement as SyntaxElement, YamlSyntaxNode as SyntaxNode,

--- a/crates/biome_yaml_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_yaml_factory/src/generated/syntax_factory.rs
@@ -1,5 +1,6 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+#![allow(unused_mut)]
 use biome_rowan::{
     AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind,
 };
@@ -8,7 +9,6 @@ use biome_yaml_syntax::{YamlSyntaxKind, YamlSyntaxKind::*, T, *};
 pub struct YamlSyntaxFactory;
 impl SyntaxFactory for YamlSyntaxFactory {
     type Kind = YamlSyntaxKind;
-    #[allow(unused_mut)]
     fn make_syntax(
         kind: Self::Kind,
         children: ParsedChildren<Self::Kind>,

--- a/crates/biome_yaml_parser/src/lexer/mod.rs
+++ b/crates/biome_yaml_parser/src/lexer/mod.rs
@@ -1,11 +1,10 @@
-use std::iter::FusedIterator;
-
 use biome_parser::{
     diagnostic::ParseDiagnostic,
     lexer::{LexContext, Lexer, TokenFlags},
 };
 use biome_rowan::{TextRange, TextSize};
 use biome_yaml_syntax::{YamlSyntaxKind, T};
+use std::iter::FusedIterator;
 
 #[rustfmt::skip]
 mod tests;
@@ -16,12 +15,12 @@ pub struct Token {
 }
 
 impl Token {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn kind(&self) -> YamlSyntaxKind {
         self.kind
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn range(&self) -> TextRange {
         self.range
     }
@@ -38,7 +37,7 @@ pub(crate) struct YamlLexer<'src> {
     after_newline: bool,
 
     /// If the source starts with a Unicode BOM, this is the number of bytes for that token.
-    #[allow(unused)]
+    #[expect(unused)]
     unicode_bom_length: usize,
 
     /// Byte offset of the current token from the start of the source
@@ -58,22 +57,6 @@ pub(crate) struct YamlLexer<'src> {
 }
 
 impl<'source> YamlLexer<'source> {
-    /// Creates a new lexer from the given string
-    #[allow(dead_code)]
-    pub fn from_str(source: &'source str) -> Self {
-        Self {
-            source,
-            position: 0,
-            after_newline: false,
-            unicode_bom_length: 0,
-            current_start: TextSize::from(0),
-            current_kind: YamlSyntaxKind::EOF,
-            current_flags: TokenFlags::empty(),
-            diagnostics: vec![],
-            context: YamlLexContext::Regular,
-        }
-    }
-
     fn current_char(&self) -> Option<u8> {
         self.source.as_bytes().get(self.position).copied()
     }

--- a/crates/biome_yaml_syntax/src/generated/kind.rs
+++ b/crates/biome_yaml_syntax/src/generated/kind.rs
@@ -1,6 +1,5 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::all)]
 #![allow(bad_style, missing_docs, unreachable_pub)]
 #[doc = r" The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`."]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -65,28 +64,49 @@ pub enum YamlSyntaxKind {
 use self::YamlSyntaxKind::*;
 impl YamlSyntaxKind {
     pub const fn is_punct(self) -> bool {
-        match self {
-            COLON | COMMA | L_CURLY | R_CURLY | L_BRACK | R_BRACK | DASH | PERCENT | STAR
-            | HASH | BANG | AT | SHL | AMP | PIPE | R_ANGLE | TILDE | BACKTICK | DOC_START
-            | DOC_END => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            COLON
+                | COMMA
+                | L_CURLY
+                | R_CURLY
+                | L_BRACK
+                | R_BRACK
+                | DASH
+                | PERCENT
+                | STAR
+                | HASH
+                | BANG
+                | AT
+                | SHL
+                | AMP
+                | PIPE
+                | R_ANGLE
+                | TILDE
+                | BACKTICK
+                | DOC_START
+                | DOC_END
+        )
     }
     pub const fn is_literal(self) -> bool {
-        match self {
-            YAML_STRING_VALUE | YAML_NUMBER_VALUE | YAML_BOOLEAN_VALUE | YAML_NULL_VALUE
-            | YAML_BLOCK_VALUE | YAML_IDENTIFIER => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            YAML_STRING_VALUE
+                | YAML_NUMBER_VALUE
+                | YAML_BOOLEAN_VALUE
+                | YAML_NULL_VALUE
+                | YAML_BLOCK_VALUE
+                | YAML_IDENTIFIER
+        )
     }
     pub const fn is_list(self) -> bool {
-        match self {
+        matches!(
+            self,
             YAML_DOCUMENT_LIST
-            | YAML_ARRAY_INLINE_LIST
-            | YAML_OBJECT_MEMBER_LIST
-            | YAML_ARRAY_ITEM_LIST => true,
-            _ => false,
-        }
+                | YAML_ARRAY_INLINE_LIST
+                | YAML_OBJECT_MEMBER_LIST
+                | YAML_ARRAY_ITEM_LIST
+        )
     }
     pub fn from_keyword(ident: &str) -> Option<YamlSyntaxKind> {
         let kw = match ident {

--- a/crates/biome_yaml_syntax/src/generated/nodes.rs
+++ b/crates/biome_yaml_syntax/src/generated/nodes.rs
@@ -1,7 +1,7 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-#![allow(clippy::enum_variant_names)]
-#![allow(clippy::match_like_matches_macro)]
+#![allow(dead_code)]
+#![allow(unused)]
 use crate::{
     macros::map_syntax_node,
     YamlLanguage as Language, YamlSyntaxElement as SyntaxElement,
@@ -9,18 +9,15 @@ use crate::{
     YamlSyntaxKind::{self as SyntaxKind, *},
     YamlSyntaxList as SyntaxList, YamlSyntaxNode as SyntaxNode, YamlSyntaxToken as SyntaxToken,
 };
-use biome_rowan::{support, AstNode, RawSyntaxKind, SyntaxKindSet, SyntaxResult};
-#[allow(unused)]
 use biome_rowan::{
-    AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
-    AstSeparatedListNodesIterator,
+    support, AstNode, AstNodeList, AstNodeListIterator, AstNodeSlotMap, AstSeparatedList,
+    AstSeparatedListNodesIterator, RawSyntaxKind, SyntaxKindSet, SyntaxResult,
 };
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 #[doc = r" Sentinel value indicating a missing element in a dynamic node, where"]
 #[doc = r" the slots are not statically known."]
-#[allow(dead_code)]
 pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct YamlArray {

--- a/fuzz/fuzz_targets/rome_common.rs
+++ b/fuzz/fuzz_targets/rome_common.rs
@@ -1,7 +1,7 @@
 //! Common functionality between different fuzzers. Look here if you need to inspect implementation
 //! details for the fuzzer harnesses!
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, RuleFilter};
 use biome_diagnostics::Diagnostic;

--- a/xtask/codegen/src/formatter.rs
+++ b/xtask/codegen/src/formatter.rs
@@ -6,13 +6,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::ast::load_ast;
+use crate::language_kind::{LanguageKind, ALL_LANGUAGE_KIND};
 use git2::{Repository, Status, StatusOptions};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use xtask::project_root;
-
-use crate::ast::load_ast;
-use crate::language_kind::{LanguageKind, ALL_LANGUAGE_KIND};
 
 struct GitRepo {
     repo: Repository,
@@ -201,7 +200,7 @@ impl ModuleIndex {
                 // Clippy complains about child modules having the same
                 // names as their parent, eg. js/name/name.rs
                 if import == stem {
-                    content.push_str("#[allow(clippy::module_inception)]\n");
+                    content.push_str("#[expect(clippy::module_inception)]\n");
                 }
 
                 content.push_str("pub(crate) mod ");
@@ -513,7 +512,6 @@ impl BoilerplateImpls {
                 type Format<'a> = FormatRefWithRule<'a, #syntax_crate_ident::#node_id, #format_id>;
 
                 fn format(&self) -> Self::Format<'_> {
-                    #![allow(clippy::default_constructed_unit_structs)]
                     FormatRefWithRule::new(self, #format_id::default())
                 }
             }
@@ -522,7 +520,6 @@ impl BoilerplateImpls {
                 type Format = FormatOwnedWithRule<#syntax_crate_ident::#node_id, #format_id>;
 
                 fn into_format(self) -> Self::Format {
-                    #![allow(clippy::default_constructed_unit_structs)]
                     FormatOwnedWithRule::new(self, #format_id::default())
                 }
             }
@@ -536,6 +533,7 @@ impl BoilerplateImpls {
         let formatter_context_ident = self.language.format_context_ident();
 
         let tokens = quote! {
+            #![expect(clippy::default_constructed_unit_structs)]
             use crate::{AsFormat, IntoFormat, FormatNodeRule, FormatBogusNodeRule, #formatter_ident, #formatter_context_ident};
             use biome_formatter::{FormatRefWithRule, FormatOwnedWithRule, FormatRule, FormatResult};
 

--- a/xtask/codegen/src/generate_license.rs
+++ b/xtask/codegen/src/generate_license.rs
@@ -92,30 +92,30 @@ fn create_data(license_list: LicenseList) -> io::Result<TokenStream> {
 
         #[derive(Debug)]
         pub struct LicenseList {
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) license_list_version: &'static str,
             pub(crate) license_list: &'static [&'static Licence],
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) release_date: &'static str,
         }
 
         #[derive(Debug)]
         pub struct Licence {
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) reference: &'static str,
             pub(crate) is_deprecated_license_id: bool,
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) details_url: &'static str,
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) reference_number: u16,
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) name: &'static str,
             pub(crate) license_id: &'static str,
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) see_also: &'static [&'static str],
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) is_osi_approved: bool,
-            #[allow(unused)]
+            #[expect(unused)]
             pub(crate) is_fsf_libre: bool,
         }
 

--- a/xtask/codegen/src/generate_node_factory.rs
+++ b/xtask/codegen/src/generate_node_factory.rs
@@ -206,7 +206,6 @@ pub fn generate_node_factory(ast: &AstSrc, language_kind: LanguageKind) -> Resul
 
     let output = quote! {
         #![allow(clippy::redundant_closure)]
-        #![allow(clippy::too_many_arguments)]
         use #syntax_crate::{*, #syntax_token as SyntaxToken, #syntax_node as SyntaxNode, #syntax_element as SyntaxElement};
         use biome_rowan::AstNode;
 

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -196,7 +196,7 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
 
                     /// Construct the `slot_map` for this node by checking the `kind` of
                     /// each child of `syntax` against the defined grammar for the node.
-                    #[allow(clippy::explicit_counter_loop)]
+                    #![allow(clippy::explicit_counter_loop)]
                     pub fn build_slot_map(syntax: &SyntaxNode) -> #slot_map_type {
                         #slot_map_builder_impl
                     }
@@ -885,26 +885,23 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
     };
 
     let ast = quote! {
-        #![allow(clippy::enum_variant_names)]
-        // sometimes we generate comparison of simple tokens
-        #![allow(clippy::match_like_matches_macro)]
+        #![allow(dead_code)]
+        #![allow(unused)]
         use crate::{
             macros::map_syntax_node,
             #language as Language, #syntax_element as SyntaxElement, #syntax_element_children as SyntaxElementChildren,
             #syntax_kind::{self as SyntaxKind, *},
             #syntax_list as SyntaxList, #syntax_node as SyntaxNode, #syntax_token as SyntaxToken,
         };
-        #[allow(unused)]
         use biome_rowan::{
-            AstNodeList, AstNodeListIterator,  AstNodeSlotMap, AstSeparatedList, AstSeparatedListNodesIterator
+            AstNodeList, AstNodeListIterator,  AstNodeSlotMap, AstSeparatedList, AstSeparatedListNodesIterator,
+            support, AstNode,SyntaxKindSet, RawSyntaxKind, SyntaxResult
         };
-        use biome_rowan::{support, AstNode,SyntaxKindSet, RawSyntaxKind, SyntaxResult};
         use std::fmt::{Debug, Formatter};
         #serde_import
 
         /// Sentinel value indicating a missing element in a dynamic node, where
         /// the slots are not statically known.
-        #[allow(dead_code)]
         pub(crate) const SLOT_MAP_EMPTY_VALUE: u8 = u8::MAX;
 
         #(#node_defs)*

--- a/xtask/codegen/src/generate_syntax_factory.rs
+++ b/xtask/codegen/src/generate_syntax_factory.rs
@@ -149,6 +149,7 @@ pub fn generate_syntax_factory(ast: &AstSrc, language_kind: LanguageKind) -> Res
         .map(|node| format_ident!("{}", Case::Constant.convert(node)));
 
     let output = quote! {
+        #![allow(unused_mut)]
         use #syntax_crate::{*, #syntax_kind, #syntax_kind::*, T};
         use biome_rowan::{AstNode, ParsedChildren, RawNodeSlots, RawSyntaxNode, SyntaxFactory, SyntaxKind};
 
@@ -158,7 +159,6 @@ pub fn generate_syntax_factory(ast: &AstSrc, language_kind: LanguageKind) -> Res
         impl SyntaxFactory for #factory_kind {
             type Kind = #syntax_kind;
 
-            #[allow(unused_mut)]
             fn make_syntax(
                 kind: Self::Kind,
                 children: ParsedChildren<Self::Kind>,

--- a/xtask/codegen/src/generate_syntax_kinds.rs
+++ b/xtask/codegen/src/generate_syntax_kinds.rs
@@ -200,7 +200,6 @@ pub fn generate_syntax_kinds(grammar: KindsSrc, language_kind: LanguageKind) -> 
     };
 
     let ast = quote! {
-        #![allow(clippy::all)]
         #![allow(bad_style, missing_docs, unreachable_pub)]
         /// The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`.
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
@@ -229,24 +228,15 @@ pub fn generate_syntax_kinds(grammar: KindsSrc, language_kind: LanguageKind) -> 
 
         impl #syntax_kind {
             pub const fn is_punct(self) -> bool {
-                match self {
-                    #(#punctuation)|* => true,
-                    _ => false,
-                }
+                matches!(self, #(#punctuation)|*)
             }
 
             pub const fn is_literal(self) -> bool {
-                match self {
-                    #(#literals)|* => true,
-                    _ => false,
-                }
+                matches!(self, #(#literals)|*)
             }
 
             pub const fn is_list(self) -> bool {
-                match self {
-                    #(#lists)|* => true,
-                    _ => false,
-                }
+                matches!(self, #(#lists)|*)
             }
 
             pub fn from_keyword(ident: &str) -> Option<#syntax_kind> {

--- a/xtask/codegen/src/js_kinds_src.rs
+++ b/xtask/codegen/src/js_kinds_src.rs
@@ -581,7 +581,7 @@ pub struct AstListSeparatorConfiguration {
 
 #[derive(Debug)]
 pub struct AstNodeSrc {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub documentation: Vec<String>,
     pub name: String,
     // pub traits: Vec<String>,
@@ -615,7 +615,7 @@ pub enum Field {
 
 #[derive(Debug, Clone)]
 pub struct AstEnumSrc {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub documentation: Vec<String>,
     pub name: String,
     // pub traits: Vec<String>,
@@ -726,7 +726,7 @@ impl Field {
             }
         }
     }
-    #[allow(dead_code)]
+
     pub fn ty(&self) -> proc_macro2::Ident {
         match self {
             Field::Token { .. } => format_ident!("SyntaxToken"),

--- a/xtask/codegen/src/termcolorful.rs
+++ b/xtask/codegen/src/termcolorful.rs
@@ -1,5 +1,5 @@
 #[derive(Copy, Clone, Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) enum Color {
     Red,
     Green,

--- a/xtask/coverage/src/symbols/msts.rs
+++ b/xtask/coverage/src/symbols/msts.rs
@@ -220,14 +220,14 @@ impl TestSuite for SymbolsMicrosoftTestSuite {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct Decl {
     file: String,
     row_start: Option<usize>,
     col_start: Option<usize>,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug)]
 struct Symbol {
     name: String,

--- a/xtask/libs_bench/benches/contains.rs
+++ b/xtask/libs_bench/benches/contains.rs
@@ -1,9 +1,6 @@
-#![allow(dead_code)]
-
-use std::collections::{BTreeSet, HashSet};
-
 use fastbloom_rs::{BloomFilter, FilterBuilder, Membership};
 use qp_trie::Trie;
+use std::collections::{BTreeSet, HashSet};
 
 pub fn keywords() -> Vec<String> {
     let repeat = std::env::var("ROME_BENCH_CONTAINS_REPEAT")
@@ -17,45 +14,14 @@ pub fn keywords() -> Vec<String> {
         .collect()
 }
 
-pub fn search_for() -> &'static [&'static str] {
-    &[
-        "undefined",
-        "a",
-        "NaN",
-        "longVariableName",
-        "Infinity",
-        "xxxxxxxx",
-        "arguments",
-        "eval",
-    ][..]
-}
-
 pub fn contains_slice_setup() -> Vec<String> {
     keywords()
-}
-
-pub fn contains_slice() -> usize {
-    let set = contains_slice_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += set.iter().position(|x| x == k).unwrap_or(0);
-    }
-    count
 }
 
 pub fn contains_binary_search_setup() -> Vec<String> {
     let mut words = keywords();
     words.sort();
     words
-}
-
-pub fn contains_binary_search() -> usize {
-    let set = contains_binary_search_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += set.binary_search_by(|v| (*k).cmp(v.as_str())).unwrap_or(1);
-    }
-    count
 }
 
 pub fn contains_hashset_setup() -> HashSet<String> {
@@ -66,30 +32,12 @@ pub fn contains_hashset_setup() -> HashSet<String> {
     set
 }
 
-pub fn contains_hashset() -> i32 {
-    let set = contains_hashset_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += i32::from(set.contains(*k));
-    }
-    count
-}
-
 pub fn contains_btreeset_setup() -> BTreeSet<String> {
     let mut set = BTreeSet::new();
     for k in keywords() {
         set.insert(k.to_string());
     }
     set
-}
-
-pub fn contains_btreeset() -> i32 {
-    let set = contains_btreeset_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count = i32::from(set.contains(*k));
-    }
-    count
 }
 
 pub fn contains_bloom_setup() -> BloomFilter {
@@ -103,15 +51,6 @@ pub fn contains_bloom_setup() -> BloomFilter {
     set
 }
 
-pub fn contains_bloom() -> i32 {
-    let set = contains_bloom_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += i32::from(set.contains(k.as_bytes()));
-    }
-    count
-}
-
 pub fn contains_trie_setup() -> Trie<Vec<u8>, i32> {
     let mut set = Trie::new();
 
@@ -120,15 +59,6 @@ pub fn contains_trie_setup() -> Trie<Vec<u8>, i32> {
     }
 
     set
-}
-
-pub fn contains_trie() -> i32 {
-    let set = contains_trie_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += i32::from(set.contains_key(k.as_bytes()));
-    }
-    count
 }
 
 pub fn contains_fst_setup() -> fst::Set<Vec<u8>> {
@@ -144,28 +74,6 @@ pub fn contains_fst_setup() -> fst::Set<Vec<u8>> {
     set.into_set()
 }
 
-pub fn contains_fst() -> i32 {
-    let set = contains_fst_setup();
-    let mut count = 0;
-    for k in search_for() {
-        count += i32::from(set.contains(k));
-    }
-    count
-}
-
 pub fn contains_memchr_setup() -> Vec<String> {
     contains_binary_search_setup()
-}
-
-pub fn contains_memchr() -> i32 {
-    let set = contains_memchr_setup();
-
-    let mut count = 0;
-    for k in search_for() {
-        for item in set.iter() {
-            count +=
-                i32::from(memchr::memmem::find(k.as_bytes(), item.as_str().as_bytes()).is_some());
-        }
-    }
-    count
 }

--- a/xtask/libs_bench/benches/contains_criterion.rs
+++ b/xtask/libs_bench/benches/contains_criterion.rs
@@ -4,12 +4,23 @@ use contains::*;
 use criterion::{criterion_group, criterion_main, Criterion};
 use fastbloom_rs::Membership;
 
+const SEARCH_FOR: &[&str] = &[
+    "undefined",
+    "a",
+    "NaN",
+    "longVariableName",
+    "Infinity",
+    "xxxxxxxx",
+    "arguments",
+    "eval",
+];
+
 fn criterion_benchmark(c: &mut Criterion) {
     let set = contains_hashset_setup();
     c.bench_function("contains_hashset", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += i32::from(set.contains(*k));
             }
             count
@@ -20,7 +31,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_btreeset", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count = i32::from(set.contains(*k));
             }
             count
@@ -31,7 +42,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_bloom", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += i32::from(set.contains(k.as_bytes()))
             }
             count
@@ -42,7 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_trie", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += i32::from(set.contains_key(k.as_bytes()));
             }
             count
@@ -53,7 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_slice", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += set.iter().position(|x| x == k).unwrap_or(0);
             }
             count
@@ -64,7 +75,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_fst", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += i32::from(set.contains(k));
             }
             count
@@ -76,7 +87,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("contains_binary_search", |b| {
         b.iter(|| {
             let mut count = 0;
-            for k in search_for() {
+            for k in SEARCH_FOR {
                 count += set.binary_search_by(|v| (*k).cmp(v.as_str())).unwrap_or(1);
             }
             count
@@ -88,7 +99,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             {
                 let mut count = 0;
-                for k in search_for() {
+                for k in SEARCH_FOR {
                     for item in set.iter() {
                         count += i32::from(
                             memchr::memmem::find(k.as_bytes(), item.as_str().as_bytes()).is_some(),

--- a/xtask/libs_bench/benches/contains_iai.rs
+++ b/xtask/libs_bench/benches/contains_iai.rs
@@ -7,19 +7,11 @@ use contains::*;
 
 iai::main!(
     contains_hashset_setup,
-    contains_hashset,
     contains_btreeset_setup,
-    contains_btreeset,
     contains_bloom_setup,
-    contains_bloom,
     contains_trie_setup,
-    contains_trie,
     contains_slice_setup,
-    contains_slice,
     contains_fst_setup,
-    contains_fst,
     contains_binary_search_setup,
-    contains_binary_search,
     contains_memchr_setup,
-    contains_memchr,
 );


### PR DESCRIPTION
## Summary (Purpose)

Clippy's `allow` method allows the next line of code to be exempted from a given lint (e.g. Clippy's [unnecessary_mut_passed](https://rust-lang.github.io/rust-clippy/master/#unnecessary_mut_passed) lint).

Clippy's `expect` method is similar, except the next line of code is required for fail the given lint. This:

- Prevents unnecessary use of `allow` (`expect`), so as many lines of code are subjected to as much linting as possible.
- Ensures that `allow` (`expect`) usages are removed as soon as they're no longer needed. 

Closes #3969.

## Test Plan

Ensure CI passes, confirm code diffs are reasonable.

## Summary (Code Changes)

- Convert all uses of `allow` to `expect`.
- Remove unnecessary `expect`s.
- Adjust code generation and CI to eliminate failed `expect`s in generated code.


