### PR TITLE
fix(lint): don't report missing dependency on incomplete statement

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -602,7 +602,7 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::JsArrayBindingPatternRestElement(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternProperty(_)
         | AnyJsBindingDeclaration::JsObjectBindingPatternRest(_)
-        | AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(_) => true,
+        | AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(_) => false,
 
         // This should be unreachable because of the test if the capture is imported
         AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4567.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4567.js
@@ -1,0 +1,3 @@
+import {useCallback,utte } from"react";
+function{
+  const [width,(dh]  = useCallback(() =>{ width) }, [w

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4567.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue4567.js.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue4567.js
+---
+# Input
+```js
+import {useCallback,utte } from"react";
+function{
+  const [width,(dh]  = useCallback(() =>{ width) }, [w
+
+```
+
+# Diagnostics
+```
+issue4567.js:3:24 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This hook specifies more dependencies than necessary: w
+  
+    1 │ import {useCallback,utte } from"react";
+    2 │ function{
+  > 3 │   const [width,(dh]  = useCallback(() =>{ width) }, [w
+      │                        ^^^^^^^^^^^
+    4 │ 
+  
+  i This dependency can be removed from the list.
+  
+    1 │ import {useCallback,utte } from"react";
+    2 │ function{
+  > 3 │   const [width,(dh]  = useCallback(() =>{ width) }, [w
+      │                                                      ^
+    4 │ 
+  
+
+```


### PR DESCRIPTION
## Summary

Adds a test case for #4567 . It appears the panic was already fixed, so I didn't have to do much for it. But I did notice an error was reported on the hook call, while the statement itself is not even complete in the given snippet. In practice, I think this means people may see the error appear while they're still writing the code, which seems not very user-friendly. So all I did was disable the error in this case.

Seeing how small this change is, I don't even think it warrants a CHANGELOG entry :sweat_smile: 

## Test Plan

Test case added.
