### PR TITLE
feat(linter): assign severity to groups

### DIFF
--- a/.changeset/better_control_over_linter_groups.md
+++ b/.changeset/better_control_over_linter_groups.md
@@ -5,7 +5,7 @@ cli: minor
 # Better control over linter groups
 
 Linter groups now accept new options to enable/disable all rules that belong to a group, and control the severity
-of the rule that belong to those groups.
+of the rules that belong to those groups.
 
 For example, you can downgrade the severity of rules that belong to `"style"` to emit `"info"` diagnostics:
 

--- a/.changeset/better_control_over_linter_groups.md
+++ b/.changeset/better_control_over_linter_groups.md
@@ -7,7 +7,7 @@ cli: minor
 Linter groups now accept new options to enable/disable all rules that belong to a group, and control the severity
 of the rule that belong to those groups.
 
-For example, it's you can downgrade the severity of rule that belong to `"style"` to emit `"info"` diagnostics:
+For example, you can downgrade the severity of rules that belong to `"style"` to emit `"info"` diagnostics:
 
 ```json
 {

--- a/.changeset/better_control_over_linter_groups.md
+++ b/.changeset/better_control_over_linter_groups.md
@@ -1,0 +1,32 @@
+---
+cli: minor
+---
+
+# Better control over linter groups
+
+Linter groups now accept new options to enable/disable all rules that belong to a group, and control the severity
+of the rule that belong to those groups.
+
+For example, it's you can downgrade the severity of rule that belong to `"style"` to emit `"info"` diagnostics:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": "info"
+    }
+  }
+}
+```
+
+You can also enable all rules that belong to a group using the default severity of the rule using the `"on"` option:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "complexity": "on"
+    }
+  }
+}
+```

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -11,7 +11,10 @@ pub(crate) fn migrate_eslint_any_rule(
     match eslint_name {
         "@mysticatea/no-this-in-static" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_this_in_static.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_this_in_static
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@next/google-font-display" => {
@@ -20,6 +23,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_google_font_display
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -30,6 +34,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_google_font_preconnect
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -40,6 +45,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_document_import_in_page
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -49,7 +55,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_head_element.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_head_element
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@next/no-head-import-in-document" => {
@@ -58,6 +67,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_head_import_in_document
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -67,7 +77,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_img_element.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_img_element
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@next/no-unwanted-polyfillio" => {
@@ -76,6 +89,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_unwanted_polyfillio
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -83,6 +97,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@stylistic/jsx-self-closing-comp" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_self_closing_elements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -93,6 +108,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_adjacent_overload_signatures
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -100,13 +116,17 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/array-type" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_consistent_array_type
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/ban-types" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_banned_types.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_banned_types
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/consistent-type-exports" => {
@@ -115,7 +135,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_export_type.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_export_type
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/consistent-type-imports" => {
@@ -124,19 +147,26 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_import_type.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_import_type
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/default-param-last" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_default_parameter_last
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/dot-notation" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_literal_keys.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_literal_keys
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-function-return-type" => {
@@ -144,7 +174,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_explicit_type.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_explicit_type
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-member-accessibility" => {
@@ -153,6 +186,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_consistent_member_accessibility
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -164,18 +198,23 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_naming_convention
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-array-constructor" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.use_array_literals.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_array_literals
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-dupe-class-members" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_class_members
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -183,6 +222,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-empty-function" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_empty_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -193,65 +233,90 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_empty_interface.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_empty_interface
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-explicit-any" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_explicit_any.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_explicit_any
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-extra-non-null-assertion" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_extra_non_null_assertion
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-extraneous-class" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_static_only_class.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_static_only_class
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-inferrable-types" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_inferrable_types.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_inferrable_types
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-invalid-void-type" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_confusing_void_type
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-loss-of-precision" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_precision_loss.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_precision_loss
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-misused-new" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_misleading_instantiator
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-namespace" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_namespace.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_namespace
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-non-null-assertion" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_non_null_assertion
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-redeclare" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_redeclare.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_redeclare
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-require-imports" => {
@@ -259,7 +324,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_common_js.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_common_js
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-restricted-imports" => {
@@ -268,6 +336,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_restricted_imports
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -277,7 +346,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_restricted_types.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_restricted_types
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-this-alias" => {
@@ -287,6 +359,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_this_alias
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -294,6 +367,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-unnecessary-type-constraint" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_type_constraint
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -301,18 +375,23 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-unsafe-declaration-merging" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_unsafe_declaration_merging
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-unused-vars" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unused_variables.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unused_variables
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-use-before-define" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_invalid_use_before_declaration
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -320,6 +399,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-useless-constructor" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_constructor
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -327,6 +407,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/no-useless-empty-export" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_empty_export
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -337,7 +418,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_throw_only_error.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_throw_only_error
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/parameter-properties" => {
@@ -347,6 +431,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_parameter_properties
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -354,6 +439,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/prefer-as-const" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_as_const_assertion
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -361,18 +447,23 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/prefer-enum-initializers" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_enum_initializers
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/prefer-for-of" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_for_of.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_for_of
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/prefer-function-type" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_shorthand_function_type
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -380,6 +471,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/prefer-literal-enum-member" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_literal_enum_members
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -387,18 +479,25 @@ pub(crate) fn migrate_eslint_any_rule(
         "@typescript-eslint/prefer-namespace-keyword" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_namespace_keyword
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/prefer-optional-chain" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_optional_chain.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_optional_chain
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/require-await" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_await.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_await
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "ban-ts-comment" => {
@@ -410,7 +509,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_ts_ignore.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_ts_ignore
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "barrel-files/avoid-barrel-files" => {
@@ -419,34 +521,48 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.performance.get_or_insert_with(Default::default);
-            let rule = group.no_barrel_file.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_barrel_file
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "barrel-files/avoid-namespace-import" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_namespace_import.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_namespace_import
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "barrel-files/avoid-re-export-all" => {
             let group = rules.performance.get_or_insert_with(Default::default);
-            let rule = group.no_re_export_all.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_re_export_all
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "constructor-super" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_invalid_constructor_super
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "curly" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_block_statements.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_block_statements
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "default-case" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_default_switch_clause
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -454,6 +570,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "default-case-last" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_default_switch_clause_last
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -461,6 +578,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "default-param-last" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_default_parameter_last
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -470,29 +588,42 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_process_global.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_process_global
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "dot-notation" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_literal_keys.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_literal_keys
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "eqeqeq" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_double_equals.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_double_equals
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "for-direction" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_valid_for_direction
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "getter-return" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_getter_return.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_getter_return
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "guard-for-in" => {
@@ -500,7 +631,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_guard_for_in.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_guard_for_in
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "import-access/eslint-plugin-import-access" => {
@@ -509,6 +643,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_package_private_imports
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -518,7 +653,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_exports_last.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_exports_last
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "import/no-commonjs" => {
@@ -526,29 +664,40 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_common_js.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_common_js
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "import/no-default-export" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_default_export.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_default_export
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "import/no-extraneous-dependencies" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_undeclared_dependencies
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "import/no-nodejs-modules" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_nodejs_modules.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_nodejs_modules
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jest/max-nested-describe" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_excessive_nested_test_suites
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -559,12 +708,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_skipped_tests.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_skipped_tests
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jest/no-done-callback" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_done_callback.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_done_callback
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jest/no-duplicate-hooks" => {
@@ -574,6 +729,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_test_hooks
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -584,7 +740,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_exports_in_test.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_exports_in_test
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jest/no-focused-tests" => {
@@ -593,7 +752,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_focused_tests.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_focused_tests
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jest/no-standalone-expect" => {
@@ -603,52 +765,71 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_misplaced_assertion
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/alt-text" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_alt_text.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_alt_text
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/anchor-has-content" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_anchor_content.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_anchor_content
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/anchor-is-valid" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_valid_anchor.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_anchor
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/aria-activedescendant-has-tabindex" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_aria_activedescendant_with_tabindex
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/aria-props" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_valid_aria_props.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_aria_props
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/aria-proptypes" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_valid_aria_values
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/aria-role" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_valid_aria_role.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_aria_role
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/aria-unsupported-elements" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_aria_unsupported_elements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -659,6 +840,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_valid_autocomplete
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -666,33 +848,47 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/click-events-have-key-events" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_key_with_click_events
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/heading-has-content" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_heading_content.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_heading_content
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/html-has-lang" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_html_lang.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_html_lang
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/iframe-has-title" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_iframe_title.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_iframe_title
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/img-redundant-alt" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_redundant_alt.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_redundant_alt
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/interactive-supports-focus" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_focusable_interactive
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -700,47 +896,63 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/label-has-associated-control" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_label_without_control
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/lang" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_valid_lang.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_lang
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/media-has-caption" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_media_caption.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_media_caption
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/mouse-events-have-key-events" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_key_with_mouse_events
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-access-key" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_access_key.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_access_key
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-aria-hidden-on-focusable" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_aria_hidden_on_focusable
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-autofocus" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_autofocus.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_autofocus
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-distracting-elements" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_distracting_elements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -748,6 +960,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/no-interactive-element-to-noninteractive-role" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_interactive_element_to_noninteractive_role
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -755,6 +968,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/no-noninteractive-element-to-interactive-role" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_noninteractive_element_to_interactive_role
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -762,13 +976,17 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/no-noninteractive-tabindex" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_noninteractive_tabindex
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-redundant-roles" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_redundant_roles.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_redundant_roles
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/no-static-element-interactions" => {
@@ -777,6 +995,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_static_element_interactions
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -784,6 +1003,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/prefer-tag-over-role" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_semantic_elements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -791,6 +1011,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "jsx-a11y/role-has-required-aria-props" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_aria_props_for_role
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -801,18 +1022,25 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_aria_props_supported_by_role
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/scope" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_header_scope.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_header_scope
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "jsx-a11y/tabindex-no-positive" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_positive_tabindex.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_positive_tabindex
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "n/no-process-env" => {
@@ -820,17 +1048,24 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_process_env.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_process_env
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-array-constructor" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.use_array_literals.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_array_literals
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-async-promise-executor" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_async_promise_executor
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -838,18 +1073,25 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-case-declarations" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_switch_declarations
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-class-assign" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_class_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_class_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-compare-neg-zero" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_compare_neg_zero.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_compare_neg_zero
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-cond-assign" => {
@@ -859,23 +1101,31 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_assign_in_expressions
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-console" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_console.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_console
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-const-assign" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_const_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_const_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-constant-condition" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_constant_condition
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -883,6 +1133,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-constructor-return" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_constructor_return
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -890,18 +1141,23 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-control-regex" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_control_characters_in_regex
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-debugger" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_debugger.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_debugger
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-dupe-args" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_parameters
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -909,6 +1165,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-dupe-class-members" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_class_members
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -918,19 +1175,26 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_duplicate_else_if.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_duplicate_else_if
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-dupe-keys" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_object_keys
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-duplicate-case" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_duplicate_case.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_duplicate_case
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-else-return" => {
@@ -939,12 +1203,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_useless_else.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_else
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-empty" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_empty_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -952,6 +1220,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-empty-character-class" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_empty_character_class_in_regex
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -959,69 +1228,95 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-empty-function" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_empty_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-empty-pattern" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_empty_pattern.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_empty_pattern
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-empty-static-block" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_empty_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-eval" => {
             let group = rules.security.get_or_insert_with(Default::default);
-            let rule = group.no_global_eval.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_global_eval
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-ex-assign" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_catch_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_catch_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-extra-boolean-cast" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_extra_boolean_cast
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-extra-label" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_useless_label.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_label
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-fallthrough" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_fallthrough_switch_clause
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-func-assign" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_function_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_function_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-global-assign" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_global_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_global_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-import-assign" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_import_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_import_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-inner-declarations" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_inner_declarations
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1032,13 +1327,17 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_irregular_whitespace
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-label-var" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_label_var.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_label_var
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-labels" => {
@@ -1047,12 +1346,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_confusing_labels.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_confusing_labels
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-lone-blocks" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_lone_block_statements
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1060,25 +1363,33 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-lonely-if" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_collapsed_else_if
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-loss-of-precision" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_precision_loss.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_precision_loss
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-misleading-character-class" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_misleading_character_class
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-negated-condition" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_negation_else.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_negation_else
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-nested-ternary" => {
@@ -1086,24 +1397,32 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_nested_ternary.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_nested_ternary
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-new-native-nonconstructor" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_invalid_builtin_instantiation
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-new-symbol" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_new_symbol.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_new_symbol
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-new-wrappers" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_consistent_builtin_instantiation
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1111,6 +1430,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-nonoctal-decimal-escape" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_nonoctal_decimal_escape
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1118,6 +1438,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-obj-calls" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_global_object_calls
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1127,29 +1448,40 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_octal_escape.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_octal_escape
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-param-reassign" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_parameter_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_parameter_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-prototype-builtins" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_prototype_builtins
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-redeclare" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_redeclare.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_redeclare
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-regex-spaces" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_multiple_spaces_in_regular_expression_literals
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1157,6 +1489,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-restricted-globals" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_restricted_globals
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1167,6 +1500,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_restricted_imports
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1180,39 +1514,58 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_secrets.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_secrets
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-self-assign" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_self_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_self_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-self-compare" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_self_compare.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_self_compare
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-sequences" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_comma_operator.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_comma_operator
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-setter-return" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_setter_return.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_setter_return
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-shadow-restricted-names" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_shadow_restricted_names
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-sparse-arrays" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_sparse_array.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_sparse_array
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-template-curly-in-string" => {
@@ -1221,13 +1574,17 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_template_curly_in_string
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-this-before-super" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unreachable_super.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unreachable_super
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-throw-literal" => {
@@ -1236,12 +1593,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_throw_only_error.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_throw_only_error
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-undef" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_undeclared_variables
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1249,69 +1610,95 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-undef-init" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_undefined_initialization
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unneeded-ternary" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_useless_ternary.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_ternary
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unreachable" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unreachable.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unreachable
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unsafe-finally" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unsafe_finally.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unsafe_finally
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unsafe-negation" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_unsafe_negation.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unsafe_negation
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unsafe-optional-chaining" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_unsafe_optional_chaining
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unused-labels" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unused_labels.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unused_labels
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unused-private-class-members" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_unused_private_class_members
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-unused-vars" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unused_variables.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unused_variables
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-use-before-define" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_invalid_use_before_declaration
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-useless-catch" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_useless_catch.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_catch
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-useless-concat" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_string_concat
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1319,6 +1706,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "no-useless-constructor" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_constructor
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1329,40 +1717,57 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_escape_in_regex
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-useless-rename" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_useless_rename.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_rename
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-var" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_var.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_var
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-void" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_void.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_void
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "no-with" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_with.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_with
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "one-var" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_single_var_declarator
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "operator-assignment" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_shorthand_assign.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_shorthand_assign
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-arrow-callback" => {
@@ -1371,46 +1776,66 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_arrow_function.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_arrow_function
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-const" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_const.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_const
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-exponentiation-operator" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_exponentiation_operator
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-numeric-literals" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_numeric_literals.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_numeric_literals
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-object-has-own" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_prototype_builtins
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-regex-literals" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_regex_literals.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_regex_literals
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-rest-params" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_arguments.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_arguments
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "prefer-template" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_template.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_template
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "radix" => {
@@ -1418,12 +1843,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_parse_int_radix.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_parse_int_radix
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react-hooks/exhaustive-deps" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_exhaustive_dependencies
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1431,6 +1860,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "react-hooks/rules-of-hooks" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_hook_at_top_level
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1445,13 +1875,17 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_component_export_only_modules
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/button-has-type" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.use_button_type.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_button_type
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-boolean-value" => {
@@ -1460,7 +1894,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_implicit_boolean.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_implicit_boolean
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-curly-brace-presence" => {
@@ -1473,57 +1910,79 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_consistent_curly_braces
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-fragments" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_fragment_syntax.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_fragment_syntax
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-key" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_jsx_key_in_iterable
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-no-comment-textnodes" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_comment_text.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_comment_text
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-no-duplicate-props" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_duplicate_jsx_props
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-no-target-blank" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
-            let rule = group.no_blank_target.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_blank_target
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/jsx-no-useless-fragment" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_useless_fragments.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_fragments
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/no-array-index-key" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_array_index_key.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_array_index_key
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/no-children-prop" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_children_prop.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_children_prop
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "react/no-danger" => {
             let group = rules.security.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_dangerously_set_inner_html
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1531,6 +1990,7 @@ pub(crate) fn migrate_eslint_any_rule(
         "react/no-danger-with-children" => {
             let group = rules.security.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_dangerously_set_inner_html_with_children
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1538,23 +1998,31 @@ pub(crate) fn migrate_eslint_any_rule(
         "react/void-dom-elements-no-children" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_void_elements_with_children
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "require-await" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_await.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_await
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "require-yield" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.use_yield.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_yield
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "solidjs/no-react-specific-props" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_react_specific_props
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1562,23 +2030,31 @@ pub(crate) fn migrate_eslint_any_rule(
         "sonarjs/cognitive-complexity" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_excessive_cognitive_complexity
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "sonarjs/prefer-while" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_while.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_while
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/error-message" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_error_message.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_error_message
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/explicit-length-check" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_explicit_length_check
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1590,6 +2066,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_filenaming_convention
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1597,13 +2074,17 @@ pub(crate) fn migrate_eslint_any_rule(
         "unicorn/new-for-builtins" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_invalid_builtin_instantiation
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-array-for-each" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_for_each.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_for_each
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-document-cookie" => {
@@ -1611,17 +2092,26 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_document_cookie.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_document_cookie
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-for-loop" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_for_of.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_for_of
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-instanceof-array" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_is_array.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_is_array
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-lonely-if" => {
@@ -1629,22 +2119,32 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_collapsed_if.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_collapsed_if
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-static-only-class" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.no_static_only_class.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_static_only_class
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-thenable" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.no_then_property.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_then_property
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/no-useless-switch-case" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_useless_switch_case
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1654,12 +2154,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_useless_undefined.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_useless_undefined
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-array-flat-map" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_flat_map.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_flat_map
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-at" => {
@@ -1671,12 +2177,18 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_at_index.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_at_index
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-date-now" => {
             let group = rules.complexity.get_or_insert_with(Default::default);
-            let rule = group.use_date_now.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_date_now
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-module" => {
@@ -1689,6 +2201,7 @@ pub(crate) fn migrate_eslint_any_rule(
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .no_global_dirname_filename
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
@@ -1696,13 +2209,17 @@ pub(crate) fn migrate_eslint_any_rule(
         "unicorn/prefer-node-protocol" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_nodejs_import_protocol
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-number-properties" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_number_namespace.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_number_namespace
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-string-slice" => {
@@ -1710,7 +2227,10 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_substr.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_substr
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/prefer-string-trim-start-end" => {
@@ -1718,44 +2238,66 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.use_trim_start_end.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_trim_start_end
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/require-number-to-fixed-digits-argument" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
             let rule = group
+                .unwrap_group_as_mut()
                 .use_number_to_fixed_digits_argument
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unicorn/throw-new-error" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.use_throw_new_error.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_throw_new_error
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unused-imports/no-unused-imports" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unused_imports.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unused_imports
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "unused-imports/no-unused-vars" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.no_unused_variables.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_unused_variables
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "use-isnan" => {
             let group = rules.correctness.get_or_insert_with(Default::default);
-            let rule = group.use_is_nan.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_is_nan
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "valid-typeof" => {
             let group = rules.suspicious.get_or_insert_with(Default::default);
-            let rule = group.use_valid_typeof.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_valid_typeof
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "yoda" => {
             let group = rules.style.get_or_insert_with(Default::default);
-            let rule = group.no_yoda_expression.get_or_insert(Default::default());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_yoda_expression
+                .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         _ => {

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -1,3 +1,4 @@
+use biome_configuration::analyzer::SeverityOrGroup;
 use biome_configuration::{self as biome_config};
 use biome_deserialize::Merge;
 use biome_js_analyze::lint::style::no_restricted_globals;
@@ -220,13 +221,15 @@ fn migrate_eslint_rule(
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.suspicious.get_or_insert_with(Default::default);
-                    group.no_console = Some(biome_config::RuleFixConfiguration::WithOptions(
-                        biome_config::RuleWithFixOptions {
-                            level: severity.into(),
-                            fix: None,
-                            options: Box::new((*rule_options).into()),
-                        },
-                    ));
+                    if let SeverityOrGroup::Group(group) = group {
+                        group.no_console = Some(biome_config::RuleFixConfiguration::WithOptions(
+                            biome_config::RuleWithFixOptions {
+                                level: severity.into(),
+                                fix: None,
+                                options: Box::new((*rule_options).into()),
+                            },
+                        ));
+                    }
                 }
             }
         }
@@ -238,28 +241,37 @@ fn migrate_eslint_rule(
                     .into_iter()
                     .map(|g| g.into_name().into_boxed_str());
                 let group = rules.style.get_or_insert_with(Default::default);
-                group.no_restricted_globals = Some(biome_config::RuleConfiguration::WithOptions(
-                    biome_config::RuleWithOptions {
-                        level: severity.into(),
-                        options: Box::new(no_restricted_globals::RestrictedGlobalsOptions {
-                            denied_globals: globals.collect::<Vec<_>>().into_boxed_slice(),
-                        }),
-                    },
-                ));
+                if let SeverityOrGroup::Group(group) = group {
+                    group.no_restricted_globals =
+                        Some(biome_config::RuleConfiguration::WithOptions(
+                            biome_config::RuleWithOptions {
+                                level: severity.into(),
+                                options: Box::new(
+                                    no_restricted_globals::RestrictedGlobalsOptions {
+                                        denied_globals: globals
+                                            .collect::<Vec<_>>()
+                                            .into_boxed_slice(),
+                                    },
+                                ),
+                            },
+                        ));
+                }
             }
         }
         eslint_eslint::Rule::Jsxa11yArioaRoles(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.a11y.get_or_insert_with(Default::default);
-                    group.use_valid_aria_role =
-                        Some(biome_config::RuleFixConfiguration::WithOptions(
-                            biome_config::RuleWithFixOptions {
-                                level: severity.into(),
-                                fix: None,
-                                options: Box::new((*rule_options).into()),
-                            },
-                        ));
+                    if let SeverityOrGroup::Group(group) = group {
+                        group.use_valid_aria_role =
+                            Some(biome_config::RuleFixConfiguration::WithOptions(
+                                biome_config::RuleWithFixOptions {
+                                    level: severity.into(),
+                                    fix: None,
+                                    options: Box::new((*rule_options).into()),
+                                },
+                            ));
+                    }
                 }
             }
         }
@@ -267,14 +279,16 @@ fn migrate_eslint_rule(
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.style.get_or_insert_with(Default::default);
-                    group.use_consistent_array_type =
-                        Some(biome_config::RuleFixConfiguration::WithOptions(
-                            biome_config::RuleWithFixOptions {
-                                level: severity.into(),
-                                fix: None,
-                                options: rule_options.into(),
-                            },
-                        ));
+                    if let SeverityOrGroup::Group(group) = group {
+                        group.use_consistent_array_type =
+                            Some(biome_config::RuleFixConfiguration::WithOptions(
+                                biome_config::RuleWithFixOptions {
+                                    level: severity.into(),
+                                    fix: None,
+                                    options: rule_options.into(),
+                                },
+                            ));
+                    }
                 }
             }
         }
@@ -282,13 +296,15 @@ fn migrate_eslint_rule(
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 if let eslint_eslint::RuleConf::Option(severity, rule_options) = conf {
                     let group = rules.nursery.get_or_insert_with(Default::default);
-                    group.use_consistent_member_accessibility =
-                        Some(biome_config::RuleConfiguration::WithOptions(
-                            biome_config::RuleWithOptions {
-                                level: severity.into(),
-                                options: rule_options.into(),
-                            },
-                        ));
+                    if let SeverityOrGroup::Group(group) = group {
+                        group.use_consistent_member_accessibility =
+                            Some(biome_config::RuleConfiguration::WithOptions(
+                                biome_config::RuleWithOptions {
+                                    level: severity.into(),
+                                    options: rule_options.into(),
+                                },
+                            ));
+                    }
                 }
             }
         }
@@ -299,25 +315,30 @@ fn migrate_eslint_rule(
                     conf.into_vec().into_iter().map(|v| *v),
                 );
                 let group = rules.style.get_or_insert_with(Default::default);
-                group.use_naming_convention =
-                    Some(biome_config::RuleFixConfiguration::WithOptions(
-                        biome_config::RuleWithFixOptions {
-                            level: severity.into(),
-                            fix: None,
-                            options: options.into(),
-                        },
-                    ));
+                if let SeverityOrGroup::Group(group) = group {
+                    group.use_naming_convention =
+                        Some(biome_config::RuleFixConfiguration::WithOptions(
+                            biome_config::RuleWithFixOptions {
+                                level: severity.into(),
+                                fix: None,
+                                options: options.into(),
+                            },
+                        ));
+                }
             }
         }
         eslint_eslint::Rule::UnicornFilenameCase(conf) => {
             if migrate_eslint_any_rule(rules, &name, conf.severity(), opts, results) {
                 let group = rules.style.get_or_insert_with(Default::default);
-                group.use_filenaming_convention = Some(
-                    biome_config::RuleConfiguration::WithOptions(biome_config::RuleWithOptions {
-                        level: conf.severity().into(),
-                        options: Box::new(conf.option_or_default().into()),
-                    }),
-                );
+                if let SeverityOrGroup::Group(group) = group {
+                    group.use_filenaming_convention =
+                        Some(biome_config::RuleConfiguration::WithOptions(
+                            biome_config::RuleWithOptions {
+                                level: conf.severity().into(),
+                                options: Box::new(conf.option_or_default().into()),
+                            },
+                        ));
+                }
             }
         }
     }
@@ -401,7 +422,13 @@ mod tests {
             ["*.test.js".into(), "*.spec.js".into()]
         );
         assert_eq!(
-            linter.rules.unwrap().suspicious.unwrap().no_double_equals,
+            linter
+                .rules
+                .unwrap()
+                .suspicious
+                .unwrap()
+                .unwrap_group()
+                .no_double_equals,
             Some(biome_config::RuleFixConfiguration::Plain(
                 biome_config::RulePlainConfiguration::Error
             ))
@@ -419,6 +446,7 @@ mod tests {
                 .unwrap()
                 .suspicious
                 .unwrap()
+                .unwrap_group()
                 .no_double_equals,
             Some(biome_config::RuleFixConfiguration::Plain(
                 biome_config::RulePlainConfiguration::Off

--- a/crates/biome_cli/tests/cases/linter_groups_plain.rs
+++ b/crates/biome_cli/tests/cases/linter_groups_plain.rs
@@ -1,0 +1,134 @@
+use crate::run_cli;
+use crate::snap_test::{assert_cli_snapshot, SnapshotPayload};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+use camino::Utf8Path;
+
+#[test]
+fn enables_all_rules_when_group_is_on_with_default_severity() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let config = Utf8Path::new("biome.json");
+    fs.insert(
+        config.into(),
+        r#"{
+    "linter": {
+        "rules": {
+            "style": "on"
+        }
+    }
+}
+"#
+        .as_bytes(),
+    );
+    let test1 = Utf8Path::new("test1.js");
+    fs.insert(
+        test1.into(),
+        r#"function f() { console.log(arguments); }
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", test1.as_str()].as_slice()),
+    );
+
+    // style rules have warnings
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "enables_all_rules_when_group_is_on_with_default_severity",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn enables_all_rules_when_group_is_error() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let config = Utf8Path::new("biome.json");
+    fs.insert(
+        config.into(),
+        r#"{
+    "linter": {
+        "rules": {
+            "style": "error"
+        }
+    }
+}
+"#
+        .as_bytes(),
+    );
+    let test1 = Utf8Path::new("test1.js");
+    fs.insert(
+        test1.into(),
+        r#"function f() { console.log(arguments); }
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", test1.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "enables_all_rules_when_group_is_error",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn disable_all_rules_when_group_is_off() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let config = Utf8Path::new("biome.json");
+    fs.insert(
+        config.into(),
+        r#"{
+    "linter": {
+        "rules": {
+            "a11y": "off"
+        }
+    }
+}
+"#
+        .as_bytes(),
+    );
+    let test1 = Utf8Path::new("test1.jsx");
+    // img without alt should trigger a recommended rule, but not in this case
+    fs.insert(
+        test1.into(),
+        r#"<img src="foo.png" />
+"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", test1.as_str()].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "disable_all_rules_when_group_is_off",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -15,6 +15,7 @@ mod handle_svelte_files;
 mod handle_vue_files;
 mod included_files;
 mod linter_domains;
+mod linter_groups_plain;
 mod overrides_formatter;
 mod overrides_linter;
 mod overrides_organize_imports;

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/disable_all_rules_when_group_is_off.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/disable_all_rules_when_group_is_off.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "a11y": "off"
+    }
+  }
+}
+```
+
+## `test1.jsx`
+
+```jsx
+<img src="foo.png" />
+
+```
+
+# Emitted Messages
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_error.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": "error"
+    }
+  }
+}
+```
+
+## `test1.js`
+
+```js
+function f() { console.log(arguments); }
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test1.js:1:28 lint/style/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use the rest parameters instead of arguments.
+  
+  > 1 │ function f() { console.log(arguments); }
+      │                            ^^^^^^^^^
+    2 │ 
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_on_with_default_severity.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_groups_plain/enables_all_rules_when_group_is_on_with_default_severity.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": "on"
+    }
+  }
+}
+```
+
+## `test1.js`
+
+```js
+function f() { console.log(arguments); }
+
+```
+
+# Emitted Messages
+
+```block
+test1.js:1:28 lint/style/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the rest parameters instead of arguments.
+  
+  > 1 │ function f() { console.log(arguments); }
+      │                            ^^^^^^^^^
+    2 │ 
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 warning.
+```

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -1,6 +1,8 @@
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
-use crate::analyzer::{RuleConfiguration, RuleFixConfiguration, RulePlainConfiguration};
+use crate::analyzer::{
+    RuleConfiguration, RuleFixConfiguration, RuleGroupExt, RulePlainConfiguration, SeverityOrGroup,
+};
 use biome_analyze::{options::RuleOptions, RuleFilter};
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_diagnostics::{Category, Severity};
@@ -73,28 +75,28 @@ pub struct Rules {
     pub recommended: Option<bool>,
     #[deserializable(rename = "a11y")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub a11y: Option<A11y>,
+    pub a11y: Option<SeverityOrGroup<A11y>>,
     #[deserializable(rename = "complexity")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub complexity: Option<Complexity>,
+    pub complexity: Option<SeverityOrGroup<Complexity>>,
     #[deserializable(rename = "correctness")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub correctness: Option<Correctness>,
+    pub correctness: Option<SeverityOrGroup<Correctness>>,
     #[deserializable(rename = "nursery")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nursery: Option<Nursery>,
+    pub nursery: Option<SeverityOrGroup<Nursery>>,
     #[deserializable(rename = "performance")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub performance: Option<Performance>,
+    pub performance: Option<SeverityOrGroup<Performance>>,
     #[deserializable(rename = "security")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub security: Option<Security>,
+    pub security: Option<SeverityOrGroup<Security>>,
     #[deserializable(rename = "style")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub style: Option<Style>,
+    pub style: Option<SeverityOrGroup<Style>>,
     #[deserializable(rename = "suspicious")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub suspicious: Option<Suspicious>,
+    pub suspicious: Option<SeverityOrGroup<Suspicious>>,
 }
 impl Rules {
     #[doc = r" Checks if the code coming from [biome_diagnostics::Diagnostic] corresponds to a rule."]
@@ -225,28 +227,28 @@ impl Rules {
             self.recommended = Some(true)
         }
         if let Some(group) = &mut self.a11y {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.complexity {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.correctness {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.nursery {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.performance {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.security {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.style {
-            group.recommended = None;
+            group.set_recommended(None);
         }
         if let Some(group) = &mut self.suspicious {
-            group.recommended = None;
+            group.set_recommended(None);
         }
     }
     pub(crate) const fn is_recommended_false(&self) -> bool {
@@ -559,14 +561,51 @@ impl A11y {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+    ];
+}
+impl RuleGroupExt for A11y {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_access_key.as_ref() {
             if rule.is_enabled() {
@@ -740,7 +779,7 @@ impl A11y {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_access_key.as_ref() {
             if rule.is_disabled() {
@@ -915,14 +954,17 @@ impl A11y {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -931,7 +973,10 @@ impl A11y {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -1273,14 +1318,50 @@ impl Complexity {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+    ];
+}
+impl RuleGroupExt for Complexity {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_banned_types.as_ref() {
             if rule.is_enabled() {
@@ -1452,7 +1533,7 @@ impl Complexity {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_banned_types.as_ref() {
             if rule.is_disabled() {
@@ -1625,14 +1706,17 @@ impl Complexity {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -1641,7 +1725,10 @@ impl Complexity {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -2087,14 +2174,70 @@ impl Correctness {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
+    ];
+}
+impl RuleGroupExt for Correctness {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_children_prop.as_ref() {
             if rule.is_enabled() {
@@ -2363,7 +2506,7 @@ impl Correctness {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_children_prop.as_ref() {
             if rule.is_disabled() {
@@ -2633,14 +2776,17 @@ impl Correctness {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -2649,7 +2795,10 @@ impl Correctness {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -3173,14 +3322,75 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]),
+    ];
+}
+impl RuleGroupExt for Nursery {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_common_js.as_ref() {
             if rule.is_enabled() {
@@ -3474,7 +3684,7 @@ impl Nursery {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_common_js.as_ref() {
             if rule.is_disabled() {
@@ -3769,14 +3979,17 @@ impl Nursery {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -3785,7 +3998,10 @@ impl Nursery {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -4064,14 +4280,22 @@ impl Performance {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+    ];
+}
+impl RuleGroupExt for Performance {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_accumulating_spread.as_ref() {
             if rule.is_enabled() {
@@ -4100,7 +4324,7 @@ impl Performance {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_accumulating_spread.as_ref() {
             if rule.is_disabled() {
@@ -4130,14 +4354,17 @@ impl Performance {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -4146,7 +4373,10 @@ impl Performance {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -4207,14 +4437,20 @@ impl Security {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+    ];
+}
+impl RuleGroupExt for Security {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_dangerously_set_inner_html.as_ref() {
             if rule.is_enabled() {
@@ -4233,7 +4469,7 @@ impl Security {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_dangerously_set_inner_html.as_ref() {
             if rule.is_disabled() {
@@ -4253,14 +4489,17 @@ impl Security {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -4269,7 +4508,10 @@ impl Security {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -4532,14 +4774,65 @@ impl Style {
         "useThrowOnlyError",
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+    ];
+}
+impl RuleGroupExt for Style {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_arguments.as_ref() {
             if rule.is_enabled() {
@@ -4783,7 +5076,7 @@ impl Style {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_arguments.as_ref() {
             if rule.is_disabled() {
@@ -5028,14 +5321,17 @@ impl Style {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -5044,7 +5340,10 @@ impl Style {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {
@@ -5621,14 +5920,84 @@ impl Suspicious {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[64]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[66]),
     ];
-    #[doc = r" Retrieves the recommended rules"]
-    pub(crate) fn is_recommended_true(&self) -> bool {
+    const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[60]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[61]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[62]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[63]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[64]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[65]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[66]),
+    ];
+}
+impl RuleGroupExt for Suspicious {
+    fn is_recommended_true(&self) -> bool {
         matches!(self.recommended, Some(true))
     }
-    pub(crate) fn is_recommended_unset(&self) -> bool {
+    fn is_recommended_unset(&self) -> bool {
         self.recommended.is_none()
     }
-    pub(crate) fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_enabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_approximative_numeric_constant.as_ref() {
             if rule.is_enabled() {
@@ -5967,7 +6336,7 @@ impl Suspicious {
         }
         index_set
     }
-    pub(crate) fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
+    fn get_disabled_rules(&self) -> FxHashSet<RuleFilter<'static>> {
         let mut index_set = FxHashSet::default();
         if let Some(rule) = self.no_approximative_numeric_constant.as_ref() {
             if rule.is_disabled() {
@@ -6307,14 +6676,17 @@ impl Suspicious {
         index_set
     }
     #[doc = r" Checks if, given a rule name, matches one of the rules contained in this category"]
-    pub(crate) fn has_rule(rule_name: &str) -> Option<&'static str> {
+    fn has_rule(rule_name: &str) -> Option<&'static str> {
         Some(Self::GROUP_RULES[Self::GROUP_RULES.binary_search(&rule_name).ok()?])
     }
-    pub(crate) fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
+    fn recommended_rules_as_filters() -> &'static [RuleFilter<'static>] {
         Self::RECOMMENDED_RULES_AS_FILTERS
     }
+    fn all_rules_as_filters() -> &'static [RuleFilter<'static>] {
+        Self::ALL_RULES_AS_FILTERS
+    }
     #[doc = r" Select preset rules"]
-    pub(crate) fn collect_preset_rules(
+    fn collect_preset_rules(
         &self,
         parent_is_recommended: bool,
         enabled_rules: &mut FxHashSet<RuleFilter<'static>>,
@@ -6323,7 +6695,10 @@ impl Suspicious {
             enabled_rules.extend(Self::recommended_rules_as_filters());
         }
     }
-    pub(crate) fn get_rule_configuration(
+    fn set_recommended(&mut self, value: Option<bool>) {
+        self.recommended = value;
+    }
+    fn get_rule_configuration(
         &self,
         rule_name: &str,
     ) -> Option<(RulePlainConfiguration, Option<RuleOptions>)> {

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ upgrade-tools:
 # Generate all files across crates and tools. You rarely want to use it locally.
 gen-all:
   cargo run -p xtask_codegen -- all
-  cargo codegen-configuration
+  just gen-configuration
   cargo codegen-migrate
   just gen-bindings
   just format
@@ -29,16 +29,24 @@ gen-all:
 # Generates TypeScript types and JSON schema of the configuration
 gen-bindings:
   cargo codegen-schema
-  cargo codegen-bindings
+  cargo run -p xtask_codegen --features schema -- bindings
 
 # Generates code generated files for the linter
 gen-analyzer:
   cargo run -p xtask_codegen -- analyzer
-  cargo codegen-configuration
+  just gen-configuration
   cargo codegen-migrate
   just gen-bindings
   cargo run -p rules_check
   just format
+
+gen-configuration:
+    cargo run -p xtask_codegen --features configuration -- configuration
+
+# Generates code for eslint migration
+gen-migrate:
+   cargo run -p xtask_codegen --features configuration -- migrate-eslint
+
 
 # Generates the initial files for all formatter crates
 gen-formatter:

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -729,18 +729,18 @@ export interface JsonParserConfiguration {
 	allowTrailingCommas?: Bool;
 }
 export interface Rules {
-	a11y?: A11y;
-	complexity?: Complexity;
-	correctness?: Correctness;
-	nursery?: Nursery;
-	performance?: Performance;
+	a11y?: SeverityOrGroup_for_A11y;
+	complexity?: SeverityOrGroup_for_Complexity;
+	correctness?: SeverityOrGroup_for_Correctness;
+	nursery?: SeverityOrGroup_for_Nursery;
+	performance?: SeverityOrGroup_for_Performance;
 	/**
 	 * It enables the lint rules recommended by Biome. `true` by default.
 	 */
 	recommended?: boolean;
-	security?: Security;
-	style?: Style;
-	suspicious?: Suspicious;
+	security?: SeverityOrGroup_for_Security;
+	style?: SeverityOrGroup_for_Style;
+	suspicious?: SeverityOrGroup_for_Suspicious;
 }
 export interface OverridePattern {
 	/**
@@ -841,6 +841,92 @@ export type Semicolons = "always" | "asNeeded";
 export type TrailingCommas = "all" | "es5" | "none";
 export type Expand = "always" | "followSource";
 export type TrailingCommas2 = "none" | "all";
+export type SeverityOrGroup_for_A11y = GroupPlainConfiguration | A11y;
+export type SeverityOrGroup_for_Complexity =
+	| GroupPlainConfiguration
+	| Complexity;
+export type SeverityOrGroup_for_Correctness =
+	| GroupPlainConfiguration
+	| Correctness;
+export type SeverityOrGroup_for_Nursery = GroupPlainConfiguration | Nursery;
+export type SeverityOrGroup_for_Performance =
+	| GroupPlainConfiguration
+	| Performance;
+export type SeverityOrGroup_for_Security = GroupPlainConfiguration | Security;
+export type SeverityOrGroup_for_Style = GroupPlainConfiguration | Style;
+export type SeverityOrGroup_for_Suspicious =
+	| GroupPlainConfiguration
+	| Suspicious;
+export interface OverrideAssistConfiguration {
+	/**
+	 * List of actions
+	 */
+	actions?: Actions;
+	/**
+	 * if `false`, it disables the feature and the assist won't be executed. `true` by default
+	 */
+	enabled?: Bool;
+}
+export interface OverrideFormatterConfiguration {
+	/**
+	 * The attribute position style.
+	 */
+	attributePosition?: AttributePosition;
+	/**
+	 * Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+	 */
+	bracketSameLine?: BracketSameLine;
+	/**
+	 * Whether to insert spaces around brackets in object literals. Defaults to true.
+	 */
+	bracketSpacing?: BracketSpacing;
+	enabled?: Bool;
+	/**
+	 * Stores whether formatting should be allowed to proceed if a given file has syntax errors
+	 */
+	formatWithErrors?: Bool;
+	/**
+	 * The size of the indentation, 2 by default (deprecated, use `indent-width`)
+	 */
+	indentSize?: IndentWidth;
+	/**
+	 * The indent style.
+	 */
+	indentStyle?: IndentStyle;
+	/**
+	 * The size of the indentation, 2 by default
+	 */
+	indentWidth?: IndentWidth;
+	/**
+	 * The type of line ending.
+	 */
+	lineEnding?: LineEnding;
+	/**
+	 * What's the max width of a line. Defaults to 80.
+	 */
+	lineWidth?: LineWidth;
+}
+export interface OverrideLinterConfiguration {
+	/**
+	 * List of rules
+	 */
+	domains?: {};
+	/**
+	 * if `false`, it disables the feature and the linter won't be executed. `true` by default
+	 */
+	enabled?: Bool;
+	/**
+	 * List of rules
+	 */
+	rules?: Rules;
+}
+export type RuleAssistConfiguration_for_Options =
+	| RuleAssistPlainConfiguration
+	| RuleAssistWithOptions_for_Options;
+export type RuleAssistConfiguration_for_Null =
+	| RuleAssistPlainConfiguration
+	| RuleAssistWithOptions_for_Null;
+export type GroupPlainConfiguration = "off" | "on" | "info" | "warn" | "error";
 /**
  * A list of rules that belong to this group
  */
@@ -2117,75 +2203,27 @@ export interface Suspicious {
 	 */
 	useValidTypeof?: RuleFixConfiguration_for_Null;
 }
-export interface OverrideAssistConfiguration {
+export type RuleAssistPlainConfiguration = "off" | "on";
+export interface RuleAssistWithOptions_for_Options {
 	/**
-	 * List of actions
+	 * The severity of the emitted diagnostics by the rule
 	 */
-	actions?: Actions;
+	level: RuleAssistPlainConfiguration;
 	/**
-	 * if `false`, it disables the feature and the assist won't be executed. `true` by default
+	 * Rule's options
 	 */
-	enabled?: Bool;
+	options: Options;
 }
-export interface OverrideFormatterConfiguration {
+export interface RuleAssistWithOptions_for_Null {
 	/**
-	 * The attribute position style.
+	 * The severity of the emitted diagnostics by the rule
 	 */
-	attributePosition?: AttributePosition;
+	level: RuleAssistPlainConfiguration;
 	/**
-	 * Put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+	 * Rule's options
 	 */
-	bracketSameLine?: BracketSameLine;
-	/**
-	 * Whether to insert spaces around brackets in object literals. Defaults to true.
-	 */
-	bracketSpacing?: BracketSpacing;
-	enabled?: Bool;
-	/**
-	 * Stores whether formatting should be allowed to proceed if a given file has syntax errors
-	 */
-	formatWithErrors?: Bool;
-	/**
-	 * The size of the indentation, 2 by default (deprecated, use `indent-width`)
-	 */
-	indentSize?: IndentWidth;
-	/**
-	 * The indent style.
-	 */
-	indentStyle?: IndentStyle;
-	/**
-	 * The size of the indentation, 2 by default
-	 */
-	indentWidth?: IndentWidth;
-	/**
-	 * The type of line ending.
-	 */
-	lineEnding?: LineEnding;
-	/**
-	 * What's the max width of a line. Defaults to 80.
-	 */
-	lineWidth?: LineWidth;
+	options: null;
 }
-export interface OverrideLinterConfiguration {
-	/**
-	 * List of rules
-	 */
-	domains?: {};
-	/**
-	 * if `false`, it disables the feature and the linter won't be executed. `true` by default
-	 */
-	enabled?: Bool;
-	/**
-	 * List of rules
-	 */
-	rules?: Rules;
-}
-export type RuleAssistConfiguration_for_Options =
-	| RuleAssistPlainConfiguration
-	| RuleAssistWithOptions_for_Options;
-export type RuleAssistConfiguration_for_Null =
-	| RuleAssistPlainConfiguration
-	| RuleAssistWithOptions_for_Null;
 export type RuleFixConfiguration_for_Null =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_Null;
@@ -2264,26 +2302,9 @@ export type RuleFixConfiguration_for_NoConsoleOptions =
 export type RuleFixConfiguration_for_NoDoubleEqualsOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_NoDoubleEqualsOptions;
-export type RuleAssistPlainConfiguration = "off" | "on";
-export interface RuleAssistWithOptions_for_Options {
-	/**
-	 * The severity of the emitted diagnostics by the rule
-	 */
-	level: RuleAssistPlainConfiguration;
-	/**
-	 * Rule's options
-	 */
-	options: Options;
-}
-export interface RuleAssistWithOptions_for_Null {
-	/**
-	 * The severity of the emitted diagnostics by the rule
-	 */
-	level: RuleAssistPlainConfiguration;
-	/**
-	 * Rule's options
-	 */
-	options: null;
+export interface Options {
+	importGroups?: ImportGroup[];
+	legacy?: boolean;
 }
 export type RulePlainConfiguration = "off" | "on" | "info" | "warn" | "error";
 export interface RuleWithFixOptions_for_Null {
@@ -2590,10 +2611,7 @@ export interface RuleWithFixOptions_for_NoDoubleEqualsOptions {
 	 */
 	options: NoDoubleEqualsOptions;
 }
-export interface Options {
-	importGroups?: ImportGroup[];
-	legacy?: boolean;
-}
+export type ImportGroup = PredefinedImportGroup | Regex;
 /**
  * Used to identify the kind of code action emitted by a rule
  */
@@ -2811,7 +2829,12 @@ If `false`, no such exception will be made.
 	 */
 	ignoreNull: boolean;
 }
-export type ImportGroup = PredefinedImportGroup | Regex;
+export type PredefinedImportGroup =
+	| ":blank-line:"
+	| ":bun:"
+	| ":node:"
+	| ":types:";
+export type Regex = string;
 export type DependencyAvailability = boolean | string[];
 export interface Hook {
 	/**
@@ -2842,7 +2865,6 @@ For example, for React's `useRef()` hook the value would be `true`, while for `u
 export type Accessibility = "noPublic" | "explicit" | "none";
 export type ConsistentArrayType = "shorthand" | "generic";
 export type FilenameCases = FilenameCase[];
