### PR TITLE
refactor: simplify language settings implementations

### DIFF
--- a/crates/biome_configuration/src/analyzer/assist/mod.rs
+++ b/crates/biome_configuration/src/analyzer/assist/mod.rs
@@ -7,6 +7,7 @@ use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
 
 pub type AssistEnabled = Bool<true>;
+
 #[derive(
     Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Bpaf, Deserializable, Merge,
 )]

--- a/crates/biome_configuration/src/grit.rs
+++ b/crates/biome_configuration/src/grit.rs
@@ -76,6 +76,7 @@ pub struct GritLinterConfiguration {
 }
 
 pub type GritAssistEnabled = Bool<true>;
+
 #[derive(
     Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, Bpaf, Deserializable, Merge,
 )]

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -9,9 +9,8 @@ use crate::file_handlers::{
     AnalyzerCapabilities, Capabilities, FormatterCapabilities, ParserCapabilities,
 };
 use crate::settings::{
-    check_feature_activity, check_override_feature_activity, FormatSettings, LanguageListSettings,
-    LanguageSettings, LinterSettings, OverrideSettings, ServiceLanguage, Settings,
-    WorkspaceSettingsHandle,
+    FormatSettings, LanguageListSettings, LanguageSettings, LinterSettings, OverrideSettingPattern,
+    OverrideSettings, ServiceLanguage, Settings, WorkspaceSettingsHandle,
 };
 use crate::workspace::{
     CodeAction, DocumentFileSource, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
@@ -225,109 +224,28 @@ impl ServiceLanguage for CssLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.css.formatter.enabled.map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.css.formatter.enabled.map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
+    fn assist_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.css.assist.enabled.map(Into::into)
+    }
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn assist_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.css.assist.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.css.linter.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.css.linter.enabled.map(Into::into)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -8,9 +8,8 @@ use crate::file_handlers::{
     AnalyzerCapabilities, Capabilities, FormatterCapabilities, ParserCapabilities,
 };
 use crate::settings::{
-    check_feature_activity, check_override_feature_activity, FormatSettings, LanguageListSettings,
-    LanguageSettings, LinterSettings, OverrideSettings, ServiceLanguage, Settings,
-    WorkspaceSettingsHandle,
+    FormatSettings, LanguageListSettings, LanguageSettings, LinterSettings, OverrideSettingPattern,
+    OverrideSettings, ServiceLanguage, Settings, WorkspaceSettingsHandle,
 };
 use crate::workspace::{
     CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
@@ -168,109 +167,28 @@ impl ServiceLanguage for GraphqlLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.graphql.formatter.enabled.map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.graphql.formatter.enabled.map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
+    fn assist_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.graphql.assist.enabled.map(Into::into)
+    }
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn assist_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.graphql.assist.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.graphql.linter.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.graphql.linter.enabled.map(Into::into)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -3,7 +3,7 @@ use super::{
     ExtensionHandler, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities, SearchCapabilities,
 };
-use crate::settings::{check_feature_activity, check_override_feature_activity};
+use crate::settings::OverrideSettingPattern;
 use crate::workspace::GetSyntaxTreeResult;
 use crate::{
     settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle},
@@ -139,109 +139,28 @@ impl ServiceLanguage for GritLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.grit.formatter.enabled.map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.grit.formatter.enabled.map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
+    fn assist_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.grit.assist.enabled.map(Into::into)
+    }
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn assist_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.grit.assist.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.grit.linter.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.grit.linter.enabled.map(Into::into)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -18,7 +18,7 @@ use super::{
     AnalyzerCapabilities, Capabilities, DebugCapabilities, DocumentFileSource, EnabledForPath,
     ExtensionHandler, FormatterCapabilities, ParseResult, ParserCapabilities, SearchCapabilities,
 };
-use crate::settings::{check_feature_activity, check_override_feature_activity};
+use crate::settings::OverrideSettingPattern;
 use crate::{
     settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle},
     workspace::GetSyntaxTreeResult,
