### PR TITLE
feat(html): set up HTML configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "biome_formatter",
  "biome_graphql_analyze",
  "biome_graphql_syntax",
+ "biome_html_formatter",
  "biome_html_syntax",
  "biome_js_analyze",
  "biome_js_formatter",
@@ -729,6 +730,8 @@ dependencies = [
 name = "biome_html_formatter"
 version = "0.0.0"
 dependencies = [
+ "biome_deserialize",
+ "biome_deserialize_macros",
  "biome_diagnostics_categories",
  "biome_formatter",
  "biome_formatter_test",

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -24,6 +24,7 @@ biome_flags              = { workspace = true }
 biome_formatter          = { workspace = true, features = ["serde"] }
 biome_graphql_analyze    = { workspace = true }
 biome_graphql_syntax     = { workspace = true }
+biome_html_formatter     = { workspace = true, features = ["serde"] }
 biome_html_syntax        = { workspace = true }
 biome_js_analyze         = { workspace = true }
 biome_js_formatter       = { workspace = true, features = ["serde"] }

--- a/crates/biome_configuration/src/html.rs
+++ b/crates/biome_configuration/src/html.rs
@@ -1,0 +1,122 @@
+use biome_deserialize_macros::{Deserializable, Merge, Partial};
+use biome_formatter::{
+    AttributePosition, BracketSameLine, IndentStyle, IndentWidth, LineEnding, LineWidth,
+};
+use biome_html_formatter::context::{IndentScriptAndStyle, WhitespaceSensitivity};
+use bpaf::Bpaf;
+use serde::{Deserialize, Serialize};
+
+/// Options applied to HTML files
+#[derive(Clone, Default, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct HtmlConfiguration {
+    /// HTML parsing options
+    #[partial(type, bpaf(external(partial_html_parser), optional))]
+    pub parser: HtmlParser,
+
+    /// HTML formatter options
+    #[partial(type, bpaf(external(partial_html_formatter), optional))]
+    pub formatter: HtmlFormatter,
+}
+
+/// Options that changes how the HTML parser behaves
+#[derive(Clone, Default, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct HtmlParser;
+
+/// Options that changes how the HTML formatter behaves
+#[derive(Clone, Debug, Deserialize, Eq, Partial, PartialEq, Serialize)]
+#[partial(derive(Bpaf, Clone, Deserializable, Eq, Merge, PartialEq))]
+#[partial(cfg_attr(feature = "schema", derive(schemars::JsonSchema)))]
+#[partial(serde(rename_all = "camelCase", default, deny_unknown_fields))]
+pub struct HtmlFormatter {
+    /// Control the formatter for HTML (and its super languages) files.
+    #[partial(bpaf(long("html-formatter-enabled"), argument("true|false"), optional))]
+    pub enabled: bool,
+
+    /// The indent style applied to HTML (and its super languages) files.
+    #[partial(bpaf(long("html-formatter-indent-style"), argument("tab|space"), optional))]
+    pub indent_style: Option<IndentStyle>,
+
+    /// The size of the indentation applied to HTML (and its super languages) files. Default to 2.
+    #[partial(bpaf(long("html-formatter-indent-width"), argument("NUMBER"), optional))]
+    pub indent_width: Option<IndentWidth>,
+
+    /// The type of line ending applied to HTML (and its super languages) files.
+    #[partial(bpaf(long("html-formatter-line-ending"), argument("lf|crlf|cr"), optional))]
+    pub line_ending: Option<LineEnding>,
+
+    /// What's the max width of a line applied to HTML (and its super languages) files. Defaults to 80.
+    #[partial(bpaf(long("html-formatter-line-width"), argument("NUMBER"), optional))]
+    pub line_width: Option<LineWidth>,
+
+    /// The attribute position style in HTML elements. Defaults to auto.
+    #[partial(bpaf(
+        long("html-formatter-attribute-position"),
+        argument("multiline|auto"),
+        optional
+    ))]
+    pub attribute_position: Option<AttributePosition>,
+
+    /// Whether to hug the closing bracket of multiline HTMLtags to the end of the last line, rather than being alone on the following line. Defaults to false.
+    #[partial(bpaf(
+        long("html-formatter-bracket-same-line"),
+        argument("true|false"),
+        optional
+    ))]
+    pub bracket_same_line: Option<BracketSameLine>,
+
+    /// Whether or not to account for whitespace sensitivity when formatting HTML (and its super languages). Defaults to "strict".
+    #[partial(bpaf(
+        long("html-formatter-whitespace-sensitivity"),
+        argument("strict|ignore"),
+        optional
+    ))]
+    pub whitespace_sensitivity: Option<WhitespaceSensitivity>,
+
+    /// Whether or not to indent the `<script>` and `<style>` tags for HTML (and its super languages). Defaults to false.
+    #[partial(bpaf(
+        long("html-formatter-indent-script-and-style"),
+        argument("true|false"),
+        optional
+    ))]
+    pub indent_script_and_style: Option<IndentScriptAndStyle>,
+}
+
+// ignoring lint because eventually we will want `enabled: true` by default.
+#[expect(clippy::derivable_impls)]
+impl Default for HtmlFormatter {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            indent_style: Default::default(),
+            indent_width: Default::default(),
+            line_ending: Default::default(),
+            line_width: Default::default(),
+            attribute_position: Default::default(),
+            bracket_same_line: Default::default(),
+            whitespace_sensitivity: Default::default(),
+            indent_script_and_style: Default::default(),
+        }
+    }
+}
+
+impl PartialHtmlFormatter {
+    pub fn get_formatter_configuration(&self) -> HtmlFormatter {
+        HtmlFormatter {
+            enabled: self.enabled.unwrap_or_default(),
+            indent_style: self.indent_style,
+            indent_width: self.indent_width,
+            line_ending: self.line_ending,
+            line_width: self.line_width,
+            attribute_position: self.attribute_position,
+            bracket_same_line: self.bracket_same_line,
+            whitespace_sensitivity: self.whitespace_sensitivity,
+            indent_script_and_style: self.indent_script_and_style,
+        }
+    }
+}

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -10,6 +10,7 @@ pub mod formatter;
 pub mod generated;
 pub mod graphql;
 pub mod grit;
