### PR TITLE
fix(biome_diagnostics): fix JetBrains relative file URLs should be clickable when given line and column numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - `noDuplicateProperties` now throws lint errors properly when we use `@supports` (fix [#4756](https://github.com/biomejs/biome/issues/4756)) Contributed by @mehm8128
 
+- Fix [#4719](https://github.com/biomejs/biome/issues/4719), `bracketSameLine` now performs as expected when a comment is placed before the last JSX attribute. Contributed by @bushuai
+
 ### JavaScript APIs
 
 ### Linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,6 +352,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 
 - [noUselessFragments](https://biomejs.dev/linter/rules/no-useless-fragments/) now handles `JsxAttributeInitializerClause`, ensuring that fragments inside expressions like `<A b=<></> />` are preserved. ([#4208](https://github.com/biomejs/biome/issues/4208)). Contributed by @MaxtuneLee
 
+- [useSortedClasses](https://biomejs.dev/linter/rules/use-sorted-classes/) now suggests code fixes that match the JSX quote style of the formatter ([#4855](https://github.com/biomejs/biome/issues/4855)). Contributed by @lucasweng
+
 ### Parser
 
 #### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ## Unreleased
 
 - Fix [#4323](https://github.com/biomejs/biome/issues/4258), where `lint/a11y/useSemanticElement` accidentally showed recommendations for `role="searchbox"` instead of `role="search"`
+- Fix [#4875](https://github.com/biomejs/biome/issues/4875), where the Jetbrains IDE terminal would output unclickable, relative file path links to files. This does not fix paths without line and column numbers. Contributed by @Andrew-Chen-Wang
 
 ### Analyzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 - `biome migrate eslint` now correctly handles ESLint configuration with `null` values in file lists ([#4740](https://github.com/biomejs/biome/issues/4740)).
   Contributed by @Conaclos
 
+- Fix [#4202](https://github.com/biomejs/biome/issues/4202), where the formatting of the test function was different from prettier. Contributed by @mdm317
+
 ### Configuration
 
 ### Editors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ name = "biome_js_syntax"
 version = "0.5.7"
 dependencies = [
  "biome_aria",
+ "biome_aria_metadata",
  "biome_js_factory",
  "biome_js_parser",
  "biome_rowan",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,14 +2394,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
 dependencies = [
  "console",
  "globset",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "similar",
  "walkdir",
 ]
@@ -2762,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ getrandom          = "0.2.15"
 globset            = "0.4.15"
 ignore             = "0.4.23"
 indexmap           = { version = "2.7.0", features = ["serde"] }
-insta              = "1.41.1"
+insta              = "1.42.0"
 natord             = "1.0.9"
 oxc_resolver       = "3.0.3"
 proc-macro2        = "1.0.86"

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -11,7 +11,7 @@
     "node": ">20.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "8.18.1",
+    "@typescript-eslint/eslint-plugin": "8.19.1",
     "dprint": "0.48.0",
     "eslint": "9.17.0",
     "prettier": "3.3.3"

--- a/crates/biome_analyze/src/context.rs
+++ b/crates/biome_analyze/src/context.rs
@@ -17,6 +17,7 @@ pub struct RuleContext<'a, R: Rule> {
     file_path: &'a Path,
     options: &'a R::Options,
     preferred_quote: &'a PreferredQuote,
+    preferred_jsx_quote: &'a PreferredQuote,
     jsx_runtime: Option<JsxRuntime>,
 }
 
@@ -33,6 +34,7 @@ where
         file_path: &'a Path,
         options: &'a R::Options,
         preferred_quote: &'a PreferredQuote,
+        preferred_jsx_quote: &'a PreferredQuote,
         jsx_runtime: Option<JsxRuntime>,
     ) -> Result<Self, Error> {
         let rule_key = RuleKey::rule::<R>();
@@ -45,6 +47,7 @@ where
             file_path,
             options,
             preferred_quote,
+            preferred_jsx_quote,
             jsx_runtime,
         })
     }
@@ -166,6 +169,11 @@ where
     /// Returns the preferred quote that should be used when providing code actions
     pub fn as_preferred_quote(&self) -> &PreferredQuote {
         self.preferred_quote
+    }
+
+    /// Returns the preferred JSX quote that should be used when providing code actions
+    pub fn as_preferred_jsx_quote(&self) -> &PreferredQuote {
+        self.preferred_jsx_quote
     }
 
     /// Attempts to retrieve a service from the current context

--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -65,6 +65,9 @@ pub struct AnalyzerConfiguration {
     /// Allows to choose a different quote when applying fixes inside the lint rules
     pub preferred_quote: PreferredQuote,
 
+    /// Allows to choose a different JSX quote when applying fixes inside the lint rules
+    pub preferred_jsx_quote: PreferredQuote,
+
     /// Indicates the type of runtime or transformation used for interpreting JSX.
     pub jsx_runtime: Option<JsxRuntime>,
 }
@@ -116,6 +119,10 @@ impl AnalyzerOptions {
 
     pub fn preferred_quote(&self) -> &PreferredQuote {
         &self.configuration.preferred_quote
+    }
+
+    pub fn preferred_jsx_quote(&self) -> &PreferredQuote {
+        &self.configuration.preferred_jsx_quote
     }
 }
 

--- a/crates/biome_analyze/src/registry.rs
+++ b/crates/biome_analyze/src/registry.rs
@@ -399,6 +399,7 @@ impl<L: Language + Default> RegistryRule<L> {
             let query_result = <R::Query as Queryable>::unwrap_match(params.services, query_result);
             let globals = params.options.globals();
             let preferred_quote = params.options.preferred_quote();
+            let preferred_jsx_quote = params.options.preferred_jsx_quote();
             let jsx_runtime = params.options.jsx_runtime();
             let options = params.options.rule_options::<R>().unwrap_or_default();
             let ctx = match RuleContext::new(
@@ -409,6 +410,7 @@ impl<L: Language + Default> RegistryRule<L> {
                 &params.options.file_path,
                 &options,
                 preferred_quote,
+                preferred_jsx_quote,
                 jsx_runtime,
             ) {
                 Ok(ctx) => ctx,

--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -346,6 +346,7 @@ where
     fn diagnostic(&self) -> Option<AnalyzerDiagnostic> {
         let globals = self.options.globals();
         let preferred_quote = self.options.preferred_quote();
+        let preferred_jsx_quote = self.options.preferred_jsx_quote();
         let options = self.options.rule_options::<R>().unwrap_or_default();
         let ctx = RuleContext::new(
             &self.query_result,
@@ -355,6 +356,7 @@ where
             &self.options.file_path,
             &options,
             preferred_quote,
+            preferred_jsx_quote,
             self.options.jsx_runtime(),
         )
         .ok()?;
@@ -386,6 +388,7 @@ where
             &self.options.file_path,
             &options,
             self.options.preferred_quote(),
+            self.options.preferred_jsx_quote(),
             self.options.jsx_runtime(),
         )
         .ok();
@@ -435,6 +438,7 @@ where
             &self.options.file_path,
             &options,
             self.options.preferred_quote(),
+            self.options.preferred_jsx_quote(),
             self.options.jsx_runtime(),
         )
         .ok();

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -238,7 +238,7 @@ impl AriaRoles {
 
     /// Given an element name and attributes, it returns the role associated with that element.
     /// If no explicit role attribute is present, an implicit role is returned.
-    fn get_role_by_element_name(&self, element: &impl Element) -> Option<AriaRole> {
+    pub fn get_role_by_element_name(&self, element: &impl Element) -> Option<AriaRole> {
         element
             .find_attribute_by_name(|name| name == "role")
             .as_ref()

--- a/crates/biome_aria_metadata/src/lib.rs
+++ b/crates/biome_aria_metadata/src/lib.rs
@@ -129,7 +129,7 @@ fn is_valid_html_id(id: &str) -> bool {
 }
 
 impl AriaRole {
-    /// Returns the first valid role from `values`, a space-separated list of roles.
+    /// Returns the first valid role from `roles`, a space-separated list of roles.
     ///
     /// If a role attribute has multiple values, the first valid role (specified role) will be used.
     /// See <https://www.w3.org/TR/2014/REC-wai-aria-implementation-20140320/#mapping_role>

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -734,6 +734,16 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule_severity.into());
         }
+        "jsx-a11y/no-noninteractive-element-interactions" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .no_noninteractive_element_interactions
+                .get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "jsx-a11y/no-noninteractive-element-to-interactive-role" => {
             let group = rules.a11y.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3337,6 +3337,10 @@ pub struct Nursery {
     #[doc = "Disallow nested ternary expressions."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_nested_ternary: Option<RuleConfiguration<biome_js_analyze::options::NoNestedTernary>>,
+    #[doc = "Disallow use event handlers on non-interactive elements."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_noninteractive_element_interactions:
+        Option<RuleConfiguration<biome_js_analyze::options::NoNoninteractiveElementInteractions>>,
     #[doc = "Disallow octal escape sequences in string literals"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_octal_escape: Option<RuleConfiguration<biome_js_analyze::options::NoOctalEscape>>,
@@ -3512,6 +3516,7 @@ impl Nursery {
         "noIrregularWhitespace",
         "noMissingVarFunction",
         "noNestedTernary",
+        "noNoninteractiveElementInteractions",
         "noOctalEscape",
         "noProcessEnv",
         "noProcessGlobal",
@@ -3577,17 +3582,17 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -3646,6 +3651,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
     ];
     #[doc = r" Retrieves the recommended rules"]
     pub(crate) fn is_recommended_true(&self) -> bool {
@@ -3752,194 +3758,199 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_octal_escape.as_ref() {
+        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_process_env.as_ref() {
+        if let Some(rule) = self.no_octal_escape.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_process_global.as_ref() {
+        if let Some(rule) = self.no_process_env.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_process_global.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_restricted_types.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_static_element_interactions.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_substr.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
+        if let Some(rule) = self.no_substr.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
+        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_useless_string_raw.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_string_raw.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_value_at_rule.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
+        if let Some(rule) = self.no_value_at_rule.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
+        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.use_at_index.as_ref() {
+        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.use_collapsed_if.as_ref() {
+        if let Some(rule) = self.use_at_index.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
+        if let Some(rule) = self.use_collapsed_if.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
+        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
+        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_deprecated_reason.as_ref() {
+        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_deprecated_reason.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_google_font_display.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_google_font_display.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
         index_set
@@ -4036,194 +4047,199 @@ impl Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_octal_escape.as_ref() {
+        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_process_env.as_ref() {
+        if let Some(rule) = self.no_octal_escape.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_process_global.as_ref() {
+        if let Some(rule) = self.no_process_env.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_process_global.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_restricted_types.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_static_element_interactions.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_substr.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
+        if let Some(rule) = self.no_substr.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
+        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_useless_string_raw.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_string_raw.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_value_at_rule.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
+        if let Some(rule) = self.no_value_at_rule.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
+        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.use_at_index.as_ref() {
+        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.use_collapsed_if.as_ref() {
+        if let Some(rule) = self.use_at_index.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
+        if let Some(rule) = self.use_collapsed_if.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
+        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
+        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_deprecated_reason.as_ref() {
+        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_deprecated_reason.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_google_font_display.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_google_font_display.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_import_restrictions.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_import_restrictions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
         index_set
@@ -4332,6 +4348,10 @@ impl Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noNestedTernary" => self
                 .no_nested_ternary
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noNoninteractiveElementInteractions" => self
+                .no_noninteractive_element_interactions
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noOctalEscape" => self

--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -109,6 +109,7 @@ impl<D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'_, D> {
         };
 
         let is_vscode = env::var("TERM_PROGRAM").unwrap_or_default() == "vscode";
+        let is_jetbrains = env::var("TERMINAL_EMULATOR").unwrap_or_default().contains("JetBrains");
 
         if let Some(name) = file_name {
             if is_vscode {
@@ -121,7 +122,11 @@ impl<D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'_, D> {
                         <Hyperlink href={link}>{name}</Hyperlink>
                     })?;
                 } else {
-                    fmt.write_str(name)?;
+                    if is_jetbrains {
+                        fmt.write_str(&format!(" at {name}"))?;
+                    } else {
+                        fmt.write_str(name)?;
+                    }
                 }
             }
 

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -160,6 +160,7 @@ define_categories! {
     "lint/nursery/noMissingGenericFamilyKeyword": "https://biomejs.dev/linter/rules/no-missing-generic-family-keyword",
     "lint/nursery/noMissingVarFunction": "https://biomejs.dev/linter/rules/no-missing-var-function",
     "lint/nursery/noNestedTernary": "https://biomejs.dev/linter/rules/no-nested-ternary",
+    "lint/nursery/noNoninteractiveElementInteractions": "https://biomejs.dev/linter/rules/no-noninteractive-element-interactions",
     "lint/nursery/noOctalEscape": "https://biomejs.dev/linter/rules/no-octal-escape",
     "lint/nursery/noProcessEnv": "https://biomejs.dev/linter/rules/no-process-env",
     "lint/nursery/noProcessGlobal": "https://biomejs.dev/linter/rules/no-process-global",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -15,6 +15,7 @@ pub mod no_head_import_in_document;
 pub mod no_img_element;
 pub mod no_irregular_whitespace;
 pub mod no_nested_ternary;
+pub mod no_noninteractive_element_interactions;
 pub mod no_octal_escape;
 pub mod no_process_env;
 pub mod no_process_global;
@@ -63,6 +64,7 @@ declare_lint_group! {
             self :: no_img_element :: NoImgElement ,
             self :: no_irregular_whitespace :: NoIrregularWhitespace ,
             self :: no_nested_ternary :: NoNestedTernary ,
+            self :: no_noninteractive_element_interactions :: NoNoninteractiveElementInteractions ,
             self :: no_octal_escape :: NoOctalEscape ,
             self :: no_process_env :: NoProcessEnv ,
             self :: no_process_global :: NoProcessGlobal ,

--- a/crates/biome_js_analyze/src/lint/nursery/no_noninteractive_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_noninteractive_element_interactions.rs
@@ -1,0 +1,215 @@
+use crate::services::aria::Aria;
+use biome_analyze::{context::RuleContext, declare_lint_rule, Rule, RuleDiagnostic, RuleSource};
+use biome_console::markup;
+use biome_js_syntax::jsx_ext::AnyJsxElement;
+use biome_rowan::AstNode;
+
+declare_lint_rule! {
+    /// Disallow use event handlers on non-interactive elements.
+    ///
+    /// Non-interactive HTML elements indicate _content_ and _containers_ in the user interface.
+    /// Non-interactive elements include `<main>`, `<area>`, `<h1>` (,`<h2>`, etc), `<img>`, `<li>`, `<ul>` and `<ol>`.
+    ///
+    /// A Non-interactive element does not support event handlers(mouse and key handlers).
+    ///
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```jsx,expect_diagnostic
+    /// <div onClick={() => {}}>button</div>
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```jsx
+    /// <button onClick={() => { }}>button</button>
+    /// ```
+    ///
+    /// ```jsx
+    /// // Adding a role to element does not add behavior.
+    /// // If not used semantic HTML elements like `button`, developers need to implement the expected behavior for role(like focusability and key press support)
+    /// // See https://www.w3.org/WAI/ARIA/apg/
+    /// <div role="button" onClick={() => { }}>button</div>
+    /// ```
+    ///
+    /// ```jsx
+    /// // The role="presentation" attribute removes the semantic meaning of an element, indicating that it should be ignored by assistive technologies.
+    /// // Therefore, it's acceptable to add event handlers to elements with role="presentation" for visual effects or other purposes,
+    /// // but users relying on assistive technologies may not be able to interact with these elements.
+    /// <div role="presentation" onClick={() => { }}>button</div>
+    /// ```
+    ///
+    /// ```jsx
+    /// // Hidden from screen reader.
+    /// <div onClick={() => {}} aria-hidden />
+    /// ```
+    ///
+    /// ```jsx
+    /// // Custom component is not checked.
+    /// <SomeComponent onClick={() => {}}>button</SomeComponent>
+    /// ```
+    ///
+    /// ```jsx
+    /// // Spread attributes is not supported.
+    /// <div {...{"onClick":() => {}}}>button</div>
+    /// ```
+    ///
+    /// ## Accessibility guidelines
+    ///
+    /// - [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+    ///
+    /// ### Resources
+    ///
+    /// - [WAI-ARIA roles](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
+    /// - [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
+    /// - [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+    /// - [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+    ///
+    pub NoNoninteractiveElementInteractions {
+        version: "next",
+        name: "noNoninteractiveElementInteractions",
+        language: "jsx",
+        sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-interactions")],
+        recommended: false,
+    }
+}
+
+impl Rule for NoNoninteractiveElementInteractions {
+    type Query = Aria<AnyJsxElement>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let element = ctx.query();
+
+        // Custom components are not checked because we do not know what DOM will be used.
+        if element.is_custom_component() {
+            return None;
+        }
+
+        let aria_roles = ctx.aria_roles();
+        let role = aria_roles.get_role_by_element_name(element);
+        let has_interactive_role = role.is_some_and(|role| role.is_interactive());
+
+        if !has_handler_props(element)
+            || is_content_editable(element)
+            || has_presentation_role(element)
+            || is_hidden_from_screen_reader(element)?
+            || has_interactive_role
+        {
+            return None;
+        }
+
+        // Non-interactive elements what contains event handler should be reported.
+        if has_handler_props(element) && aria_roles.is_not_interactive_element(element) {
+            return Some(());
+        };
+
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "Non-interactive element should not have event handler."
+                },
+            )
+            .note(markup! {
+                "Consider replace semantically interactive element like "<Emphasis>"<button/>"</Emphasis>" or "<Emphasis>"<a href/>"</Emphasis>"."
+            })
+        )
+    }
+}
+
+/// Ref: https://github.com/jsx-eslint/jsx-ast-utils/blob/v3.3.5/src/eventHandlers.js
+const INTERACTIVE_HANDLERS: &[&str] = &[
+    "onClick",
+    "onContextMenu",
+    "onDblClick",
+    "onDoubleClick",
+    "onDrag",
+    "onDragEnd",
+    "onDragEnter",
+    "onDragExit",
+    "onDragLeave",
+    "onDragOver",
+    "onDragStart",
+    "onDrop",
+    "onMouseDown",
+    "onMouseEnter",
+    "onMouseLeave",
+    "onMouseMove",
+    "onMouseOut",
+    "onMouseOver",
+    "onKeyDown",
+    "onKeyPress",
+    "onKeyUp",
+    "onFocus",
+    "onBlur",
+    "onLoad",
+    "onError",
+];
+
+/// Check if the element contains event handler
+fn has_handler_props(element: &AnyJsxElement) -> bool {
+    INTERACTIVE_HANDLERS
+        .iter()
+        .any(|handler| element.find_attribute_by_name(handler).is_some())
+}
+
+/// Check if the element's implicit ARIA semantics have been removed.
+/// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role
+///
+/// Ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isPresentationRole.js
+fn has_presentation_role(element: &AnyJsxElement) -> bool {
+    if let Some(attribute) = element.find_attribute_by_name("role") {
+        let value = attribute.as_static_value();
+        if let Some(value) = value {
+            return matches!(value.as_string_constant(), Some("presentation" | "none"));
+        }
+    }
+    false
+}
+
+/// Check the element is hidden from screen reader.
+/// See
+/// - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
+/// - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/hidden
+///
+/// Ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isHiddenFromScreenReader.js
+fn is_hidden_from_screen_reader(element_name: &AnyJsxElement) -> Option<bool> {
+    let is_aria_hidden = element_name.has_truthy_attribute("aria-hidden");
+
+    let name = element_name.name_value_token().ok()?;
+
+    let is_input_hidden = if name.text_trimmed() == "input" {
+        element_name
+            .find_attribute_by_name("type")
+            .and_then(|attribute| attribute.as_static_value())
+            .and_then(|value| value.as_string_constant().map(|value| value == "hidden"))
+            .unwrap_or_default()
+    } else {
+        false
+    };
+
+    Some(is_aria_hidden || is_input_hidden)
+}
+
+/// Check if the element is `contentEditable`
+/// See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
+///
+/// Ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isContentEditable.js
+fn is_content_editable(element: &AnyJsxElement) -> bool {
+    element
+        .find_attribute_by_name("contentEditable")
+        .and_then(|attribute| attribute.as_static_value())
+        .and_then(|value| value.as_string_constant().map(|value| value == "true"))
+        .unwrap_or_default()
+}

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -239,7 +239,7 @@ impl Rule for UseSortedClasses {
                 mutation.replace_node(string_literal.clone(), replacement);
             }
             AnyClassStringLike::JsxString(jsx_string_node) => {
-                let replacement = jsx_string(if ctx.as_preferred_quote().is_double() {
+                let replacement = jsx_string(if ctx.as_preferred_jsx_quote().is_double() {
                     js_string_literal(state)
                 } else {
                     js_string_literal_single_quotes(state)

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -160,6 +160,7 @@ pub type NoNodejsModules =
     <lint::correctness::no_nodejs_modules::NoNodejsModules as biome_analyze::Rule>::Options;
 pub type NoNonNullAssertion =
     <lint::style::no_non_null_assertion::NoNonNullAssertion as biome_analyze::Rule>::Options;
+pub type NoNoninteractiveElementInteractions = < lint :: nursery :: no_noninteractive_element_interactions :: NoNoninteractiveElementInteractions as biome_analyze :: Rule > :: Options ;
 pub type NoNoninteractiveElementToInteractiveRole = < lint :: a11y :: no_noninteractive_element_to_interactive_role :: NoNoninteractiveElementToInteractiveRole as biome_analyze :: Rule > :: Options ;
 pub type NoNoninteractiveTabindex = < lint :: a11y :: no_noninteractive_tabindex :: NoNoninteractiveTabindex as biome_analyze :: Rule > :: Options ;
 pub type NoNonoctalDecimalEscape = < lint :: correctness :: no_nonoctal_decimal_escape :: NoNonoctalDecimalEscape as biome_analyze :: Rule > :: Options ;

--- a/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/invalid.jsx
@@ -1,0 +1,90 @@
+<>
+    <div onClick={() => { }} />
+    <main onClick={() => void 0} />
+    <article onClick={() => { }} />
+    <aside onClick={() => { }} />
+    <blockquote onClick={() => { }} />
+    <body onClick={() => { }} />
+    <br onClick={() => { }} />
+    <caption onClick={() => { }} />
+    <dd onClick={() => { }} />
+    <details onClick={() => { }} />
+    <dfn onClick={() => { }} />
+    <dl onClick={() => { }} />
+    <dir onClick={() => { }} />
+    <dt onClick={() => { }} />
+    <fieldset onClick={() => { }} />
+    <figcaption onClick={() => { }} />
+    <figure onClick={() => { }} />
+    <footer onClick={() => { }} />
+    <form onClick={() => { }} />
+    <frame onClick={() => { }} />
+    <h1 onClick={() => { }} />
+    <h2 onClick={() => { }} />
+    <h3 onClick={() => { }} />
+    <h4 onClick={() => { }} />
+    <h5 onClick={() => { }} />
+    <h6 onClick={() => { }} />
+    <iframe onClick={() => { }} />
+    <img onClick={() => { }} />
+    <label onClick={() => { }} />
+    <legend onClick={() => { }} />
+    <li onClick={() => { }} />
+    <mark onClick={() => { }} />
+    <marquee onClick={() => { }} />
+    <menu onClick={() => { }} />
+    <meter onClick={() => { }} />
+    <nav onClick={() => { }} />
+    <ol onClick={() => { }} />
+    <optgroup onClick={() => { }} />
+    <output onClick={() => { }} />
+    <p onClick={() => { }} />
+    <pre onClick={() => { }} />
+    <progress onClick={() => { }} />
+    <ruby onClick={() => { }} />
+    <section onClick={() => { }} aria-label="Aardvark" />
+    <section onClick={() => { }} aria-labelledby="js_1" />
+    <table onClick={() => { }} />
+    <tbody onClick={() => { }} />
+    <td onClick={() => { }} />
+    <tfoot onClick={() => { }} />
+    <thead onClick={() => { }} />
+    <time onClick={() => { }} />
+    <ul onClick={() => { }} />
+    <ul contentEditable="false" onClick={() => { }} />
+    <div role="alert" onClick={() => { }} />
+    <div role="alertdialog" onClick={() => { }} />
+    <div role="application" onClick={() => { }} />
+    <div role="banner" onClick={() => { }} />
+    <div role="cell" onClick={() => { }} />
+    <div role="complementary" onClick={() => { }} />
+    <div role="contentinfo" onClick={() => { }} />
+    <div role="definition" onClick={() => { }} />
+    <div role="dialog" onClick={() => { }} />
+    <div role="directory" onClick={() => { }} />
+    <div role="document" onClick={() => { }} />
+    <div role="feed" onClick={() => { }} />
+    <div role="figure" onClick={() => { }} />
+    <div role="form" onClick={() => { }} />
+    <div role="group" onClick={() => { }} />
+    <div role="heading" onClick={() => { }} />
+    <div role="img" onClick={() => { }} />
+    <div role="list" onClick={() => { }} />
+    <div role="listitem" onClick={() => { }} />
+    <div role="log" onClick={() => { }} />
+    <div role="main" onClick={() => { }} />
+    <div role="marquee" onClick={() => { }} />
+    <div role="math" onClick={() => { }} />
+    <div role="navigation" onClick={() => { }} />
+    <div role="note" onClick={() => { }} />
+    <div role="region" onClick={() => { }} />
+    <div role="rowgroup" onClick={() => { }} />
+    <div role="search" onClick={() => { }} />
+    <div role="status" onClick={() => { }} />
+    <div role="table" onClick={() => { }} />
+    <div role="tabpanel" onClick={() => { }} />
+    <div role="term" onClick={() => { }} />
+    <div role="timer" onClick={() => { }} />
+    <div role="tooltip" onClick={() => { }} />
+	  <div role="progressbar" onClick={() => { }} />
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/invalid.jsx.snap
@@ -1,0 +1,1578 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+snapshot_kind: text
+---
+# Input
+```jsx
+<>
+    <div onClick={() => { }} />
+    <main onClick={() => void 0} />
+    <article onClick={() => { }} />
+    <aside onClick={() => { }} />
+    <blockquote onClick={() => { }} />
+    <body onClick={() => { }} />
+    <br onClick={() => { }} />
+    <caption onClick={() => { }} />
+    <dd onClick={() => { }} />
+    <details onClick={() => { }} />
+    <dfn onClick={() => { }} />
+    <dl onClick={() => { }} />
+    <dir onClick={() => { }} />
+    <dt onClick={() => { }} />
+    <fieldset onClick={() => { }} />
+    <figcaption onClick={() => { }} />
+    <figure onClick={() => { }} />
+    <footer onClick={() => { }} />
+    <form onClick={() => { }} />
+    <frame onClick={() => { }} />
+    <h1 onClick={() => { }} />
+    <h2 onClick={() => { }} />
+    <h3 onClick={() => { }} />
+    <h4 onClick={() => { }} />
+    <h5 onClick={() => { }} />
+    <h6 onClick={() => { }} />
+    <iframe onClick={() => { }} />
+    <img onClick={() => { }} />
+    <label onClick={() => { }} />
+    <legend onClick={() => { }} />
+    <li onClick={() => { }} />
+    <mark onClick={() => { }} />
+    <marquee onClick={() => { }} />
+    <menu onClick={() => { }} />
+    <meter onClick={() => { }} />
+    <nav onClick={() => { }} />
+    <ol onClick={() => { }} />
+    <optgroup onClick={() => { }} />
+    <output onClick={() => { }} />
+    <p onClick={() => { }} />
+    <pre onClick={() => { }} />
+    <progress onClick={() => { }} />
+    <ruby onClick={() => { }} />
+    <section onClick={() => { }} aria-label="Aardvark" />
+    <section onClick={() => { }} aria-labelledby="js_1" />
+    <table onClick={() => { }} />
+    <tbody onClick={() => { }} />
+    <td onClick={() => { }} />
+    <tfoot onClick={() => { }} />
+    <thead onClick={() => { }} />
+    <time onClick={() => { }} />
+    <ul onClick={() => { }} />
+    <ul contentEditable="false" onClick={() => { }} />
+    <div role="alert" onClick={() => { }} />
+    <div role="alertdialog" onClick={() => { }} />
+    <div role="application" onClick={() => { }} />
+    <div role="banner" onClick={() => { }} />
+    <div role="cell" onClick={() => { }} />
+    <div role="complementary" onClick={() => { }} />
+    <div role="contentinfo" onClick={() => { }} />
+    <div role="definition" onClick={() => { }} />
+    <div role="dialog" onClick={() => { }} />
+    <div role="directory" onClick={() => { }} />
+    <div role="document" onClick={() => { }} />
+    <div role="feed" onClick={() => { }} />
+    <div role="figure" onClick={() => { }} />
+    <div role="form" onClick={() => { }} />
+    <div role="group" onClick={() => { }} />
+    <div role="heading" onClick={() => { }} />
+    <div role="img" onClick={() => { }} />
+    <div role="list" onClick={() => { }} />
+    <div role="listitem" onClick={() => { }} />
+    <div role="log" onClick={() => { }} />
+    <div role="main" onClick={() => { }} />
+    <div role="marquee" onClick={() => { }} />
+    <div role="math" onClick={() => { }} />
+    <div role="navigation" onClick={() => { }} />
+    <div role="note" onClick={() => { }} />
+    <div role="region" onClick={() => { }} />
+    <div role="rowgroup" onClick={() => { }} />
+    <div role="search" onClick={() => { }} />
+    <div role="status" onClick={() => { }} />
+    <div role="table" onClick={() => { }} />
+    <div role="tabpanel" onClick={() => { }} />
+    <div role="term" onClick={() => { }} />
+    <div role="timer" onClick={() => { }} />
+    <div role="tooltip" onClick={() => { }} />
+	  <div role="progressbar" onClick={() => { }} />
+</>
+
+```
+
+# Diagnostics
+```
+invalid.jsx:2:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    1 │ <>
+  > 2 │     <div onClick={() => { }} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │     <main onClick={() => void 0} />
+    4 │     <article onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:3:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    1 │ <>
+    2 │     <div onClick={() => { }} />
+  > 3 │     <main onClick={() => void 0} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │     <article onClick={() => { }} />
+    5 │     <aside onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:4:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    2 │     <div onClick={() => { }} />
+    3 │     <main onClick={() => void 0} />
+  > 4 │     <article onClick={() => { }} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │     <aside onClick={() => { }} />
+    6 │     <blockquote onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:5:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    3 │     <main onClick={() => void 0} />
+    4 │     <article onClick={() => { }} />
+  > 5 │     <aside onClick={() => { }} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │     <blockquote onClick={() => { }} />
+    7 │     <body onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:6:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    4 │     <article onClick={() => { }} />
+    5 │     <aside onClick={() => { }} />
+  > 6 │     <blockquote onClick={() => { }} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │     <body onClick={() => { }} />
+    8 │     <br onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:7:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    5 │     <aside onClick={() => { }} />
+    6 │     <blockquote onClick={() => { }} />
+  > 7 │     <body onClick={() => { }} />
+      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │     <br onClick={() => { }} />
+    9 │     <caption onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:8:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+     6 │     <blockquote onClick={() => { }} />
+     7 │     <body onClick={() => { }} />
+   > 8 │     <br onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │     <caption onClick={() => { }} />
+    10 │     <dd onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:9:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+     7 │     <body onClick={() => { }} />
+     8 │     <br onClick={() => { }} />
+   > 9 │     <caption onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │     <dd onClick={() => { }} />
+    11 │     <details onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:10:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+     8 │     <br onClick={() => { }} />
+     9 │     <caption onClick={() => { }} />
+  > 10 │     <dd onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │     <details onClick={() => { }} />
+    12 │     <dfn onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:11:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+     9 │     <caption onClick={() => { }} />
+    10 │     <dd onClick={() => { }} />
+  > 11 │     <details onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │     <dfn onClick={() => { }} />
+    13 │     <dl onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:12:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    10 │     <dd onClick={() => { }} />
+    11 │     <details onClick={() => { }} />
+  > 12 │     <dfn onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │     <dl onClick={() => { }} />
+    14 │     <dir onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:14:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    12 │     <dfn onClick={() => { }} />
+    13 │     <dl onClick={() => { }} />
+  > 14 │     <dir onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │     <dt onClick={() => { }} />
+    16 │     <fieldset onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:15:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    13 │     <dl onClick={() => { }} />
+    14 │     <dir onClick={() => { }} />
+  > 15 │     <dt onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │     <fieldset onClick={() => { }} />
+    17 │     <figcaption onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:16:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    14 │     <dir onClick={() => { }} />
+    15 │     <dt onClick={() => { }} />
+  > 16 │     <fieldset onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    17 │     <figcaption onClick={() => { }} />
+    18 │     <figure onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:17:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    15 │     <dt onClick={() => { }} />
+    16 │     <fieldset onClick={() => { }} />
+  > 17 │     <figcaption onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │     <figure onClick={() => { }} />
+    19 │     <footer onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:18:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    16 │     <fieldset onClick={() => { }} />
+    17 │     <figcaption onClick={() => { }} />
+  > 18 │     <figure onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    19 │     <footer onClick={() => { }} />
+    20 │     <form onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:19:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    17 │     <figcaption onClick={() => { }} />
+    18 │     <figure onClick={() => { }} />
+  > 19 │     <footer onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │     <form onClick={() => { }} />
+    21 │     <frame onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:20:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    18 │     <figure onClick={() => { }} />
+    19 │     <footer onClick={() => { }} />
+  > 20 │     <form onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │     <frame onClick={() => { }} />
+    22 │     <h1 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:21:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    19 │     <footer onClick={() => { }} />
+    20 │     <form onClick={() => { }} />
+  > 21 │     <frame onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    22 │     <h1 onClick={() => { }} />
+    23 │     <h2 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:22:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    20 │     <form onClick={() => { }} />
+    21 │     <frame onClick={() => { }} />
+  > 22 │     <h1 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    23 │     <h2 onClick={() => { }} />
+    24 │     <h3 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:23:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    21 │     <frame onClick={() => { }} />
+    22 │     <h1 onClick={() => { }} />
+  > 23 │     <h2 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    24 │     <h3 onClick={() => { }} />
+    25 │     <h4 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:24:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    22 │     <h1 onClick={() => { }} />
+    23 │     <h2 onClick={() => { }} />
+  > 24 │     <h3 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    25 │     <h4 onClick={() => { }} />
+    26 │     <h5 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:25:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    23 │     <h2 onClick={() => { }} />
+    24 │     <h3 onClick={() => { }} />
+  > 25 │     <h4 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │     <h5 onClick={() => { }} />
+    27 │     <h6 onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:26:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    24 │     <h3 onClick={() => { }} />
+    25 │     <h4 onClick={() => { }} />
+  > 26 │     <h5 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    27 │     <h6 onClick={() => { }} />
+    28 │     <iframe onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:27:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    25 │     <h4 onClick={() => { }} />
+    26 │     <h5 onClick={() => { }} />
+  > 27 │     <h6 onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    28 │     <iframe onClick={() => { }} />
+    29 │     <img onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:28:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    26 │     <h5 onClick={() => { }} />
+    27 │     <h6 onClick={() => { }} />
+  > 28 │     <iframe onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    29 │     <img onClick={() => { }} />
+    30 │     <label onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:29:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    27 │     <h6 onClick={() => { }} />
+    28 │     <iframe onClick={() => { }} />
+  > 29 │     <img onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    30 │     <label onClick={() => { }} />
+    31 │     <legend onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:30:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    28 │     <iframe onClick={() => { }} />
+    29 │     <img onClick={() => { }} />
+  > 30 │     <label onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    31 │     <legend onClick={() => { }} />
+    32 │     <li onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:31:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    29 │     <img onClick={() => { }} />
+    30 │     <label onClick={() => { }} />
+  > 31 │     <legend onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    32 │     <li onClick={() => { }} />
+    33 │     <mark onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:32:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    30 │     <label onClick={() => { }} />
+    31 │     <legend onClick={() => { }} />
+  > 32 │     <li onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    33 │     <mark onClick={() => { }} />
+    34 │     <marquee onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:33:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    31 │     <legend onClick={() => { }} />
+    32 │     <li onClick={() => { }} />
+  > 33 │     <mark onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    34 │     <marquee onClick={() => { }} />
+    35 │     <menu onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:34:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    32 │     <li onClick={() => { }} />
+    33 │     <mark onClick={() => { }} />
+  > 34 │     <marquee onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    35 │     <menu onClick={() => { }} />
+    36 │     <meter onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:35:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    33 │     <mark onClick={() => { }} />
+    34 │     <marquee onClick={() => { }} />
+  > 35 │     <menu onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    36 │     <meter onClick={() => { }} />
+    37 │     <nav onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:36:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    34 │     <marquee onClick={() => { }} />
+    35 │     <menu onClick={() => { }} />
+  > 36 │     <meter onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    37 │     <nav onClick={() => { }} />
+    38 │     <ol onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:37:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    35 │     <menu onClick={() => { }} />
+    36 │     <meter onClick={() => { }} />
+  > 37 │     <nav onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    38 │     <ol onClick={() => { }} />
+    39 │     <optgroup onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:38:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    36 │     <meter onClick={() => { }} />
+    37 │     <nav onClick={() => { }} />
+  > 38 │     <ol onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    39 │     <optgroup onClick={() => { }} />
+    40 │     <output onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:39:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    37 │     <nav onClick={() => { }} />
+    38 │     <ol onClick={() => { }} />
+  > 39 │     <optgroup onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    40 │     <output onClick={() => { }} />
+    41 │     <p onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:40:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    38 │     <ol onClick={() => { }} />
+    39 │     <optgroup onClick={() => { }} />
+  > 40 │     <output onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    41 │     <p onClick={() => { }} />
+    42 │     <pre onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:41:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    39 │     <optgroup onClick={() => { }} />
+    40 │     <output onClick={() => { }} />
+  > 41 │     <p onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^
+    42 │     <pre onClick={() => { }} />
+    43 │     <progress onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:42:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    40 │     <output onClick={() => { }} />
+    41 │     <p onClick={() => { }} />
+  > 42 │     <pre onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    43 │     <progress onClick={() => { }} />
+    44 │     <ruby onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:43:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    41 │     <p onClick={() => { }} />
+    42 │     <pre onClick={() => { }} />
+  > 43 │     <progress onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    44 │     <ruby onClick={() => { }} />
+    45 │     <section onClick={() => { }} aria-label="Aardvark" />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:44:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    42 │     <pre onClick={() => { }} />
+    43 │     <progress onClick={() => { }} />
+  > 44 │     <ruby onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    45 │     <section onClick={() => { }} aria-label="Aardvark" />
+    46 │     <section onClick={() => { }} aria-labelledby="js_1" />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:45:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    43 │     <progress onClick={() => { }} />
+    44 │     <ruby onClick={() => { }} />
+  > 45 │     <section onClick={() => { }} aria-label="Aardvark" />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    46 │     <section onClick={() => { }} aria-labelledby="js_1" />
+    47 │     <table onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:46:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    44 │     <ruby onClick={() => { }} />
+    45 │     <section onClick={() => { }} aria-label="Aardvark" />
+  > 46 │     <section onClick={() => { }} aria-labelledby="js_1" />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    47 │     <table onClick={() => { }} />
+    48 │     <tbody onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:47:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    45 │     <section onClick={() => { }} aria-label="Aardvark" />
+    46 │     <section onClick={() => { }} aria-labelledby="js_1" />
+  > 47 │     <table onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    48 │     <tbody onClick={() => { }} />
+    49 │     <td onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:48:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    46 │     <section onClick={() => { }} aria-labelledby="js_1" />
+    47 │     <table onClick={() => { }} />
+  > 48 │     <tbody onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    49 │     <td onClick={() => { }} />
+    50 │     <tfoot onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:49:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    47 │     <table onClick={() => { }} />
+    48 │     <tbody onClick={() => { }} />
+  > 49 │     <td onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    50 │     <tfoot onClick={() => { }} />
+    51 │     <thead onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:50:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    48 │     <tbody onClick={() => { }} />
+    49 │     <td onClick={() => { }} />
+  > 50 │     <tfoot onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    51 │     <thead onClick={() => { }} />
+    52 │     <time onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:51:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    49 │     <td onClick={() => { }} />
+    50 │     <tfoot onClick={() => { }} />
+  > 51 │     <thead onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    52 │     <time onClick={() => { }} />
+    53 │     <ul onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:52:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    50 │     <tfoot onClick={() => { }} />
+    51 │     <thead onClick={() => { }} />
+  > 52 │     <time onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    53 │     <ul onClick={() => { }} />
+    54 │     <ul contentEditable="false" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:53:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    51 │     <thead onClick={() => { }} />
+    52 │     <time onClick={() => { }} />
+  > 53 │     <ul onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    54 │     <ul contentEditable="false" onClick={() => { }} />
+    55 │     <div role="alert" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:54:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    52 │     <time onClick={() => { }} />
+    53 │     <ul onClick={() => { }} />
+  > 54 │     <ul contentEditable="false" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    55 │     <div role="alert" onClick={() => { }} />
+    56 │     <div role="alertdialog" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:55:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    53 │     <ul onClick={() => { }} />
+    54 │     <ul contentEditable="false" onClick={() => { }} />
+  > 55 │     <div role="alert" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    56 │     <div role="alertdialog" onClick={() => { }} />
+    57 │     <div role="application" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:56:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    54 │     <ul contentEditable="false" onClick={() => { }} />
+    55 │     <div role="alert" onClick={() => { }} />
+  > 56 │     <div role="alertdialog" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    57 │     <div role="application" onClick={() => { }} />
+    58 │     <div role="banner" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:57:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    55 │     <div role="alert" onClick={() => { }} />
+    56 │     <div role="alertdialog" onClick={() => { }} />
+  > 57 │     <div role="application" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    58 │     <div role="banner" onClick={() => { }} />
+    59 │     <div role="cell" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:58:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    56 │     <div role="alertdialog" onClick={() => { }} />
+    57 │     <div role="application" onClick={() => { }} />
+  > 58 │     <div role="banner" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    59 │     <div role="cell" onClick={() => { }} />
+    60 │     <div role="complementary" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:59:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    57 │     <div role="application" onClick={() => { }} />
+    58 │     <div role="banner" onClick={() => { }} />
+  > 59 │     <div role="cell" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    60 │     <div role="complementary" onClick={() => { }} />
+    61 │     <div role="contentinfo" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:60:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    58 │     <div role="banner" onClick={() => { }} />
+    59 │     <div role="cell" onClick={() => { }} />
+  > 60 │     <div role="complementary" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    61 │     <div role="contentinfo" onClick={() => { }} />
+    62 │     <div role="definition" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:61:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    59 │     <div role="cell" onClick={() => { }} />
+    60 │     <div role="complementary" onClick={() => { }} />
+  > 61 │     <div role="contentinfo" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    62 │     <div role="definition" onClick={() => { }} />
+    63 │     <div role="dialog" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:62:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    60 │     <div role="complementary" onClick={() => { }} />
+    61 │     <div role="contentinfo" onClick={() => { }} />
+  > 62 │     <div role="definition" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    63 │     <div role="dialog" onClick={() => { }} />
+    64 │     <div role="directory" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:63:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    61 │     <div role="contentinfo" onClick={() => { }} />
+    62 │     <div role="definition" onClick={() => { }} />
+  > 63 │     <div role="dialog" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    64 │     <div role="directory" onClick={() => { }} />
+    65 │     <div role="document" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:64:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    62 │     <div role="definition" onClick={() => { }} />
+    63 │     <div role="dialog" onClick={() => { }} />
+  > 64 │     <div role="directory" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    65 │     <div role="document" onClick={() => { }} />
+    66 │     <div role="feed" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:65:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    63 │     <div role="dialog" onClick={() => { }} />
+    64 │     <div role="directory" onClick={() => { }} />
+  > 65 │     <div role="document" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    66 │     <div role="feed" onClick={() => { }} />
+    67 │     <div role="figure" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:66:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    64 │     <div role="directory" onClick={() => { }} />
+    65 │     <div role="document" onClick={() => { }} />
+  > 66 │     <div role="feed" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    67 │     <div role="figure" onClick={() => { }} />
+    68 │     <div role="form" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:67:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    65 │     <div role="document" onClick={() => { }} />
+    66 │     <div role="feed" onClick={() => { }} />
+  > 67 │     <div role="figure" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    68 │     <div role="form" onClick={() => { }} />
+    69 │     <div role="group" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:68:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    66 │     <div role="feed" onClick={() => { }} />
+    67 │     <div role="figure" onClick={() => { }} />
+  > 68 │     <div role="form" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    69 │     <div role="group" onClick={() => { }} />
+    70 │     <div role="heading" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:69:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    67 │     <div role="figure" onClick={() => { }} />
+    68 │     <div role="form" onClick={() => { }} />
+  > 69 │     <div role="group" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    70 │     <div role="heading" onClick={() => { }} />
+    71 │     <div role="img" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:70:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    68 │     <div role="form" onClick={() => { }} />
+    69 │     <div role="group" onClick={() => { }} />
+  > 70 │     <div role="heading" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    71 │     <div role="img" onClick={() => { }} />
+    72 │     <div role="list" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:71:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    69 │     <div role="group" onClick={() => { }} />
+    70 │     <div role="heading" onClick={() => { }} />
+  > 71 │     <div role="img" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    72 │     <div role="list" onClick={() => { }} />
+    73 │     <div role="listitem" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:72:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    70 │     <div role="heading" onClick={() => { }} />
+    71 │     <div role="img" onClick={() => { }} />
+  > 72 │     <div role="list" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    73 │     <div role="listitem" onClick={() => { }} />
+    74 │     <div role="log" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:73:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    71 │     <div role="img" onClick={() => { }} />
+    72 │     <div role="list" onClick={() => { }} />
+  > 73 │     <div role="listitem" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    74 │     <div role="log" onClick={() => { }} />
+    75 │     <div role="main" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:74:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    72 │     <div role="list" onClick={() => { }} />
+    73 │     <div role="listitem" onClick={() => { }} />
+  > 74 │     <div role="log" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    75 │     <div role="main" onClick={() => { }} />
+    76 │     <div role="marquee" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:75:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    73 │     <div role="listitem" onClick={() => { }} />
+    74 │     <div role="log" onClick={() => { }} />
+  > 75 │     <div role="main" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    76 │     <div role="marquee" onClick={() => { }} />
+    77 │     <div role="math" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:76:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    74 │     <div role="log" onClick={() => { }} />
+    75 │     <div role="main" onClick={() => { }} />
+  > 76 │     <div role="marquee" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    77 │     <div role="math" onClick={() => { }} />
+    78 │     <div role="navigation" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:77:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    75 │     <div role="main" onClick={() => { }} />
+    76 │     <div role="marquee" onClick={() => { }} />
+  > 77 │     <div role="math" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    78 │     <div role="navigation" onClick={() => { }} />
+    79 │     <div role="note" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:78:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    76 │     <div role="marquee" onClick={() => { }} />
+    77 │     <div role="math" onClick={() => { }} />
+  > 78 │     <div role="navigation" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    79 │     <div role="note" onClick={() => { }} />
+    80 │     <div role="region" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:79:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    77 │     <div role="math" onClick={() => { }} />
+    78 │     <div role="navigation" onClick={() => { }} />
+  > 79 │     <div role="note" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    80 │     <div role="region" onClick={() => { }} />
+    81 │     <div role="rowgroup" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:80:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    78 │     <div role="navigation" onClick={() => { }} />
+    79 │     <div role="note" onClick={() => { }} />
+  > 80 │     <div role="region" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    81 │     <div role="rowgroup" onClick={() => { }} />
+    82 │     <div role="search" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:81:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    79 │     <div role="note" onClick={() => { }} />
+    80 │     <div role="region" onClick={() => { }} />
+  > 81 │     <div role="rowgroup" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    82 │     <div role="search" onClick={() => { }} />
+    83 │     <div role="status" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:82:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    80 │     <div role="region" onClick={() => { }} />
+    81 │     <div role="rowgroup" onClick={() => { }} />
+  > 82 │     <div role="search" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    83 │     <div role="status" onClick={() => { }} />
+    84 │     <div role="table" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:83:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    81 │     <div role="rowgroup" onClick={() => { }} />
+    82 │     <div role="search" onClick={() => { }} />
+  > 83 │     <div role="status" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    84 │     <div role="table" onClick={() => { }} />
+    85 │     <div role="tabpanel" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:84:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    82 │     <div role="search" onClick={() => { }} />
+    83 │     <div role="status" onClick={() => { }} />
+  > 84 │     <div role="table" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    85 │     <div role="tabpanel" onClick={() => { }} />
+    86 │     <div role="term" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:85:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    83 │     <div role="status" onClick={() => { }} />
+    84 │     <div role="table" onClick={() => { }} />
+  > 85 │     <div role="tabpanel" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    86 │     <div role="term" onClick={() => { }} />
+    87 │     <div role="timer" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:86:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    84 │     <div role="table" onClick={() => { }} />
+    85 │     <div role="tabpanel" onClick={() => { }} />
+  > 86 │     <div role="term" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    87 │     <div role="timer" onClick={() => { }} />
+    88 │     <div role="tooltip" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:87:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    85 │     <div role="tabpanel" onClick={() => { }} />
+    86 │     <div role="term" onClick={() => { }} />
+  > 87 │     <div role="timer" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    88 │     <div role="tooltip" onClick={() => { }} />
+    89 │ 	  <div role="progressbar" onClick={() => { }} />
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:88:5 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    86 │     <div role="term" onClick={() => { }} />
+    87 │     <div role="timer" onClick={() => { }} />
+  > 88 │     <div role="tooltip" onClick={() => { }} />
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    89 │ 	  <div role="progressbar" onClick={() => { }} />
+    90 │ </>
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```
+
+```
+invalid.jsx:89:4 lint/nursery/noNoninteractiveElementInteractions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Non-interactive element should not have event handler.
+  
+    87 │     <div role="timer" onClick={() => { }} />
+    88 │     <div role="tooltip" onClick={() => { }} />
+  > 89 │ 	  <div role="progressbar" onClick={() => { }} />
+       │ 	  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    90 │ </>
+    91 │ 
+  
+  i Consider replace semantically interactive element like <button/> or <a href/>.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/valid.jsx
@@ -1,0 +1,50 @@
+<>
+    {/* Custom Components */}
+    <TestComponent onClick={doFoo} />
+    <Button onClick={doFoo} />
+    <Image onClick={() => void 0} />
+
+    {/* Input element */}
+    <input onClick={() => void 0} />
+    <input type="button" onClick={() => void 0} />
+    <input type="checkbox" onClick={() => void 0} />
+    <input type="color" onClick={() => void 0} />
+
+    {/* Interactive element */}
+    <a onClick={() => void 0} />
+    <area onClick={() => { }} />
+    <button onClick={() => void 0} />
+    <menuitem onClick={() => { }} />
+    <option onClick={() => void 0} className="foo" />
+    <select onClick={() => void 0} className="foo" />
+    <textarea onClick={() => void 0} className="foo" />
+    <tr onClick={() => { }} />
+
+    {/* Element attributed with an interactive role*/}
+    <div role="button" onClick={() => { }} />
+    <div role="checkbox" onClick={() => { }} />
+    <div role="combobox" onClick={() => { }} />
+    <div role="gridcell" onClick={() => { }} />
+    <div role="link" onClick={() => { }} />
+    <div role="listbox" onClick={() => { }} />
+    <div role="menuitem" onClick={() => { }} />
+    <div role="menuitemcheckbox" onClick={() => { }} />
+    <div role="menuitemradio" onClick={() => { }} />
+    <div role="option" onClick={() => { }} />
+    <div role="radio" onClick={() => { }} />
+    <div role="row" onClick={() => { }} />
+    <div role="scrollbar" onClick={() => { }} />
+    <div role="searchbox" onClick={() => { }} />
+    <div role="slider" onClick={() => { }} />
+    <div role="spinbutton" onClick={() => { }} />
+    <div role="switch" onClick={() => { }} />
+    <div role="tab" onClick={() => { }} />
+    <div role="textbox" onClick={() => { }} />
+
+    {/* Presentation role */}
+    <div role="presentation" onClick={() => { }} />
+
+		<div onClick={() => {}} aria-hidden />
+		<div onClick={() => {}} aria-hidden="true" />
+
+</>

--- a/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noNoninteractiveElementInteractions/valid.jsx.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+snapshot_kind: text
+---
+# Input
+```jsx
+<>
+    {/* Custom Components */}
+    <TestComponent onClick={doFoo} />
+    <Button onClick={doFoo} />
+    <Image onClick={() => void 0} />
+
+    {/* Input element */}
+    <input onClick={() => void 0} />
+    <input type="button" onClick={() => void 0} />
+    <input type="checkbox" onClick={() => void 0} />
+    <input type="color" onClick={() => void 0} />
+
+    {/* Interactive element */}
+    <a onClick={() => void 0} />
+    <area onClick={() => { }} />
+    <button onClick={() => void 0} />
+    <menuitem onClick={() => { }} />
+    <option onClick={() => void 0} className="foo" />
+    <select onClick={() => void 0} className="foo" />
+    <textarea onClick={() => void 0} className="foo" />
+    <tr onClick={() => { }} />
+
+    {/* Element attributed with an interactive role*/}
+    <div role="button" onClick={() => { }} />
+    <div role="checkbox" onClick={() => { }} />
+    <div role="combobox" onClick={() => { }} />
+    <div role="gridcell" onClick={() => { }} />
+    <div role="link" onClick={() => { }} />
+    <div role="listbox" onClick={() => { }} />
+    <div role="menuitem" onClick={() => { }} />
+    <div role="menuitemcheckbox" onClick={() => { }} />
+    <div role="menuitemradio" onClick={() => { }} />
+    <div role="option" onClick={() => { }} />
+    <div role="radio" onClick={() => { }} />
+    <div role="row" onClick={() => { }} />
+    <div role="scrollbar" onClick={() => { }} />
+    <div role="searchbox" onClick={() => { }} />
+    <div role="slider" onClick={() => { }} />
+    <div role="spinbutton" onClick={() => { }} />
+    <div role="switch" onClick={() => { }} />
+    <div role="tab" onClick={() => { }} />
+    <div role="textbox" onClick={() => { }} />
+
+    {/* Presentation role */}
+    <div role="presentation" onClick={() => { }} />
+
+		<div onClick={() => {}} aria-hidden />
+		<div onClick={() => {}} aria-hidden="true" />
+
+</>
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx
@@ -1,0 +1,2 @@
+<div class="content-[''] absolute">Hello</div>;
+<div class='top-0 absolute'>Hello</div>;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_4855.jsx
+snapshot_kind: text
+---
+# Input
+```jsx
+<div class="content-[''] absolute">Hello</div>;
+<div class='top-0 absolute'>Hello</div>;
+
+```
+
+# Diagnostics
+```
+issue_4855.jsx:1:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These CSS classes should be sorted.
+  
+  > 1 │ <div class="content-[''] absolute">Hello</div>;
+      │            ^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ <div class='top-0 absolute'>Hello</div>;
+    3 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+    1   │ - <div·class="content-['']·absolute">Hello</div>;
+      1 │ + <div·class="absolute·content-['']">Hello</div>;
+    2 2 │   <div class='top-0 absolute'>Hello</div>;
+    3 3 │   
+  
+
+```
+
+```
+issue_4855.jsx:2:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! These CSS classes should be sorted.
+  
+    1 │ <div class="content-[''] absolute">Hello</div>;
+  > 2 │ <div class='top-0 absolute'>Hello</div>;
+      │            ^^^^^^^^^^^^^^^^
+    3 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+    1 1 │   <div class="content-[''] absolute">Hello</div>;
+    2   │ - <div·class='top-0·absolute'>Hello</div>;
+      2 │ + <div·class="absolute·top-0">Hello</div>;
+    3 3 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.options.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double"
+    }
+  },
+  "linter": {
+    "rules": {
+      "nursery": {
+        "useSortedClasses": {
+          "level": "error",
+          "options": {
+            "attributes": ["customClassAttribute"],
+            "functions": ["clsx", "tw", "tw.*"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
+++ b/crates/biome_js_formatter/src/jsx/tag/opening_element.rs
@@ -152,6 +152,9 @@ impl AnyJsxOpeningElement {
     fn compute_layout(&self, comments: &JsComments) -> SyntaxResult<OpeningElementLayout> {
         let attributes = self.attributes();
         let name = self.name()?;
+        let last_attribute_has_comments = self.attributes().last().map_or(false, |attribute| {
+            comments.has_trailing_comments(attribute.syntax())
+        });
 
         let name_has_comments = comments.has_comments(name.syntax())
             || self
@@ -171,7 +174,7 @@ impl AnyJsxOpeningElement {
         } else {
             OpeningElementLayout::IndentAttributes {
                 name_has_comments,
-                last_attribute_has_comments: has_last_attribute_comments(self, comments),
+                last_attribute_has_comments,
             }
         };
 
@@ -248,19 +251,4 @@ fn as_string_literal_attribute_value(attribute: &AnyJsxAttribute) -> Option<JsxS
         }
         JsxSpreadAttribute(_) => None,
     }
-}
-
-fn has_last_attribute_comments(element: &AnyJsxOpeningElement, comments: &JsComments) -> bool {
-    let has_comments_on_last_attribute = element
-        .attributes()
-        .last()
-        .map_or(false, |attribute| comments.has_comments(attribute.syntax()));
-
-    let last_attribute_has_comments = element
-        .syntax()
-        .tokens()
-        .map(|token| token.text().contains('>') && token.has_leading_comments())
-        .any(|has_comment| has_comment);
-
-    has_comments_on_last_attribute || last_attribute_has_comments
 }

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js
@@ -1,0 +1,26 @@
+describe("test", () => {
+  it(``, async () => {
+  });
+});
+  
+describe("test", () => {
+  it("wrooooooooooooooooooooooooooooooooooooooooooooong string" +
+    "second string", async () => {
+  });
+});
+
+it(`${foo + bar}
+  handles
+  some
+    newlines does something really long and complicated 
+    so I have to write a very long name for the test`, () => {
+});
+
+describe(`${foo + bar}`, 
+  () => {}
+);
+
+describe(`${foo + bar} wroooooooooooooooooooooooooooooong string`, 
+  () => {}
+);
+

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
@@ -1,0 +1,82 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/declarations/test_declaration.js
+---
+# Input
+
+```js
+describe("test", () => {
+  it(``, async () => {
+  });
+});
+  
+describe("test", () => {
+  it("wrooooooooooooooooooooooooooooooooooooooooooooong string" +
+    "second string", async () => {
+  });
+});
+
+it(`${foo + bar}
+  handles
+  some
+    newlines does something really long and complicated 
+    so I have to write a very long name for the test`, () => {
+});
+
+describe(`${foo + bar}`, 
+  () => {}
+);
+
+describe(`${foo + bar} wroooooooooooooooooooooooooooooong string`, 
+  () => {}
+);
+
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+-----
+
+```js
+describe("test", () => {
+	it(``, async () => {});
+});
+
+describe("test", () => {
+	it(
+		"wrooooooooooooooooooooooooooooooooooooooooooooong string" +
+			"second string",
+		async () => {},
+	);
+});
+
+it(`${foo + bar}
+  handles
+  some
+    newlines does something really long and complicated 
+    so I have to write a very long name for the test`, () => {});
+
+describe(`${foo + bar}`, () => {});
+
+describe(`${foo + bar} wroooooooooooooooooooooooooooooong string`, () => {});
+```

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx
@@ -29,5 +29,15 @@ const a = <div></div>;
 	Hi
 </Foo>;
 
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
+>
+	Hi
+</Foo>;
+
 <div className="hi" />;
 <div className="hi"></div>;

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 212
 info: jsx/bracket_same_line/bracket_same_line.jsx
 ---
 # Input
@@ -33,6 +32,16 @@ const a = <div></div>;
 		reallyLongAttributeName1={longComplexValue}
 		reallyLongAttributeName2={anotherLongValue}
 		// comment
+>
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
 >
 	Hi
 </Foo>;
@@ -97,6 +106,16 @@ const a = <div></div>;
 	Hi
 </Foo>;
 
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}
+>
+	Hi
+</Foo>;
+
 <div className="hi" />;
 <div className="hi"></div>;
 ```
@@ -147,6 +166,15 @@ const a = <div></div>;
 	reallyLongAttributeName2={anotherLongValue}
 	// comment
 >
+	Hi
+</Foo>;
+
+<Foo
+	className={style}
+	reallyLongAttributeName1={longComplexValue}
+	reallyLongAttributeName2={anotherLongValue}
+	// comment
+	reallyLongAttributeName3={yetAnotherLongValue}>
 	Hi
 </Foo>;
 

--- a/crates/biome_js_syntax/Cargo.toml
+++ b/crates/biome_js_syntax/Cargo.toml
@@ -11,12 +11,13 @@ repository.workspace = true
 version              = "0.5.7"
 
 [dependencies]
-biome_aria        = { workspace = true }
-biome_rowan       = { workspace = true, features = ["serde"] }
-biome_string_case = { workspace = true }
-enumflags2        = { workspace = true }
-schemars          = { workspace = true, optional = true }
-serde             = { workspace = true, features = ["derive"] }
+biome_aria          = { workspace = true }
+biome_aria_metadata = { workspace = true }
+biome_rowan         = { workspace = true, features = ["serde"] }
+biome_string_case   = { workspace = true }
+enumflags2          = { workspace = true }
+schemars            = { workspace = true, optional = true }
+serde               = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 biome_js_factory = { path = "../biome_js_factory" }

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -147,6 +147,7 @@ impl ServiceLanguage for CssLanguage {
                 .unwrap_or_default(),
             globals: Vec::new(),
             preferred_quote,
+            preferred_jsx_quote: Default::default(),
             jsx_runtime: None,
         };
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -210,6 +210,19 @@ impl ServiceLanguage for JsLanguage {
                     )
                 })
                 .unwrap_or_default();
+        let preferred_jsx_quote = global
+            .and_then(|global| {
+                global.languages.javascript.formatter.jsx_quote_style.map(
+                    |quote_style: QuoteStyle| {
+                        if quote_style == QuoteStyle::Single {
+                            PreferredQuote::Single
+                        } else {
+                            PreferredQuote::Double
+                        }
+                    },
+                )
+            })
+            .unwrap_or_default();
 
         let mut jsx_runtime = None;
         let mut globals = Vec::new();
@@ -276,6 +289,7 @@ impl ServiceLanguage for JsLanguage {
                 .unwrap_or_default(),
             globals,
             preferred_quote,
+            preferred_jsx_quote,
             jsx_runtime,
         };
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -140,6 +140,7 @@ impl ServiceLanguage for JsonLanguage {
                 .unwrap_or_default(),
             globals: vec![],
             preferred_quote: PreferredQuote::Double,
+            preferred_jsx_quote: Default::default(),
             jsx_runtime: Default::default(),
         };
         AnalyzerOptions {

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -42,6 +42,7 @@ pub fn create_analyzer_options(
         rules: AnalyzerRules::default(),
         globals: vec![],
         preferred_quote: PreferredQuote::Double,
+        preferred_jsx_quote: PreferredQuote::Double,
         jsx_runtime: Some(JsxRuntime::Transparent),
     };
     let options_file = input_file.with_extension("options.json");

--- a/justfile
+++ b/justfile
@@ -56,30 +56,30 @@ gen-grammar *args='':
 documentation:
   RUSTDOCFLAGS='-D warnings' cargo documentation
 
-# Creates a new lint rule in the given path, with the given name. Name has to be camel case.
+# Creates a new js lint rule with the given name. Name has to be camel case.
 new-js-lintrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=js --category=lint --name={{rulename}}
   just gen-lint
   just documentation
 
-# Creates a new lint rule in the given path, with the given name. Name has to be camel case.
+# Creates a new js assist rule with the given name. Name has to be camel case.
 new-js-assistrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=js --category=assist --name={{rulename}}
   just gen-lint
   just documentation
 
-  # Creates a new lint rule in the given path, with the given name. Name has to be camel case.
+# Creates a new json assist rule with the given name. Name has to be camel case.
 new-json-assistrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=json --category=assist --name={{rulename}}
   just gen-lint
   just documentation
 
-# Creates a new css lint rule in the given path, with the given name. Name has to be camel case.
+# Creates a new css lint rule with the given name. Name has to be camel case.
 new-css-lintrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=css --category=lint --name={{rulename}}
   just gen-lint
 
-# Creates a new css lint rule in the given path, with the given name. Name has to be camel case.
+# Creates a new graphql lint rule with the given name. Name has to be camel case.
 new-graphql-lintrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=graphql --category=lint --name={{rulename}}
   just gen-lint
@@ -167,4 +167,3 @@ new-changeset:
 # Dry-run of the release
 dry-run-release *args='':
     knope release --dry-run {{args}}
-

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "keywords": [],
   "author": "Biome Developers and Contributors",
   "license": "MIT OR Apache-2.0",
-  "packageManager": "pnpm@9.15.2"
+  "packageManager": "pnpm@9.15.3"
 }

--- a/packages/@biomejs/backend-jsonrpc/package.json
+++ b/packages/@biomejs/backend-jsonrpc/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT OR Apache-2.0",
   "devDependencies": {
-    "@types/node": "20.17.10",
+    "@types/node": "20.17.12",
     "typescript": "5.7.2",
     "vite": "5.4.11",
     "vitest": "1.6.0"

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1299,6 +1299,10 @@ export interface Nursery {
 	 */
 	noNestedTernary?: RuleConfiguration_for_Null;
 	/**
+	 * Disallow use event handlers on non-interactive elements.
+	 */
+	noNoninteractiveElementInteractions?: RuleConfiguration_for_Null;
+	/**
 	 * Disallow octal escape sequences in string literals
 	 */
 	noOctalEscape?: RuleConfiguration_for_Null;
@@ -3112,6 +3116,7 @@ export type Category =
 	| "lint/nursery/noMissingGenericFamilyKeyword"
 	| "lint/nursery/noMissingVarFunction"
 	| "lint/nursery/noNestedTernary"
+	| "lint/nursery/noNoninteractiveElementInteractions"
 	| "lint/nursery/noOctalEscape"
 	| "lint/nursery/noProcessEnv"
 	| "lint/nursery/noProcessGlobal"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2316,6 +2316,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noNoninteractiveElementInteractions": {
+					"description": "Disallow use event handlers on non-interactive elements.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noOctalEscape": {
 					"description": "Disallow octal escape sequences in string literals",
 					"anyOf": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,17 +57,17 @@ importers:
         version: 1.9.4
     devDependencies:
       '@types/node':
-        specifier: 20.17.10
-        version: 20.17.10
+        specifier: 20.17.12
+        version: 20.17.12
       typescript:
         specifier: 5.7.2
         version: 5.7.2
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.10)
+        version: 5.4.11(@types/node@20.17.12)
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.17.10)(happy-dom@15.11.7)
+        version: 1.6.0(@types/node@20.17.12)(happy-dom@15.11.7)
 
   packages/@biomejs/biome:
     optionalDependencies:
@@ -128,10 +128,10 @@ importers:
         version: 5.7.2
       vite:
         specifier: 5.4.11
-        version: 5.4.11(@types/node@20.17.10)
+        version: 5.4.11(@types/node@20.17.12)
       vitest:
         specifier: 1.6.0
-        version: 1.6.0(@types/node@20.17.10)(happy-dom@15.11.7)
+        version: 1.6.0(@types/node@20.17.12)(happy-dom@15.11.7)
 
   packages/@biomejs/wasm-bundler: {}
 
@@ -601,8 +601,8 @@ packages:
   '@types/node@20.12.12':
     resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
 
-  '@types/node@20.17.10':
-    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
+  '@types/node@20.17.12':
+    resolution: {integrity: sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1977,7 +1977,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.17.10':
+  '@types/node@20.17.12':
     dependencies:
       undici-types: 6.19.8
 
@@ -1985,7 +1985,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.12
 
   '@typescript-eslint/eslint-plugin@8.18.1(@typescript-eslint/parser@8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
@@ -3003,13 +3003,13 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite-node@1.6.0(@types/node@20.17.10):
+  vite-node@1.6.0(@types/node@20.17.12):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.11(@types/node@20.17.10)
+      vite: 5.4.11(@types/node@20.17.12)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3021,16 +3021,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@20.17.10):
+  vite@5.4.11(@types/node@20.17.12):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.23.0
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.12
       fsevents: 2.3.3
 
-  vitest@1.6.0(@types/node@20.17.10)(happy-dom@15.11.7):
+  vitest@1.6.0(@types/node@20.17.12)(happy-dom@15.11.7):
     dependencies:
       '@vitest/expect': 1.6.0
       '@vitest/runner': 1.6.0
@@ -3049,11 +3049,11 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.11(@types/node@20.17.10)
-      vite-node: 1.6.0(@types/node@20.17.10)
+      vite: 5.4.11(@types/node@20.17.12)
+      vite-node: 1.6.0(@types/node@20.17.12)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 20.17.12
       happy-dom: 15.11.7
     transitivePeerDependencies:
       - less

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   benchmark:
     devDependencies:
       '@typescript-eslint/eslint-plugin':
-        specifier: 8.18.1
-        version: 8.18.1(@typescript-eslint/parser@8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+        specifier: 8.19.1
+        version: 8.19.1(@typescript-eslint/parser@8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       dprint:
         specifier: 0.48.0
         version: 0.48.0
@@ -610,8 +610,8 @@ packages:
   '@types/ws@8.5.10':
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
 
-  '@typescript-eslint/eslint-plugin@8.18.1':
-    resolution: {integrity: sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==}
+  '@typescript-eslint/eslint-plugin@8.19.1':
+    resolution: {integrity: sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
@@ -628,31 +628,31 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/scope-manager@8.18.1':
-    resolution: {integrity: sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==}
+  '@typescript-eslint/scope-manager@8.19.1':
+    resolution: {integrity: sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/scope-manager@8.3.0':
     resolution: {integrity: sha512-mz2X8WcN2nVu5Hodku+IR8GgCOl4C0G/Z1ruaWN4dgec64kDBabuXyPAr+/RgJtumv8EEkqIzf3X2U5DUKB2eg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.18.1':
-    resolution: {integrity: sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==}
+  '@typescript-eslint/type-utils@8.19.1':
+    resolution: {integrity: sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/types@8.18.1':
-    resolution: {integrity: sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==}
+  '@typescript-eslint/types@8.19.1':
+    resolution: {integrity: sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.3.0':
     resolution: {integrity: sha512-y6sSEeK+facMaAyixM36dQ5NVXTnKWunfD1Ft4xraYqxP0lC0POJmIaL/mw72CUMqjY9qfyVfXafMeaUj0noWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.18.1':
-    resolution: {integrity: sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==}
+  '@typescript-eslint/typescript-estree@8.19.1':
+    resolution: {integrity: sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
@@ -666,15 +666,15 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@8.18.1':
-    resolution: {integrity: sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==}
+  '@typescript-eslint/utils@8.19.1':
+    resolution: {integrity: sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/visitor-keys@8.18.1':
-    resolution: {integrity: sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==}
+  '@typescript-eslint/visitor-keys@8.19.1':
+    resolution: {integrity: sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.3.0':
@@ -1532,6 +1532,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.0.0:
+    resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -1987,19 +1993,19 @@ snapshots:
     dependencies:
       '@types/node': 20.17.12
 
-  '@typescript-eslint/eslint-plugin@8.18.1(@typescript-eslint/parser@8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
+  '@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2))(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 8.3.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
-      '@typescript-eslint/scope-manager': 8.18.1
-      '@typescript-eslint/type-utils': 8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
-      '@typescript-eslint/visitor-keys': 8.18.1
+      '@typescript-eslint/scope-manager': 8.19.1
+      '@typescript-eslint/type-utils': 8.19.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.19.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.19.1
       eslint: 9.17.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.0(typescript@5.7.2)
+      ts-api-utils: 2.0.0(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2017,41 +2023,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.18.1':
+  '@typescript-eslint/scope-manager@8.19.1':
     dependencies:
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/visitor-keys': 8.18.1
+      '@typescript-eslint/types': 8.19.1
+      '@typescript-eslint/visitor-keys': 8.19.1
 
   '@typescript-eslint/scope-manager@8.3.0':
     dependencies:
       '@typescript-eslint/types': 8.3.0
       '@typescript-eslint/visitor-keys': 8.3.0
 
-  '@typescript-eslint/type-utils@8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
+  '@typescript-eslint/type-utils@8.19.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.7.2)
-      '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.19.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)
       debug: 4.3.7
       eslint: 9.17.0(jiti@1.21.6)
-      ts-api-utils: 1.4.0(typescript@5.7.2)
+      ts-api-utils: 2.0.0(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.18.1': {}
+  '@typescript-eslint/types@8.19.1': {}
 
   '@typescript-eslint/types@8.3.0': {}
 
-  '@typescript-eslint/typescript-estree@8.18.1(typescript@5.7.2)':
+  '@typescript-eslint/typescript-estree@8.19.1(typescript@5.7.2)':
     dependencies:
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/visitor-keys': 8.18.1
+      '@typescript-eslint/types': 8.19.1
+      '@typescript-eslint/visitor-keys': 8.19.1
       debug: 4.3.7
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.4.0(typescript@5.7.2)
+      ts-api-utils: 2.0.0(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
@@ -2071,20 +2077,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
+  '@typescript-eslint/utils@8.19.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.17.0(jiti@1.21.6))
-      '@typescript-eslint/scope-manager': 8.18.1
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 8.19.1
+      '@typescript-eslint/types': 8.19.1
+      '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.7.2)
       eslint: 9.17.0(jiti@1.21.6)
       typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.18.1':
+  '@typescript-eslint/visitor-keys@8.19.1':
     dependencies:
-      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/types': 8.19.1
       eslint-visitor-keys: 4.2.0
 
   '@typescript-eslint/visitor-keys@8.3.0':
@@ -2969,6 +2975,10 @@ snapshots:
       is-number: 7.0.0
 
   ts-api-utils@1.4.0(typescript@5.7.2):
+    dependencies:
+      typescript: 5.7.2
+
+  ts-api-utils@2.0.0(typescript@5.7.2):
     dependencies:
       typescript: 5.7.2
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #4874 

Jetbrains IDEs for relative file paths aren't clickable in diagnostics output. In webstorm, it requires prepending ` at ` (notice the whitespaces)

This does not fix the case where no line numbers and column numbers are displayed for relative paths. See test cases

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
<img width="929" alt="Screenshot 2025-01-11 at 7 55 24 AM" src="https://github.com/user-attachments/assets/bbad33b7-b1a9-480e-81a1-9adb3662bbd1" />

Test cases display:
- the environment variable
- a test where my relative path in my app was caught with a lint error but nothing was highlighted
- this PR only resolves relative file paths with column numbers and/or line numbers
- separate variant with only a line number
- test case that the absolute path case does work, regardless if there's a line number or not

<img width="629" alt="Screenshot 2025-01-11 at 7 57 24 AM" src="https://github.com/user-attachments/assets/3cfe8026-6ae5-4d4b-bb5f-b9fc66e4205d" />
- This is in PyCharm. Some devs develop across IDEs, and here it does work

<!-- What demonstrates that your implementation is correct? -->
