### PR TITLE
refactor: drop "current" project from workspace and cleanup workspace methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "biome_text_edit",
  "camino",
  "futures",
+ "papaya",
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",

--- a/crates/biome_cli/examples/text_reporter.rs
+++ b/crates/biome_cli/examples/text_reporter.rs
@@ -1,21 +1,26 @@
 use biome_cli::{
     DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary, VcsTargeted,
 };
+use biome_service::projects::ProjectKey;
 
 /// This will be the visitor, which where we **write** the data
 struct BufferVisitor(String);
 
 /// This is the reporter, which will be a type that will hold the information needed to the reporter
 struct TextReport {
+    project_key: ProjectKey,
     summary: TraversalSummary,
 }
 
 impl Reporter for TextReport {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> std::io::Result<()> {
-        let execution = Execution::new_format(VcsTargeted {
-            staged: false,
-            changed: false,
-        });
+        let execution = Execution::new_format(
+            self.project_key,
+            VcsTargeted {
+                staged: false,
+                changed: false,
+            },
+        );
         visitor.report_summary(&execution, self.summary)?;
         Ok(())
     }
@@ -42,13 +47,20 @@ impl ReporterVisitor for BufferVisitor {
 }
 
 pub fn main() {
+    // In a real scenario, the project key is obtained from the
+    // `Workspace::open_project()` call.
+    let project_key = ProjectKey::new();
+
     let summary = TraversalSummary {
         changed: 32,
         unchanged: 28,
         ..TraversalSummary::default()
     };
     let mut visitor = BufferVisitor(String::new());
-    let reporter = TextReport { summary };
+    let reporter = TextReport {
+        project_key,
+        summary,
+    };
     reporter.write(&mut visitor).unwrap();
 
     assert_eq!(visitor.0.as_str(), "Total is 64")

--- a/crates/biome_cli/src/commands/check.rs
+++ b/crates/biome_cli/src/commands/check.rs
@@ -9,6 +9,7 @@ use biome_configuration::{
 use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
+use biome_service::projects::ProjectKey;
 use biome_service::{configuration::LoadedConfiguration, Workspace, WorkspaceError};
 use std::ffi::OsString;
 
@@ -123,6 +124,7 @@ impl CommandRunner for CheckCommandPayload {
         cli_options: &CliOptions,
         console: &mut dyn Console,
         _workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
         let fix_file_mode = determine_fix_file_mode(FixFileModeOptions {
             write: self.write,
@@ -133,6 +135,7 @@ impl CommandRunner for CheckCommandPayload {
         })?;
 
         Ok(Execution::new(TraversalMode::Check {
+            project_key,
             fix_file_mode,
             stdin: self.get_stdin(console)?,
             vcs_targeted: (self.staged, self.changed).into(),

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -9,6 +9,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
+use biome_service::projects::ProjectKey;
 use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
@@ -114,8 +115,9 @@ impl CommandRunner for CiCommandPayload {
         cli_options: &CliOptions,
         _console: &mut dyn Console,
         _workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
-        Ok(Execution::new_ci((false, self.changed).into()).set_report(cli_options))
+        Ok(Execution::new_ci(project_key, (false, self.changed).into()).set_report(cli_options))
     }
 
     fn check_incompatible_arguments(&self) -> Result<(), CliDiagnostic> {

--- a/crates/biome_cli/src/commands/format.rs
+++ b/crates/biome_cli/src/commands/format.rs
@@ -11,6 +11,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
+use biome_service::projects::ProjectKey;
 use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
@@ -134,8 +135,10 @@ impl CommandRunner for FormatCommandPayload {
         cli_options: &CliOptions,
         console: &mut dyn Console,
         _workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
         Ok(Execution::new(TraversalMode::Format {
+            project_key,
             ignore_errors: cli_options.skip_errors,
             write: self.should_write(),
             stdin: self.get_stdin(console)?,

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -15,6 +15,7 @@ use biome_console::Console;
 use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
+use biome_service::projects::ProjectKey;
 use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
 
@@ -128,6 +129,7 @@ impl CommandRunner for LintCommandPayload {
         cli_options: &CliOptions,
         console: &mut dyn Console,
         _workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
         let fix_file_mode = determine_fix_file_mode(FixFileModeOptions {
             write: self.write,
@@ -137,6 +139,7 @@ impl CommandRunner for LintCommandPayload {
             suppression_reason: self.suppression_reason.clone(),
         })?;
         Ok(Execution::new(TraversalMode::Lint {
+            project_key,
             fix_file_mode,
             stdin: self.get_stdin(console)?,
             only: self.only.clone(),

--- a/crates/biome_cli/src/commands/migrate.rs
+++ b/crates/biome_cli/src/commands/migrate.rs
@@ -9,6 +9,7 @@ use biome_configuration::PartialConfiguration;
 use biome_console::{markup, Console, ConsoleExt};
 use biome_fs::FileSystem;
 use biome_service::configuration::LoadedConfiguration;
+use biome_service::projects::ProjectKey;
 use biome_service::{Workspace, WorkspaceError};
 use camino::Utf8PathBuf;
 use std::ffi::OsString;
@@ -56,12 +57,14 @@ impl CommandRunner for MigrateCommandPayload {
         _cli_options: &CliOptions,
         console: &mut dyn Console,
         _workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
         if let (Some(path), Some(directory_path)) = (
             self.configuration_file_path.clone(),
             self.configuration_directory_path.clone(),
         ) {
             Ok(Execution::new(TraversalMode::Migrate {
+                project_key,
                 write: self.should_write(),
                 configuration_file_path: path,
                 configuration_directory_path: directory_path,

--- a/crates/biome_cli/src/commands/search.rs
+++ b/crates/biome_cli/src/commands/search.rs
@@ -9,6 +9,7 @@ use biome_deserialize::Merge;
 use biome_fs::FileSystem;
 use biome_grit_patterns::GritTargetLanguage;
 use biome_service::configuration::LoadedConfiguration;
+use biome_service::projects::ProjectKey;
 use biome_service::workspace::ParsePatternParams;
 use biome_service::{Workspace, WorkspaceError};
 use std::ffi::OsString;
@@ -63,6 +64,7 @@ impl CommandRunner for SearchCommandPayload {
         cli_options: &CliOptions,
         console: &mut dyn Console,
         workspace: &dyn Workspace,
+        project_key: ProjectKey,
     ) -> Result<Execution, CliDiagnostic> {
         let pattern = workspace
             .parse_pattern(ParsePatternParams {
@@ -71,6 +73,7 @@ impl CommandRunner for SearchCommandPayload {
             })?
             .pattern_id;
         Ok(Execution::new(TraversalMode::Search {
+            project_key,
             pattern,
             language: self.language.clone(),
             stdin: self.get_stdin(console)?,

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -15,6 +15,7 @@ use biome_json_parser::{parse_json_with_cache, JsonParserOptions};
 use biome_json_syntax::{JsonFileSource, JsonRoot};
 use biome_migrate::{migrate_configuration, ControlFlow};
 use biome_rowan::{AstNode, NodeCache};
+use biome_service::projects::ProjectKey;
 use biome_service::workspace::{
     ChangeFileParams, FileContent, FixAction, FormatFileParams, OpenFileParams,
 };
@@ -34,6 +35,7 @@ mod prettier;
 
 pub(crate) struct MigratePayload<'a> {
     pub(crate) session: CliSession<'a>,
+    pub(crate) project_key: ProjectKey,
     pub(crate) write: bool,
     pub(crate) configuration_file_path: Utf8PathBuf,
     pub(crate) configuration_directory_path: Utf8PathBuf,
@@ -44,6 +46,7 @@ pub(crate) struct MigratePayload<'a> {
 pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> {
     let MigratePayload {
         session,
+        project_key,
         write,
         configuration_file_path,
         configuration_directory_path,
@@ -67,6 +70,7 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
 
     let biome_path = BiomePath::new(configuration_file_path.as_path());
     workspace.open_file(OpenFileParams {
+        project_key,
         path: biome_path.clone(),
         content: FileContent::FromClient(biome_config_content.to_string()),
         version: 0,
@@ -131,11 +135,15 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
                     })
                 })?;
                 workspace.change_file(ChangeFileParams {
+                    project_key,
                     path: biome_path.clone(),
                     content: new_content,
                     version: 1,
                 })?;
-                let printed = workspace.format_file(FormatFileParams { path: biome_path })?;
+                let printed = workspace.format_file(FormatFileParams {
+                    project_key,
+                    path: biome_path,
+                })?;
                 if write {
                     biome_config_file.set_content(printed.as_code().as_bytes())?;
                     console.log(markup!{
@@ -208,11 +216,15 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
                     })
                 })?;
                 workspace.change_file(ChangeFileParams {
+                    project_key,
                     path: biome_path.clone(),
                     content: new_content,
                     version: 1,
                 })?;
-                let printed = workspace.format_file(FormatFileParams { path: biome_path })?;
+                let printed = workspace.format_file(FormatFileParams {
+                    project_key,
+                    path: biome_path,
+                })?;
                 if write {
                     biome_config_file.set_content(printed.as_code().as_bytes())?;
                     console.log(markup!{

--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -130,6 +130,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, biome_path: &BiomePath) -> Fi
     let file_features = ctx
         .workspace
         .file_features(SupportsFeatureParams {
+            project_key: ctx.project_key,
             path: biome_path.clone(),
             features: ctx.execution.to_feature(),
         })

--- a/crates/biome_cli/src/execute/process_file/workspace_file.rs
+++ b/crates/biome_cli/src/execute/process_file/workspace_file.rs
@@ -34,6 +34,7 @@ impl<'ctx, 'app> WorkspaceFile<'ctx, 'app> {
         let guard = FileGuard::open(
             ctx.workspace,
             OpenFileParams {
+                project_key: ctx.project_key,
                 document_file_source: None,
                 path: path.clone(),
                 version: 0,

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
@@ -22,6 +22,10 @@ internalError/io ━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
+Scanned project folder in <TIME>.
+```
+
+```block
 package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file package-lock.json is protected because is handled by another tool. Biome won't process it.

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
@@ -34,6 +34,10 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+Scanned project folder in <TIME>.
+```
+
+```block
 other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Formatter would have printed the following content:

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
@@ -34,6 +34,10 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+Scanned project folder in <TIME>.
+```
+
+```block
 other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Formatter would have printed the following content:

--- a/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
@@ -22,6 +22,10 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+Scanned project folder in <TIME>.
+```
+
+```block
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Formatter would have printed the following content:

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -90,6 +90,11 @@ pub struct Configuration {
     #[partial(bpaf(hide, pure(Default::default())))]
     pub schema: Box<str>,
 
+    /// Indicates whether this configuration file is at the root of a Biome
+    /// project. By default, this is `true`.
+    #[partial(bpaf(hide, hide_usage))]
+    pub root: bool,
+
     /// A list of paths to other JSON files, used to extends the current configuration.
     #[partial(bpaf(hide, pure(Default::default())))]
     pub extends: Vec<Box<str>>,

--- a/crates/biome_configuration/tests/invalid/top_level_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/top_level_extraneous_field.json.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_configuration/tests/spec_tests.rs
 expression: top_level_extraneous_field.json
-snapshot_kind: text
 ---
 top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -16,6 +15,7 @@ top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━�
   i Known keys:
   
   - $schema
+  - root
   - extends
   - vcs
   - files

--- a/crates/biome_css_formatter/tests/spec_test.rs
+++ b/crates/biome_css_formatter/tests/spec_test.rs
@@ -27,24 +27,26 @@ mod language {
 /// * `null` -> input: `tests/specs/null.css`, expected output: `tests/specs/null.css.snap`
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
-    let settings = UpdateSettingsParams {
-        configuration: PartialConfiguration {
-            css: Some(PartialCssConfiguration {
-                formatter: Some(PartialCssFormatter {
-                    enabled: Some(true),
+    let settings = |project_key| {
+        Some(UpdateSettingsParams {
+            project_key,
+            configuration: PartialConfiguration {
+                css: Some(PartialCssConfiguration {
+                    formatter: Some(PartialCssFormatter {
+                        enabled: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        },
-        vcs_base_path: None,
-        gitignore_matches: vec![],
-        workspace_directory: None,
+            },
+            vcs_base_path: None,
+            gitignore_matches: vec![],
+            workspace_directory: None,
+        })
     };
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, Some(settings))
-    else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, settings) else {
         return;
     };
 

--- a/crates/biome_graphql_formatter/tests/spec_test.rs
+++ b/crates/biome_graphql_formatter/tests/spec_test.rs
@@ -29,24 +29,26 @@ mod language {
 /// * `null` -> input: `tests/specs/null.graphql`, expected output: `tests/specs/null.graphql.snap`
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
-    let settings = UpdateSettingsParams {
-        configuration: PartialConfiguration {
-            graphql: Some(PartialGraphqlConfiguration {
-                formatter: Some(PartialGraphqlFormatter {
-                    enabled: Some(true),
+    let settings = |project_key| {
+        Some(UpdateSettingsParams {
+            project_key,
+            configuration: PartialConfiguration {
+                graphql: Some(PartialGraphqlConfiguration {
+                    formatter: Some(PartialGraphqlFormatter {
+                        enabled: Some(true),
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        },
-        vcs_base_path: None,
-        gitignore_matches: vec![],
-        workspace_directory: None,
+            },
+            vcs_base_path: None,
+            gitignore_matches: vec![],
+            workspace_directory: None,
+        })
     };
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, Some(settings))
-    else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, settings) else {
         return;
     };
 

--- a/crates/biome_grit_formatter/src/generated.rs
+++ b/crates/biome_grit_formatter/src/generated.rs
@@ -2029,7 +2029,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternUntilClause {
         crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause::default(),
@@ -2042,7 +2041,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternUntilClause
         crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause::default(),

--- a/crates/biome_grit_formatter/tests/spec_test.rs
+++ b/crates/biome_grit_formatter/tests/spec_test.rs
@@ -9,7 +9,7 @@ mod language {
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, None) else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, |_| None) else {
         panic!("Failed to set up snapshot test");
     };
 

--- a/crates/biome_html_formatter/tests/spec_test.rs
+++ b/crates/biome_html_formatter/tests/spec_test.rs
@@ -27,7 +27,7 @@ mod language {
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/html"));
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, None) else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, |_| None) else {
         panic!("Failed to set up snapshot test");
     };
 

--- a/crates/biome_js_formatter/tests/spec_test.rs
+++ b/crates/biome_js_formatter/tests/spec_test.rs
@@ -27,7 +27,7 @@ mod language {
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, None) else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, |_| None) else {
         return;
     };
 

--- a/crates/biome_json_formatter/tests/spec_test.rs
+++ b/crates/biome_json_formatter/tests/spec_test.rs
@@ -28,7 +28,7 @@ mod language {
 pub fn run(spec_input_file: &str, _expected_file: &str, test_directory: &str, _file_type: &str) {
     let root_path = Utf8Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/specs/"));
 
-    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, None) else {
+    let Some(test_file) = SpecTestFile::try_from_file(spec_input_file, root_path, |_| None) else {
         return;
     };
     let mut diagnostics = vec![];

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -27,6 +27,7 @@ biome_service        = { workspace = true }
 biome_text_edit      = { workspace = true }
 camino               = { workspace = true }
 futures              = "0.3.31"
+papaya               = { workspace = true }
 rustc-hash           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }

--- a/crates/biome_lsp/src/documents.rs
+++ b/crates/biome_lsp/src/documents.rs
@@ -1,17 +1,20 @@
 use biome_lsp_converters::line_index::LineIndex;
+use biome_service::projects::ProjectKey;
 
 /// Represents an open [`textDocument`]. Can be cheaply cloned.
 ///
 /// [`textDocument`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
 #[derive(Clone)]
 pub(crate) struct Document {
+    pub(crate) project_key: ProjectKey,
     pub(crate) version: i32,
     pub(crate) line_index: LineIndex,
 }
 
 impl Document {
-    pub(crate) fn new(version: i32, text: &str) -> Self {
+    pub(crate) fn new(project_key: ProjectKey, version: i32, text: &str) -> Self {
         Self {
+            project_key,
             version,
             line_index: LineIndex::new(text),
         }

--- a/crates/biome_lsp/src/handlers/rename.rs
+++ b/crates/biome_lsp/src/handlers/rename.rs
@@ -13,7 +13,7 @@ pub(crate) fn rename(
     params: RenameParams,
 ) -> Result<Option<WorkspaceEdit>, LspError> {
     let url = params.text_document_position.text_document.uri;
-    let biome_path = session.file_path(&url)?;
+    let path = session.file_path(&url)?;
 
     trace!("Renaming...");
 
@@ -34,7 +34,8 @@ pub(crate) fn rename(
     let result = session
         .workspace
         .rename(biome_service::workspace::RenameParams {
-            path: biome_path,
+            project_key: doc.project_key,
+            path,
             symbol_at: cursor_range,
             new_name: params.new_name,
         })?;

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -1,12 +1,13 @@
+use crate::diagnostics::LspError;
 use crate::utils::apply_document_changes;
 use crate::{documents::Document, session::Session};
-use anyhow::Result;
+use biome_fs::BiomePath;
 use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DocumentFileSource, FileContent, GetFileContentParams,
-    OpenFileParams,
+    OpenFileParams, OpenProjectParams,
 };
 use tower_lsp::lsp_types;
-use tracing::{error, field};
+use tracing::{debug, error, field, info};
 
 /// Handler for `textDocument/didOpen` LSP notification
 #[tracing::instrument(
@@ -20,17 +21,36 @@ use tracing::{error, field};
 pub(crate) async fn did_open(
     session: &Session,
     params: lsp_types::DidOpenTextDocumentParams,
-) -> Result<()> {
+) -> Result<(), LspError> {
     let url = params.text_document.uri;
     let version = params.text_document.version;
     let content = params.text_document.text;
     let language_hint = DocumentFileSource::from_language_id(&params.text_document.language_id);
 
-    let biome_path = session.file_path(&url)?;
-    let doc = Document::new(version, &content);
+    let path = session.file_path(&url)?;
+    let project_key = match session.project_for_path(&path) {
+        Some(project_key) => project_key,
+        None => {
+            info!("No open project for path: {path:?}. Opening new project.");
+            let parent_path = BiomePath::new(
+                path.parent()
+                    .map(|parent| parent.to_path_buf())
+                    .unwrap_or_default(),
+            );
+            let project_key = session.workspace.open_project(OpenProjectParams {
+                path: parent_path.clone(),
+                open_uninitialized: true,
+            })?;
+            session.insert_project(parent_path, project_key);
+            project_key
+        }
+    };
+
+    let doc = Document::new(project_key, version, &content);
 
     session.workspace.open_file(OpenFileParams {
-        path: biome_path,
+        project_key,
+        path,
         version,
         content: FileContent::FromClient(content),
         document_file_source: Some(language_hint),
@@ -51,14 +71,16 @@ pub(crate) async fn did_open(
 pub(crate) async fn did_change(
     session: &Session,
     params: lsp_types::DidChangeTextDocumentParams,
-) -> Result<()> {
+) -> Result<(), LspError> {
     let url = params.text_document.uri;
     let version = params.text_document.version;
 
-    let biome_path = session.file_path(&url)?;
+    let path = session.file_path(&url)?;
+    let doc = session.document(&url)?;
 
     let old_text = session.workspace.get_file_content(GetFileContentParams {
-        path: biome_path.clone(),
+        project_key: doc.project_key,
+        path: path.clone(),
     })?;
     tracing::trace!("old document: {:?}", old_text);
     tracing::trace!("content changes: {:?}", params.content_changes);
@@ -71,10 +93,11 @@ pub(crate) async fn did_change(
 
     tracing::trace!("new document: {:?}", text);
 
-    session.insert_document(url.clone(), Document::new(version, &text));
+    session.insert_document(url.clone(), Document::new(doc.project_key, version, &text));
 
     session.workspace.change_file(ChangeFileParams {
-        path: biome_path,
+        project_key: doc.project_key,
+        path,
         version,
         content: text,
     })?;
@@ -91,21 +114,21 @@ pub(crate) async fn did_change(
 pub(crate) async fn did_close(
     session: &Session,
     params: lsp_types::DidCloseTextDocumentParams,
-) -> Result<()> {
+) -> Result<(), LspError> {
     let url = params.text_document.uri;
-    let biome_path = session.file_path(&url)?;
+    let path = session.file_path(&url)?;
+    let Some(project_key) = session.remove_document(&url) else {
+        debug!("Document wasn't open: {url}");
+        return Ok(());
+    };
 
     session
         .workspace
-        .close_file(CloseFileParams { path: biome_path })?;
+        .close_file(CloseFileParams { project_key, path })?;
 
-    session.remove_document(&url);
-
-    let diagnostics = vec![];
-    let version = None;
     session
         .client
-        .publish_diagnostics(url, diagnostics, version)
+        .publish_diagnostics(url, Vec::new(), None)
         .await;
 
     Ok(())

--- a/crates/biome_lsp/src/requests/syntax_tree.rs
+++ b/crates/biome_lsp/src/requests/syntax_tree.rs
@@ -1,5 +1,4 @@
-use crate::session::Session;
-use anyhow::Result;
+use crate::{diagnostics::LspError, session::Session};
 use biome_service::workspace::GetSyntaxTreeParams;
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::{TextDocumentIdentifier, Url};
@@ -13,11 +12,13 @@ pub struct SyntaxTreePayload {
     pub text_document: TextDocumentIdentifier,
 }
 
-pub(crate) fn syntax_tree(session: &Session, url: &Url) -> Result<String> {
+pub(crate) fn syntax_tree(session: &Session, url: &Url) -> Result<String, LspError> {
     info!("Showing syntax tree");
-    let biome_path = session.file_path(url)?;
-    let syntax_tree = session
-        .workspace
-        .get_syntax_tree(GetSyntaxTreeParams { path: biome_path })?;
+    let path = session.file_path(url)?;
+    let doc = session.document(url)?;
+    let syntax_tree = session.workspace.get_syntax_tree(GetSyntaxTreeParams {
+        project_key: doc.project_key,
+        path,
+    })?;
     Ok(syntax_tree.ast)
 }

--- a/crates/biome_lsp/tests/server.rs
+++ b/crates/biome_lsp/tests/server.rs
@@ -7,6 +7,7 @@ use biome_lsp::LSPServer;
 use biome_lsp::ServerFactory;
 use biome_lsp::WorkspaceSettings;
 use biome_service::workspace::GetSyntaxTreeResult;
+use biome_service::workspace::OpenProjectParams;
 use biome_service::workspace::{GetFileContentParams, GetSyntaxTreeParams};
 use camino::Utf8PathBuf;
 use futures::channel::mpsc::{channel, Sender};
@@ -491,11 +492,26 @@ async fn document_lifecycle() -> Result<()> {
         )
         .await?;
 
+    // `open_project()` will return an existing key if called with a path
+    // for an existing project.
+    let project_key = server
+        .request(
+            "biome/open_project",
+            "open_project",
+            OpenProjectParams {
+                path: BiomePath::new(""),
+                open_uninitialized: true,
+            },
+        )
+        .await?
+        .expect("open_project returned an error");
+
     let res: GetSyntaxTreeResult = server
         .request(
             "biome/get_syntax_tree",
             "get_syntax_tree",
             GetSyntaxTreeParams {
+                project_key,
                 path: BiomePath::try_from(url!("document.js").to_file_path().unwrap()).unwrap(),
             },
         )
@@ -2188,11 +2204,26 @@ isSpreadAssignment;
         )
         .await?;
 
+    // `open_project()` will return an existing key if called with a path
+    // for an existing project.
+    let project_key = server
+        .request(
+            "biome/open_project",
+            "open_project",
+            OpenProjectParams {
+                path: BiomePath::new(""),
+                open_uninitialized: true,
+            },
+        )
+        .await?
+        .expect("open_project returned an error");
+
     let actual: String = server
         .request(
             "biome/get_file_content",
             "get_file_content",
             GetFileContentParams {
+                project_key,
                 path: BiomePath::new(
                     Utf8PathBuf::from_path_buf(url!("document.js").to_file_path().unwrap())
                         .unwrap(),

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -67,6 +67,10 @@ impl WorkspaceError {
         Self::CantReadFile(CantReadFile { path })
     }
 
+    pub fn invalid_pattern() -> Self {
+        Self::SearchError(SearchError::InvalidPattern(InvalidPattern))
+    }
+
     pub fn not_found() -> Self {
         Self::NotFound(NotFound)
     }

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -436,6 +436,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
+            .with_enabled_rules(&params.enabled_rules)
             .with_manifest(params.manifest.as_ref())
             .finish();
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -417,6 +417,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
+            .with_enabled_rules(&params.enabled_rules)
             .with_manifest(params.manifest.as_ref())
             .finish();
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -6,19 +6,15 @@ use super::{
 use crate::configuration::to_analyzer_rules;
 use crate::diagnostics::extension_error;
 use crate::file_handlers::{is_diagnostic_error, FixAllParams};
-use crate::settings::{LinterSettings, OverrideSettings, Settings};
-use crate::workspace::DocumentFileSource;
-use crate::{
-    settings::{
-        FormatSettings, LanguageListSettings, LanguageSettings, ServiceLanguage,
-        WorkspaceSettingsHandle,
-    },
-    workspace::{
-        CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
-        RenameResult,
-    },
-    WorkspaceError,
+use crate::settings::{
+    FormatSettings, LanguageListSettings, LanguageSettings, LinterSettings, OverrideSettings,
+    ServiceLanguage, Settings, WorkspaceSettingsHandle,
 };
+use crate::workspace::{
+    CodeAction, DocumentFileSource, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
+    PullActionsResult, RenameResult,
+};
+use crate::WorkspaceError;
 use biome_analyze::options::PreferredQuote;
 use biome_analyze::{
     AnalysisFilter, AnalyzerConfiguration, AnalyzerOptions, ControlFlow, Never, QueryMatch,
@@ -572,6 +568,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
+            .with_enabled_rules(&params.enabled_rules)
             .with_manifest(params.manifest.as_ref())
             .finish();
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -473,6 +473,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
+            .with_enabled_rules(&params.enabled_rules)
             .with_manifest(params.manifest.as_ref())
             .finish();
 

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -7,13 +7,11 @@ pub use crate::file_handlers::astro::{AstroFileHandler, ASTRO_FENCE};
 use crate::file_handlers::graphql::GraphqlFileHandler;
 pub use crate::file_handlers::svelte::{SvelteFileHandler, SVELTE_FENCE};
 pub use crate::file_handlers::vue::{VueFileHandler, VUE_FENCE};
-use crate::settings::Settings;
-use crate::workspace::FixFileMode;
-use crate::{
-    settings::WorkspaceSettingsHandle,
-    workspace::{FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult},
-    WorkspaceError,
+use crate::settings::{Settings, WorkspaceSettingsHandle};
+use crate::workspace::{
+    FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult,
 };
+use crate::WorkspaceError;
 use biome_analyze::{
     AnalyzerDiagnostic, AnalyzerOptions, AnalyzerSignal, ControlFlow, GroupCategory, Never,
     Queryable, RegistryVisitor, Rule, RuleCategories, RuleCategory, RuleFilter, RuleGroup,
@@ -395,6 +393,7 @@ pub struct FixAllParams<'a> {
     pub(crate) skip: Vec<RuleSelector>,
     pub(crate) rule_categories: RuleCategories,
     pub(crate) suppression_reason: Option<String>,
+    pub(crate) enabled_rules: Vec<RuleSelector>,
 }
 
 #[derive(Default)]

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -2,6 +2,7 @@ pub mod documentation;
 pub mod file_handlers;
 
 pub mod matcher;
+pub mod projects;
 pub mod settings;
 pub mod workspace;
 

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -1,0 +1,220 @@
+use crate::is_dir;
+use crate::settings::{FilesSettings, Settings, DEFAULT_FILE_SIZE_LIMIT};
+use crate::workspace::FeatureKind;
+use biome_fs::BiomePath;
+use biome_project::{NodeJsProject, PackageJson};
+use camino::{Utf8Path, Utf8PathBuf};
+use papaya::HashMap;
+use rustc_hash::FxBuildHasher;
+use serde::{Deserialize, Serialize};
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tracing::trace;
+
+/// Type that holds all the settings and information for different projects
+/// inside the workspace.
+///
+/// ## Terminology
+///
+/// Every project within a Biome workspace correlates with a single
+/// **top-level** `biome.json`. This means that if the `biome.json` is at the
+/// root of a monorepo, multiple packages (or "JavaScript projects") may reside
+/// within a single project.
+#[derive(Debug, Default)]
+pub struct Projects(HashMap<ProjectKey, ProjectData, FxBuildHasher>);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[repr(transparent)]
+pub struct ProjectKey(NonZeroUsize);
+
+impl ProjectKey {
+    #[expect(clippy::new_without_default)]
+    pub fn new() -> Self {
+        static KEY: AtomicUsize = AtomicUsize::new(1);
+        let key = KEY.fetch_add(1, Ordering::Relaxed);
+        Self(NonZeroUsize::new(key).unwrap())
+    }
+}
+
+/// The information tracked for each project.
+#[derive(Debug, Default)]
+struct ProjectData {
+    /// The root path of the project. This path should be **absolute**.
+    path: BiomePath,
+
+    /// The settings of the project, usually inferred from the configuration
+    /// file e.g. `biome.json`.
+    settings: Settings,
+
+    /// Optional Node.js-specific package information, if relevant for the
+    /// project.
+    ///
+    /// TODO: This should be moved into the upcoming `ProjectLayout` service
+    ///       data.
+    package: Option<NodeJsProject>,
+}
+
+impl Projects {
+    /// Inserts a new project with the given root path.
+    ///
+    /// Returns the key of the newly inserted project, or returns an existing
+    /// project key if a project with the given path already existed.
+    pub fn insert_project(&self, path: Utf8PathBuf) -> ProjectKey {
+        let path = BiomePath::new(path);
+        trace!("Insert workspace folder: {path:?}");
+
+        let data = self.0.pin();
+        for (key, project_data) in data.iter() {
+            if project_data.path == path {
+                return *key;
+            }
+        }
+
+        let key = ProjectKey::new();
+        self.0.pin().insert(
+            key,
+            ProjectData {
+                path,
+                settings: Settings::default(),
+                package: None,
+            },
+        );
+        key
+    }
+
+    /// Removes the project with the given key.
+    pub fn remove_project(&self, project_key: ProjectKey) {
+        self.0.pin().remove(&project_key);
+    }
+
+    /// Retrieves the settings for the given project.
+    pub fn get_settings(&self, project_key: ProjectKey) -> Option<Settings> {
+        self.0
+            .pin()
+            .get(&project_key)
+            .map(|data| data.settings.clone())
+    }
+
+    /// Retrieves the `files` settings for the given project.
+    pub fn get_files_settings(&self, project_key: ProjectKey) -> Option<FilesSettings> {
+        self.0
+            .pin()
+            .get(&project_key)
+            .map(|data| data.settings.files.clone())
+    }
+
+    /// Sets the settings for the given project.
+    pub fn set_settings(&self, project_key: ProjectKey, settings: Settings) {
+        let data = self.0.pin();
+        let Some(project_data) = data.get(&project_key) else {
+            return;
+        };
+
+        let project_data = ProjectData {
+            path: project_data.path.clone(),
+            settings,
+            package: project_data.package.clone(),
+        };
+
+        data.insert(project_key, project_data);
+    }
+
+    pub fn get_manifest(&self, project_key: ProjectKey) -> Option<PackageJson> {
+        self.0
+            .pin()
+            .get(&project_key)
+            .and_then(|data| data.package.as_ref())
+            .map(|project| project.manifest.clone())
+    }
+
+    pub fn get_project_path(&self, project_key: ProjectKey) -> Option<BiomePath> {
+        self.0.pin().get(&project_key).map(|data| data.path.clone())
+    }
+
+    pub fn insert_manifest(&self, project_key: ProjectKey, manifest: NodeJsProject) {
+        let data = self.0.pin();
+        let Some(project_data) = data.get(&project_key) else {
+            return;
+        };
+
+        let project_data = ProjectData {
+            path: project_data.path.clone(),
+            settings: project_data.settings.clone(),
+            package: Some(manifest),
+        };
+
+        data.insert(project_key, project_data);
+    }
+
+    /// Checks whether the given `path` belongs to project with the given path
+    /// and no other project.
+    pub fn path_belongs_only_to_project_with_path(
+        &self,
+        path: &BiomePath,
+        project_path: &Utf8Path,
+    ) -> bool {
+        let mut belongs_to_project = false;
+        let mut belongs_to_other = false;
+        for project_data in self.0.pin().values() {
+            if path.strip_prefix(project_data.path.as_path()).is_ok() {
+                if project_data.path.as_path() == project_path {
+                    belongs_to_project = true;
+                } else {
+                    belongs_to_other = true;
+                }
+            }
+        }
+
+        belongs_to_project && !belongs_to_other
+    }
+
+    /// Returns the maximum file size setting for the given project.
+    pub fn get_max_file_size(&self, project_key: ProjectKey) -> usize {
+        let limit = self
+            .0
+            .pin()
+            .get(&project_key)
+            .map_or(DEFAULT_FILE_SIZE_LIMIT, |data| data.settings.files.max_size)
+            .get();
+        usize::try_from(limit).unwrap_or(usize::MAX)
+    }
+
+    /// Checks whether a file is ignored through the feature's
+    /// `ignore`/`include` settings.
+    pub fn is_ignored_by_feature_config(
+        &self,
+        project_key: ProjectKey,
+        path: &Utf8Path,
+        feature: FeatureKind,
+    ) -> bool {
+        let data = self.0.pin();
+        let Some(project_data) = data.get(&project_key) else {
+            return false;
+        };
+
+        let settings = &project_data.settings;
+        let (feature_included_files, feature_ignored_files) = match feature {
+            FeatureKind::Format => {
+                let formatter = &settings.formatter;
+                (&formatter.included_files, &formatter.ignored_files)
+            }
+            FeatureKind::Lint => {
+                let linter = &settings.linter;
+                (&linter.included_files, &linter.ignored_files)
+            }
+
+            FeatureKind::Assist => {
+                let assists = &settings.assist;
+                (&assists.included_files, &assists.ignored_files)
+            }
+            // TODO: enable once the configuration is available
+            FeatureKind::Search => return false, // There is no search-specific config.
+            FeatureKind::Debug => return false,
+        };
+        let is_feature_included = feature_included_files.is_empty()
+            || is_dir(path)
+            || feature_included_files.matches_path(path);
+        !is_feature_included || feature_ignored_files.matches_path(path)
+    }
+}

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -985,7 +985,7 @@ pub struct CloseProjectParams {
 }
 
 pub trait Workspace: Send + Sync + RefUnwindSafe {
-    // --- PROJECT-LEVEL METHODS ---
+    // #region PROJECT-LEVEL METHODS
 
     /// Opens a project within the workspace.
     ///
@@ -1057,7 +1057,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// `scan_project_folder()`, it will also be unregistered.
     fn close_project(&self, params: CloseProjectParams) -> Result<(), WorkspaceError>;
 
-    // --- FILE-LEVEL METHODS ---
+    // #endregion
+
+    // #region FILE-LEVEL METHODS
 
     /// Opens a new file in the workspace.
     ///
@@ -1153,7 +1155,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// This may be an in-memory file system.
     fn fs(&self) -> &dyn FileSystem;
 
-    // --- SEARCH-RELATED METHODS ---
+    // #endregion
+
+    // #region SEARCH-RELATED METHODS
 
     /// Parses a pattern to be used in follow-up [`Self::search_pattern`]
     /// requests.
@@ -1171,7 +1175,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Used to indicate a client no longer needs a specific pattern.
     fn drop_pattern(&self, params: DropPatternParams) -> Result<(), WorkspaceError>;
 
-    // --- MISC METHODS ---
+    // #endregion
+
+    // #region MISC METHODS
 
     /// Returns debug information about this workspace.
     fn rage(&self, params: RageParams) -> Result<RageResult, WorkspaceError>;
@@ -1179,6 +1185,8 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Returns information about the server this workspace is connected to or
     /// `None` if the workspace isn't connected to a server.
     fn server_info(&self) -> Option<&ServerInfo>;
+
+    // #endregion
 }
 
 /// Convenience function for constructing a server instance of [Workspace]

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -58,6 +58,7 @@ mod server;
 pub use self::client::{TransportRequest, WorkspaceClient, WorkspaceTransport};
 use crate::file_handlers::Capabilities;
 pub use crate::file_handlers::DocumentFileSource;
+use crate::projects::ProjectKey;
 use crate::settings::Settings;
 use crate::{Deserialize, Serialize, WorkspaceError};
 use biome_analyze::ActionCategory;
@@ -79,20 +80,22 @@ use enumflags2::{bitflags, BitFlags};
 use schemars::{gen::SchemaGenerator, schema::Schema};
 use smallvec::SmallVec;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::{borrow::Cow, panic::RefUnwindSafe, sync::Arc};
 use tracing::{debug, instrument};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct SupportsFeatureParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub features: FeatureName,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Default)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct SupportsFeatureResult {
     pub reason: Option<SupportKind>,
 }
@@ -489,6 +492,7 @@ impl FeaturesBuilder {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSettingsParams {
+    pub project_key: ProjectKey,
     pub configuration: PartialConfiguration,
     // @ematipico TODO: have a better data structure for this
     pub vcs_base_path: Option<BiomePath>,
@@ -512,6 +516,7 @@ pub struct ProjectFeaturesResult {}
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct OpenFileParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub content: FileContent,
     pub version: i32,
@@ -541,14 +546,16 @@ pub enum FileContent {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SetManifestForProjectParams {
+    pub project_key: ProjectKey,
     pub manifest_path: BiomePath,
     pub content: String,
     pub version: i32,
 }
 
-impl From<(BiomePath, String)> for SetManifestForProjectParams {
-    fn from((manifest_path, content): (BiomePath, String)) -> Self {
+impl From<(ProjectKey, BiomePath, String)> for SetManifestForProjectParams {
+    fn from((project_key, manifest_path, content): (ProjectKey, BiomePath, String)) -> Self {
         Self {
+            project_key,
             manifest_path,
             content,
             version: 0,
@@ -560,6 +567,7 @@ impl From<(BiomePath, String)> for SetManifestForProjectParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetSyntaxTreeParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
 
@@ -575,13 +583,16 @@ pub struct GetSyntaxTreeResult {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetControlFlowGraphParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub cursor: TextSize,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetFormatterIRParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
 
@@ -589,12 +600,15 @@ pub struct GetFormatterIRParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct GetFileContentParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CheckFileSizeParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
 
@@ -616,6 +630,7 @@ impl CheckFileSizeResult {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeFileParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub content: String,
     pub version: i32,
@@ -625,6 +640,7 @@ pub struct ChangeFileParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct CloseFileParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
 
@@ -632,6 +648,7 @@ pub struct CloseFileParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullDiagnosticsParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub categories: RuleCategories,
     pub max_diagnostics: u64,
@@ -657,6 +674,7 @@ pub struct PullDiagnosticsResult {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct PullActionsParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub range: Option<TextRange>,
     pub suppression_reason: Option<String>,
@@ -688,6 +706,7 @@ pub struct CodeAction {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatFileParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
 }
 
@@ -695,6 +714,7 @@ pub struct FormatFileParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatRangeParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub range: TextRange,
 }
@@ -703,6 +723,7 @@ pub struct FormatRangeParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FormatOnTypeParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub offset: TextSize,
 }
@@ -724,6 +745,7 @@ pub enum FixFileMode {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FixFileParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub fix_file_mode: FixFileMode,
     pub should_format: bool,
@@ -768,6 +790,7 @@ pub struct FixAction {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct RenameParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub symbol_at: TextSize,
     pub new_name: String,
@@ -867,6 +890,7 @@ pub struct ParsePatternResult {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SearchPatternParams {
+    pub project_key: ProjectKey,
     pub path: BiomePath,
     pub pattern: PatternId,
 }
@@ -875,7 +899,7 @@ pub struct SearchPatternParams {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct SearchResults {
-    pub file: BiomePath,
+    pub path: BiomePath,
     pub matches: Vec<TextRange>,
 }
 
@@ -919,30 +943,131 @@ impl From<&str> for PatternId {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct IsPathIgnoredParams {
-    pub biome_path: BiomePath,
+    pub project_key: ProjectKey,
+    pub path: BiomePath,
     pub features: FeatureName,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct RegisterProjectFolderParams {
-    pub path: Option<BiomePath>,
-    pub set_as_current_workspace: bool,
+pub struct OpenProjectParams {
+    /// The path to open
+    pub path: BiomePath,
+
+    /// Whether the folder should be opened as a project, even if no
+    /// `biome.json` can be found.
+    pub open_uninitialized: bool,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
-pub struct UnregisterProjectFolderParams {
-    pub path: BiomePath,
+pub struct ScanProjectFolderParams {
+    pub project_key: ProjectKey,
+
+    /// Optional path within the project to scan.
+    ///
+    /// If omitted, the project is scanned from its root folder.
+    ///
+    /// This is a potential optimization that allows scanning to be limited to
+    /// a subset of the full project. Clients should specify it to indicate
+    /// which part of the project they are interested in. The server may or may
+    /// not use this to avoid scanning parts that are irrelevant to clients.
+    pub path: Option<BiomePath>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct CloseProjectParams {
+    pub project_key: ProjectKey,
 }
 
 pub trait Workspace: Send + Sync + RefUnwindSafe {
-    /// Returns the filesystem implementation to open files with.
-    fn fs(&self) -> &dyn FileSystem;
+    // --- PROJECT-LEVEL METHODS ---
 
-    /// Checks whether a certain feature is supported. There are different conditions:
+    /// Opens a project within the workspace.
+    ///
+    /// The path given as part of the `params` is used to determine the root of
+    /// the Biome project, but it may not have to be the root itself. The first
+    /// ancestor directory of the path (including the path itself) that contains
+    /// a **top-level** `biome.json` is determined to be the project root and
+    /// will be used for opening the project.
+    ///
+    /// If no `biome.json` file can be found in any of the ancestors, and
+    /// `open_uninitialized` is `true` the directory will be opened as a Biome
+    /// project will default settings.
+    ///
+    /// Note: Opening a project does not mean the project is ready for use. You
+    /// probably want to follow it up with a call to `scan_project_folder()` or
+    /// explicitly load settings into the project using `update_settings()`.
+    ///
+    /// Returns the key of the opened project. This key can be used with
+    /// follow-up methods to perform actions related to the project, such as
+    /// opening files or querying them.
+    fn open_project(&self, params: OpenProjectParams) -> Result<ProjectKey, WorkspaceError>;
+
+    /// Scans the given project from a given path, and initializes all settings
+    /// and service data.
+    ///
+    /// The first time you call this method, it may take a long time since it
+    /// will traverse the entire project folder recursively, parse all included
+    /// files (and possibly their dependencies), and perform processing for
+    /// extracting the service data.
+    ///
+    /// Follow-up calls may be much faster as they can reuse cached data.
+    ///
+    /// TODO: This method also registers file watchers to make sure the cache
+    ///       remains up-to-date.
+    fn scan_project_folder(
+        &self,
+        params: ScanProjectFolderParams,
+    ) -> Result<ScanProjectFolderResult, WorkspaceError>;
+
+    /// Updates the global settings for the given project.
+    ///
+    /// This method should not be used in combination with
+    /// `scan_project_folder()`. When scanning is enabled, the server will
+    /// manage project settings on its own.
+    fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError>;
+
+    /// Sets a new package manifest for the given project.
+    ///
+    /// This method should not be used in combination with
+    /// `scan_project_folder()`. When scanning is enabled, the server will
+    /// manage packages on its own.
+    fn set_manifest_for_project(
+        &self,
+        params: SetManifestForProjectParams,
+    ) -> Result<(), WorkspaceError>;
+
+    /// Closes the project with the given key.
+    ///
+    /// Any settings related to the project are unloaded, and any open files
+    /// that belong to the project are also closed.
+    ///
+    /// Projects should normally **not** be closed, so that follow-up
+    /// invocations to Biome can reuse the loaded settings and open files. Only
+    /// when the user explicitly asks for a project to be closed, will we do so
+    /// in order to allow the user to reclaim memory. (Although in reality
+    /// they'll probably just kill the daemon anyway.)
+    ///
+    /// If a file watcher was registered as a result of a call to
+    /// `scan_project_folder()`, it will also be unregistered.
+    fn close_project(&self, params: CloseProjectParams) -> Result<(), WorkspaceError>;
+
+    // --- FILE-LEVEL METHODS ---
+
+    /// Opens a new file in the workspace.
+    ///
+    /// If the file path is under a folder that belongs to an opened project
+    /// other than the current one, the current project is changed accordingly.
+    fn open_file(&self, params: OpenFileParams) -> Result<(), WorkspaceError>;
+
+    /// Checks whether a certain feature is supported for the given file path.
+    ///
+    /// There are different conditions:
     /// - Biome doesn't recognize a file, so it can't provide the feature;
     /// - the feature is disabled inside the configuration;
     /// - the file is ignored
@@ -951,129 +1076,90 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
         params: SupportsFeatureParams,
     ) -> Result<FileFeaturesResult, WorkspaceError>;
 
-    /// Checks if the current path is ignored by the workspace, against a particular feature.
+    /// Checks if the given path is ignored by the project for a specific
+    /// feature.
     ///
-    /// Takes as input the path of the file that workspace is currently processing and
-    /// a list of paths to match against.
-    ///
-    /// If the file path matches, then `true` is returned, and it should be considered ignored.
+    /// If the file path matches, `true` is returned, and it should be
+    /// considered ignored.
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError>;
 
-    /// Update the global settings for this workspace
-    fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError>;
-
-    /// Add a new file to the workspace.
-    ///
-    /// If the file path is under a folder that belongs to a registered project other than the
-    /// current one, the current project is changed accordingly.
-    fn open_file(&self, params: OpenFileParams) -> Result<(), WorkspaceError>;
-
-    /// Add a new project to the workspace
-    fn set_manifest_for_project(
-        &self,
-        params: SetManifestForProjectParams,
-    ) -> Result<(), WorkspaceError>;
-
-    /// Registers a possible workspace project folder.
-    ///
-    /// The newly registered project becomes the new current project.
-    ///
-    /// Returns the key of said project. Use this key later if you want to switch back to this
-    /// project after switching to another.
-    fn register_project_folder(
-        &self,
-        params: RegisterProjectFolderParams,
-    ) -> Result<ProjectKey, WorkspaceError>;
-
-    /// Scans the folder of the current project and populates service data.
-    ///
-    /// The first time you call this method, it may take a long data since it will traverse the
-    /// entire project folder recursively, parse all included files (and possibly their
-    /// dependencies), and perform processing for extracting the service data.
-    ///
-    /// Follow-up calls may be much faster as they can reuse cached data.
-    ///
-    /// TODO: This method also registers file watchers to make sure the cache remains up-to-date.
-    fn scan_current_project_folder(
-        &self,
-        params: (), // workspace methods must have 1 argument...
-    ) -> Result<ScanProjectFolderResult, WorkspaceError>;
-
-    /// Unregisters a workspace project folder.
-    ///
-    /// The settings that belong to that project are deleted. Any open files that belong to the
-    /// project are also closed.
-    ///
-    /// If a file watcher was registered as a result of a call to `scan_project_folder()`, it will
-    /// also be unregistered.
-    fn unregister_project_folder(
-        &self,
-        params: UnregisterProjectFolderParams,
-    ) -> Result<(), WorkspaceError>;
-
-    // Return a textual, debug representation of the syntax tree for a given document
+    /// Returns a textual, debug representation of the syntax tree for a given
+    /// document.
     fn get_syntax_tree(
         &self,
         params: GetSyntaxTreeParams,
     ) -> Result<GetSyntaxTreeResult, WorkspaceError>;
 
-    // Return a textual, debug representation of the control flow graph at a given position in the document
+    /// Returns a textual, debug representation of the control flow graph at a
+    /// given position in the document.
     fn get_control_flow_graph(
         &self,
         params: GetControlFlowGraphParams,
     ) -> Result<String, WorkspaceError>;
 
-    // Return a textual, debug representation of the formatter IR for a given document
+    /// Returns a textual, debug representation of the formatter IR for a given
+    /// document.
     fn get_formatter_ir(&self, params: GetFormatterIRParams) -> Result<String, WorkspaceError>;
 
-    /// Return the content of a file
+    /// Returns the content of a given file.
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError>;
 
-    /// Returns `true` if the size of the file is smaller than the configured limit, `false` if equals or greater.
+    /// Returns the size of a given file, as well as the allowed maximum file
+    /// size for that file.
     fn check_file_size(
         &self,
         params: CheckFileSizeParams,
     ) -> Result<CheckFileSizeResult, WorkspaceError>;
 
-    /// Change the content of an open file
+    /// Changes the content of an open file.
     fn change_file(&self, params: ChangeFileParams) -> Result<(), WorkspaceError>;
 
-    /// Removes a file from the workspace.
-    fn close_file(&self, params: CloseFileParams) -> Result<(), WorkspaceError>;
-
-    /// Retrieves the list of diagnostics associated to a file
+    /// Retrieves the list of diagnostics associated with a file.
     fn pull_diagnostics(
         &self,
         params: PullDiagnosticsParams,
     ) -> Result<PullDiagnosticsResult, WorkspaceError>;
 
     /// Retrieves the list of code actions available for a given cursor
-    /// position within a file
+    /// position within a file.
     fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, WorkspaceError>;
 
     /// Runs the given file through the formatter using the provided options
-    /// and returns the resulting source code
+    /// and returns the resulting source code.
     fn format_file(&self, params: FormatFileParams) -> Result<Printed, WorkspaceError>;
 
-    /// Runs a range of an open document through the formatter
+    /// Runs a range of an open document through the formatter.
     fn format_range(&self, params: FormatRangeParams) -> Result<Printed, WorkspaceError>;
 
     /// Runs a "block" ending at the specified character of an open document
-    /// through the formatter
+    /// through the formatter.
     fn format_on_type(&self, params: FormatOnTypeParams) -> Result<Printed, WorkspaceError>;
 
-    /// Return the content of the file with all safe code actions applied
+    /// Returns the content of the file with all safe code actions applied.
     fn fix_file(&self, params: FixFileParams) -> Result<FixFileResult, WorkspaceError>;
 
-    /// Return the content of the file after renaming a symbol
+    /// Returns the content of the file after renaming a symbol.
     fn rename(&self, params: RenameParams) -> Result<RenameResult, WorkspaceError>;
 
-    /// Returns debug information about this workspace.
-    fn rage(&self, params: RageParams) -> Result<RageResult, WorkspaceError>;
-
-    /// Parses a pattern to be used in follow-up [`Self::search_pattern`] requests.
+    /// Closes a file that is opened in the workspace.
     ///
-    /// Clients should call [`Self::drop_pattern()`] when they no need longer need it.
+    /// This only unloads the document from the workspace if the file is NOT
+    /// opened by the scanner as well. If the scanner has opened the file, it
+    /// may still be required for multi-file analysis.
+    fn close_file(&self, params: CloseFileParams) -> Result<(), WorkspaceError>;
+
+    /// Returns the filesystem implementation to open files with.
+    ///
+    /// This may be an in-memory file system.
+    fn fs(&self) -> &dyn FileSystem;
+
+    // --- SEARCH-RELATED METHODS ---
+
+    /// Parses a pattern to be used in follow-up [`Self::search_pattern`]
+    /// requests.
+    ///
+    /// Clients should call [`Self::drop_pattern()`] when they no need longer
+    /// need it.
     fn parse_pattern(
         &self,
         params: ParsePatternParams,
@@ -1085,7 +1171,13 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
     /// Used to indicate a client no longer needs a specific pattern.
     fn drop_pattern(&self, params: DropPatternParams) -> Result<(), WorkspaceError>;
 
-    /// Returns information about the server this workspace is connected to or `None` if the workspace isn't connected to a server.
+    // --- MISC METHODS ---
+
+    /// Returns debug information about this workspace.
+    fn rage(&self, params: RageParams) -> Result<RageResult, WorkspaceError>;
+
+    /// Returns information about the server this workspace is connected to or
+    /// `None` if the workspace isn't connected to a server.
     fn server_info(&self) -> Option<&ServerInfo>;
 }
 
@@ -1115,18 +1207,25 @@ where
 /// automatically on drop
 pub struct FileGuard<'app, W: Workspace + ?Sized> {
     workspace: &'app W,
+    project_key: ProjectKey,
     path: BiomePath,
 }
 
 impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn open(workspace: &'app W, params: OpenFileParams) -> Result<Self, WorkspaceError> {
+        let project_key = params.project_key;
         let path = params.path.clone();
         workspace.open_file(params)?;
-        Ok(Self { workspace, path })
+        Ok(Self {
+            workspace,
+            project_key,
+            path,
+        })
     }
 
     pub fn get_syntax_tree(&self) -> Result<GetSyntaxTreeResult, WorkspaceError> {
         self.workspace.get_syntax_tree(GetSyntaxTreeParams {
+            project_key: self.project_key,
             path: self.path.clone(),
         })
     }
@@ -1134,6 +1233,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn get_control_flow_graph(&self, cursor: TextSize) -> Result<String, WorkspaceError> {
         self.workspace
             .get_control_flow_graph(GetControlFlowGraphParams {
+                project_key: self.project_key,
                 path: self.path.clone(),
                 cursor,
             })
@@ -1141,6 +1241,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
     pub fn change_file(&self, version: i32, content: String) -> Result<(), WorkspaceError> {
         self.workspace.change_file(ChangeFileParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             version,
             content,
@@ -1149,6 +1250,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
     pub fn get_file_content(&self) -> Result<String, WorkspaceError> {
         self.workspace.get_file_content(GetFileContentParams {
+            project_key: self.project_key,
             path: self.path.clone(),
         })
     }
@@ -1161,6 +1263,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         skip: Vec<RuleSelector>,
     ) -> Result<PullDiagnosticsResult, WorkspaceError> {
         self.workspace.pull_diagnostics(PullDiagnosticsParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             categories,
             max_diagnostics: max_diagnostics.into(),
@@ -1179,6 +1282,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         enabled_rules: Vec<RuleSelector>,
     ) -> Result<PullActionsResult, WorkspaceError> {
         self.workspace.pull_actions(PullActionsParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             range,
             only,
@@ -1190,18 +1294,21 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
     pub fn format_file(&self) -> Result<Printed, WorkspaceError> {
         self.workspace.format_file(FormatFileParams {
+            project_key: self.project_key,
             path: self.path.clone(),
         })
     }
 
     pub fn check_file_size(&self) -> Result<CheckFileSizeResult, WorkspaceError> {
         self.workspace.check_file_size(CheckFileSizeParams {
+            project_key: self.project_key,
             path: self.path.clone(),
         })
     }
 
     pub fn format_range(&self, range: TextRange) -> Result<Printed, WorkspaceError> {
         self.workspace.format_range(FormatRangeParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             range,
         })
@@ -1209,6 +1316,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
     pub fn format_on_type(&self, offset: TextSize) -> Result<Printed, WorkspaceError> {
         self.workspace.format_on_type(FormatOnTypeParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             offset,
         })
@@ -1224,6 +1332,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         suppression_reason: Option<String>,
     ) -> Result<FixFileResult, WorkspaceError> {
         self.workspace.fix_file(FixFileParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             fix_file_mode,
             should_format,
@@ -1237,6 +1346,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
 
     pub fn search_pattern(&self, pattern: &PatternId) -> Result<SearchResults, WorkspaceError> {
         self.workspace.search_pattern(SearchPatternParams {
+            project_key: self.project_key,
             path: self.path.clone(),
             pattern: pattern.clone(),
         })
@@ -1247,24 +1357,13 @@ impl<'app, W: Workspace + ?Sized> Drop for FileGuard<'app, W> {
     fn drop(&mut self) {
         self.workspace
             .close_file(CloseFileParams {
+                project_key: self.project_key,
                 path: self.path.clone(),
             })
             // `close_file` can only error if the file was already closed, in
             // this case it's generally better to silently matcher the error
             // than panic (especially in a drop handler)
             .ok();
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub struct ProjectKey(usize);
-
-impl ProjectKey {
-    pub fn new() -> Self {
-        static KEY: AtomicUsize = AtomicUsize::new(1);
-        let key = KEY.fetch_add(1, Ordering::Relaxed);
-        Self(key)
     }
 }
 

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -1,7 +1,7 @@
 use crate::workspace::{
-    CheckFileSizeParams, CheckFileSizeResult, FileFeaturesResult, GetFileContentParams,
-    IsPathIgnoredParams, ProjectKey, RageParams, RageResult, RegisterProjectFolderParams,
-    ServerInfo, SetManifestForProjectParams, UnregisterProjectFolderParams,
+    CheckFileSizeParams, CheckFileSizeResult, CloseProjectParams, FileFeaturesResult,
+    GetFileContentParams, IsPathIgnoredParams, OpenProjectParams, ProjectKey, RageParams,
+    RageResult, ServerInfo, SetManifestForProjectParams,
 };
 use crate::{TransportError, Workspace, WorkspaceError};
 use biome_formatter::Printed;
@@ -18,8 +18,8 @@ use super::{
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
     GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, PullActionsParams, PullActionsResult,
     PullDiagnosticsParams, PullDiagnosticsResult, RenameParams, RenameResult,
-    ScanProjectFolderResult, SearchPatternParams, SearchResults, SupportsFeatureParams,
-    UpdateSettingsParams,
+    ScanProjectFolderParams, ScanProjectFolderResult, SearchPatternParams, SearchResults,
+    SupportsFeatureParams, UpdateSettingsParams,
 };
 
 pub struct WorkspaceClient<T> {
@@ -115,9 +115,11 @@ where
     ) -> Result<FileFeaturesResult, WorkspaceError> {
         self.request("biome/file_features", params)
     }
+
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
         self.request("biome/is_path_ignored", params)
     }
+
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
         self.request("biome/update_settings", params)
     }
@@ -133,25 +135,19 @@ where
         self.request("biome/set_manifest_for_project", params)
     }
 
-    fn register_project_folder(
-        &self,
-        params: RegisterProjectFolderParams,
-    ) -> Result<ProjectKey, WorkspaceError> {
-        self.request("biome/register_project_folder", params)
+    fn open_project(&self, params: OpenProjectParams) -> Result<ProjectKey, WorkspaceError> {
+        self.request("biome/open_project", params)
     }
 
-    fn scan_current_project_folder(
+    fn scan_project_folder(
         &self,
-        params: (),
+        params: ScanProjectFolderParams,
     ) -> Result<ScanProjectFolderResult, WorkspaceError> {
-        self.request("biome/scan_current_project_folder", params)
+        self.request("biome/scan_project_folder", params)
     }
 
-    fn unregister_project_folder(
-        &self,
-        params: UnregisterProjectFolderParams,
-    ) -> Result<(), WorkspaceError> {
-        self.request("biome/unregister_project_folder", params)
+    fn close_project(&self, params: CloseProjectParams) -> Result<(), WorkspaceError> {
+        self.request("biome/close_project", params)
     }
 
     fn get_syntax_tree(

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1,26 +1,30 @@
 use super::scanner::scan;
 use super::{
-    ChangeFileParams, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams, FeatureName,
-    FileContent, FixFileResult, FormatFileParams, FormatOnTypeParams, FormatRangeParams,
-    GetControlFlowGraphParams, GetFormatterIRParams, GetSyntaxTreeParams, GetSyntaxTreeResult,
-    OpenFileParams, ParsePatternParams, ParsePatternResult, PatternId, ProjectKey,
-    PullActionsParams, PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult,
-    RegisterProjectFolderParams, RenameResult, ScanProjectFolderResult, SearchPatternParams,
-    SearchResults, SetManifestForProjectParams, SupportsFeatureParams,
-    UnregisterProjectFolderParams, UpdateSettingsParams,
+    ChangeFileParams, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams,
+    CloseProjectParams, FeatureName, FileContent, FixFileParams, FixFileResult, FormatFileParams,
+    FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
+    GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, OpenProjectParams,
+    ParsePatternParams, ParsePatternResult, PatternId, ProjectKey, PullActionsParams,
+    PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult, RenameResult,
+    ScanProjectFolderParams, ScanProjectFolderResult, SearchPatternParams, SearchResults,
+    SetManifestForProjectParams, SupportsFeatureParams, UpdateSettingsParams,
 };
-use crate::diagnostics::{FileTooLarge, InvalidPattern, NoProject, SearchError};
+use crate::diagnostics::FileTooLarge;
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, FixAllParams, LintParams, ParseResult,
 };
 use crate::is_dir;
-use crate::settings::WorkspaceSettings;
+use crate::projects::Projects;
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, IsPathIgnoredParams, RageEntry, RageParams,
     RageResult, ServerInfo,
 };
 use crate::{file_handlers::Features, Workspace, WorkspaceError};
 use append_only_vec::AppendOnlyVec;
+use biome_configuration::{BiomeDiagnostic, PartialConfiguration};
+use biome_deserialize::json::deserialize_from_json_str;
+use biome_deserialize::Deserialized;
+use biome_diagnostics::print_diagnostic_to_string;
 use biome_diagnostics::{
     serde::Diagnostic as SerdeDiagnostic, Diagnostic, DiagnosticExt, Severity,
 };
@@ -38,7 +42,7 @@ use papaya::HashMap;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::panic::RefUnwindSafe;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, RwLock};
+use std::sync::Mutex;
 use tracing::{debug, info, info_span};
 
 pub(super) struct WorkspaceServer {
@@ -46,13 +50,10 @@ pub(super) struct WorkspaceServer {
     features: Features,
 
     /// global settings object for this workspace
-    settings: WorkspaceSettings,
+    settings: Projects,
 
     /// Stores the document (text content + version number) associated with a URL
     documents: HashMap<BiomePath, Document, FxBuildHasher>,
-
-    /// The current focused project
-    current_project_path: RwLock<Option<BiomePath>>,
 
     /// Stores the document sources used across the workspace
     file_sources: AppendOnlyVec<DocumentFileSource>,
@@ -114,7 +115,7 @@ pub(crate) struct Document {
 }
 
 impl WorkspaceServer {
-    /// Create a new [Workspace]
+    /// Creates a new [Workspace].
     ///
     /// This is implemented as a crate-private method instead of using
     /// [Default] to disallow instances of [Workspace] from being created
@@ -124,7 +125,6 @@ impl WorkspaceServer {
             features: Features::new(),
             settings: Default::default(),
             documents: Default::default(),
-            current_project_path: RwLock::default(),
             file_sources: AppendOnlyVec::default(),
             patterns: Default::default(),
             node_cache: Default::default(),
@@ -132,7 +132,70 @@ impl WorkspaceServer {
         }
     }
 
-    /// Get the supported capabilities for a given file path
+    /// Attempts to find the root of a project by searching upwards from the
+    /// given `path`.
+    ///
+    /// The root of a project is where the top-level `biome.json` resides. So
+    /// the returned path is always the given path or one of its parents.
+    ///
+    /// An error may be returned if no top-level `biome.json` can be found, or
+    /// if there is an error opening a config file.
+    fn find_project_root(&self, path: BiomePath) -> Result<Utf8PathBuf, WorkspaceError> {
+        let path: Utf8PathBuf = path.into();
+
+        for ancestor in path.ancestors() {
+            let Some(config_path) = self.get_config_file(ancestor) else {
+                continue;
+            };
+
+            let content = self.fs.read_file_from_path(&config_path)?;
+            let extension = config_path
+                .extension()
+                .ok_or_else(|| BiomeDiagnostic::invalid_configuration("Missing extension"))?;
+            let file_source = JsonFileSource::try_from_extension(extension)
+                .map_err(|err| BiomeDiagnostic::invalid_configuration(err.to_string()))?;
+            let parser_options = JsonParserOptions::from(&file_source);
+            let deserialized: Deserialized<PartialConfiguration> =
+                deserialize_from_json_str(&content, parser_options, "config");
+            if let Some(error) = deserialized
+                .diagnostics()
+                .iter()
+                .find(|diagnostic| diagnostic.severity() == Severity::Error)
+            {
+                return Err(
+                    BiomeDiagnostic::invalid_configuration(print_diagnostic_to_string(error))
+                        .into(),
+                );
+            }
+
+            if deserialized
+                .into_deserialized()
+                .and_then(|config| config.root)
+                .is_none_or(|root| root)
+            {
+                // Found our root config!
+                return Ok(ancestor.to_path_buf());
+            }
+        }
+
+        Err(WorkspaceError::not_found())
+    }
+
+    /// Checks whether the directory identified by the given `path` contains a
+    /// Biome configuration file, and returns its path if found.
+    fn get_config_file(&self, path: &Utf8Path) -> Option<Utf8PathBuf> {
+        for config_file in ConfigName::file_names() {
+            let mut config_path = path.to_path_buf();
+            config_path.push(config_file);
+            if self.fs().path_exists(&config_path) {
+                return Some(config_path);
+            }
+        }
+
+        None
+    }
+
+    /// Gets the supported capabilities for a given file path.
     fn get_file_capabilities(&self, path: &BiomePath) -> Capabilities {
         let language = self.get_file_source(path);
 
@@ -140,7 +203,7 @@ impl WorkspaceServer {
         self.features.get_capabilities(path, language)
     }
 
-    /// Retrieves the supported language of a file
+    /// Retrieves the supported language of a file.
     fn get_file_source(&self, path: &BiomePath) -> DocumentFileSource {
         self.documents
             .pin()
@@ -150,7 +213,8 @@ impl WorkspaceServer {
             .unwrap_or(DocumentFileSource::from_path(path))
     }
 
-    /// Return an error factory function for unsupported features at a given path
+    /// Returns an error factory function for unsupported features at a given
+    /// path.
     fn build_capability_error<'a>(
         &'a self,
         path: &'a BiomePath,
@@ -168,14 +232,18 @@ impl WorkspaceServer {
         }
     }
 
-    /// Returns the current project. The information of this project depend on path set by [WorkspaceServer::set_current_project]
+    /// Returns the manifest for the given project.
+    ///
+    /// TODO: This needs to be updated to support multiple packages within a
+    ///       project.
     ///
     /// ## Errors
     ///
-    /// - If no document is found in the workspace. Usually, you'll have to call [WorkspaceServer::set_manifest_for_project] to store said document.
+    /// - If no document is found in the workspace. Usually, you'll have to call
+    ///   [WorkspaceServer::set_manifest_for_project] to store said document.
     #[tracing::instrument(level = "trace", skip(self))]
-    fn get_current_manifest(&self) -> Result<Option<PackageJson>, WorkspaceError> {
-        Ok(self.settings.get_current_manifest())
+    fn get_manifest(&self, project_key: ProjectKey) -> Result<Option<PackageJson>, WorkspaceError> {
+        Ok(self.settings.get_manifest(project_key))
     }
 
     /// Returns a previously inserted file source by index.
@@ -202,35 +270,6 @@ impl WorkspaceServer {
             .unwrap_or_else(|| self.file_sources.push(document_file_source))
     }
 
-    /// Retrieves the current project path
-    fn get_current_project_path(&self) -> Option<BiomePath> {
-        self.current_project_path.read().unwrap().as_ref().cloned()
-    }
-
-    /// Updates the current project path
-    fn set_current_project_path(&self, path: BiomePath) {
-        let mut current_project_path = self.current_project_path.write().unwrap();
-        let _ = current_project_path.insert(path);
-    }
-
-    /// Registers a new project in the current workspace.
-    fn register_project(&self, path: Utf8PathBuf) -> ProjectKey {
-        self.settings.insert_project(path)
-    }
-
-    /// Sets the current project of the current workspace.
-    fn set_current_project(&self, project_key: ProjectKey) {
-        self.settings.set_current_project(project_key);
-    }
-
-    /// Checks whether the given `path` belongs to another registered project.
-    ///
-    /// If there's a match, and the match is for a project **other than** the
-    /// current project, it returns the key of that project.
-    fn path_belongs_to_other_project(&self, path: &BiomePath) -> Option<ProjectKey> {
-        self.settings.path_belongs_to_other_project(path)
-    }
-
     /// Opens the file and marks it as opened by the scanner.
     pub(super) fn open_file_by_scanner(
         &self,
@@ -243,12 +282,17 @@ impl WorkspaceServer {
     fn open_file_internal(
         &self,
         opened_by_scanner: bool,
-        params: OpenFileParams,
+        OpenFileParams {
+            project_key,
+            path,
+            content,
+            version,
+            document_file_source,
+            persist_node_cache,
+        }: OpenFileParams,
     ) -> Result<(), WorkspaceError> {
-        let mut source = params
-            .document_file_source
-            .unwrap_or(DocumentFileSource::from_path(&params.path));
-        let manifest = self.get_current_manifest()?;
+        let mut source = document_file_source.unwrap_or(DocumentFileSource::from_path(&path));
+        let manifest = self.get_manifest(project_key)?;
 
         if let DocumentFileSource::Js(js) = &mut source {
             if let Some(manifest) = manifest {
@@ -258,25 +302,21 @@ impl WorkspaceServer {
             }
         }
 
-        if let Some(project_key) = self.path_belongs_to_other_project(&params.path) {
-            self.set_current_project(project_key);
-        }
-
-        let content = match params.content {
+        let content = match content {
             FileContent::FromClient(content) => content,
-            FileContent::FromServer => self.fs.read_file_from_path(&params.path)?,
+            FileContent::FromServer => self.fs.read_file_from_path(&path)?,
         };
 
         let mut index = self.insert_source(source);
 
         let size = content.as_bytes().len();
-        let limit = self.settings.get_max_file_size();
+        let limit = self.settings.get_max_file_size(project_key);
         if size > limit {
             self.documents.pin().insert(
-                params.path,
+                path,
                 Document {
                     content,
-                    version: params.version,
+                    version,
                     file_source_index: index,
                     syntax: Err(FileTooLarge { size, limit }),
                     opened_by_scanner,
@@ -286,23 +326,23 @@ impl WorkspaceServer {
         }
 
         let mut node_cache = NodeCache::default();
-        let parsed = self.parse(&params.path, &content, index, &mut node_cache)?;
+        let parsed = self.parse(project_key, &path, &content, index, &mut node_cache)?;
 
         if let Some(language) = parsed.language {
             index = self.insert_source(language);
         }
 
-        if params.persist_node_cache {
+        if persist_node_cache {
             self.node_cache
                 .lock()
                 .unwrap()
-                .insert(params.path.to_path_buf(), node_cache);
+                .insert(path.to_path_buf(), node_cache);
         }
 
         {
             let mut document = Document {
                 content,
-                version: params.version,
+                version,
                 file_source_index: index,
                 syntax: Ok(parsed.any_parse),
                 opened_by_scanner,
@@ -332,12 +372,12 @@ impl WorkspaceServer {
             // the document, which seems hardly worth it.
             // That said, I don't think this code is particularly pretty either
             // :sweat_smile:
-            if let Some(existing) = documents.get(&params.path) {
+            if let Some(existing) = documents.get(&path) {
                 if existing.opened_by_scanner {
                     document.opened_by_scanner = true;
                 }
 
-                if existing.version > params.version {
+                if existing.version > version {
                     document.version = existing.version;
                 }
             }
@@ -345,11 +385,11 @@ impl WorkspaceServer {
             let opened_by_scanner = document.opened_by_scanner;
             let version = document.version;
 
-            if let Some(existing) = documents.insert(params.path.clone(), document) {
+            if let Some(existing) = documents.insert(path.clone(), document) {
                 if (existing.opened_by_scanner && !opened_by_scanner)
                     || (existing.version > version)
                 {
-                    documents.update(params.path, |document| {
+                    documents.update(path, |document| {
                         let mut document = document.clone();
                         if existing.opened_by_scanner && !opened_by_scanner {
                             document.opened_by_scanner = true;
@@ -384,14 +424,15 @@ impl WorkspaceServer {
 
     fn parse(
         &self,
+        project_key: ProjectKey,
         biome_path: &BiomePath,
         content: &str,
         file_source_index: usize,
         node_cache: &mut NodeCache,
     ) -> Result<ParseResult, WorkspaceError> {
-        let Some(file_source) = self.get_source(file_source_index) else {
-            return Err(WorkspaceError::not_found());
-        };
+        let file_source = self
+            .get_source(file_source_index)
+            .ok_or_else(WorkspaceError::not_found)?;
         let capabilities = self.features.get_capabilities(biome_path, file_source);
 
         let parse = capabilities
@@ -403,36 +444,38 @@ impl WorkspaceServer {
             biome_path,
             file_source,
             content,
-            self.settings.get_current_settings().as_ref(),
+            self.settings.get_settings(project_key).as_ref(),
             node_cache,
         );
         Ok(parsed)
     }
 
-    /// Check whether a file is ignored in the top-level config `files.ignore`/`files.include`
-    /// or in the feature `ignore`/`include`
-    fn is_ignored(&self, path: &Utf8Path, features: FeatureName) -> bool {
+    /// Checks whether a file is ignored in the top-level config's
+    /// `files.ignore`/`files.include` or in the feature's `ignore`/`include`.
+    fn is_ignored(&self, project_key: ProjectKey, path: &Utf8Path, features: FeatureName) -> bool {
         let file_name = path.file_name();
         let ignored_by_features = {
             let mut ignored = false;
 
             for feature in features.iter() {
                 // a path is ignored if it's ignored by all features
-                ignored &= self.settings.is_ignored_by_feature_config(path, feature)
+                ignored &= self
+                    .settings
+                    .is_ignored_by_feature_config(project_key, path, feature)
             }
             ignored
         };
         // Never ignore Biome's config file regardless `include`/`ignore`
         (file_name != Some(ConfigName::biome_json()) || file_name != Some(ConfigName::biome_jsonc())) &&
             // Apply top-level `include`/`ignore`
-            (self.is_ignored_by_top_level_config(path) ||
+            (self.is_ignored_by_top_level_config(project_key, path) ||
                 // Apply feature-level `include`/`ignore`
                 ignored_by_features)
     }
 
     /// Check whether a file is ignored in the top-level config `files.ignore`/`files.include`
-    fn is_ignored_by_top_level_config(&self, path: &Utf8Path) -> bool {
-        let Some(files_settings) = self.settings.get_current_files_settings() else {
+    fn is_ignored_by_top_level_config(&self, project_key: ProjectKey, path: &Utf8Path) -> bool {
+        let Some(files_settings) = self.settings.get_files_settings(project_key) else {
             return false;
         };
 
@@ -473,7 +516,7 @@ impl Workspace for WorkspaceServer {
         };
 
         let file_size = document.content.as_bytes().len();
-        let limit = self.settings.get_max_file_size();
+        let limit = self.settings.get_max_file_size(params.project_key);
         Ok(CheckFileSizeResult { file_size, limit })
     }
 
@@ -481,10 +524,12 @@ impl Workspace for WorkspaceServer {
         &self,
         params: SupportsFeatureParams,
     ) -> Result<FileFeaturesResult, WorkspaceError> {
-        let capabilities = self.get_file_capabilities(&params.path);
-        let language = DocumentFileSource::from_path(&params.path);
+        let project_key = params.project_key;
         let path = params.path.as_path();
-        let settings = self.settings.get_current_settings();
+
+        let capabilities = self.get_file_capabilities(&params.path);
+        let language = DocumentFileSource::from_path(path);
+        let settings = self.settings.get_settings(project_key);
         let mut file_features = FileFeaturesResult::new();
 
         let file_name = path.file_name();
@@ -492,6 +537,7 @@ impl Workspace for WorkspaceServer {
         let Some(settings) = settings else {
             return Ok(file_features);
         };
+
         file_features = file_features.with_settings_and_language(&settings, &language, path);
 
         if settings.files.ignore_unknown
@@ -503,11 +549,14 @@ impl Workspace for WorkspaceServer {
             || file_name == Some(ConfigName::biome_jsonc())
         {
             // Never ignore Biome's config file
-        } else if self.is_ignored_by_top_level_config(path) {
+        } else if self.is_ignored_by_top_level_config(project_key, path) {
             file_features.set_ignored_for_all_features();
         } else {
             for feature in params.features.iter() {
-                if self.settings.is_ignored_by_feature_config(path, feature) {
+                if self
+                    .settings
+                    .is_ignored_by_feature_config(project_key, path, feature)
+                {
                     file_features.ignored(feature);
                 }
             }
@@ -523,7 +572,7 @@ impl Workspace for WorkspaceServer {
     }
 
     fn is_path_ignored(&self, params: IsPathIgnoredParams) -> Result<bool, WorkspaceError> {
-        Ok(self.is_ignored(params.biome_path.as_path(), params.features))
+        Ok(self.is_ignored(params.project_key, params.path.as_path(), params.features))
     }
 
     /// Updates the global settings for this workspace.
@@ -533,7 +582,7 @@ impl Workspace for WorkspaceServer {
     /// by another thread having previously panicked while holding the lock
     #[tracing::instrument(level = "trace", skip(self))]
     fn update_settings(&self, params: UpdateSettingsParams) -> Result<(), WorkspaceError> {
-        let Some(mut settings) = self.settings.get_current_settings() else {
+        let Some(mut settings) = self.settings.get_settings(params.project_key) else {
             return Err(WorkspaceError::no_project());
         };
 
@@ -544,7 +593,7 @@ impl Workspace for WorkspaceServer {
             params.gitignore_matches.as_slice(),
         )?;
 
-        self.settings.set_current_settings(settings);
+        self.settings.set_settings(params.project_key, settings);
 
         Ok(())
     }
@@ -563,7 +612,8 @@ impl Workspace for WorkspaceServer {
 
         let mut node_js_project = NodeJsProject::default();
         node_js_project.deserialize_manifest(&parsed.tree());
-        self.settings.insert_manifest(node_js_project);
+        self.settings
+            .insert_manifest(params.project_key, node_js_project);
 
         self.documents.pin().insert(
             params.manifest_path.clone(),
@@ -578,43 +628,25 @@ impl Workspace for WorkspaceServer {
         Ok(())
     }
 
-    fn register_project_folder(
-        &self,
-        params: RegisterProjectFolderParams,
-    ) -> Result<ProjectKey, WorkspaceError> {
-        let current_project_path = self.get_current_project_path();
-        debug!(
-            "Compare the current project with the new one {:?} {:?} {:?}",
-            current_project_path.as_deref(),
-            params.path.as_ref(),
-            current_project_path.as_deref() != params.path.as_deref()
-        );
-
-        let is_new_path = match (current_project_path.as_deref(), params.path.as_deref()) {
-            (Some(current_project_path), Some(params_path)) => current_project_path != params_path,
-            _ => true,
+    fn open_project(&self, params: OpenProjectParams) -> Result<ProjectKey, WorkspaceError> {
+        let path = if params.open_uninitialized {
+            let path = params.path.to_path_buf();
+            self.find_project_root(params.path).unwrap_or(path)
+        } else {
+            self.find_project_root(params.path)?
         };
 
-        if is_new_path {
-            let path = params.path.unwrap_or_default();
-            let key = self.register_project(path.to_path_buf());
-            if params.set_as_current_workspace {
-                self.set_current_project(key);
-                self.set_current_project_path(BiomePath::new(path));
-            }
-            Ok(key)
-        } else {
-            Ok(self.settings.get_current_project_key())
-        }
+        Ok(self.settings.insert_project(path))
     }
 
-    fn scan_current_project_folder(
+    fn scan_project_folder(
         &self,
-        _params: (),
+        params: ScanProjectFolderParams,
     ) -> Result<ScanProjectFolderResult, WorkspaceError> {
-        let path = self
-            .get_current_project_path()
-            .ok_or(WorkspaceError::NoProject(NoProject))?;
+        let path = params
+            .path
+            .or_else(|| self.settings.get_project_path(params.project_key))
+            .ok_or_else(WorkspaceError::no_project)?;
 
         // TODO: Need to register a file watcher. This should happen before we
         //       start scanning, or we might miss changes that happened during
@@ -624,7 +656,7 @@ impl Workspace for WorkspaceServer {
         //       **But** if we are using a polling backend for the watching, we
         //       probably want to force a poll at this moment.
 
-        let result = scan(self, &path)?;
+        let result = scan(self, params.project_key, &path)?;
 
         Ok(ScanProjectFolderResult {
             diagnostics: result.diagnostics,
@@ -632,10 +664,12 @@ impl Workspace for WorkspaceServer {
         })
     }
 
-    fn unregister_project_folder(
-        &self,
-        params: UnregisterProjectFolderParams,
-    ) -> Result<(), WorkspaceError> {
+    fn close_project(&self, params: CloseProjectParams) -> Result<(), WorkspaceError> {
+        let project_path = self
+            .settings
+            .get_project_path(params.project_key)
+            .ok_or_else(WorkspaceError::no_project)?;
+
         // Limit the scope of the pin and the lock inside.
         {
             let documents = self.documents.pin();
@@ -644,15 +678,15 @@ impl Workspace for WorkspaceServer {
                 if document.opened_by_scanner
                     && self
                         .settings
-                        .path_belongs_only_to_project_with_path(path, &params.path)
+                        .path_belongs_only_to_project_with_path(path, &project_path)
                 {
                     documents.remove(path);
-                    node_cache.remove(params.path.as_path());
+                    node_cache.remove(path.as_path());
                 }
             }
         }
 
-        self.settings.remove_project(params.path.as_path());
+        self.settings.remove_project(params.project_key);
 
         Ok(())
     }
@@ -696,7 +730,7 @@ impl Workspace for WorkspaceServer {
             .debug
             .debug_formatter_ir
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings.get_current_settings();
+        let settings = self.settings.get_settings(params.project_key);
         let parse = self.get_parse(&params.path)?;
 
         if let Some(settings) = &settings {
@@ -718,12 +752,20 @@ impl Workspace for WorkspaceServer {
     }
 
     /// Changes the content of an open file.
-    fn change_file(&self, params: ChangeFileParams) -> Result<(), WorkspaceError> {
+    fn change_file(
+        &self,
+        ChangeFileParams {
+            project_key,
+            path,
+            content,
+            version,
+        }: ChangeFileParams,
+    ) -> Result<(), WorkspaceError> {
         let documents = self.documents.pin();
         let (index, opened_by_scanner) = documents
-            .get(&params.path)
+            .get(&path)
             .map(|document| {
-                debug_assert!(params.version > document.version);
+                debug_assert!(version > document.version);
                 (document.file_source_index, document.opened_by_scanner)
             })
             .ok_or_else(WorkspaceError::not_found)?;
@@ -735,20 +777,16 @@ impl Workspace for WorkspaceServer {
         // second would have a cache miss, and not update the cache either.
         // This seems an unlikely scenario however, and the impact is small
         // anyway, so this seems a worthwhile tradeoff.
-        let node_cache = self
-            .node_cache
-            .lock()
-            .unwrap()
-            .remove(params.path.as_path());
+        let node_cache = self.node_cache.lock().unwrap().remove(path.as_path());
 
         let persist_node_cache = node_cache.is_some();
         let mut node_cache = node_cache.unwrap_or_default();
 
-        let parsed = self.parse(&params.path, &params.content, index, &mut node_cache)?;
+        let parsed = self.parse(project_key, &path, &content, index, &mut node_cache)?;
 
         let document = Document {
-            content: params.content,
-            version: params.version,
+            content,
+            version,
             file_source_index: index,
             syntax: Ok(parsed.any_parse),
             opened_by_scanner,
@@ -758,11 +796,11 @@ impl Workspace for WorkspaceServer {
             self.node_cache
                 .lock()
                 .unwrap()
-                .insert(params.path.to_path_buf(), node_cache);
+                .insert(path.to_path_buf(), node_cache);
         }
 
         documents
-            .insert(params.path, document)
+            .insert(path, document)
             .ok_or_else(WorkspaceError::not_found)?;
         Ok(())
     }
@@ -795,25 +833,33 @@ impl Workspace for WorkspaceServer {
     #[tracing::instrument(level = "trace", skip(self))]
     fn pull_diagnostics(
         &self,
-        params: PullDiagnosticsParams,
+        PullDiagnosticsParams {
+            project_key,
+            path,
+            categories,
+            max_diagnostics,
+            only,
+            skip,
+            enabled_rules,
+        }: PullDiagnosticsParams,
     ) -> Result<PullDiagnosticsResult, WorkspaceError> {
-        let parse = self.get_parse(&params.path)?;
-        let manifest = self.get_current_manifest()?;
+        let parse = self.get_parse(&path)?;
+        let manifest = self.get_manifest(project_key)?;
         let (diagnostics, errors, skipped_diagnostics) =
-            if let Some(lint) = self.get_file_capabilities(&params.path).analyzer.lint {
-                info_span!("Pulling diagnostics", categories =? params.categories).in_scope(|| {
+            if let Some(lint) = self.get_file_capabilities(&path).analyzer.lint {
+                info_span!("Pulling diagnostics", categories =? categories).in_scope(|| {
                     let results = lint(LintParams {
                         parse,
-                        workspace: &self.settings.get_current_settings().into(),
-                        max_diagnostics: params.max_diagnostics as u32,
-                        path: &params.path,
-                        only: params.only,
-                        skip: params.skip,
-                        language: self.get_file_source(&params.path),
-                        categories: params.categories,
+                        workspace: &self.settings.get_settings(project_key).into(),
+                        max_diagnostics: max_diagnostics as u32,
+                        path: &path,
+                        only,
+                        skip,
+                        language: self.get_file_source(&path),
+                        categories,
                         manifest,
                         suppression_reason: None,
-                        enabled_rules: params.enabled_rules,
+                        enabled_rules,
                     });
 
                     (
@@ -837,7 +883,7 @@ impl Workspace for WorkspaceServer {
             diagnostics: diagnostics
                 .into_iter()
                 .map(|diag| {
-                    let diag = diag.with_file_path(params.path.to_string());
+                    let diag = diag.with_file_path(path.to_string());
                     SerdeDiagnostic::new(diag)
                 })
                 .collect(),
@@ -849,27 +895,38 @@ impl Workspace for WorkspaceServer {
     /// Retrieves the list of code actions available for a given cursor
     /// position within a file
     #[tracing::instrument(level = "trace", skip(self))]
-    fn pull_actions(&self, params: PullActionsParams) -> Result<PullActionsResult, WorkspaceError> {
-        let capabilities = self.get_file_capabilities(&params.path);
+    fn pull_actions(
+        &self,
+        PullActionsParams {
+            project_key,
+            path,
+            range,
+            suppression_reason,
+            only,
+            skip,
+            enabled_rules,
+        }: PullActionsParams,
+    ) -> Result<PullActionsResult, WorkspaceError> {
+        let capabilities = self.get_file_capabilities(&path);
         let code_actions = capabilities
             .analyzer
             .code_actions
-            .ok_or_else(self.build_capability_error(&params.path))?;
+            .ok_or_else(self.build_capability_error(&path))?;
 
-        let parse = self.get_parse(&params.path)?;
-        let manifest = self.get_current_manifest()?;
-        let language = self.get_file_source(&params.path);
+        let parse = self.get_parse(&path)?;
+        let manifest = self.get_manifest(project_key)?;
+        let language = self.get_file_source(&path);
         Ok(code_actions(CodeActionsParams {
             parse,
-            range: params.range,
-            workspace: &self.settings.get_current_settings().into(),
-            path: &params.path,
+            range,
+            workspace: &self.settings.get_settings(project_key).into(),
+            path: &path,
             manifest,
             language,
-            only: params.only,
-            skip: params.skip,
+            only,
+            skip,
             suppression_reason: None,
-            enabled_rules: params.enabled_rules,
+            enabled_rules,
         }))
     }
 
@@ -881,7 +938,7 @@ impl Workspace for WorkspaceServer {
             .formatter
             .format
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings.get_current_settings();
+        let settings = self.settings.get_settings(params.project_key);
         let parse = self.get_parse(&params.path)?;
 
         if let Some(settings) = &settings {
@@ -899,7 +956,7 @@ impl Workspace for WorkspaceServer {
             .formatter
             .format_range
             .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings.get_current_settings();
+        let settings = self.settings.get_settings(params.project_key);
         let parse = self.get_parse(&params.path)?;
 
         if let Some(settings) = &settings {
@@ -924,7 +981,7 @@ impl Workspace for WorkspaceServer {
             .format_on_type
             .ok_or_else(self.build_capability_error(&params.path))?;
 
-        let settings = self.settings.get_current_settings();
+        let settings = self.settings.get_settings(params.project_key);
         let parse = self.get_parse(&params.path)?;
         if let Some(settings) = &settings {
             if !settings.formatter().format_with_errors && parse.has_errors() {
@@ -942,31 +999,43 @@ impl Workspace for WorkspaceServer {
         )
     }
 
-    fn fix_file(&self, params: super::FixFileParams) -> Result<FixFileResult, WorkspaceError> {
-        let capabilities = self.get_file_capabilities(&params.path);
+    fn fix_file(
+        &self,
+        FixFileParams {
+            project_key,
+            path,
+            fix_file_mode,
+            should_format,
+            only,
+            skip,
+            enabled_rules,
+            rule_categories,
+            suppression_reason,
+        }: FixFileParams,
+    ) -> Result<FixFileResult, WorkspaceError> {
+        let capabilities = self.get_file_capabilities(&path);
 
         let fix_all = capabilities
             .analyzer
             .fix_all
-            .ok_or_else(self.build_capability_error(&params.path))?;
-        let parse = self.get_parse(&params.path)?;
+            .ok_or_else(self.build_capability_error(&path))?;
+        let parse = self.get_parse(&path)?;
 
-        let manifest = self.get_current_manifest()?;
-        let language = self.get_file_source(&params.path);
+        let manifest = self.get_manifest(project_key)?;
+        let language = self.get_file_source(&path);
         fix_all(FixAllParams {
             parse,
-            // rules: rules.as_ref().map(|x| x.borrow()),
-            fix_file_mode: params.fix_file_mode,
-            // filter,
-            workspace: self.settings.get_current_settings().into(),
-            should_format: params.should_format,
-            biome_path: &params.path,
+            fix_file_mode,
+            workspace: self.settings.get_settings(project_key).into(),
+            should_format,
+            biome_path: &path,
             manifest,
             document_file_source: language,
-            only: params.only,
-            skip: params.skip,
-            rule_categories: params.rule_categories,
-            suppression_reason: params.suppression_reason,
+            only,
+            skip,
+            rule_categories,
+            suppression_reason,
+            enabled_rules,
         })
     }
 
@@ -1005,35 +1074,31 @@ impl Workspace for WorkspaceServer {
         Ok(ParsePatternResult { pattern_id })
     }
 
-    fn search_pattern(&self, params: SearchPatternParams) -> Result<SearchResults, WorkspaceError> {
+    fn search_pattern(
+        &self,
+        SearchPatternParams {
+            project_key,
+            path,
+            pattern,
+        }: SearchPatternParams,
+    ) -> Result<SearchResults, WorkspaceError> {
         let patterns = self.patterns.pin();
-        let Some(query) = patterns.get(&params.pattern) else {
-            return Err(WorkspaceError::SearchError(SearchError::InvalidPattern(
-                InvalidPattern,
-            )));
-        };
+        let query = patterns
+            .get(&pattern)
+            .ok_or_else(WorkspaceError::invalid_pattern)?;
 
-        let capabilities = self.get_file_capabilities(&params.path);
+        let capabilities = self.get_file_capabilities(&path);
         let search = capabilities
             .search
             .search
-            .ok_or_else(self.build_capability_error(&params.path))?;
-        let settings = self.settings.get_current_settings();
-        let parse = self.get_parse(&params.path)?;
+            .ok_or_else(self.build_capability_error(&path))?;
+        let settings = self.settings.get_settings(project_key);
+        let parse = self.get_parse(&path)?;
 
-        let document_file_source = self.get_file_source(&params.path);
-        let matches = search(
-            &params.path,
-            &document_file_source,
-            parse,
-            query,
-            settings.into(),
-        )?;
+        let document_file_source = self.get_file_source(&path);
+        let matches = search(&path, &document_file_source, parse, query, settings.into())?;
 
-        Ok(SearchResults {
-            file: params.path,
-            matches,
-        })
+        Ok(SearchResults { path, matches })
     }
 
     fn drop_pattern(&self, params: super::DropPatternParams) -> Result<(), WorkspaceError> {

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -455,7 +455,7 @@ pub fn methods() -> [WorkspaceMethod; 22] {
     [
         workspace_method!(file_features),
         workspace_method!(update_settings),
-        workspace_method!(register_project_folder),
+        workspace_method!(open_project),
         workspace_method!(set_manifest_for_project),
         workspace_method!(open_file),
         workspace_method!(change_file),

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -10,10 +10,9 @@ use biome_project::PackageJson;
 use biome_rowan::{SyntaxKind, SyntaxNode, SyntaxSlot};
 use biome_service::configuration::to_analyzer_rules;
 use biome_service::file_handlers::DocumentFileSource;
-use biome_service::settings::{
-    ServiceLanguage, Settings, WorkspaceSettings, WorkspaceSettingsHandle,
-};
-use camino::Utf8Path;
+use biome_service::projects::Projects;
+use biome_service::settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle};
+use camino::{Utf8Path, Utf8PathBuf};
 use json_comments::StripComments;
 use similar::{DiffableStr, TextDiff};
 use std::ffi::c_int;
@@ -121,9 +120,8 @@ pub fn create_formatting_options<L>(
 where
     L: ServiceLanguage,
 {
-    let workspace = WorkspaceSettings::default();
-    let key = workspace.insert_project(Utf8Path::new(""));
-    workspace.set_current_project(key);
+    let projects = Projects::default();
+    let key = projects.insert_project(Utf8PathBuf::from(""));
 
     let options_file = input_file.with_extension("options.json");
     let Ok(json) = std::fs::read_to_string(options_file.clone()) else {
@@ -148,7 +146,7 @@ where
         Default::default()
     } else {
         let configuration = deserialized.into_deserialized().unwrap_or_default();
-        let mut settings = workspace.get_current_settings().unwrap_or_default();
+        let mut settings = projects.get_settings(key).unwrap_or_default();
         settings
             .merge_with_configuration(configuration, None, None, &[])
             .unwrap();

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -5,8 +5,8 @@ use biome_fs::MemoryFileSystem;
 use biome_service::workspace::{
     self, ChangeFileParams, CloseFileParams, FixFileParams, FormatFileParams, FormatOnTypeParams,
     FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams, GetFormatterIRParams,
-    GetSyntaxTreeParams, PullActionsParams, PullDiagnosticsParams, RegisterProjectFolderParams,
-    RenameParams, UpdateSettingsParams,
+    GetSyntaxTreeParams, OpenProjectParams, PullActionsParams, PullDiagnosticsParams, RenameParams,
+    UpdateSettingsParams,
 };
 use biome_service::workspace::{OpenFileParams, SupportsFeatureParams};
 
@@ -56,17 +56,11 @@ impl Workspace {
         self.inner.update_settings(params).map_err(into_error)
     }
 
-    #[wasm_bindgen(js_name = registerProjectFolder)]
-    pub fn register_workspace_folder(
-        &self,
-        params: IRegisterProjectFolderParams,
-    ) -> Result<IProjectKey, Error> {
-        let params: RegisterProjectFolderParams =
+    #[wasm_bindgen(js_name = openProject)]
+    pub fn open_project(&self, params: IOpenProjectParams) -> Result<IProjectKey, Error> {
+        let params: OpenProjectParams =
             serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
-        let result = self
-            .inner
-            .register_project_folder(params)
-            .map_err(into_error)?;
+        let result = self.inner.open_project(params).map_err(into_error)?;
 
         to_value(&result).map(IProjectKey::from).map_err(into_error)
     }

--- a/packages/@biomejs/backend-jsonrpc/tests/workspace.test.mjs
+++ b/packages/@biomejs/backend-jsonrpc/tests/workspace.test.mjs
@@ -14,7 +14,10 @@ describe("Workspace API", () => {
 		);
 
 		const workspace = await createWorkspaceWithBinary(command);
-		const projectKey = await workspace.openProject({ path: "" });
+		const projectKey = await workspace.openProject({
+			path: "",
+			openUninitialized: true,
+		});
 		await workspace.openFile({
 			projectKey,
 			path: "test.js",

--- a/packages/@biomejs/backend-jsonrpc/tests/workspace.test.mjs
+++ b/packages/@biomejs/backend-jsonrpc/tests/workspace.test.mjs
@@ -14,22 +14,23 @@ describe("Workspace API", () => {
 		);
 
 		const workspace = await createWorkspaceWithBinary(command);
-		workspace.registerProjectFolder({
-			setAsCurrentWorkspace: true,
-		});
+		const projectKey = await workspace.openProject({ path: "" });
 		await workspace.openFile({
+			projectKey,
 			path: "test.js",
 			content: { type: "fromClient", content: "statement()" },
 			version: 0,
 		});
 
 		const printed = await workspace.formatFile({
+			projectKey,
 			path: "test.js",
 		});
 
 		expect(printed.code).toBe("statement();\n");
 
 		await workspace.closeFile({
+			projectKey,
 			path: "test.js",
 		});
 

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -84,6 +84,10 @@
 			"description": "List of plugins to load.",
 			"anyOf": [{ "$ref": "#/definitions/Plugins" }, { "type": "null" }]
 		},
+		"root": {
+			"description": "Indicates whether this configuration file is at the root of a Biome project. By default, this is `true`.",
+			"type": ["boolean", "null"]
+		},
 		"vcs": {
 			"description": "The configuration of the VCS integration",
 			"anyOf": [

--- a/packages/@biomejs/js-api/src/index.ts
+++ b/packages/@biomejs/js-api/src/index.ts
@@ -143,6 +143,7 @@ export class Biome {
 	openProject(path?: string): ProjectKey {
 		return this.workspace.openProject({
 			path: path || "",
+			openUninitialized: true,
 		});
 	}
 

--- a/packages/@biomejs/js-api/tests/formatContent.test.ts
+++ b/packages/@biomejs/js-api/tests/formatContent.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProjectKey } from "../../backend-jsonrpc/dist";
 import { Biome, Distribution } from "../dist";
 
 describe("Biome WebAssembly formatContent", () => {
 	let biome: Biome;
+	let projectKey: ProjectKey;
 	beforeEach(async () => {
 		biome = await Biome.create({
 			distribution: Distribution.NODE,
 		});
+		projectKey = await biome.openProject();
 	});
 
 	afterEach(() => {
@@ -14,7 +17,7 @@ describe("Biome WebAssembly formatContent", () => {
 	});
 
 	it("should format JavaScript content", () => {
-		const result = biome.formatContent("function f   () {  }", {
+		const result = biome.formatContent(projectKey, "function f   () {  }", {
 			filePath: "example.js",
 		});
 
@@ -24,10 +27,9 @@ describe("Biome WebAssembly formatContent", () => {
 
 	it("should format JSON content", () => {
 		const result = biome.formatContent(
+			projectKey,
 			'{ "lorem": "ipsum", "foo": false, "bar": 23, "lorem": "ipsum", "foo": false, "bar": 23 }',
-			{
-				filePath: "example.json",
-			},
+			{ filePath: "example.json" },
 		);
 
 		expect(result.content).toEqual(
@@ -38,7 +40,7 @@ describe("Biome WebAssembly formatContent", () => {
 
 	it("should not format and have diagnostics", () => {
 		const content = "function   () {  }";
-		const result = biome.formatContent(content, {
+		const result = biome.formatContent(projectKey, content, {
 			filePath: "example.js",
 		});
 
@@ -51,7 +53,7 @@ describe("Biome WebAssembly formatContent", () => {
 	});
 
 	it("should format content in debug mode", () => {
-		const result = biome.formatContent("function f() {}", {
+		const result = biome.formatContent(projectKey, "function f() {}", {
 			filePath: "example.js",
 			debug: true,
 		});
@@ -64,21 +66,26 @@ describe("Biome WebAssembly formatContent", () => {
 	});
 
 	it("should not format content with range", () => {
-		const result = biome.formatContent("let a   ; function g () {  }", {
-			filePath: "file.js",
-			range: [20, 25],
-		});
+		const result = biome.formatContent(
+			projectKey,
+			"let a   ; function g () {  }",
+			{ filePath: "file.js", range: [20, 25] },
+		);
 
 		expect(result.content).toEqual("function g() {}");
 		expect(result.diagnostics).toEqual([]);
 	});
 
 	it("should not format content with range in debug mode", () => {
-		const result = biome.formatContent("let a   ; function g () {  }", {
-			filePath: "file.js",
-			range: [20, 25],
-			debug: true,
-		});
+		const result = biome.formatContent(
+			projectKey,
+			"let a   ; function g () {  }",
+			{
+				filePath: "file.js",
+				range: [20, 25],
+				debug: true,
+			},
+		);
 
 		expect(result.content).toEqual("function g() {}");
 		expect(result.diagnostics).toEqual([]);
@@ -104,7 +111,7 @@ describe("Biome WebAssembly formatContent", () => {
 }
 `;
 
-		biome.applyConfiguration({
+		biome.applyConfiguration(projectKey, {
 			formatter: {
 				indentStyle: "space",
 				indentWidth: 8,
@@ -117,7 +124,7 @@ describe("Biome WebAssembly formatContent", () => {
 			},
 		});
 
-		const result = biome.formatContent(content, {
+		const result = biome.formatContent(projectKey, content, {
 			filePath: "example.js",
 		});
 
@@ -129,7 +136,7 @@ describe("Biome WebAssembly formatContent", () => {
 		const formatted = `<div bar='foo' baz={"foo"} />;
 `;
 
-		biome.applyConfiguration({
+		biome.applyConfiguration(projectKey, {
 			formatter: {
 				indentStyle: "space",
 				indentWidth: 8,
@@ -142,7 +149,7 @@ describe("Biome WebAssembly formatContent", () => {
 			},
 		});
 
-		const result = biome.formatContent(content, {
+		const result = biome.formatContent(projectKey, content, {
 			filePath: "example.js",
 		});
 

--- a/packages/@biomejs/js-api/tests/lintContent.test.ts
+++ b/packages/@biomejs/js-api/tests/lintContent.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ProjectKey } from "../../backend-jsonrpc/dist";
 import { Biome, Distribution } from "../dist";
 
 describe("Biome WebAssembly lintContent", () => {
@@ -8,10 +9,12 @@ describe("Biome WebAssembly lintContent", () => {
 	`;
 
 	let biome: Biome;
+	let projectKey: ProjectKey;
 	beforeEach(async () => {
 		biome = await Biome.create({
 			distribution: Distribution.NODE,
 		});
+		projectKey = await biome.openProject();
 	});
 
 	afterEach(() => {
@@ -20,7 +23,7 @@ describe("Biome WebAssembly lintContent", () => {
 
 	describe("fixFileMode is undefined/omitted", () => {
 		it("should emit diagnotics", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 			});
 			expect(result.diagnostics).toMatchObject([
@@ -32,7 +35,7 @@ describe("Biome WebAssembly lintContent", () => {
 			]);
 		});
 		it("should not fix the code", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 			});
 			expect(result.content).toMatchSnapshot();
@@ -41,7 +44,7 @@ describe("Biome WebAssembly lintContent", () => {
 
 	describe("fixFileMode is SafeFixes", () => {
 		it("should emit diagnotics", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeFixes",
 			});
@@ -50,7 +53,7 @@ describe("Biome WebAssembly lintContent", () => {
 			]);
 		});
 		it("should fix the SafeFixes only", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeFixes",
 			});
@@ -60,14 +63,14 @@ describe("Biome WebAssembly lintContent", () => {
 
 	describe("fixFileMode is SafeAndUnsafeFixes", () => {
 		it("should emit diagnotics", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeAndUnsafeFixes",
 			});
 			expect(result.diagnostics).toHaveLength(0);
 		});
 		it("should fix the code", () => {
-			const result = biome.lintContent(inputCode, {
+			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeAndUnsafeFixes",
 			});

--- a/packages/@biomejs/wasm-bundler/package.json
+++ b/packages/@biomejs/wasm-bundler/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@biomejs/wasm-bundler",
+  "name": "@biomejs/biome_wasm",
+  "type": "module",
   "collaborators": [
     "Biome Developers and Contributors"
   ],
@@ -8,8 +9,7 @@
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/biomejs/biome.git",
-    "directory": "packages/@biomejs/biome/wasm-bundler"
+    "url": "https://github.com/biomejs/biome"
   },
   "files": [
     "biome_wasm_bg.wasm",
@@ -17,11 +17,8 @@
     "biome_wasm_bg.js",
     "biome_wasm.d.ts"
   ],
-  "module": "biome_wasm.js",
+  "main": "biome_wasm.js",
   "homepage": "https://biomejs.dev/",
-  "publishConfig": {
-    "provenance": true
-  },
   "types": "biome_wasm.d.ts",
   "sideEffects": [
     "./biome_wasm.js",


### PR DESCRIPTION
## Summary

This eliminates the concept of a "current" project in the workspace. Because of this, most methods now need to specify a `project_key` as part of their params, to decide which project to operate upon.

The reason for dropping the current project is that it makes the workspace less stateful, we can drop a few locks from our global state, and the `open_file()` method doesn't need to check anymore whether the correct project is still the current one. Other methods no longer make assumptions based upon the current project, but specify the project explicitly. This should help reduce the occurrence of race conditions.

In addition, I've tried to improve the documentation of the workspace methods, and made a start with making terminology more consistent:

* **Workspace** remains as it is today: A place in Biome’s memory, where we can open one or more projects and which is managed through the workspace protocol.
* **Project** is a Biome project, meaning it corresponds to a top-level `biome.json` file.
* **Package** is an NPM package or other “JavaScript project”. Each of these may have their own nested `biome.json` file.

Implementation-wise "project" and "package" still have a one-to-one relationship, but I want to change this in a follow-up PR.

## Test Plan

CI should remain green.

I manually tested the CLI, and it still seems alright. There is a very slight regression in performance, probably due to serializing the `project_key` across workspace methods, but it's <1% over the total runtime.
