### PR TITLE
refactor: cargo features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "quickcheck",
  "quickcheck_macros",
  "rustc-hash 2.1.0",
+ "schemars",
  "serde",
  "serde_json",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ biome_flags          = { path = "./crates/biome_flags" }
 biome_formatter_test = { path = "./crates/biome_formatter_test" }
 biome_lsp            = { path = "./crates/biome_lsp" }
 biome_migrate        = { path = "./crates/biome_migrate" }
-biome_service        = { path = "./crates/biome_service", default-features = false }
+biome_service        = { path = "./crates/biome_service" }
 biome_test_utils     = { path = "./crates/biome_test_utils" }
 tests_macros         = { path = "./crates/tests_macros" }
 

--- a/crates/biome_analyze/Cargo.toml
+++ b/crates/biome_analyze/Cargo.toml
@@ -29,7 +29,8 @@ tracing                  = { workspace = true }
 
 
 [features]
-serde = ["dep:serde", "dep:schemars", "dep:biome_deserialize", "dep:biome_deserialize_macros"]
+schema = ["dep:schemars", "biome_console/schema", "serde"]
+serde  = ["dep:serde", "dep:biome_deserialize", "dep:biome_deserialize_macros"]
 
 [lints]
 workspace = true

--- a/crates/biome_analyze/src/categories.rs
+++ b/crates/biome_analyze/src/categories.rs
@@ -4,9 +4,10 @@ use std::borrow::Cow;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RuleCategory {
     /// This rule checks the syntax according to the language specification
     /// and emits error diagnostics accordingly
@@ -33,9 +34,10 @@ pub const SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY: &str = "quickfix.suppressRule.t
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum ActionCategory {
     /// Base kind for quickfix actions: 'quickfix'.
     ///
@@ -57,9 +59,10 @@ pub enum ActionCategory {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum OtherActionCategory {
     /// Base kind for inline suppressions actions: `quickfix.suppressRule.inline.biome`
     InlineSuppression,
@@ -148,9 +151,10 @@ impl ActionCategory {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RefactorKind {
     /// This action describes a refactor with no particular sub-category
     None,
@@ -189,9 +193,10 @@ pub enum RefactorKind {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum SourceActionKind {
     /// This action describes a source action with no particular sub-category
     None,
@@ -332,7 +337,7 @@ impl<'de> serde::Deserialize<'de> for RuleCategories {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for RuleCategories {
     fn schema_name() -> String {
         String::from("RuleCategories")

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -201,12 +201,12 @@ impl Display for DisplayDomains {
     feature = "serde",
     derive(
         biome_deserialize_macros::Deserializable,
-        schemars::JsonSchema,
         serde::Deserialize,
         serde::Serialize
     )
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 /// Used to identify the kind of code action emitted by a rule
 pub enum FixKind {
     /// The rule doesn't emit code actions.
@@ -241,7 +241,8 @@ impl TryFrom<FixKind> for Applicability {
 }
 
 #[derive(Debug, Clone, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum RuleSource {
     /// Rules from [Rust Clippy](https://rust-lang.github.io/rust-clippy/master/index.html)
@@ -460,8 +461,9 @@ impl RuleSource {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RuleSourceKind {
     /// The rule implements the same logic of the source
     #[default]
@@ -481,13 +483,13 @@ impl RuleSourceKind {
 #[cfg_attr(
     feature = "serde",
     derive(
-        schemars::JsonSchema,
         serde::Deserialize,
         serde::Serialize,
         biome_deserialize_macros::Deserializable
     )
 )]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum RuleDomain {
     /// React library rules
     React,

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -45,12 +45,14 @@ schema = [
   "dep:schemars",
   "biome_js_analyze/schema",
   "biome_css_analyze/schema",
-  "biome_formatter/serde",
+  "biome_formatter/schema",
   "biome_json_syntax/schema",
   "biome_css_syntax/schema",
   "biome_graphql_syntax/schema",
   "biome_html_syntax/schema",
-  "biome_analyze/serde",
+  "biome_analyze/schema",
+  "biome_json_formatter/schema",
+  "biome_js_formatter/schema",
 ]
 
 [dev-dependencies]

--- a/crates/biome_console/Cargo.toml
+++ b/crates/biome_console/Cargo.toml
@@ -24,8 +24,10 @@ unicode-width        = { workspace = true }
 [dev-dependencies]
 trybuild = "1.0.101"
 
+
 [features]
-serde_markup = ["serde", "schemars"]
+schema = ["dep:schemars", "serde", "biome_text_size/schema"]
+serde  = ["dep:serde"]
 
 [lints]
 workspace = true

--- a/crates/biome_console/src/markup.rs
+++ b/crates/biome_console/src/markup.rs
@@ -11,10 +11,8 @@ use crate::fmt::{Display, Formatter, MarkupElements, Write};
 
 /// Enumeration of all the supported markup elements
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum MarkupElement<'fmt> {
     Emphasis,
     Dim,
@@ -122,10 +120,8 @@ pub struct MarkupNode<'fmt> {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MarkupNodeBuf {
     pub elements: Vec<MarkupElement<'static>>,
     pub content: String,
@@ -181,10 +177,8 @@ impl Markup<'_> {
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MarkupBuf(pub Vec<MarkupNodeBuf>);
 
 impl MarkupBuf {

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -28,15 +28,15 @@ test = true
 
 [dependencies]
 backtrace                    = "0.3.74"
-biome_console                = { workspace = true, features = ["serde_markup"] }
+biome_console                = { workspace = true, features = ["serde"] }
 biome_diagnostics_categories = { workspace = true, features = ["serde"] }
 biome_diagnostics_macros     = { workspace = true }
 biome_rowan                  = { workspace = true }
-biome_text_edit              = { workspace = true }
-biome_text_size              = { workspace = true }
+biome_text_edit              = { workspace = true, features = ["serde"] }
+biome_text_size              = { workspace = true, features = ["serde"] }
 bpaf                         = { workspace = true, optional = true }
 camino                       = { workspace = true, optional = true }
-enumflags2                   = { workspace = true }
+enumflags2                   = { workspace = true, features = ["serde"] }
 oxc_resolver                 = { workspace = true, optional = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
@@ -49,7 +49,7 @@ unicode-width                = { workspace = true }
 bpaf         = ["dep:bpaf"]
 camino       = ["dep:camino"]
 oxc_resolver = ["dep:oxc_resolver"]
-schema       = ["schemars", "biome_text_edit/schemars", "biome_diagnostics_categories/schemars"]
+schema       = ["dep:schemars", "biome_text_edit/schema", "biome_diagnostics_categories/schema", "biome_console/schema"]
 serde_ini    = ["dep:serde_ini"]
 std          = []
 

--- a/crates/biome_diagnostics_categories/Cargo.toml
+++ b/crates/biome_diagnostics_categories/Cargo.toml
@@ -17,5 +17,9 @@ serde    = { workspace = true, optional = true }
 [build-dependencies]
 quote = "1.0.14"
 
+[features]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde"]
+
 [lints]
 workspace = true

--- a/crates/biome_diagnostics_categories/build.rs
+++ b/crates/biome_diagnostics_categories/build.rs
@@ -64,7 +64,7 @@ pub fn main() -> io::Result<()> {
             }
         }
 
-        #[cfg(feature = "schemars")]
+        #[cfg(feature = "schema")]
         impl schemars::JsonSchema for &'static Category {
             fn schema_name() -> String {
                 String::from("Category")

--- a/crates/biome_fs/Cargo.toml
+++ b/crates/biome_fs/Cargo.toml
@@ -33,7 +33,8 @@ serde_json = { workspace = true }
 
 
 [features]
-serde = ["schemars", "camino/serde1", "biome_diagnostics/schema"]
+schema = ["dep:schemars", "serde", "biome_diagnostics/schema"]
+serde  = ["camino/serde1"]
 
 [lints]
 workspace = true

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -20,9 +20,10 @@ use std::{fs::File, io, io::Write, ops::Deref};
 #[bitflags]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 // NOTE: The order of the variants is important, the one on the top has the highest priority
 pub enum FileKind {
     /// A configuration file has the highest priority. It's usually `biome.json` and `biome.jsonc`
@@ -124,7 +125,7 @@ impl<'de> serde::Deserialize<'de> for BiomePath {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for BiomePath {
     fn schema_name() -> String {
         "BiomePath".to_string()
@@ -244,7 +245,7 @@ impl TryFrom<PathBuf> for BiomePath {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for FileKinds {
     fn schema_name() -> String {
         String::from("FileKind")

--- a/crates/biome_glob/Cargo.toml
+++ b/crates/biome_glob/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 authors.workspace    = true
 categories.workspace = true
@@ -23,5 +22,5 @@ serde             = { workspace = true, optional = true }
 
 [features]
 biome_deserialize = ["dep:biome_deserialize", "dep:biome_text_size"]
-schemars          = ["dep:schemars"]
+schema            = ["dep:schemars", "serde"]
 serde             = ["dep:serde"]

--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -254,7 +254,7 @@ impl biome_deserialize::Deserializable for Glob {
         }
     }
 }
-#[cfg(feature = "schemars")]
+#[cfg(feature = "schema")]
 impl schemars::JsonSchema for Glob {
     fn schema_name() -> String {
         "Regex".to_string()

--- a/crates/biome_grit_patterns/Cargo.toml
+++ b/crates/biome_grit_patterns/Cargo.toml
@@ -32,7 +32,7 @@ rand                 = { version = "0.8.5" }
 regex                = { workspace = true }
 rustc-hash           = { workspace = true }
 schemars             = { workspace = true, optional = true }
-serde                = { workspace = true, features = ["derive"] }
+serde                = { workspace = true, features = ["derive"], optional = true }
 serde_json           = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -41,7 +41,8 @@ insta            = { workspace = true }
 tests_macros     = { path = "../tests_macros" }
 
 [features]
-schema = ["dep:schemars", "dep:serde_json"]
+schema = ["dep:schemars", "serde", "biome_js_parser/schema"]
+serde  = ["dep:serde", "dep:serde_json"]
 
 [lints]
 workspace = true

--- a/crates/biome_grit_patterns/src/grit_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language.rs
@@ -6,7 +6,6 @@ pub use js_target_language::JsTargetLanguage;
 
 use camino::Utf8Path;
 use grit_util::{AnalysisLogs, Ast, CodeRange, EffectRange, Language, Parser, SnippetTree};
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::path::Path;
 use std::str::FromStr;
@@ -41,18 +40,20 @@ macro_rules! generate_target_language {
             }
         })+
 
-        impl Serialize for GritTargetLanguage {
+        #[cfg(feature = "serde")]
+        impl serde::Serialize for GritTargetLanguage {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
             {
                 match self {
-                    $(Self::$language(_) => Serialize::serialize($name, serializer)),+
+                    $(Self::$language(_) => serde::Serialize::serialize($name, serializer)),+
                 }
             }
         }
 
-        impl<'de> Deserialize<'de> for GritTargetLanguage {
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for GritTargetLanguage {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: serde::Deserializer<'de>,

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -19,7 +19,7 @@ biome_control_flow       = { workspace = true }
 biome_deserialize        = { workspace = true, features = ["smallvec"] }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
-biome_glob               = { workspace = true, features = ["biome_deserialize", "schemars", "serde"] }
+biome_glob               = { workspace = true, features = ["biome_deserialize", "serde"] }
 biome_js_factory         = { workspace = true }
 biome_js_semantic        = { workspace = true }
 biome_js_syntax          = { workspace = true }
@@ -49,7 +49,7 @@ insta               = { workspace = true, features = ["glob"] }
 tests_macros        = { path = "../tests_macros" }
 
 [features]
-schema = ["schemars"]
+schema = ["schemars", "biome_glob/schema"]
 
 [lints]
 workspace = true

--- a/crates/biome_js_formatter/Cargo.toml
+++ b/crates/biome_js_formatter/Cargo.toml
@@ -44,7 +44,8 @@ serde_json           = { workspace = true }
 tests_macros         = { path = "../tests_macros" }
 
 [features]
-serde = ["dep:serde", "schemars"]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde"]
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -406,9 +406,10 @@ impl fmt::Display for JsFormatOptions {
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum QuoteProperties {
     #[default]
     AsNeeded,
@@ -440,9 +441,10 @@ impl fmt::Display for QuoteProperties {
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum Semicolons {
     #[default]
     Always,
@@ -483,9 +485,10 @@ impl fmt::Display for Semicolons {
 #[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum ArrowParentheses {
     #[default]
     Always,
@@ -527,9 +530,10 @@ impl fmt::Display for ArrowParentheses {
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct BracketSameLine(bool);
 
 impl BracketSameLine {

--- a/crates/biome_js_formatter/src/context/trailing_commas.rs
+++ b/crates/biome_js_formatter/src/context/trailing_commas.rs
@@ -54,9 +54,10 @@ impl Format<JsFormatContext> for FormatTrailingCommas {
 #[derive(Clone, Copy, Default, Debug, Deserializable, Eq, Hash, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum TrailingCommas {
     /// Trailing commas wherever possible (including function parameters and calls).
     #[default]

--- a/crates/biome_js_parser/Cargo.toml
+++ b/crates/biome_js_parser/Cargo.toml
@@ -23,7 +23,7 @@ enumflags2          = { workspace = true }
 indexmap            = { workspace = true }
 rustc-hash          = { workspace = true }
 schemars            = { workspace = true, optional = true }
-serde               = { workspace = true, features = ["derive"] }
+serde               = { workspace = true, features = ["derive"], optional = true }
 serde_json          = { workspace = true }
 smallvec            = { workspace = true }
 tracing             = { workspace = true }
@@ -42,9 +42,9 @@ tests_macros        = { path = "../tests_macros" }
 
 
 [features]
-schemars = ["dep:schemars"]
-serde    = ["biome_js_syntax/schema"]
-tests    = []
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde", "biome_js_syntax/schema"]
+tests  = []
 
 # cargo-workspaces metadata
 [package.metadata.workspaces]

--- a/crates/biome_js_parser/src/options.rs
+++ b/crates/biome_js_parser/src/options.rs
@@ -1,16 +1,21 @@
 /// Options to pass to the JavaScript parser
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct JsParserOptions {
     /// Enables parsing of Grit metavariables.
     /// Defaults to `false`.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub grit_metavariables: bool,
 
     /// Whether the parsing of the class parameter decorators should happen.
     ///
     /// This parameter decorators belong to the old language proposal.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub parse_class_parameter_decorators: bool,
 }
 

--- a/crates/biome_json_formatter/Cargo.toml
+++ b/crates/biome_json_formatter/Cargo.toml
@@ -39,7 +39,8 @@ tests_macros         = { path = "../tests_macros" }
 independent = true
 
 [features]
-serde = ["dep:serde", "schemars"]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde"]
 
 [lints]
 workspace = true

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -72,9 +72,10 @@ pub struct JsonFormatOptions {
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Deserializable, Merge, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum TrailingCommas {
     #[default]
     /// The formatter will remove the trailing commas

--- a/crates/biome_rowan/Cargo.toml
+++ b/crates/biome_rowan/Cargo.toml
@@ -16,6 +16,7 @@ biome_text_size = { workspace = true }
 countme         = { workspace = true }
 hashbrown       = { version = "0.14.5", features = ["inline-more"], default-features = false }
 rustc-hash      = { workspace = true }
+schemars        = { workspace = true, optional = true }
 serde           = { workspace = true, optional = true }
 tracing         = { workspace = true }
 
@@ -26,7 +27,8 @@ quickcheck_macros = { workspace = true }
 serde_json        = { workspace = true }
 
 [features]
-serde = ["dep:serde", "biome_text_size/serde", "biome_text_size/schemars"]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde", "biome_text_size/serde", "biome_text_size/serde"]
 
 [[bench]]
 harness = false

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -32,7 +32,7 @@ biome_graphql_parser    = { workspace = true }
 biome_graphql_syntax    = { workspace = true }
 biome_grit_formatter    = { workspace = true }
 biome_grit_parser       = { workspace = true }
-biome_grit_patterns     = { workspace = true }
+biome_grit_patterns     = { workspace = true, features = ["serde"] }
 biome_grit_syntax       = { workspace = true }
 biome_html_formatter    = { workspace = true }
 biome_html_parser       = { workspace = true }
@@ -80,12 +80,13 @@ schema = [
   "biome_formatter/schema",
   "biome_js_factory",
   "biome_js_syntax/schema",
-  "biome_text_edit/schemars",
+  "biome_text_edit/schema",
   "biome_json_syntax/schema",
   "biome_css_syntax/schema",
   "biome_graphql_syntax/schema",
   "biome_grit_syntax/schema",
   "biome_grit_patterns/schema",
+  "biome_fs/schema",
 ]
 
 

--- a/crates/biome_text_edit/Cargo.toml
+++ b/crates/biome_text_edit/Cargo.toml
@@ -11,13 +11,14 @@ repository.workspace = true
 version              = "0.5.7"
 
 [dependencies]
-biome_text_size = { workspace = true, features = ["serde"] }
+biome_text_size = { workspace = true }
 schemars        = { workspace = true, optional = true }
-serde           = { workspace = true, features = ["derive"] }
+serde           = { workspace = true, features = ["derive"], optional = true }
 similar         = { workspace = true, features = ["unicode"] }
 
 [features]
-schemars = ["dep:schemars", "biome_text_size/schemars"]
+schema = ["dep:schemars", "biome_text_size/schema", "serde"]
+serde  = ["dep:serde", "biome_text_size/serde"]
 
 [lints]
 workspace = true

--- a/crates/biome_text_edit/src/lib.rs
+++ b/crates/biome_text_edit/src/lib.rs
@@ -8,32 +8,42 @@
     semicolon_in_expressions_from_macros
 )]
 
-use std::{cmp::Ordering, num::NonZeroU32};
-
 use biome_text_size::{TextRange, TextSize};
-use serde::{Deserialize, Serialize};
 pub use similar::ChangeTag;
 use similar::{utils::TextDiffRemapper, TextDiff};
+use std::{cmp::Ordering, num::NonZeroU32};
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct TextEdit {
     dictionary: String,
     ops: Vec<CompressedOp>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
 pub enum CompressedOp {
     DiffOp(DiffOp),
     EqualLines { line_count: NonZeroU32 },
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
 pub enum DiffOp {
     Equal { range: TextRange },
     Insert { range: TextRange },

--- a/crates/biome_text_size/Cargo.toml
+++ b/crates/biome_text_size/Cargo.toml
@@ -14,6 +14,10 @@ version              = "0.5.7"
 schemars = { workspace = true, optional = true }
 serde    = { workspace = true, optional = true }
 
+[features]
+schema = ["dep:schemars", "serde"]
+serde  = ["dep:serde"]
+
 [dev-dependencies]
 serde_test        = "1.0.177"
 static_assertions = "1.1"

--- a/crates/biome_text_size/src/lib.rs
+++ b/crates/biome_text_size/src/lib.rs
@@ -23,7 +23,7 @@ mod range;
 mod size;
 mod traits;
 
-#[cfg(feature = "schemars")]
+#[cfg(feature = "schema")]
 mod schemars_impls;
 #[cfg(feature = "serde")]
 mod serde_impls;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Many of our crates have a mix of `serde` feature and `schema` feature, however in some cases they are mixed together, or they have different names (`schema` VS `schemars`).

Also, there was a problem where `schemars` was pulled inside the final `biome_cli` binary, even though it supposed to be used as an opt-in feature only when we create the configuration schema of the configuration file.

This PR does refactor various crates in order to make everything opt-in. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The CI should stay green.

I ran `cargo tree --package biome_cli` and confirmed that `schemars` dependency isn't part of the binary anymore.

<!-- What demonstrates that your implementation is correct? -->