-export type Regex = string;
 export interface Convention {
 	/**
 	 * String cases to enforce
@@ -2865,11 +2887,6 @@ export type Format =
 	| "CONSTANT_CASE"
 	| "PascalCase"
 	| "snake_case";
-export type PredefinedImportGroup =
-	| ":blank-line:"
-	| ":bun:"
-	| ":node:"
-	| ":types:";
 export type StableHookResult = boolean | number[];
 /**
  * Supported cases for file names.

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1664,24 +1664,28 @@
 		},
 		"GroupPlainConfiguration": {
 			"oneOf": [
-				{ "type": "string", "enum": ["off"] },
 				{
-					"description": "Enables the recommended rules with their default",
+					"description": "It disables all the rules of this group",
+					"type": "string",
+					"enum": ["off"]
+				},
+				{
+					"description": "It enables all the rules of this group, with their default severity",
 					"type": "string",
 					"enum": ["on"]
 				},
 				{
-					"description": "Enables the rule, and it will emit a diagnostic with information severity",
+					"description": "It enables all the rules of this group, and set their severity to \"info\"",
 					"type": "string",
 					"enum": ["info"]
 				},
 				{
-					"description": "Enables the rule, and it will emit a diagnostic with warning severity",
+					"description": "It enables all the rules of this group, and set their severity to \"warn\"",
 					"type": "string",
 					"enum": ["warn"]
 				},
 				{
-					"description": "Enables the rule, and it will emit a diagnostic with error severity",
+					"description": "It enables all the rules of this group, and set their severity to \"error+\"",
 					"type": "string",
 					"enum": ["error"]
 				}

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1662,6 +1662,31 @@
 			},
 			"additionalProperties": false
 		},
+		"GroupPlainConfiguration": {
+			"oneOf": [
+				{ "type": "string", "enum": ["off"] },
+				{
+					"description": "Enables the recommended rules with their default",
+					"type": "string",
+					"enum": ["on"]
+				},
+				{
+					"description": "Enables the rule, and it will emit a diagnostic with information severity",
+					"type": "string",
+					"enum": ["info"]
+				},
+				{
+					"description": "Enables the rule, and it will emit a diagnostic with warning severity",
+					"type": "string",
+					"enum": ["warn"]
+				},
+				{
+					"description": "Enables the rule, and it will emit a diagnostic with error severity",
+					"type": "string",
+					"enum": ["error"]
+				}
+			]
+		},
 		"Hook": {
 			"type": "object",
 			"properties": {
@@ -3658,32 +3683,56 @@
 			"type": "object",
 			"properties": {
 				"a11y": {
-					"anyOf": [{ "$ref": "#/definitions/A11y" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_A11y" },
+						{ "type": "null" }
+					]
 				},
 				"complexity": {
-					"anyOf": [{ "$ref": "#/definitions/Complexity" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Complexity" },
+						{ "type": "null" }
+					]
 				},
 				"correctness": {
-					"anyOf": [{ "$ref": "#/definitions/Correctness" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Correctness" },
+						{ "type": "null" }
+					]
 				},
 				"nursery": {
-					"anyOf": [{ "$ref": "#/definitions/Nursery" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Nursery" },
+						{ "type": "null" }
+					]
 				},
 				"performance": {
-					"anyOf": [{ "$ref": "#/definitions/Performance" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Performance" },
+						{ "type": "null" }
+					]
 				},
 				"recommended": {
 					"description": "It enables the lint rules recommended by Biome. `true` by default.",
 					"type": ["boolean", "null"]
 				},
 				"security": {
-					"anyOf": [{ "$ref": "#/definitions/Security" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Security" },
+						{ "type": "null" }
+					]
 				},
 				"style": {
-					"anyOf": [{ "$ref": "#/definitions/Style" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Style" },
+						{ "type": "null" }
+					]
 				},
 				"suspicious": {
-					"anyOf": [{ "$ref": "#/definitions/Suspicious" }, { "type": "null" }]
+					"anyOf": [
+						{ "$ref": "#/definitions/SeverityOrGroup_for_Suspicious" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false
@@ -3740,6 +3789,54 @@
 			"additionalProperties": false
 		},
 		"Semicolons": { "type": "string", "enum": ["always", "asNeeded"] },
+		"SeverityOrGroup_for_A11y": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/A11y" }
+			]
+		},
+		"SeverityOrGroup_for_Complexity": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Complexity" }
+			]
+		},
+		"SeverityOrGroup_for_Correctness": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Correctness" }
+			]
+		},
+		"SeverityOrGroup_for_Nursery": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Nursery" }
+			]
+		},
+		"SeverityOrGroup_for_Performance": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Performance" }
+			]
+		},
+		"SeverityOrGroup_for_Security": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Security" }
+			]
+		},
+		"SeverityOrGroup_for_Style": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Style" }
+			]
+		},
+		"SeverityOrGroup_for_Suspicious": {
+			"anyOf": [
+				{ "$ref": "#/definitions/GroupPlainConfiguration" },
+				{ "$ref": "#/definitions/Suspicious" }
+			]
+		},
 		"Source": {
 			"description": "A list of rules that belong to this group",
 			"type": "object",

--- a/xtask/codegen/src/generate_migrate_eslint.rs
+++ b/xtask/codegen/src/generate_migrate_eslint.rs
@@ -44,7 +44,7 @@ pub(crate) fn generate_migrate_eslint(mode: Mode) -> Result<()> {
                 #check_inspired
                 #check_nursery
                 let group = rules.#group_ident.get_or_insert_with(Default::default);
-                let rule = group.#name_ident.get_or_insert(Default::default());
+                let rule = group.unwrap_group_as_mut().#name_ident.get_or_insert(Default::default());
                 rule.set_level(rule.level().max(rule_severity.into()));
             }
         });


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Part of https://github.com/biomejs/biome/issues/4662

It allows to assign to each group of the linter new options: 
- `"on"`: it enables all rules of the group, using the default severity of the rule
- `"off"`: it disable all rules
- `"info"`: it enables all rules of group, and all rules have the info severity
- `"warn"` it enables all rules of group, and all rules have the warn severity
- `"error"`: it enables all rules of group, and all rules have the error severity


### Technical changes

I created a new type called `SeverityOrGroup<G>`, which is in charge of implementing all the functions that we already generate for each group.

I also created a new trait called `RuleGroupExt`: this allowed me to use functions like `G::default()` or `G::all_rules_as_filters()`, otherwise I would have to create an `impl SeverityOrGroup<A11y>`, etc. for each group, which wasn't optimal, imho. 

Now all groups implement `RuleGroupExt`.

## Test Plan

Added new tests. The existing tests should stay as is and not change

<!-- What demonstrates that your implementation is correct? -->
