### PR TITLE
fix: RegExpStringIterator missing from globals

### DIFF
--- a/crates/biome_js_analyze/src/globals/typescript/language.rs
+++ b/crates/biome_js_analyze/src/globals/typescript/language.rs
@@ -1048,6 +1048,7 @@ pub const ES_2020: &[&str] = &[
     "RegExpConstructor",
     "RegExpExecArray",
     "RegExpMatchArray",
+    "RegExpStringIterator",
     "Required",
     "ReturnType",
     "Set",


### PR DESCRIPTION
## Summary

TL;DR: Added RegExpStringIterator to the list of TypeScript Globals. It already exists in the codebase that Biome used as a source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/scope-manager/src/lib/es2020.symbol.wellknown.ts#L16, however looks like Biome was using an older commit which is why it didn't exist in the list.

Demonstration of the current problem:

I have some code as follows:

```ts
const matches = doc.matchAll(/^-\s+(?<ip>.*)$/gm) as RegExpStringIterator<
  RegExpExecArray & {
    groups: {
      ip?: string
    }
  }
>
```

Ideally, I'd use `matches.groups['ip']`, but then Biome complains that I should use the property directly instead of indexed access. To solve that, I'm asserting the type by specifying the groups that should optionally exist based on my Regular Expression. The default type of `.matchAll` is `RegExpStringIterator`, so I'm using `RegExpStringIterator` as well.

## Test Plan

Biome should no longer complain as follows:

```
lint/correctness/noUndeclaredVariables ━━━━━━━━━━

  ⚠ The RegExpStringIterator variable is undeclared.
  
<omitted>

  ℹ By default, Biome recognizes browser and Node.js globals.
    You can ignore more globals using the javascript.globals configuration.
```