+pub mod html;
 pub mod javascript;
 pub mod json;
 mod overrides;
@@ -51,6 +52,7 @@ pub use graphql::{
     partial_graphql_configuration, GraphqlConfiguration, GraphqlFormatter, GraphqlLinter,
     PartialGraphqlConfiguration, PartialGraphqlFormatter, PartialGraphqlLinter,
 };
+use html::{partial_html_configuration, HtmlConfiguration, PartialHtmlConfiguration};
 pub use javascript::{
     partial_javascript_configuration, JavascriptConfiguration, JavascriptFormatter,
     PartialJavascriptConfiguration, PartialJavascriptFormatter,
@@ -132,6 +134,11 @@ pub struct Configuration {
     /// Specific configuration for the GraphQL language
     #[partial(type, bpaf(external(partial_grit_configuration), optional))]
     pub grit: GritConfiguration,
+
+    // hidden for now. show when it's to be shown to end users.
+    /// Specific configuration for the HTML language
+    #[partial(type, bpaf(external(partial_html_configuration), optional, hide))]
+    pub html: HtmlConfiguration,
 
     /// A list of granular patterns that should be applied only to a sub set of files
     #[partial(bpaf(hide))]

--- a/crates/biome_configuration/tests/invalid/top_level_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/top_level_extraneous_field.json.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_configuration/tests/spec_tests.rs
 expression: top_level_extraneous_field.json
-snapshot_kind: text
 ---
 top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -26,6 +25,7 @@ top_level_extraneous_field.json:2:2 deserialize ━━━━━━━━━━�
   - css
   - graphql
   - grit
+  - html
   - overrides
   - plugins
   - assist

--- a/crates/biome_grit_formatter/src/generated.rs
+++ b/crates/biome_grit_formatter/src/generated.rs
@@ -2029,7 +2029,6 @@ impl AsFormat<GritFormatContext> for biome_grit_syntax::GritPatternUntilClause {
         crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause,
     >;
     fn format(&self) -> Self::Format<'_> {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatRefWithRule::new(
             self,
             crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause::default(),
@@ -2042,7 +2041,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritPatternUntilClause
         crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause,
     >;
     fn into_format(self) -> Self::Format {
-        #![allow(clippy::default_constructed_unit_structs)]
         FormatOwnedWithRule::new(
             self,
             crate::grit::patterns::pattern_until_clause::FormatGritPatternUntilClause::default(),

--- a/crates/biome_html_formatter/Cargo.toml
+++ b/crates/biome_html_formatter/Cargo.toml
@@ -10,6 +10,8 @@ repository.workspace = true
 version              = "0.0.0"
 
 [dependencies]
+biome_deserialize            = { workspace = true }
+biome_deserialize_macros     = { workspace = true }
 biome_diagnostics_categories = { workspace = true }
 biome_formatter              = { workspace = true }
 biome_html_syntax            = { workspace = true }

--- a/crates/biome_html_formatter/src/context.rs
+++ b/crates/biome_html_formatter/src/context.rs
@@ -1,5 +1,6 @@
 use std::{fmt, rc::Rc, str::FromStr};
 
+use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
     printer::PrinterOptions, AttributePosition, BracketSameLine, BracketSpacing, CstFormatContext,
     FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
@@ -223,7 +224,7 @@ impl FormatOptions for HtmlFormatOptions {
 /// | without spaces |  `1<b>2</b>3`  |  1<b>2</b>3  |
 ///
 /// This happens because whitespace is significant in inline elements.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserializable, Merge)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -272,7 +273,7 @@ impl FromStr for WhitespaceSensitivity {
 /// Whether to indent the content of `<script>` and `<style>` tags for HTML-ish templating languages (Vue, Svelte, etc.).
 ///
 /// When true, the content of `<script>` and `<style>` tags will be indented one level.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserializable, Merge)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -1,5 +1,7 @@
 use biome_analyze::AnalyzerOptions;
-use biome_formatter::{BracketSameLine, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed};
+use biome_formatter::{
+    AttributePosition, BracketSameLine, IndentStyle, IndentWidth, LineEnding, LineWidth, Printed,
+};
 use biome_fs::BiomePath;
 use biome_html_formatter::{
     context::{IndentScriptAndStyle, WhitespaceSensitivity},
@@ -29,6 +31,7 @@ pub struct HtmlFormatterSettings {
     pub line_width: Option<LineWidth>,
     pub indent_width: Option<IndentWidth>,
     pub indent_style: Option<IndentStyle>,
+    pub attribute_position: Option<AttributePosition>,
     pub bracket_same_line: Option<BracketSameLine>,
     pub whitespace_sensitivity: Option<WhitespaceSensitivity>,
     pub indent_script_and_style: Option<IndentScriptAndStyle>,
@@ -42,6 +45,7 @@ impl Default for HtmlFormatterSettings {
             indent_width: Default::default(),
             line_ending: Default::default(),
             line_width: Default::default(),
+            attribute_position: Default::default(),
             bracket_same_line: Default::default(),
             whitespace_sensitivity: Default::default(),
             indent_script_and_style: Default::default(),
@@ -86,6 +90,10 @@ impl ServiceLanguage for HtmlLanguage {
             .and_then(|l| l.line_ending)
             .or(global.and_then(|g| g.line_ending))
             .unwrap_or_default();
+        let attribute_position = language
+            .and_then(|l| l.attribute_position)
+            .or(global.and_then(|g| g.attribute_position))
+            .unwrap_or_default();
         let bracket_same_line = language
             .and_then(|l| l.bracket_same_line)
             .or(global.and_then(|g| g.bracket_same_line))
@@ -102,6 +110,7 @@ impl ServiceLanguage for HtmlLanguage {
             .with_indent_width(indent_width)
             .with_line_width(line_width)
             .with_line_ending(line_ending)
+            .with_attribute_position(attribute_position)
             .with_bracket_same_line(bracket_same_line)
             .with_whitespace_sensitivity(whitespace_sensitivity)
             .with_indent_script_and_style(indent_script_and_style);

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -53,6 +53,10 @@ export interface PartialConfiguration {
 	 */
 	grit?: PartialGritConfiguration;
 	/**
+	 * Specific configuration for the HTML language
+	 */
+	html?: PartialHtmlConfiguration;
+	/**
 	 * Specific configuration for the JavaScript language
 	 */
 	javascript?: PartialJavascriptConfiguration;
@@ -205,6 +209,19 @@ export interface PartialGritConfiguration {
 	 * Formatting options
 	 */
 	formatter?: PartialGritFormatter;
+}
+/**
+ * Options applied to HTML files
+ */
+export interface PartialHtmlConfiguration {
+	/**
+	 * HTML formatter options
+	 */
+	formatter?: PartialHtmlFormatter;
+	/**
+	 * HTML parsing options
+	 */
+	parser?: PartialHtmlParser;
 }
 /**
  * A set of options applied to the JavaScript files
@@ -457,6 +474,51 @@ export interface PartialGritFormatter {
 	lineWidth?: LineWidth;
 }
 /**
+ * Options that changes how the HTML formatter behaves
+ */
+export interface PartialHtmlFormatter {
+	/**
+	 * The attribute position style in HTML elements. Defaults to auto.
+	 */
+	attributePosition?: AttributePosition;
+	/**
+	 * Whether to hug the closing bracket of multiline HTMLtags to the end of the last line, rather than being alone on the following line. Defaults to false.
+	 */
+	bracketSameLine?: BracketSameLine;
+	/**
+	 * Control the formatter for HTML (and its super languages) files.
+	 */
+	enabled?: boolean;
+	/**
+	 * Whether or not to indent the `<script>` and `<style>` tags for HTML (and its super languages). Defaults to false.
+	 */
+	indentScriptAndStyle?: IndentScriptAndStyle;
+	/**
+	 * The indent style applied to HTML (and its super languages) files.
+	 */
+	indentStyle?: IndentStyle;
+	/**
+	 * The size of the indentation applied to HTML (and its super languages) files. Default to 2.
+	 */
+	indentWidth?: IndentWidth;
+	/**
+	 * The type of line ending applied to HTML (and its super languages) files.
+	 */
+	lineEnding?: LineEnding;
+	/**
+	 * What's the max width of a line applied to HTML (and its super languages) files. Defaults to 80.
+	 */
+	lineWidth?: LineWidth;
+	/**
+	 * Whether or not to account for whitespace sensitivity when formatting HTML (and its super languages). Defaults to "strict".
+	 */
+	whitespaceSensitivity?: WhitespaceSensitivity;
+}
+/**
+ * Options that changes how the HTML parser behaves
+ */
+export interface PartialHtmlParser {}
+/**
  * Linter options specific to the JavaScript linter
  */
 export interface PartialJavascriptAssists {
@@ -700,6 +762,22 @@ export interface Source {
 	useSortedKeys?: RuleAssistConfiguration_for_Null;
 }
 export type QuoteStyle = "double" | "single";
+/**
+	* Whether to indent the content of `<script>` and `<style>` tags for HTML-ish templating languages (Vue, Svelte, etc.).
+
+When true, the content of `<script>` and `<style>` tags will be indented one level. 
+	 */
+export type IndentScriptAndStyle = boolean;
+/**
+	* Whitespace sensitivity for HTML formatting.
+
+The following two cases won't produce the same output:
+
+|                |      html      |    output    | | -------------- | :------------: | :----------: | | with spaces    | `1<b> 2 </b>3` | 1<b> 2 </b>3 | | without spaces |  `1<b>2</b>3`  |  1<b>2</b>3  |
+
+This happens because whitespace is significant in inline elements. 
+	 */
+export type WhitespaceSensitivity = "strict" | "ignore";
 export type ArrowParentheses = "always" | "asNeeded";
 export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -55,6 +55,13 @@
 				{ "type": "null" }
 			]
 		},
+		"html": {
+			"description": "Specific configuration for the HTML language",
+			"anyOf": [
+				{ "$ref": "#/definitions/HtmlConfiguration" },
+				{ "type": "null" }
+			]
+		},
 		"javascript": {
 			"description": "Specific configuration for the JavaScript language",
 			"anyOf": [
@@ -1604,11 +1611,93 @@
 			},
 			"additionalProperties": false
 		},
+		"HtmlConfiguration": {
+			"description": "Options applied to HTML files",
+			"type": "object",
+			"properties": {
+				"formatter": {
+					"description": "HTML formatter options",
+					"anyOf": [
+						{ "$ref": "#/definitions/HtmlFormatter" },
+						{ "type": "null" }
+					]
+				},
+				"parser": {
+					"description": "HTML parsing options",
+					"anyOf": [{ "$ref": "#/definitions/HtmlParser" }, { "type": "null" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"HtmlFormatter": {
+			"description": "Options that changes how the HTML formatter behaves",
+			"type": "object",
+			"properties": {
+				"attributePosition": {
+					"description": "The attribute position style in HTML elements. Defaults to auto.",
+					"anyOf": [
+						{ "$ref": "#/definitions/AttributePosition" },
+						{ "type": "null" }
+					]
+				},
+				"bracketSameLine": {
+					"description": "Whether to hug the closing bracket of multiline HTMLtags to the end of the last line, rather than being alone on the following line. Defaults to false.",
+					"anyOf": [
+						{ "$ref": "#/definitions/BracketSameLine" },
+						{ "type": "null" }
+					]
+				},
+				"enabled": {
+					"description": "Control the formatter for HTML (and its super languages) files.",
+					"type": ["boolean", "null"]
+				},
+				"indentScriptAndStyle": {
+					"description": "Whether or not to indent the `<script>` and `<style>` tags for HTML (and its super languages). Defaults to false.",
+					"anyOf": [
+						{ "$ref": "#/definitions/IndentScriptAndStyle" },
+						{ "type": "null" }
+					]
+				},
+				"indentStyle": {
+					"description": "The indent style applied to HTML (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/IndentStyle" }, { "type": "null" }]
+				},
+				"indentWidth": {
+					"description": "The size of the indentation applied to HTML (and its super languages) files. Default to 2.",
+					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
+				},
+				"lineEnding": {
+					"description": "The type of line ending applied to HTML (and its super languages) files.",
+					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
+				},
+				"lineWidth": {
+					"description": "What's the max width of a line applied to HTML (and its super languages) files. Defaults to 80.",
+					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
+				},
+				"whitespaceSensitivity": {
+					"description": "Whether or not to account for whitespace sensitivity when formatting HTML (and its super languages). Defaults to \"strict\".",
+					"anyOf": [
+						{ "$ref": "#/definitions/WhitespaceSensitivity" },
+						{ "type": "null" }
+					]
+				}
+			},
+			"additionalProperties": false
+		},
+		"HtmlParser": {
+			"description": "Options that changes how the HTML parser behaves",
+			"type": "object",
+			"additionalProperties": false
+		},
 		"ImportGroup": {
 			"anyOf": [
 				{ "$ref": "#/definitions/PredefinedImportGroup" },
 				{ "$ref": "#/definitions/Regex" }
 			]
+		},
+		"IndentScriptAndStyle": {
+			"description": "Whether to indent the content of `<script>` and `<style>` tags for HTML-ish templating languages (Vue, Svelte, etc.).\n\nWhen true, the content of `<script>` and `<style>` tags will be indented one level.",
+			"type": "boolean"
 		},
 		"IndentStyle": {
 			"oneOf": [
@@ -4677,6 +4766,21 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"WhitespaceSensitivity": {
+			"description": "Whitespace sensitivity for HTML formatting.\n\nThe following two cases won't produce the same output:\n\n|                |      html      |    output    | | -------------- | :------------: | :----------: | | with spaces    | `1<b> 2 </b>3` | 1<b> 2 </b>3 | | without spaces |  `1<b>2</b>3`  |  1<b>2</b>3  |\n\nThis happens because whitespace is significant in inline elements.",
+			"oneOf": [
+				{
+					"description": "Leading and trailing whitespace in content is considered significant for inline elements.\n\nThe formatter should leave at least one whitespace character if whitespace is present. Otherwise, if there is no whitespace, it should not add any after `>` or before `<`. In other words, if there's no whitespace, the text content should hug the tags.\n\nExample of text hugging the tags: ```html <b >content</b > ```",
+					"type": "string",
+					"enum": ["strict"]
+				},
+				{
+					"description": "Whitespace is considered insignificant. The formatter is free to remove or add whitespace as it sees fit.",
+					"type": "string",
+					"enum": ["ignore"]
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This sets up the end-user facing `HtmlConfiguration` for HTML. It also adds `attributePosition` to the formatter settings in some places it was missing.

This is necessary in order to test the HTML formatter with different combinations of formatter settings instead of just the defaults.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass.

<!-- What demonstrates that your implementation is correct? -->
