### PR TITLE
fix(biome_diagnostics): fix JetBrains relative file URLs should be clickable when given line and column numbers

### DIFF
--- a/.changeset/_fix_4875httpsgithubcombiomejsbiomeissues4875_where_the_jetbrains_ide_terminal_would_output_unclickable_relative_file_path_links_to_files_this_does_not_fix_paths_without_line_and_column_numbers_contributed_by_andrew_chen_wang.md
+++ b/.changeset/_fix_4875httpsgithubcombiomejsbiomeissues4875_where_the_jetbrains_ide_terminal_would_output_unclickable_relative_file_path_links_to_files_this_does_not_fix_paths_without_line_and_column_numbers_contributed_by_andrew_chen_wang.md
@@ -1,0 +1,5 @@
+---
+cli: patch
+---
+
+# - Fix [#4875](https://github.com/biomejs/biome/issues/4875), where the Jetbrains IDE terminal would output not clickable, relative file path link to the diagnostic file. This does not fix paths without line and column numbers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ## Unreleased
 
 - Fix [#4323](https://github.com/biomejs/biome/issues/4258), where `lint/a11y/useSemanticElement` accidentally showed recommendations for `role="searchbox"` instead of `role="search"`
-- Fix [#4875](https://github.com/biomejs/biome/issues/4875), where the Jetbrains IDE terminal would output unclickable, relative file path links to files. This does not fix paths without line and column numbers. Contributed by @Andrew-Chen-Wang
 
 ### Analyzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ our [guidelines for writing a good changelog entry](https://github.com/biomejs/b
 ## Unreleased
 
 - Fix [#4323](https://github.com/biomejs/biome/issues/4258), where `lint/a11y/useSemanticElement` accidentally showed recommendations for `role="searchbox"` instead of `role="search"`
+- Fix [#4875](https://github.com/biomejs/biome/issues/4875), where the Jetbrains IDE terminal would output unclickable, relative file path links to files. This does not fix paths without line and column numbers. Contributed by @Andrew-Chen-Wang
 
 ### Analyzer
 

--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -110,6 +110,11 @@ impl<D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'_, D> {
         };
 
         let is_vscode = env::var("TERM_PROGRAM").unwrap_or_default() == "vscode";
+        // https://github.com/JetBrains/jediterm/issues/253#issuecomment-1280492436
+        // https://github.com/JetBrains/intellij-community/blob/5ca79d879617e9cc82f61590b8d157d6a4ad8746/plugins/terminal/src/org/jetbrains/plugins/terminal/runner/LocalOptionsConfigurer.java#L94
+        let is_jetbrains = env::var("TERMINAL_EMULATOR")
+            .unwrap_or_default()
+            .contains("JetBrains");
 
         if let Some(name) = file_name {
             if is_vscode {
@@ -121,6 +126,8 @@ impl<D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'_, D> {
                     fmt.write_markup(markup! {
                         <Hyperlink href={link}>{name}</Hyperlink>
                     })?;
+                } else if is_jetbrains {
+                    fmt.write_str(&format!(" at {name}"))?;
                 } else {
                     fmt.write_str(name)?;
                 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #4874 

Jetbrains IDEs for relative file paths aren't clickable in diagnostics output. In webstorm, it requires prepending ` at ` (notice the whitespaces)

This does not fix the case where no line numbers and column numbers are displayed for relative paths. See test cases

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
The environment variable can be found here:
- comment: https://github.com/JetBrains/jediterm/issues/253#issuecomment-1280492436
- permalink: https://github.com/JetBrains/intellij-community/blob/5ca79d879617e9cc82f61590b8d157d6a4ad8746/plugins/terminal/src/org/jetbrains/plugins/terminal/runner/LocalOptionsConfigurer.java#L94

<img width="929" alt="Screenshot 2025-01-11 at 7 55 24 AM" src="https://github.com/user-attachments/assets/bbad33b7-b1a9-480e-81a1-9adb3662bbd1" />

Test cases display:
- the environment variable
- a test where my relative path in my app was caught with a lint error but nothing was highlighted
- this PR only resolves relative file paths with column numbers and/or line numbers
- separate variant with only a line number
- test case that the absolute path case does work, regardless if there's a line number or not

<img width="629" alt="Screenshot 2025-01-11 at 7 57 24 AM" src="https://github.com/user-attachments/assets/3cfe8026-6ae5-4d4b-bb5f-b9fc66e4205d" />
- This is in PyCharm. Some devs develop across IDEs, and here it does work

<!-- What demonstrates that your implementation is correct? -->
