### PR TITLE
fix(core): print diagnostic for scanner panics

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -809,6 +809,9 @@ pub(crate) trait CommandRunner: Sized {
                 project_key,
                 path: Some(project_path),
             })?;
+            for diagnostic in result.diagnostics {
+                console.log(markup! {{PrintDiagnostic::simple(&diagnostic)}});
+            }
             if cli_options.verbose && matches!(execution.report_mode(), ReportMode::Terminal { .. })
             {
                 console.log(markup! {


### PR DESCRIPTION
## Summary

We can now see which file triggers the panic when we run `pnpm check` in our own repo :)

## Test Plan

CI should remain green.
