### PR TITLE
feat(analyzer): useAltText don't check object spread

### DIFF
--- a/.changeset/usealttext_dont_check_object_spread.md
+++ b/.changeset/usealttext_dont_check_object_spread.md
@@ -1,0 +1,12 @@
+---
+cli: minor
+biome_js_analyze: minor
+---
+
+# Rule `lint/a11y/useAltText` don't check element's attributes contain object spread.
+
+The following code can pass check:
+
+```jsx
+<img src="test.png" alt={alt} {...restProps}></img>
+```

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -181,7 +181,6 @@ fn has_valid_alt_text(element: &AnyJsxElement) -> bool {
             attribute
                 .as_static_value()
                 .map_or(true, |value| !value.is_null_or_undefined())
-                && !element.has_trailing_spread_prop(&attribute)
         })
 }
 
@@ -194,7 +193,7 @@ fn has_valid_label(element: &AnyJsxElement, name_to_lookup: &str) -> bool {
             }
             attribute.as_static_value().map_or(true, |value| {
                 !value.is_null_or_undefined() && value.is_not_string_constant("")
-            }) && !element.has_trailing_spread_prop(&attribute)
+            })
         })
 }
 

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -15,7 +15,7 @@ use std::{fs::read_to_string, slice};
 #[ignore]
 #[test]
 fn quick_test() {
-    let input_file = Utf8Path::new("tests/specs/complexity/noUselessFragments/issue_4751.jsx");
+    let input_file = Utf8Path::new("tests/specs/a11y/useAltText/img.jsx");
     let file_name = input_file.file_name().unwrap();
 
     let (group, rule) = parse_test_path(input_file);

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx
@@ -54,4 +54,7 @@
   <img aria-labelledby="id1" />
   <img aria-hidden />
   <img aria-hidden={true} />
+  <img alt="alt tag" src="" {...(flag && { referrerPolicy: 'no-referrer' })}></img>
+  <img src="test" alt="this is a cool image" {...restProps}></img>
+  <img alt={alt || ""} {...props} />
 </>;

--- a/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useAltText/img.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: img.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -60,6 +61,9 @@ expression: img.jsx
   <img aria-labelledby="id1" />
   <img aria-hidden />
   <img aria-hidden={true} />
+  <img alt="alt tag" src="" {...(flag && { referrerPolicy: 'no-referrer' })}></img>
+  <img src="test" alt="this is a cool image" {...restProps}></img>
+  <img alt={alt || ""} {...props} />
 </>;
 
 ```


### PR DESCRIPTION
## Summary

closes: #3977 

Ignore the object spread when `lint/a11y/useAltText` check element's attribute, the following code can pass check:

```ts
<img src="test.png" alt={alt} {...restProps}></img>
```

## Test Plan

Add test case

<!-- What demonstrates that your implementation is correct? -->