@@ -139,47 +139,28 @@ impl ServiceLanguage for HtmlLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.html.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.html.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.html.formatter.enabled.map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(_settings: Option<&Settings>, _path: &Utf8Path) -> bool {
-        false
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.html.formatter.enabled.map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(_settings: Option<&Settings>, _path: &Utf8Path) -> bool {
-        false
+    fn assist_enabled_for_language(_settings: &Settings) -> Option<bool> {
+        Some(false)
+    }
+
+    fn assist_enabled_in_language_override(_pattern: &OverrideSettingPattern) -> Option<bool> {
+        Some(false)
+    }
+
+    fn linter_enabled_for_language(_settings: &Settings) -> Option<bool> {
+        Some(false)
+    }
+
+    fn linter_enabled_in_language_override(_pattern: &OverrideSettingPattern) -> Option<bool> {
+        Some(false)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -6,10 +6,7 @@ use super::{
 use crate::configuration::to_analyzer_rules;
 use crate::diagnostics::extension_error;
 use crate::file_handlers::{is_diagnostic_error, FixAllParams};
-use crate::settings::{
-    check_feature_activity, check_override_feature_activity, LinterSettings, OverrideSettings,
-    Settings,
-};
+use crate::settings::{LinterSettings, OverrideSettingPattern, OverrideSettings, Settings};
 use crate::workspace::DocumentFileSource;
 use crate::{
     settings::{
@@ -353,109 +350,38 @@ impl ServiceLanguage for JsLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
         settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+            .languages
+            .javascript
+            .formatter
+            .enabled
+            .map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern
+            .languages
+            .javascript
+            .formatter
+            .enabled
+            .map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
+    fn assist_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.javascript.assist.enabled.map(Into::into)
+    }
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn assist_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.javascript.assist.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.javascript.linter.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.javascript.linter.enabled.map(Into::into)
     }
 }
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -9,9 +9,8 @@ use crate::file_handlers::{
     LintResults, ParserCapabilities,
 };
 use crate::settings::{
-    check_feature_activity, check_override_feature_activity, FormatSettings, LanguageListSettings,
-    LanguageSettings, LinterSettings, OverrideSettings, ServiceLanguage, Settings,
-    WorkspaceSettingsHandle,
+    FormatSettings, LanguageListSettings, LanguageSettings, LinterSettings, OverrideSettingPattern,
+    OverrideSettings, ServiceLanguage, Settings, WorkspaceSettingsHandle,
 };
 use crate::workspace::{
     CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
@@ -207,109 +206,28 @@ impl ServiceLanguage for JsonLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.json.formatter.enabled.map(Into::into)
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
-
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn formatter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.json.formatter.enabled.map(Into::into)
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .and_then(|enabled| {
-                                // Then check whether the path satisfies
-                                if pattern.include.matches_path(path)
-                                    && !pattern.exclude.matches_path(path)
-                                {
-                                    Some(enabled)
-                                } else {
-                                    None
-                                }
-                            })
-                        });
+    fn assist_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.json.assist.enabled.map(Into::into)
+    }
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
-            .unwrap_or_default()
-            .into()
+    fn assist_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.json.assist.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_for_language(settings: &Settings) -> Option<bool> {
+        settings.languages.json.linter.enabled.map(Into::into)
+    }
+
+    fn linter_enabled_in_language_override(pattern: &OverrideSettingPattern) -> Option<bool> {
+        pattern.languages.json.linter.enabled.map(Into::into)
     }
 }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -286,18 +286,9 @@ impl WorkspaceServer {
     ) -> Result<(), WorkspaceError> {
         let path: Utf8PathBuf = path.into();
         let mut source = document_file_source.unwrap_or(DocumentFileSource::from_path(&path));
-        let manifest = if opened_by_scanner {
-            // FIXME: It doesn't make sense to retrieve the manifest when the
-            //        file is opened by the scanner, because it means the
-            //        project layout isn't yet initialized anyway. But that
-            //        highlights an issue with the CommonJS check below, since
-            //        we can't seem to set this correctly now.
-            None
-        } else {
-            self.project_layout.get_node_manifest_for_path(&path)
-        };
 
         if let DocumentFileSource::Js(js) = &mut source {
+            let manifest = self.project_layout.get_node_manifest_for_path(&path);
             if let Some((_, manifest)) = manifest {
                 if manifest.r#type == Some(PackageType::Commonjs) && js.file_extension() == "js" {
                     js.set_module_kind(ModuleKind::Script);


### PR DESCRIPTION
## Summary

Moves some implementations to the `LanguageSettings` traits so language implementations can reuse more.

## Test Plan

CI should remain green.
