### PR TITLE
fix(formatter): refine the logic for identifying comments on the last attribute in JSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - `noDuplicateProperties` now throws lint errors properly when we use `@supports` (fix [#4756](https://github.com/biomejs/biome/issues/4756)) Contributed by @mehm8128
 
+- Fix [#4719](https://github.com/biomejs/biome/issues/4719), `bracketSameLine` now performs as expected when a comment is placed before the last JSX attribute. Contributed by @bushuai
+
 ### JavaScript APIs
 
 ### Linter

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -152,6 +152,9 @@ impl AnyJsxOpeningElement {
     fn compute_layout(&self, comments: &JsComments) -> SyntaxResult<OpeningElementLayout> {
         let attributes = self.attributes();
         let name = self.name()?;
+        let last_attribute_has_comments = self.attributes().last().map_or(false, |attribute| {
+            comments.has_trailing_comments(attribute.syntax())
+        });
 
         let name_has_comments = comments.has_comments(name.syntax())
             || self
@@ -171,7 +174,7 @@ impl AnyJsxOpeningElement {
         } else {
             OpeningElementLayout::IndentAttributes {
                 name_has_comments,
-                last_attribute_has_comments: has_last_attribute_comments(self, comments),
+                last_attribute_has_comments,
             }
         };
 
@@ -248,19 +251,4 @@ fn as_string_literal_attribute_value(attribute: &AnyJsxAttribute) -> Option<JsxS
         }
         JsxSpreadAttribute(_) => None,
     }
-}
-
-fn has_last_attribute_comments(element: &AnyJsxOpeningElement, comments: &JsComments) -> bool {
-    let has_comments_on_last_attribute = element
-        .attributes()
-        .last()
-        .map_or(false, |attribute| comments.has_comments(attribute.syntax()));
-
-    let last_attribute_has_comments = element
-        .syntax()
-        .tokens()
-        .map(|token| token.text().contains('>') && token.has_leading_comments())
-        .any(|has_comment| has_comment);
-
-    has_comments_on_last_attribute || last_attribute_has_comments
 }

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
@@ -29,5 +29,15 @@ const a = <div></div>;
 	Hi
 </Foo>;
 
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
+>
+	Hi
+</Foo>;
+
 <div className="hi" />;
 <div className="hi"></div>;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: jsx/bracket_same_line/bracket_same_line.jsx
 ---
 # Input
@@ -33,6 +32,16 @@ const a = <div></div>;
 		reallyLongAttributeName1={longComplexValue}
 		reallyLongAttributeName2={anotherLongValue}
 		// comment
+>
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
 >
 	Hi
 </Foo>;
@@ -97,6 +106,16 @@ const a = <div></div>;
 	Hi
 </Foo>;
 
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
+>
+	Hi
+</Foo>;
+
 <div className="hi" />;
 <div className="hi"></div>;
 ```
@@ -147,6 +166,15 @@ const a = <div></div>;
 	reallyLongAttributeName2={anotherLongValue}
 	// comment
 >
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}>
 	Hi
 </Foo>;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

closes #4719 

the bracketSameLine rule now works the same as prettier when a comment is placed before the last JSX attribute with configuration:

```json
 "javascript": {
   "formatter": {
     "bracketSameLine": true
   }
 }
```

```diff
<Component
  foo={fooValue}
  // comment
- bar={barValue}
->
+ bar={barValue}>
  some content
</Component>
```

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added a test case and updated the snapshots.
