### PR TITLE
feat(lint): implement `noFloatingPromises` rule for reguler `async` function

### DIFF
--- a/.changeset/add_the_new_rule_nofloatingpromises.md
+++ b/.changeset/add_the_new_rule_nofloatingpromises.md
@@ -1,0 +1,5 @@
+---
+cli: minor
+---
+
+# Add the new rule [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-floating-promises)

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -263,6 +263,14 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "@typescript-eslint/no-floating-promises" => {
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group.no_floating_promises.get_or_insert(Default::default());
+            rule.set_level(rule_severity.into());
+        }
         "@typescript-eslint/no-inferrable-types" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -268,8 +268,11 @@ pub(crate) fn migrate_eslint_any_rule(
                 return false;
             }
             let group = rules.nursery.get_or_insert_with(Default::default);
-            let rule = group.no_floating_promises.get_or_insert(Default::default());
-            rule.set_level(rule_severity.into());
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_floating_promises
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/no-inferrable-types" => {
             let group = rules.style.get_or_insert_with(Default::default);

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3068,6 +3068,10 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_exported_imports:
         Option<RuleConfiguration<biome_js_analyze::options::NoExportedImports>>,
+    #[doc = "Require Promise-like statements to be handled appropriately."]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_floating_promises:
+        Option<RuleFixConfiguration<biome_js_analyze::options::NoFloatingPromises>>,
     #[doc = "Disallow the use of __dirname and __filename in the global scope."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_global_dirname_filename:
