### PR TITLE
refactor: resolve paths and globs from the configuration path

### DIFF
--- a/.changeset/biome_now_resolves_globs_and_paths_from_the_configuration_before_paths_and_globs_were_resolved_from_the_working_directory.md
+++ b/.changeset/biome_now_resolves_globs_and_paths_from_the_configuration_before_paths_and_globs_were_resolved_from_the_working_directory.md
@@ -1,0 +1,5 @@
+---
+cli: major
+---
+
+# Biome now resolves globs and paths from the configuration. Before, paths and globs were resolved from the working directory.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -791,7 +791,7 @@ pub(crate) trait CommandRunner: Sized {
         }
         let configuration_path = loaded_configuration.directory_path.clone();
         let configuration = self.merge_configuration(loaded_configuration, fs, console)?;
-        let vcs_base_path = configuration_path.or(fs.working_directory());
+        let vcs_base_path = configuration_path.clone().or(fs.working_directory());
         let (vcs_base_path, gitignore_matches) =
             configuration.retrieve_gitignore_matches(fs, vcs_base_path.as_deref())?;
         let paths = self.get_files_to_process(fs, &configuration)?;
@@ -806,7 +806,7 @@ pub(crate) trait CommandRunner: Sized {
             workspace.set_manifest_for_project(manifest_data.into())?;
         }
         workspace.update_settings(UpdateSettingsParams {
-            workspace_directory: fs.working_directory().map(BiomePath::from),
+            workspace_directory: configuration_path.map(BiomePath::from),
             configuration,
             vcs_base_path: vcs_base_path.map(BiomePath::from),
             gitignore_matches,

--- a/crates/biome_cli/src/reporter/summary.rs
+++ b/crates/biome_cli/src/reporter/summary.rs
@@ -42,7 +42,7 @@ impl<'a> ReporterVisitor for SummaryReporterVisitor<'a> {
 
         if !execution.is_ci() && summary.diagnostics_not_printed > 0 {
             self.0.log(markup! {
-                <Warn>"The number of diagnostics exceeds the number allowed by Biome.\n"</Warn>
+                <Warn>"The number of diagnostics exceeds the limit allowed. Use "<Emphasis>"--max-diagnostics"</Emphasis>" to increase it.\n"</Warn>
                 <Info>"Diagnostics not shown: "</Info><Emphasis>{summary.diagnostics_not_printed}</Emphasis><Info>"."</Info>
             })
         }

--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -68,7 +68,7 @@ impl<'a> ReporterVisitor for ConsoleReporterVisitor<'a> {
 
         if !execution.is_ci() && summary.diagnostics_not_printed > 0 {
             self.0.log(markup! {
-                <Warn>"The number of diagnostics exceeds the number allowed by Biome.\n"</Warn>
+                <Warn>"The number of diagnostics exceeds the limit allowed. Use "<Emphasis>"--max-diagnostics"</Emphasis>" to increase it.\n"</Warn>
                 <Info>"Diagnostics not shown: "</Info><Emphasis>{summary.diagnostics_not_printed}</Emphasis><Info>"."</Info>
             })
         }

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -187,7 +187,7 @@ fn maximum_diagnostics() {
         .filter(|m| m.level == LogLevel::Log)
         .any(|m| {
             let content = format!("{:?}", m.content);
-            content.contains("The number of diagnostics exceeds the number allowed by Biome")
+            content.contains("The number of diagnostics exceeds the limit allowed")
                 && content.contains("Diagnostics not shown")
                 && content.contains("29")
         }));

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -158,7 +158,7 @@ fn maximum_diagnostics() {
         .filter(|m| m.level == LogLevel::Log)
         .any(|m| {
             let content = format!("{:?}", m.content);
-            content.contains("The number of diagnostics exceeds the number allowed by Biome")
+            content.contains("The number of diagnostics exceeds the limit allowed")
                 && content.contains("Diagnostics not shown")
                 && content.contains("28")
         }));

--- a/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/maximum_diagnostics.snap
@@ -314,7 +314,7 @@ check.js:5:18 lint/correctness/noConstantCondition ━━━━━━━━━�
 ```
 
 ```block
-The number of diagnostics exceeds the number allowed by Biome.
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
 Diagnostics not shown: 29.
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 # Termination Message
 
@@ -16,7 +17,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-The number of diagnostics exceeds the number allowed by Biome.
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
 Diagnostics not shown: 50.
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/max_diagnostics_default.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: content
+snapshot_kind: text
 ---
 # Termination Message
 
@@ -16,7 +17,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-The number of diagnostics exceeds the number allowed by Biome.
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
 Diagnostics not shown: 40.
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/maximum_diagnostics.snap
@@ -314,7 +314,7 @@ check.js:5:18 lint/correctness/noConstantCondition ━━━━━━━━━�
 ```
 
 ```block
-The number of diagnostics exceeds the number allowed by Biome.
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
 Diagnostics not shown: 28.
 ```
 

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -560,7 +560,7 @@ impl Session {
                                 return ConfigurationStatus::Error;
                             }
                             let result = self.workspace.update_settings(UpdateSettingsParams {
-                                workspace_directory: fs.working_directory().map(BiomePath::from),
+                                workspace_directory: configuration_path.map(BiomePath::from),
                                 configuration,
                                 vcs_base_path: vcs_base_path.map(BiomePath::from),
                                 gitignore_matches,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4813

The change is very simple, and it was done in two places.

Another change I did in this PR is reviewing a warning we print on console regarding non-printed diagnostics. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested the new logic by creating a new `biome check` script in this repository, in the file `packages/@biomejs/biome/package.json`. By default, Biome should resolve the root `biome.json`, and it should keep ignoring `packages/@biomejs/biome/configuration_schema.json`. Running the `check` command still ignores the file.

I updated the relevant snapshots. 

<!-- What demonstrates that your implementation is correct? -->