@@ -3314,19 +3318,19 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -3388,6 +3392,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]),
     ];
 }
 impl RuleGroupExt for Nursery {
@@ -3489,209 +3494,214 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
+        if let Some(rule) = self.no_nested_ternary.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_octal_escape.as_ref() {
+        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_package_private_imports.as_ref() {
+        if let Some(rule) = self.no_octal_escape.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_process_env.as_ref() {
+        if let Some(rule) = self.no_package_private_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_process_global.as_ref() {
+        if let Some(rule) = self.no_process_env.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_process_global.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_restricted_types.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_types.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_static_element_interactions.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_substr.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
+        if let Some(rule) = self.no_substr.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_ts_ignore.as_ref() {
+        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_ts_ignore.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
+        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
+        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.no_useless_string_raw.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_string_raw.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.no_value_at_rule.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
+        if let Some(rule) = self.no_value_at_rule.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
+        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_at_index.as_ref() {
+        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_collapsed_if.as_ref() {
+        if let Some(rule) = self.use_at_index.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
+        if let Some(rule) = self.use_collapsed_if.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
+        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
+        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_deprecated_reason.as_ref() {
+        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_deprecated_reason.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_google_font_display.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_google_font_display.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]));
             }
         }
         index_set
@@ -3788,209 +3798,214 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
+        if let Some(rule) = self.no_nested_ternary.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_octal_escape.as_ref() {
+        if let Some(rule) = self.no_noninteractive_element_interactions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_package_private_imports.as_ref() {
+        if let Some(rule) = self.no_octal_escape.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_process_env.as_ref() {
+        if let Some(rule) = self.no_package_private_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_process_global.as_ref() {
+        if let Some(rule) = self.no_process_env.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_restricted_imports.as_ref() {
+        if let Some(rule) = self.no_process_global.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_restricted_types.as_ref() {
+        if let Some(rule) = self.no_restricted_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_types.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_static_element_interactions.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_substr.as_ref() {
+        if let Some(rule) = self.no_static_element_interactions.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
+        if let Some(rule) = self.no_substr.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.no_ts_ignore.as_ref() {
+        if let Some(rule) = self.no_template_curly_in_string.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_ts_ignore.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_class.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
+        if let Some(rule) = self.no_unknown_pseudo_element.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
+        if let Some(rule) = self.no_unknown_type_selector.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
+        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.no_useless_string_raw.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_regex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_string_raw.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.no_value_at_rule.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
+        if let Some(rule) = self.no_value_at_rule.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
+        if let Some(rule) = self.use_adjacent_overload_signatures.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_at_index.as_ref() {
+        if let Some(rule) = self.use_aria_props_supported_by_role.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_collapsed_if.as_ref() {
+        if let Some(rule) = self.use_at_index.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
+        if let Some(rule) = self.use_collapsed_if.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
+        if let Some(rule) = self.use_component_export_only_modules.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
+        if let Some(rule) = self.use_consistent_curly_braces.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_deprecated_reason.as_ref() {
+        if let Some(rule) = self.use_consistent_member_accessibility.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_deprecated_reason.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_google_font_display.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_google_font_display.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
-        if let Some(rule) = self.use_guard_for_in.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[51]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_guard_for_in.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[52]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[53]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[54]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[55]));
             }
         }
-        if let Some(rule) = self.use_strict_mode.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[56]));
             }
         }
-        if let Some(rule) = self.use_trim_start_end.as_ref() {
+        if let Some(rule) = self.use_strict_mode.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[57]));
             }
         }
-        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+        if let Some(rule) = self.use_trim_start_end.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[58]));
+            }
+        }
+        if let Some(rule) = self.use_valid_autocomplete.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[59]));
             }
         }
         index_set

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3258,6 +3258,7 @@ impl Nursery {
         "noDynamicNamespaceImportAccess",
         "noEnum",
         "noExportedImports",
+        "noFloatingPromises",
         "noGlobalDirnameFilename",
         "noHeadElement",
         "noHeadImportInDocument",
@@ -3453,37 +3454,37 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_global_dirname_filename.as_ref() {
+        if let Some(rule) = self.no_floating_promises.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_head_element.as_ref() {
+        if let Some(rule) = self.no_global_dirname_filename.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_head_import_in_document.as_ref() {
+        if let Some(rule) = self.no_head_element.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_img_element.as_ref() {
+        if let Some(rule) = self.no_head_import_in_document.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_irregular_whitespace.as_ref() {
+        if let Some(rule) = self.no_img_element.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_missing_var_function.as_ref() {
+        if let Some(rule) = self.no_irregular_whitespace.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_nested_ternary.as_ref() {
+        if let Some(rule) = self.no_missing_var_function.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
@@ -3752,37 +3753,37 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
             }
         }
-        if let Some(rule) = self.no_global_dirname_filename.as_ref() {
+        if let Some(rule) = self.no_floating_promises.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
             }
         }
-        if let Some(rule) = self.no_head_element.as_ref() {
+        if let Some(rule) = self.no_global_dirname_filename.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
             }
         }
-        if let Some(rule) = self.no_head_import_in_document.as_ref() {
+        if let Some(rule) = self.no_head_element.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
             }
         }
-        if let Some(rule) = self.no_img_element.as_ref() {
+        if let Some(rule) = self.no_head_import_in_document.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_irregular_whitespace.as_ref() {
+        if let Some(rule) = self.no_img_element.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_missing_var_function.as_ref() {
+        if let Some(rule) = self.no_irregular_whitespace.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_nested_ternary.as_ref() {
+        if let Some(rule) = self.no_missing_var_function.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
@@ -4064,6 +4065,10 @@ impl RuleGroupExt for Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noExportedImports" => self
                 .no_exported_imports
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noFloatingPromises" => self
+                .no_floating_promises
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noGlobalDirnameFilename" => self

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -149,6 +149,7 @@ define_categories! {
     "lint/nursery/noDynamicNamespaceImportAccess": "https://biomejs.dev/linter/rules/no-dynamic-namespace-import-access",
     "lint/nursery/noEnum": "https://biomejs.dev/linter/rules/no-enum",
     "lint/nursery/noExportedImports": "https://biomejs.dev/linter/rules/no-exported-imports",
+    "lint/nursery/noFloatingPromises": "https://biomejs.dev/linter/rules/no-floating-promises",
     "lint/nursery/noGlobalDirnameFilename": "https://biomejs.dev/linter/rules/no-global-dirname-filename",
     "lint/nursery/noHeadElement": "https://biomejs.dev/linter/rules/no-head-element",
     "lint/nursery/noHeadImportInDocument": "https://biomejs.dev/linter/rules/no-head-import-in-document",

--- a/crates/biome_js_analyze/src/lint/nursery.rs
+++ b/crates/biome_js_analyze/src/lint/nursery.rs
@@ -9,6 +9,7 @@ pub mod no_duplicate_else_if;
 pub mod no_dynamic_namespace_import_access;
 pub mod no_enum;
 pub mod no_exported_imports;
+pub mod no_floating_promises;
 pub mod no_global_dirname_filename;
 pub mod no_head_element;
 pub mod no_head_import_in_document;
@@ -60,6 +61,7 @@ declare_lint_group! {
             self :: no_dynamic_namespace_import_access :: NoDynamicNamespaceImportAccess ,
             self :: no_enum :: NoEnum ,
             self :: no_exported_imports :: NoExportedImports ,
+            self :: no_floating_promises :: NoFloatingPromises ,
             self :: no_global_dirname_filename :: NoGlobalDirnameFilename ,
             self :: no_head_element :: NoHeadElement ,
             self :: no_head_import_in_document :: NoHeadImportInDocument ,

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -6,8 +6,8 @@ use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     binding_ext::AnyJsBindingDeclaration, AnyJsExpression, AnyJsName, AnyTsReturnType, AnyTsType,
-    JsCallExpression, JsExpressionStatement, JsFileSource, JsFunctionDeclaration,
-    JsStaticMemberExpression, JsSyntaxKind, TsReturnTypeAnnotation,
+    JsCallExpression, JsExpressionStatement, JsFunctionDeclaration, JsStaticMemberExpression,
+    JsSyntaxKind, TsReturnTypeAnnotation,
 };
 use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
 
@@ -16,12 +16,12 @@ use crate::{services::semantic::Semantic, JsRuleAction};
 declare_lint_rule! {
     /// Require Promise-like statements to be handled appropriately.
     ///
-    /// "floating" Promise is one that is created without any code set up to handle any errors it might throw.
+    /// A "floating" `Promise` is one that is created without any code set up to handle any errors it might throw.
     /// Floating Promises can lead to several issues, including improperly sequenced operations, unhandled Promise rejections, and other unintended consequences.
     ///
     /// This rule will report Promise-valued statements that are not treated in one of the following ways:
-    /// - Calling its `.then()` with two arguments
-    /// - Calling its `.catch()` with one argument
+    /// - Calling its `.then()` method with two arguments
+    /// - Calling its `.catch()` method with one argument
     /// - `await`ing it
     /// - `return`ing it
     /// - `void`ing it
@@ -82,11 +82,6 @@ impl Rule for NoFloatingPromises {
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
-        let source_type = ctx.source_type::<JsFileSource>().language();
-        if !source_type.is_typescript() || source_type.is_definition_file() {
-            return None;
-        }
-
         let node = ctx.query();
         let model = ctx.model();
         let expression = node.expression().ok()?;
@@ -109,10 +104,6 @@ impl Rule for NoFloatingPromises {
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
-        //
-        // Read our guidelines to write great diagnostics:
-        // https://docs.rs/biome_analyze/latest/biome_analyze/#what-a-rule-should-say-to-the-user
-        //
         let node = ctx.query();
         Some(
             RuleDiagnostic::new(

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -1,0 +1,389 @@
+use biome_analyze::{
+    context::RuleContext, declare_lint_rule, FixKind, Rule, RuleDiagnostic, RuleSource,
+};
+use biome_console::markup;
+use biome_js_factory::make;
+use biome_js_semantic::SemanticModel;
+use biome_js_syntax::{
+    binding_ext::AnyJsBindingDeclaration, AnyJsExpression, AnyJsName, AnyTsReturnType, AnyTsType,
+    JsCallExpression, JsExpressionStatement, JsFileSource, JsFunctionDeclaration,
+    JsStaticMemberExpression, JsSyntaxKind, TsReturnTypeAnnotation,
+};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
+
+use crate::{services::semantic::Semantic, JsRuleAction};
+
+declare_lint_rule! {
+    /// Require Promise-like statements to be handled appropriately.
+    ///
+    /// "floating" Promise is one that is created without any code set up to handle any errors it might throw.
+    /// Floating Promises can lead to several issues, including improperly sequenced operations, unhandled Promise rejections, and other unintended consequences.
+    ///
+    /// This rule will report Promise-valued statements that are not treated in one of the following ways:
+    /// - Calling its `.then()` with two arguments
+    /// - Calling its `.catch()` with one argument
+    /// - `await`ing it
+    /// - `return`ing it
+    /// - `void`ing it
+    ///
+    /// :::caution
+    /// ## Important notes
+    ///
+    /// This rule is a work in progress, and is only partially implemented.
+    /// Progress is being tracked in the following GitHub issue: https://github.com/biomejs/biome/issues/3187
+    /// :::
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```ts,expect_diagnostic
+    /// async function returnsPromise(): Promise<string> {
+    ///   return 'value';
+    /// }
+    /// returnsPromise().then(() => {});
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```ts
+    /// async function returnsPromise(): Promise<string> {
+    ///   return 'value';
+    /// }
+    ///
+    /// await returnsPromise();
+    ///
+    /// void returnsPromise();
+    ///
+    /// // Calling .then() with two arguments
+    /// returnsPromise().then(
+    ///   () => {},
+    ///   () => {},
+    /// );
+    ///
+    /// // Calling .catch() with one argument
+    /// returnsPromise().catch(() => {});
+    /// ```
+    ///
+    pub NoFloatingPromises {
+        version: "next",
+        name: "noFloatingPromises",
+        language: "ts",
+        recommended: false,
+        sources: &[RuleSource::EslintTypeScript("no-floating-promises")],
+        fix_kind: FixKind::Safe,
+    }
+}
+
+impl Rule for NoFloatingPromises {
+    type Query = Semantic<JsExpressionStatement>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let source_type = ctx.source_type::<JsFileSource>().language();
+        if !source_type.is_typescript() || source_type.is_definition_file() {
+            return None;
+        }
+
+        let node = ctx.query();
+        let model = ctx.model();
+        let expression = node.expression().ok()?;
+        if let AnyJsExpression::JsCallExpression(js_call_expression) = expression {
+            let Ok(any_js_expression) = js_call_expression.callee() else {
+                return None;
+            };
+
+            if !is_callee_a_promise(&any_js_expression, model) {
+                return None;
+            }
+
+            if is_handled_promise(&js_call_expression) {
+                return None;
+            }
+
+            return Some(());
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        //
+        // Read our guidelines to write great diagnostics:
+        // https://docs.rs/biome_analyze/latest/biome_analyze/#what-a-rule-should-say-to-the-user
+        //
+        let node = ctx.query();
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                node.range(),
+                markup! {
+                    "A \"floating\" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior."
+                },
+            )
+            .note(markup! {
+                "This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator."
+            })
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
+        let node = ctx.query();
+        let expression = node.expression().ok()?;
+        let mut mutation = ctx.root().begin();
+
+        let await_expression = AnyJsExpression::JsAwaitExpression(make::js_await_expression(
+            make::token(JsSyntaxKind::AWAIT_KW)
+                .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
+            expression.clone().trim_leading_trivia()?,
+        ));
+
+        mutation.replace_node(expression, await_expression);
+        Some(JsRuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            ctx.metadata().applicability(),
+            markup! { "Add await operator." }.to_owned(),
+            mutation,
+        ))
+    }
+}
+
+/// Checks if the callee of a JavaScript expression is a promise.
+///
+/// This function inspects the callee of a given JavaScript expression to determine
+/// if it is a promise. It returns `true` if the callee is a promise, otherwise `false`.
+///
+/// The function works by finding the binding of the callee and checking if it is a promise.
+///
+/// # Arguments
+///
+/// * `callee` - A reference to an `AnyJsExpression` representing the callee to check.
+/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
+///
+/// # Returns
+///
+/// * `true` if the callee is a promise.
+/// * `false` otherwise.
+///
+/// # Examples
+///
+/// Example JavaScript code that would return `true`:
+/// ```typescript
+/// async function returnsPromise(): Promise<string> {
+///     return "value";
+/// }
+///
+/// returnsPromise().then(() => {});
+/// ```
+///
+/// Example JavaScript code that would return `false`:
+/// ```typescript
+/// function doesNotReturnPromise() {
+///     return 42;
+/// }
+///
+/// doesNotReturnPromise().then(() => {});
+/// ```
+fn is_callee_a_promise(callee: &AnyJsExpression, model: &SemanticModel) -> bool {
+    match callee {
+        AnyJsExpression::JsIdentifierExpression(ident_expr) => {
+            let Some(reference) = ident_expr.name().ok() else {
+                return false;
+            };
+
+            let Some(binding) = model.binding(&reference) else {
+                return false;
+            };
+
+            let Some(any_js_binding_decl) = binding.tree().declaration() else {
+                return false;
+            };
+
+            let AnyJsBindingDeclaration::JsFunctionDeclaration(func_decl) = any_js_binding_decl
+            else {
+                return false;
+            };
+
+            return is_function_a_promise(&func_decl);
+        }
+        AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
+            return is_member_expression_callee_a_promise(static_member_expr, model);
+        }
+        _ => {}
+    }
+    false
+}
+
+fn is_function_a_promise(func_decl: &JsFunctionDeclaration) -> bool {
+    func_decl.async_token().is_some() || is_return_type_promise(func_decl.return_type_annotation())
+}
+
+/// Checks if a TypeScript return type annotation is a `Promise`.
+///
+/// This function inspects the return type annotation of a TypeScript function to determine
+/// if it is a `Promise`. It returns `true` if the return type annotation is `Promise`, otherwise `false`.
+///
+/// # Arguments
+///
+/// * `return_type` - An optional `TsReturnTypeAnnotation` to check.
+///
+/// # Returns
+///
+/// * `true` if the return type annotation is `Promise`.
+/// * `false` otherwise.
+///
+/// # Examples
+///
+/// Example TypeScript code that would return `true`:
+/// ```typescript
+/// async function returnsPromise(): Promise<void> {}
+/// ```
+///
+/// Example TypeScript code that would return `false`:
+/// ```typescript
+/// function doesNotReturnPromise(): void {}
+/// ```
+fn is_return_type_promise(return_type: Option<TsReturnTypeAnnotation>) -> bool {
+    return_type
+        .and_then(|ts_return_type_anno| ts_return_type_anno.ty().ok())
+        .and_then(|any_ts_return_type| match any_ts_return_type {
+            AnyTsReturnType::AnyTsType(any_ts_type) => Some(any_ts_type),
+            _ => None,
+        })
+        .and_then(|any_ts_type| match any_ts_type {
+            AnyTsType::TsReferenceType(reference_type) => Some(reference_type),
+            _ => None,
+        })
+        .and_then(|reference_type| reference_type.name().ok())
+        .map_or(false, |name| name.text() == "Promise")
+}
+
+/// Checks if a `JsCallExpression` is a handled Promise-like expression.
+/// - Calling its .then() with two arguments
+/// - Calling its .catch() with one argument
+///
+/// Example TypeScript code that would return `true`:
+///
+/// ```typescript
+/// const promise: Promise<unknown> = new Promise((resolve, reject) => resolve('value'));
+/// promise.then(() => "aaa", () => null).finally(() => null)
+///
+/// const promise: Promise<unknown> = new Promise((resolve, reject) => resolve('value'));
+/// promise.then(() => "aaa").catch(() => null).finally(() => null)
+/// ```
+fn is_handled_promise(js_call_expression: &JsCallExpression) -> bool {
+    let Ok(expr) = js_call_expression.callee() else {
+        return false;
+    };
+
+    let AnyJsExpression::JsStaticMemberExpression(static_member_expr) = expr else {
+        return false;
+    };
+
+    let Ok(AnyJsName::JsName(name)) = static_member_expr.member() else {
+        return false;
+    };
+
+    let name = name.text();
+
+    if name == "finally" {
+        if let Ok(expr) = static_member_expr.object() {
+            if let Some(callee) = expr.as_js_call_expression() {
+                return is_handled_promise(callee);
+            }
+        }
+    }
+    if name == "catch" {
+        if let Ok(call_args) = js_call_expression.arguments() {
+            // just checking if there are any arguments, not if it's a function for simplicity
+            if call_args.args().len() > 0 {
+                return true;
+            }
+        }
+    }
+    if name == "then" {
+        if let Ok(call_args) = js_call_expression.arguments() {
+            // just checking arguments have a reject function from length
+            if call_args.args().len() >= 2 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Checks if the callee of a `JsStaticMemberExpression` is a promise expression.
+///
+/// This function inspects the callee of a `JsStaticMemberExpression` to determine
+/// if it is a promise expression. It returns `true` if the callee is a promise expression,
+/// otherwise `false`.
+///
+/// # Arguments
+///
+/// * `static_member_expr` - A reference to a `JsStaticMemberExpression` to check.
+/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
+///
+/// # Returns
+///
+/// * `true` if the callee is a promise expression.
+/// * `false` otherwise.
+///
+/// # Examples
+///
+/// Example TypeScript code that would return `true`:
+/// ```typescript
+/// async function returnsPromise(): Promise<void> {}
+///
+/// returnsPromise().then(() => null).catch(() => {});
+/// ```
+///
+/// Example TypeScript code that would return `false`:
+/// ```typescript
+/// function doesNotReturnPromise(): void {}
+///
+/// doesNotReturnPromise().then(() => null).catch(() => {});
+/// ```
+fn is_member_expression_callee_a_promise(
+    static_member_expr: &JsStaticMemberExpression,
+    model: &SemanticModel,
+) -> bool {
+    let Ok(expr) = static_member_expr.object() else {
+        return false;
+    };
+
+    let AnyJsExpression::JsCallExpression(js_call_expr) = expr else {
+        return false;
+    };
+
+    let Ok(callee) = js_call_expr.callee() else {
+        return false;
+    };
+
+    match callee {
+        AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
+            return is_member_expression_callee_a_promise(&static_member_expr, model);
+        }
+        AnyJsExpression::JsIdentifierExpression(ident_expr) => {
+            let Some(reference) = ident_expr.name().ok() else {
+                return false;
+            };
+            let Some(binding) = model.binding(&reference) else {
+                return false;
+            };
+
+            let Some(any_js_binding_decl) = binding.tree().declaration() else {
+                return false;
+            };
+
+            let AnyJsBindingDeclaration::JsFunctionDeclaration(func_decl) = any_js_binding_decl
+            else {
+                return false;
+            };
+            return is_function_a_promise(&func_decl);
+        }
+        _ => {}
+    }
+
+    false
+}

--- a/crates/biome_js_analyze/src/options.rs
+++ b/crates/biome_js_analyze/src/options.rs
@@ -98,6 +98,8 @@ pub type NoExtraNonNullAssertion = < lint :: suspicious :: no_extra_non_null_ass
 pub type NoFallthroughSwitchClause = < lint :: suspicious :: no_fallthrough_switch_clause :: NoFallthroughSwitchClause as biome_analyze :: Rule > :: Options ;
 pub type NoFlatMapIdentity =
     <lint::correctness::no_flat_map_identity::NoFlatMapIdentity as biome_analyze::Rule>::Options;
+pub type NoFloatingPromises =
+    <lint::nursery::no_floating_promises::NoFloatingPromises as biome_analyze::Rule>::Options;
 pub type NoFocusedTests =
     <lint::suspicious::no_focused_tests::NoFocusedTests as biome_analyze::Rule>::Options;
 pub type NoForEach = <lint::complexity::no_for_each::NoForEach as biome_analyze::Rule>::Options;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js
@@ -1,0 +1,5 @@
+async function returnsPromise() {
+  return 'value';
+}
+returnsPromise();
+returnsPromise().then(() => { }).finally(() => { });

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```jsx
+async function returnsPromise() {
+  return 'value';
+}
+returnsPromise();
+returnsPromise().then(() => { }).finally(() => { });
+
+```
+
+# Diagnostics
+```
+invalid.js:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │   return 'value';
+    3 │ }
+  > 4 │ returnsPromise();
+      │ ^^^^^^^^^^^^^^^^^
+    5 │ returnsPromise().then(() => { }).finally(() => { });
+    6 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Safe fix: Add await operator.
+  
+    4 │ await·returnsPromise();
+      │ ++++++                 
+
+```
+
+```
+invalid.js:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ }
+    4 │ returnsPromise();
+  > 5 │ returnsPromise().then(() => { }).finally(() => { });
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Safe fix: Add await operator.
+  
+    5 │ await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
+      │ ++++++                                                    
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
@@ -3,7 +3,7 @@ source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
 ---
 # Input
-```jsx
+```js
 async function returnsPromise() {
   return 'value';
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.js.snap
@@ -14,7 +14,7 @@ returnsPromise().then(() => { }).finally(() => { });
 
 # Diagnostics
 ```
-invalid.js:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:4:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
@@ -27,15 +27,11 @@ invalid.js:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━�
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Safe fix: Add await operator.
-  
-    4 │ await·returnsPromise();
-      │ ++++++                 
 
 ```
 
 ```
-invalid.js:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
@@ -47,9 +43,5 @@ invalid.js:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━�
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Safe fix: Add await operator.
-  
-    5 │ await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
-      │ ++++++                                                    
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -1,0 +1,5 @@
+async function returnsPromise(): Promise<string> {
+  return 'value';
+}
+returnsPromise();
+returnsPromise().then(() => { }).finally(() => { });

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -4,6 +4,20 @@ async function returnsPromise(): Promise<string> {
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
 
+async function returnsPromiseInAsyncFunction(): Promise<void> {
+  returnsPromise();
+}
+
+const returnsPromiseInAsyncArrowFunction = async (): Promise<void> => {
+  returnsPromise().then(() => { }).finally(() => { });
+}
+
+class Test {
+  async returnsPromiseInAsyncClassMethod(): Promise<void> {
+    returnsPromise();
+  }
+}
+
 
 function returnsPromiseWithoutAsync(): Promise<string> {
   return Promise.resolve("value")

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -3,3 +3,11 @@ async function returnsPromise(): Promise<string> {
 }
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
+
+
+function returnsPromiseWithoutAsync(): Promise<string> {
+  return Promise.resolve("value")
+}
+
+
+returnsPromiseWithoutAsync()

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+async function returnsPromise(): Promise<string> {
+  return 'value';
+}
+returnsPromise();
+returnsPromise().then(() => { }).finally(() => { });
+
+```
+
+# Diagnostics
+```
+invalid.ts:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │   return 'value';
+    3 │ }
+  > 4 │ returnsPromise();
+      │ ^^^^^^^^^^^^^^^^^
+    5 │ returnsPromise().then(() => { }).finally(() => { });
+    6 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Safe fix: Add await operator.
+  
+    4 │ await·returnsPromise();
+      │ ++++++                 
+
+```
+
+```
+invalid.ts:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ }
+    4 │ returnsPromise();
+  > 5 │ returnsPromise().then(() => { }).finally(() => { });
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Safe fix: Add await operator.
+  
+    5 │ await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
+      │ ++++++                                                    
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -10,6 +10,13 @@ async function returnsPromise(): Promise<string> {
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
 
+
+function returnsPromiseWithoutAsync(): Promise<string> {
+  return Promise.resolve("value")
+}
+
+
+returnsPromiseWithoutAsync()
 ```
 
 # Diagnostics
@@ -51,5 +58,22 @@ invalid.ts:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━�
   
     5 │ await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
       │ ++++++                                                    
+
+```
+
+```
+invalid.ts:13:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+  > 13 │ returnsPromiseWithoutAsync()
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Safe fix: Add await operator.
+  
+    13 │ await·returnsPromiseWithoutAsync()
+       │ ++++++                            
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -10,6 +10,20 @@ async function returnsPromise(): Promise<string> {
 returnsPromise();
 returnsPromise().then(() => { }).finally(() => { });
 
+async function returnsPromiseInAsyncFunction(): Promise<void> {
+  returnsPromise();
+}
+
+const returnsPromiseInAsyncArrowFunction = async (): Promise<void> => {
+  returnsPromise().then(() => { }).finally(() => { });
+}
+
+class Test {
+  async returnsPromiseInAsyncClassMethod(): Promise<void> {
+    returnsPromise();
+  }
+}
+
 
 function returnsPromiseWithoutAsync(): Promise<string> {
   return Promise.resolve("value")
@@ -21,7 +35,7 @@ returnsPromiseWithoutAsync()
 
 # Diagnostics
 ```
-invalid.ts:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:4:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
@@ -34,15 +48,11 @@ invalid.ts:4:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━�
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Safe fix: Add await operator.
-  
-    4 │ await·returnsPromise();
-      │ ++++++                 
 
 ```
 
 ```
-invalid.ts:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
@@ -51,29 +61,83 @@ invalid.ts:5:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━�
   > 5 │ returnsPromise().then(() => { }).finally(() => { });
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     6 │ 
+    7 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Safe fix: Add await operator.
-  
-    5 │ await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
-      │ ++++++                                                    
 
 ```
 
 ```
-invalid.ts:13:1 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:8:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-  > 13 │ returnsPromiseWithoutAsync()
+     7 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
+   > 8 │   returnsPromise();
+       │   ^^^^^^^^^^^^^^^^^
+     9 │ }
+    10 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    8 │ ··await·returnsPromise();
+      │   ++++++                 
+
+```
+
+```
+invalid.ts:12:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    11 │ const returnsPromiseInAsyncArrowFunction = async (): Promise<void> => {
+  > 12 │   returnsPromise().then(() => { }).finally(() => { });
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    13 │ }
+    14 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    12 │ ··await·returnsPromise().then(()·=>·{·}).finally(()·=>·{·});
+       │   ++++++                                                    
+
+```
+
+```
+invalid.ts:17:5 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    15 │ class Test {
+    16 │   async returnsPromiseInAsyncClassMethod(): Promise<void> {
+  > 17 │     returnsPromise();
+       │     ^^^^^^^^^^^^^^^^^
+    18 │   }
+    19 │ }
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    17 │ ····await·returnsPromise();
+       │     ++++++                 
+
+```
+
+```
+invalid.ts:27:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+  > 27 │ returnsPromiseWithoutAsync()
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Safe fix: Add await operator.
-  
-    13 │ await·returnsPromiseWithoutAsync()
-       │ ++++++                            
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js
@@ -1,0 +1,14 @@
+async function returnsPromise() {
+  return 'value';
+}
+
+await returnsPromise();
+void returnsPromise();
+return returnsPromise();
+
+returnsPromise().then(
+  () => { },
+  () => { },
+);
+
+returnsPromise().catch(() => { });

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
@@ -3,7 +3,7 @@ source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
 ---
 # Input
-```jsx
+```js
 async function returnsPromise() {
   return 'value';
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.js
+---
+# Input
+```jsx
+async function returnsPromise() {
+  return 'value';
+}
+
+await returnsPromise();
+void returnsPromise();
+return returnsPromise();
+
+returnsPromise().then(
+  () => { },
+  () => { },
+);
+
+returnsPromise().catch(() => { });
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
@@ -1,0 +1,15 @@
+/* should not generate diagnostics */
+async function returnsPromise(): Promise<string> {
+  return 'value';
+}
+
+await returnsPromise();
+void returnsPromise();
+return returnsPromise();
+
+returnsPromise().then(
+  () => { },
+  () => { },
+);
+
+returnsPromise().catch(() => { });

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+async function returnsPromise(): Promise<string> {
+  return 'value';
+}
+
+await returnsPromise();
+void returnsPromise();
+return returnsPromise();
+
+returnsPromise().then(
+  () => { },
+  () => { },
+);
+
+returnsPromise().catch(() => { });
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1483,6 +1483,10 @@ export interface Nursery {
 	 */
 	noExportedImports?: RuleConfiguration_for_Null;
 	/**
+	 * Require Promise-like statements to be handled appropriately.
+	 */
+	noFloatingPromises?: RuleFixConfiguration_for_Null;
+	/**
 	 * Disallow the use of __dirname and __filename in the global scope.
 	 */
 	noGlobalDirnameFilename?: RuleFixConfiguration_for_Null;
@@ -3272,6 +3276,7 @@ export type Category =
 	| "lint/nursery/noDynamicNamespaceImportAccess"
 	| "lint/nursery/noEnum"
 	| "lint/nursery/noExportedImports"
+	| "lint/nursery/noFloatingPromises"
 	| "lint/nursery/noGlobalDirnameFilename"
 	| "lint/nursery/noHeadElement"
 	| "lint/nursery/noHeadImportInDocument"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2533,6 +2533,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noFloatingPromises": {
+					"description": "Require Promise-like statements to be handled appropriately.",
+					"anyOf": [
+						{ "$ref": "#/definitions/RuleFixConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noGlobalDirnameFilename": {
 					"description": "Disallow the use of __dirname and __filename in the global scope.",
 					"anyOf": [


### PR DESCRIPTION


<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
related: https://github.com/biomejs/biome/issues/3187
This pull request introduces the initial implementation of the no-floating-promises rule.

The rule reports Promise-valued statements that are not treated in one of the following ways:
- Calling .then() with two arguments
- Calling .catch() with one argument
- Awaiting the Promise
- Returning
- Using the void operator

> [!NOTE]
> ### Current Scope:
> - This PR currently covers simple async functions.
> - Currently, reassigning functions is not supported 

### Example of invalid code:
```
async function returnsPromise(): Promise<string> {
  return 'value';
}
returnsPromise().then(() => {});
```

### Example of valid code:
```
async function returnsPromise(): Promise<string> {
  return 'value';
}

await returnsPromise();
void returnsPromise();

// Calling .then() with two arguments
returnsPromise().then(
  () => {},
  () => {}
);
```


### Remaining TODOs for Future PRs
- Support arrow functions
- Support promises like Promise.all, etc.
- Support class methods
- Support object methods