### PR TITLE
fix(grit): allow parsing alternative engine/language names

### DIFF
--- a/crates/biome_grit_factory/src/generated/node_factory.rs
+++ b/crates/biome_grit_factory/src/generated/node_factory.rs
@@ -198,6 +198,12 @@ pub fn grit_double_literal(value_token: SyntaxToken) -> GritDoubleLiteral {
         [Some(SyntaxElement::Token(value_token))],
     ))
 }
+pub fn grit_engine_name(engine_kind_token: SyntaxToken) -> GritEngineName {
+    GritEngineName::unwrap_cast(SyntaxNode::new_detached(
+        GritSyntaxKind::GRIT_ENGINE_NAME,
+        [Some(SyntaxElement::Token(engine_kind_token))],
+    ))
+}
 pub fn grit_every(every_token: SyntaxToken, pattern: AnyGritMaybeCurlyPattern) -> GritEvery {
     GritEvery::unwrap_cast(SyntaxNode::new_detached(
         GritSyntaxKind::GRIT_EVERY,
@@ -251,7 +257,7 @@ pub fn grit_int_literal(value_token: SyntaxToken) -> GritIntLiteral {
 }
 pub fn grit_language_declaration(
     language_token: SyntaxToken,
-    name: GritLanguageName,
+    name: AnyGritLanguageName,
 ) -> GritLanguageDeclarationBuilder {
     GritLanguageDeclarationBuilder {
         language_token,
@@ -262,7 +268,7 @@ pub fn grit_language_declaration(
 }
 pub struct GritLanguageDeclarationBuilder {
     language_token: SyntaxToken,
-    name: GritLanguageName,
+    name: AnyGritLanguageName,
     flavor: Option<GritLanguageFlavor>,
     semicolon_token: Option<SyntaxToken>,
 }
@@ -316,7 +322,7 @@ pub fn grit_language_name(language_kind_token: SyntaxToken) -> GritLanguageName 
     ))
 }
 pub fn grit_language_specific_snippet(
-    language: GritLanguageName,
+    language: AnyGritLanguageName,
     snippet_token: SyntaxToken,
 ) -> GritLanguageSpecificSnippet {
     GritLanguageSpecificSnippet::unwrap_cast(SyntaxNode::new_detached(
@@ -1468,7 +1474,7 @@ pub fn grit_variable(value_token: SyntaxToken) -> GritVariable {
 }
 pub fn grit_version(
     engine_token: SyntaxToken,
-    biome_token: SyntaxToken,
+    engine_name: GritEngineName,
     l_paren_token: SyntaxToken,
     version: GritDoubleLiteral,
     r_paren_token: SyntaxToken,
@@ -1477,7 +1483,7 @@ pub fn grit_version(
         GritSyntaxKind::GRIT_VERSION,
         [
             Some(SyntaxElement::Token(engine_token)),
-            Some(SyntaxElement::Token(biome_token)),
+            Some(SyntaxElement::Node(engine_name.into_syntax())),
             Some(SyntaxElement::Token(l_paren_token)),
             Some(SyntaxElement::Node(version.into_syntax())),
             Some(SyntaxElement::Token(r_paren_token)),
@@ -1688,6 +1694,16 @@ where
         slots,
     ))
 }
+pub fn grit_bogus_engine_name<I>(slots: I) -> GritBogusEngineName
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    GritBogusEngineName::unwrap_cast(SyntaxNode::new_detached(
+        GritSyntaxKind::GRIT_BOGUS_ENGINE_NAME,
+        slots,
+    ))
+}
 pub fn grit_bogus_language_declaration<I>(slots: I) -> GritBogusLanguageDeclaration
 where
     I: IntoIterator<Item = Option<SyntaxElement>>,
@@ -1705,6 +1721,16 @@ where
 {
     GritBogusLanguageFlavorKind::unwrap_cast(SyntaxNode::new_detached(
         GritSyntaxKind::GRIT_BOGUS_LANGUAGE_FLAVOR_KIND,
+        slots,
+    ))
+}
+pub fn grit_bogus_language_name<I>(slots: I) -> GritBogusLanguageName
+where
+    I: IntoIterator<Item = Option<SyntaxElement>>,
+    I::IntoIter: ExactSizeIterator,
+{
+    GritBogusLanguageName::unwrap_cast(SyntaxNode::new_detached(
+        GritSyntaxKind::GRIT_BOGUS_LANGUAGE_NAME,
         slots,
     ))
 }

--- a/crates/biome_grit_factory/src/generated/node_factory.rs
+++ b/crates/biome_grit_factory/src/generated/node_factory.rs
@@ -1694,16 +1694,6 @@ where
         slots,
     ))
 }
-pub fn grit_bogus_engine_name<I>(slots: I) -> GritBogusEngineName
-where
-    I: IntoIterator<Item = Option<SyntaxElement>>,
-    I::IntoIter: ExactSizeIterator,
-{
-    GritBogusEngineName::unwrap_cast(SyntaxNode::new_detached(
-        GritSyntaxKind::GRIT_BOGUS_ENGINE_NAME,
-        slots,
-    ))
-}
 pub fn grit_bogus_language_declaration<I>(slots: I) -> GritBogusLanguageDeclaration
 where
     I: IntoIterator<Item = Option<SyntaxElement>>,

--- a/crates/biome_grit_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_grit_factory/src/generated/syntax_factory.rs
@@ -17,7 +17,6 @@ impl SyntaxFactory for GritSyntaxFactory {
             GRIT_BOGUS
             | GRIT_BOGUS_CONTAINER
             | GRIT_BOGUS_DEFINITION
-            | GRIT_BOGUS_ENGINE_NAME
             | GRIT_BOGUS_LANGUAGE_DECLARATION
             | GRIT_BOGUS_LANGUAGE_FLAVOR_KIND
             | GRIT_BOGUS_LANGUAGE_NAME

--- a/crates/biome_grit_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_grit_factory/src/generated/syntax_factory.rs
@@ -17,8 +17,10 @@ impl SyntaxFactory for GritSyntaxFactory {
             GRIT_BOGUS
             | GRIT_BOGUS_CONTAINER
             | GRIT_BOGUS_DEFINITION
+            | GRIT_BOGUS_ENGINE_NAME
             | GRIT_BOGUS_LANGUAGE_DECLARATION
             | GRIT_BOGUS_LANGUAGE_FLAVOR_KIND
+            | GRIT_BOGUS_LANGUAGE_NAME
             | GRIT_BOGUS_LITERAL
             | GRIT_BOGUS_MAP_ELEMENT
             | GRIT_BOGUS_NAMED_ARG
@@ -426,6 +428,25 @@ impl SyntaxFactory for GritSyntaxFactory {
                 }
                 slots.into_node(GRIT_DOUBLE_LITERAL, children)
             }
+            GRIT_ENGINE_NAME => {
+                let mut elements = (&children).into_iter();
+                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
+                let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if matches!(element.kind(), T![biome] | T![marzano]) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if current_element.is_some() {
+                    return RawSyntaxNode::new(
+                        GRIT_ENGINE_NAME.to_bogus(),
+                        children.into_iter().map(Some),
+                    );
+                }
+                slots.into_node(GRIT_ENGINE_NAME, children)
+            }
             GRIT_EVERY => {
                 let mut elements = (&children).into_iter();
                 let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
@@ -577,7 +598,7 @@ impl SyntaxFactory for GritSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element {
-                    if GritLanguageName::can_cast(element.kind()) {
+                    if AnyGritLanguageName::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -684,7 +705,7 @@ impl SyntaxFactory for GritSyntaxFactory {
                 let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
-                    if GritLanguageName::can_cast(element.kind()) {
+                    if AnyGritLanguageName::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -2948,7 +2969,7 @@ impl SyntaxFactory for GritSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element {
-                    if element.kind() == T![biome] {
+                    if GritEngineName::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }

--- a/crates/biome_grit_formatter/src/generated.rs
+++ b/crates/biome_grit_formatter/src/generated.rs
@@ -3793,44 +3793,6 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusDefinition {
         )
     }
 }
-impl FormatRule<biome_grit_syntax::GritBogusEngineName>
-    for crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName
-{
-    type Context = GritFormatContext;
-    #[inline(always)]
-    fn fmt(
-        &self,
-        node: &biome_grit_syntax::GritBogusEngineName,
-        f: &mut GritFormatter,
-    ) -> FormatResult<()> {
-        FormatBogusNodeRule::<biome_grit_syntax::GritBogusEngineName>::fmt(self, node, f)
-    }
-}
-impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusEngineName {
-    type Format<'a> = FormatRefWithRule<
-        'a,
-        biome_grit_syntax::GritBogusEngineName,
-        crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName,
-    >;
-    fn format(&self) -> Self::Format<'_> {
-        FormatRefWithRule::new(
-            self,
-            crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName::default(),
-        )
-    }
-}
-impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusEngineName {
-    type Format = FormatOwnedWithRule<
-        biome_grit_syntax::GritBogusEngineName,
-        crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName,
-    >;
-    fn into_format(self) -> Self::Format {
-        FormatOwnedWithRule::new(
-            self,
-            crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName::default(),
-        )
-    }
-}
 impl FormatRule<biome_grit_syntax::GritBogusLanguageDeclaration>
     for crate::grit::bogus::bogus_language_declaration::FormatGritBogusLanguageDeclaration
 {

--- a/crates/biome_grit_formatter/src/generated.rs
+++ b/crates/biome_grit_formatter/src/generated.rs
@@ -559,6 +559,44 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritDoubleLiteral {
         )
     }
 }
+impl FormatRule<biome_grit_syntax::GritEngineName>
+    for crate::grit::auxiliary::engine_name::FormatGritEngineName
+{
+    type Context = GritFormatContext;
+    #[inline(always)]
+    fn fmt(
+        &self,
+        node: &biome_grit_syntax::GritEngineName,
+        f: &mut GritFormatter,
+    ) -> FormatResult<()> {
+        FormatNodeRule::<biome_grit_syntax::GritEngineName>::fmt(self, node, f)
+    }
+}
+impl AsFormat<GritFormatContext> for biome_grit_syntax::GritEngineName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_grit_syntax::GritEngineName,
+        crate::grit::auxiliary::engine_name::FormatGritEngineName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::grit::auxiliary::engine_name::FormatGritEngineName::default(),
+        )
+    }
+}
+impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritEngineName {
+    type Format = FormatOwnedWithRule<
+        biome_grit_syntax::GritEngineName,
+        crate::grit::auxiliary::engine_name::FormatGritEngineName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::grit::auxiliary::engine_name::FormatGritEngineName::default(),
+        )
+    }
+}
 impl FormatRule<biome_grit_syntax::GritEvery> for crate::grit::auxiliary::every::FormatGritEvery {
     type Context = GritFormatContext;
     #[inline(always)]
@@ -3755,6 +3793,44 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusDefinition {
         )
     }
 }
+impl FormatRule<biome_grit_syntax::GritBogusEngineName>
+    for crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName
+{
+    type Context = GritFormatContext;
+    #[inline(always)]
+    fn fmt(
+        &self,
+        node: &biome_grit_syntax::GritBogusEngineName,
+        f: &mut GritFormatter,
+    ) -> FormatResult<()> {
+        FormatBogusNodeRule::<biome_grit_syntax::GritBogusEngineName>::fmt(self, node, f)
+    }
+}
+impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusEngineName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_grit_syntax::GritBogusEngineName,
+        crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName::default(),
+        )
+    }
+}
+impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusEngineName {
+    type Format = FormatOwnedWithRule<
+        biome_grit_syntax::GritBogusEngineName,
+        crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::grit::bogus::bogus_engine_name::FormatGritBogusEngineName::default(),
+        )
+    }
+}
 impl FormatRule<biome_grit_syntax::GritBogusLanguageDeclaration>
     for crate::grit::bogus::bogus_language_declaration::FormatGritBogusLanguageDeclaration
 {
@@ -3817,6 +3893,44 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageFlavo
     >;
     fn into_format(self) -> Self::Format {
         FormatOwnedWithRule :: new (self , crate :: grit :: bogus :: bogus_language_flavor_kind :: FormatGritBogusLanguageFlavorKind :: default ())
+    }
+}
+impl FormatRule<biome_grit_syntax::GritBogusLanguageName>
+    for crate::grit::bogus::bogus_language_name::FormatGritBogusLanguageName
+{
+    type Context = GritFormatContext;
+    #[inline(always)]
+    fn fmt(
+        &self,
+        node: &biome_grit_syntax::GritBogusLanguageName,
+        f: &mut GritFormatter,
+    ) -> FormatResult<()> {
+        FormatBogusNodeRule::<biome_grit_syntax::GritBogusLanguageName>::fmt(self, node, f)
+    }
+}
+impl AsFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_grit_syntax::GritBogusLanguageName,
+        crate::grit::bogus::bogus_language_name::FormatGritBogusLanguageName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::grit::bogus::bogus_language_name::FormatGritBogusLanguageName::default(),
+        )
+    }
+}
+impl IntoFormat<GritFormatContext> for biome_grit_syntax::GritBogusLanguageName {
+    type Format = FormatOwnedWithRule<
+        biome_grit_syntax::GritBogusLanguageName,
+        crate::grit::bogus::bogus_language_name::FormatGritBogusLanguageName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::grit::bogus::bogus_language_name::FormatGritBogusLanguageName::default(),
+        )
     }
 }
 impl FormatRule<biome_grit_syntax::GritBogusLiteral>
@@ -4169,6 +4283,31 @@ impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageFlavorK
         FormatOwnedWithRule::new(
             self,
             crate::grit::any::language_flavor_kind::FormatAnyGritLanguageFlavorKind::default(),
+        )
+    }
+}
+impl AsFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageName {
+    type Format<'a> = FormatRefWithRule<
+        'a,
+        biome_grit_syntax::AnyGritLanguageName,
+        crate::grit::any::language_name::FormatAnyGritLanguageName,
+    >;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(
+            self,
+            crate::grit::any::language_name::FormatAnyGritLanguageName::default(),
+        )
+    }
+}
+impl IntoFormat<GritFormatContext> for biome_grit_syntax::AnyGritLanguageName {
+    type Format = FormatOwnedWithRule<
+        biome_grit_syntax::AnyGritLanguageName,
+        crate::grit::any::language_name::FormatAnyGritLanguageName,
+    >;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(
+            self,
+            crate::grit::any::language_name::FormatAnyGritLanguageName::default(),
         )
     }
 }

--- a/crates/biome_grit_formatter/src/grit/any/language_name.rs
+++ b/crates/biome_grit_formatter/src/grit/any/language_name.rs
@@ -1,0 +1,15 @@
+//! This is a generated file. Don't modify it by hand! Run 'cargo codegen formatter' to re-generate the file.
+
+use crate::prelude::*;
+use biome_grit_syntax::AnyGritLanguageName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatAnyGritLanguageName;
+impl FormatRule<AnyGritLanguageName> for FormatAnyGritLanguageName {
+    type Context = GritFormatContext;
+    fn fmt(&self, node: &AnyGritLanguageName, f: &mut GritFormatter) -> FormatResult<()> {
+        match node {
+            AnyGritLanguageName::GritBogusLanguageName(node) => node.format().fmt(f),
+            AnyGritLanguageName::GritLanguageName(node) => node.format().fmt(f),
+        }
+    }
+}

--- a/crates/biome_grit_formatter/src/grit/any/mod.rs
+++ b/crates/biome_grit_formatter/src/grit/any/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod container;
 pub(crate) mod definition;
 pub(crate) mod language_declaration;
 pub(crate) mod language_flavor_kind;
+pub(crate) mod language_name;
 pub(crate) mod list_accessor_subject;
 pub(crate) mod list_index;
 pub(crate) mod list_pattern;

--- a/crates/biome_grit_formatter/src/grit/auxiliary/engine_name.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/engine_name.rs
@@ -1,0 +1,10 @@
+use crate::prelude::*;
+use biome_formatter::write;
+use biome_grit_syntax::GritEngineName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatGritEngineName;
+impl FormatNodeRule<GritEngineName> for FormatGritEngineName {
+    fn fmt_fields(&self, node: &GritEngineName, f: &mut GritFormatter) -> FormatResult<()> {
+        write!(f, [node.engine_kind().format()])
+    }
+}

--- a/crates/biome_grit_formatter/src/grit/auxiliary/mod.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod bubble;
 pub(crate) mod bubble_scope;
 pub(crate) mod dot;
 pub(crate) mod dotdotdot;
+pub(crate) mod engine_name;
 pub(crate) mod every;
 pub(crate) mod files;
 pub(crate) mod language_declaration;

--- a/crates/biome_grit_formatter/src/grit/auxiliary/version.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/version.rs
@@ -7,7 +7,7 @@ impl FormatNodeRule<GritVersion> for FormatGritVersion {
     fn fmt_fields(&self, node: &GritVersion, f: &mut GritFormatter) -> FormatResult<()> {
         let GritVersionFields {
             engine_token,
-            biome_token,
+            engine_name,
             l_paren_token,
             version,
             r_paren_token,
@@ -18,7 +18,7 @@ impl FormatNodeRule<GritVersion> for FormatGritVersion {
             [
                 engine_token.format(),
                 space(),
-                biome_token.format(),
+                engine_name.format(),
                 l_paren_token.format(),
                 version.format(),
                 r_paren_token.format()

--- a/crates/biome_grit_formatter/src/grit/bogus/bogus_engine_name.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/bogus_engine_name.rs
@@ -1,5 +1,0 @@
-use crate::FormatBogusNodeRule;
-use biome_grit_syntax::GritBogusEngineName;
-#[derive(Debug, Clone, Default)]
-pub(crate) struct FormatGritBogusEngineName;
-impl FormatBogusNodeRule<GritBogusEngineName> for FormatGritBogusEngineName {}

--- a/crates/biome_grit_formatter/src/grit/bogus/bogus_engine_name.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/bogus_engine_name.rs
@@ -1,0 +1,5 @@
+use crate::FormatBogusNodeRule;
+use biome_grit_syntax::GritBogusEngineName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatGritBogusEngineName;
+impl FormatBogusNodeRule<GritBogusEngineName> for FormatGritBogusEngineName {}

--- a/crates/biome_grit_formatter/src/grit/bogus/bogus_language_name.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/bogus_language_name.rs
@@ -1,0 +1,5 @@
+use crate::FormatBogusNodeRule;
+use biome_grit_syntax::GritBogusLanguageName;
+#[derive(Debug, Clone, Default)]
+pub(crate) struct FormatGritBogusLanguageName;
+impl FormatBogusNodeRule<GritBogusLanguageName> for FormatGritBogusLanguageName {}

--- a/crates/biome_grit_formatter/src/grit/bogus/mod.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/mod.rs
@@ -4,8 +4,10 @@
 pub(crate) mod bogus;
 pub(crate) mod bogus_container;
 pub(crate) mod bogus_definition;
+pub(crate) mod bogus_engine_name;
 pub(crate) mod bogus_language_declaration;
 pub(crate) mod bogus_language_flavor_kind;
+pub(crate) mod bogus_language_name;
 pub(crate) mod bogus_literal;
 pub(crate) mod bogus_map_element;
 pub(crate) mod bogus_named_arg;

--- a/crates/biome_grit_formatter/src/grit/bogus/mod.rs
+++ b/crates/biome_grit_formatter/src/grit/bogus/mod.rs
@@ -4,7 +4,6 @@
 pub(crate) mod bogus;
 pub(crate) mod bogus_container;
 pub(crate) mod bogus_definition;
-pub(crate) mod bogus_engine_name;
 pub(crate) mod bogus_language_declaration;
 pub(crate) mod bogus_language_flavor_kind;
 pub(crate) mod bogus_language_name;

--- a/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit
+++ b/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit
@@ -1,0 +1,3 @@
+engine marzano(0.1)
+
+`console.log($var)`     => `console.log($var)`

--- a/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: grit/marzano/engine.grit
+---
+# Input
+
+```grit
+engine marzano(0.1)
+
+`console.log($var)`     => `console.log($var)`
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+-----
+
+```grit
+engine
+marzano(0.1)
+
+`console.log($var)` => `console.log($var)`
+```

--- a/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/marzano/engine.grit.snap
@@ -27,8 +27,6 @@ Attribute Position: Auto
 -----
 
 ```grit
-engine
-marzano(0.1)
-
+engine marzano(0.1)
 `console.log($var)` => `console.log($var)`
 ```

--- a/crates/biome_grit_formatter/tests/specs/grit/marzano/python.grit
+++ b/crates/biome_grit_formatter/tests/specs/grit/marzano/python.grit
@@ -1,0 +1,4 @@
+engine biome(0.1)
+language python
+
+`$var in $dict.keys()`			=> `$var in $dict`

--- a/crates/biome_grit_formatter/tests/specs/grit/marzano/python.grit.snap
+++ b/crates/biome_grit_formatter/tests/specs/grit/marzano/python.grit.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: grit/marzano/python.grit
+---
+# Input
+
+```grit
+engine biome(0.1)
+language python
+
+`$var in $dict.keys()`			=> `$var in $dict`
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+-----
+
+```grit
+engine biome(0.1)
+language python;
+`$var in $dict.keys()` => `$var in $dict`
+```

--- a/crates/biome_grit_parser/src/constants.rs
+++ b/crates/biome_grit_parser/src/constants.rs
@@ -50,7 +50,9 @@ pub(crate) const NOT_SET: TokenSet<GritSyntaxKind> = token_set![NOT_KW, T![!]];
 
 pub(crate) const REGEX_SET: TokenSet<GritSyntaxKind> = token_set![GRIT_REGEX, GRIT_SNIPPET_REGEX];
 
-pub(crate) const SUPPORTED_ENGINE_SET: TokenSet<GritSyntaxKind> = token_set![T![biome]];
+// Engine names we can parse for formatting purposes
+pub(crate) const SUPPORTED_ENGINE_SET: TokenSet<GritSyntaxKind> =
+    token_set![T![biome], T![marzano]];
 
 pub(crate) const SUPPORTED_LANGUAGE_SET: TokenSet<GritSyntaxKind> =
     token_set![T![js], T![json], T![css], T![grit], T![html]];

--- a/crates/biome_grit_parser/src/constants.rs
+++ b/crates/biome_grit_parser/src/constants.rs
@@ -50,6 +50,8 @@ pub(crate) const NOT_SET: TokenSet<GritSyntaxKind> = token_set![NOT_KW, T![!]];
 
 pub(crate) const REGEX_SET: TokenSet<GritSyntaxKind> = token_set![GRIT_REGEX, GRIT_SNIPPET_REGEX];
 
+pub(crate) const SUPPORTED_ENGINE_SET: TokenSet<GritSyntaxKind> = token_set![T![biome]];
+
 pub(crate) const SUPPORTED_LANGUAGE_SET: TokenSet<GritSyntaxKind> =
     token_set![T![js], T![json], T![css], T![grit], T![html]];
 

--- a/crates/biome_grit_parser/src/lexer/mod.rs
+++ b/crates/biome_grit_parser/src/lexer/mod.rs
@@ -777,6 +777,7 @@ impl<'src> GritLexer<'src> {
             b"multifile" => MULTIFILE_KW,
             b"engine" => ENGINE_KW,
             b"biome" => BIOME_KW,
+            b"marzano" => MARZANO_KW,
             b"language" => LANGUAGE_KW,
             b"js" => JS_KW,
             b"css" => CSS_KW,

--- a/crates/biome_grit_parser/src/parser/mod.rs
+++ b/crates/biome_grit_parser/src/parser/mod.rs
@@ -104,7 +104,8 @@ fn parse_version(p: &mut GritParser) -> ParsedSyntax {
     let mut is_supported = true;
 
     let engine_range = p.cur_range();
-    if p.eat(T![biome]) {
+
+    if parse_engine_name(p) != Absent {
         if p.eat(T!['(']) {
             match parse_double_literal(p) {
                 Present(_) => {
@@ -142,6 +143,16 @@ fn parse_version(p: &mut GritParser) -> ParsedSyntax {
             GRIT_BOGUS_VERSION
         },
     ))
+}
+
+fn parse_engine_name(p: &mut GritParser) -> ParsedSyntax {
+    if !p.at_ts(SUPPORTED_ENGINE_SET) {
+        return Absent;
+    }
+
+    let m = p.start();
+    p.bump_ts(SUPPORTED_ENGINE_SET);
+    Present(m.complete(p, GRIT_ENGINE_NAME))
 }
 
 fn parse_language_declaration(p: &mut GritParser) -> ParsedSyntax {
@@ -222,7 +233,10 @@ impl ParseSeparatedList for LanguageFlavorList {
 
 fn parse_language_name(p: &mut GritParser) -> ParsedSyntax {
     if !p.at_ts(SUPPORTED_LANGUAGE_SET) {
-        return Absent;
+        let m = p.start();
+        p.error(expected_language_name(p, p.cur_range()));
+        p.bump_any();
+        return Present(m.complete(p, GRIT_BOGUS_LANGUAGE_NAME));
     }
 
     let m = p.start();

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_engine.grit
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_engine.grit
@@ -1,1 +1,1 @@
-engine marzano (1.0)
+engine marzani (1.0)

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_engine.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_engine.grit.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 ## Input
 ```grit
-engine marzano (1.0)
+engine marzani (1.0)
 
 ```
 
@@ -22,7 +22,7 @@ GritRoot {
     definitions: GritDefinitionList [
         GritNodeLike {
             name: GritName {
-                value_token: GRIT_NAME@7..15 "marzano" [] [Whitespace(" ")],
+                value_token: GRIT_NAME@7..15 "marzani" [] [Whitespace(" ")],
             },
             l_paren_token: L_PAREN@15..16 "(" [] [],
             named_args: GritNamedArgList [
@@ -48,7 +48,7 @@ GritRoot {
   3: GRIT_DEFINITION_LIST@7..20
     0: GRIT_NODE_LIKE@7..20
       0: GRIT_NAME@7..15
-        0: GRIT_NAME@7..15 "marzano" [] [Whitespace(" ")]
+        0: GRIT_NAME@7..15 "marzani" [] [Whitespace(" ")]
       1: L_PAREN@15..16 "(" [] []
       2: GRIT_NAMED_ARG_LIST@16..19
         0: GRIT_DOUBLE_LITERAL@16..19
@@ -65,7 +65,7 @@ incorrect_engine.grit:1:8 parse ━━━━━━━━━━━━━━━━
 
   × Engine must be `biome`
   
-  > 1 │ engine marzano (1.0)
+  > 1 │ engine marzani (1.0)
       │        ^^^^^^^
     2 │ 
   

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_version.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/incorrect_version.grit.snap
@@ -15,7 +15,9 @@ GritRoot {
     version: GritBogusVersion {
         items: [
             ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
-            BIOME_KW@7..13 "biome" [] [Whitespace(" ")],
+            GritEngineName {
+                engine_kind: BIOME_KW@7..13 "biome" [] [Whitespace(" ")],
+            },
             L_PAREN@13..14 "(" [] [],
             GRIT_STRING@14..19 "\"1.0\"" [] [],
             R_PAREN@19..20 ")" [] [],
@@ -34,7 +36,8 @@ GritRoot {
   0: (empty)
   1: GRIT_BOGUS_VERSION@0..20
     0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
-    1: BIOME_KW@7..13 "biome" [] [Whitespace(" ")]
+    1: GRIT_ENGINE_NAME@7..13
+      0: BIOME_KW@7..13 "biome" [] [Whitespace(" ")]
     2: L_PAREN@13..14 "(" [] []
     3: GRIT_STRING@14..19 "\"1.0\"" [] []
     4: R_PAREN@19..20 ")" [] []

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/invalid_language.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/invalid_language.grit.snap
@@ -14,12 +14,15 @@ language non_existing;
 GritRoot {
     bom_token: missing (optional),
     version: missing (optional),
-    language: GritBogusLanguageDeclaration {
-        items: [
-            LANGUAGE_KW@0..9 "language" [] [Whitespace(" ")],
-            GRIT_NAME@9..21 "non_existing" [] [],
-            SEMICOLON@21..22 ";" [] [],
-        ],
+    language: GritLanguageDeclaration {
+        language_token: LANGUAGE_KW@0..9 "language" [] [Whitespace(" ")],
+        name: GritBogusLanguageName {
+            items: [
+                GRIT_NAME@9..21 "non_existing" [] [],
+            ],
+        },
+        flavor: missing (optional),
+        semicolon_token: SEMICOLON@21..22 ";" [] [],
     },
     definitions: GritDefinitionList [],
     eof_token: EOF@22..23 "" [Newline("\n")] [],
@@ -32,10 +35,12 @@ GritRoot {
 0: GRIT_ROOT@0..23
   0: (empty)
   1: (empty)
-  2: GRIT_BOGUS_LANGUAGE_DECLARATION@0..22
+  2: GRIT_LANGUAGE_DECLARATION@0..22
     0: LANGUAGE_KW@0..9 "language" [] [Whitespace(" ")]
-    1: GRIT_NAME@9..21 "non_existing" [] []
-    2: SEMICOLON@21..22 ";" [] []
+    1: GRIT_BOGUS_LANGUAGE_NAME@9..21
+      0: GRIT_NAME@9..21 "non_existing" [] []
+    2: (empty)
+    3: SEMICOLON@21..22 ";" [] []
   3: GRIT_DEFINITION_LIST@22..22
   4: EOF@22..23 "" [Newline("\n")] []
 

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/missing_version.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/missing_version.grit.snap
@@ -16,7 +16,9 @@ GritRoot {
     version: GritBogusVersion {
         items: [
             ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
-            BIOME_KW@7..12 "biome" [] [],
+            GritEngineName {
+                engine_kind: BIOME_KW@7..12 "biome" [] [],
+            },
         ],
     },
     language: missing (optional),
@@ -32,7 +34,8 @@ GritRoot {
   0: (empty)
   1: GRIT_BOGUS_VERSION@0..12
     0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
-    1: BIOME_KW@7..12 "biome" [] []
+    1: GRIT_ENGINE_NAME@7..12
+      0: BIOME_KW@7..12 "biome" [] []
   2: (empty)
   3: GRIT_DEFINITION_LIST@12..12
   4: EOF@12..13 "" [Newline("\n")] []

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/python_language.grit
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/python_language.grit
@@ -1,0 +1,4 @@
+engine biome(0.1)
+language python;
+
+`$var in $dict.keys()` => `$var in $dict`

--- a/crates/biome_grit_parser/tests/grit_test_suite/err/python_language.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/err/python_language.grit.snap
@@ -1,0 +1,114 @@
+---
+source: crates/biome_grit_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```grit
+engine biome(0.1)
+language python;
+
+`$var in $dict.keys()` => `$var in $dict`
+
+```
+
+## AST
+
+```
+GritRoot {
+    bom_token: missing (optional),
+    version: GritVersion {
+        engine_token: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
+        engine_name: GritEngineName {
+            engine_kind: BIOME_KW@7..12 "biome" [] [],
+        },
+        l_paren_token: L_PAREN@12..13 "(" [] [],
+        version: GritDoubleLiteral {
+            value_token: GRIT_DOUBLE@13..16 "0.1" [] [],
+        },
+        r_paren_token: R_PAREN@16..17 ")" [] [],
+    },
+    language: GritLanguageDeclaration {
+        language_token: LANGUAGE_KW@17..27 "language" [Newline("\n")] [Whitespace(" ")],
+        name: GritBogusLanguageName {
+            items: [
+                GRIT_NAME@27..33 "python" [] [],
+            ],
+        },
+        flavor: missing (optional),
+        semicolon_token: SEMICOLON@33..34 ";" [] [],
+    },
+    definitions: GritDefinitionList [
+        GritRewrite {
+            left: GritCodeSnippet {
+                source: GritBacktickSnippetLiteral {
+                    value_token: GRIT_BACKTICK_SNIPPET@34..59 "`$var in $dict.keys()`" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                },
+            },
+            annotation: missing (optional),
+            fat_arrow_token: FAT_ARROW@59..62 "=>" [] [Whitespace(" ")],
+            right: GritCodeSnippet {
+                source: GritBacktickSnippetLiteral {
+                    value_token: GRIT_BACKTICK_SNIPPET@62..77 "`$var in $dict`" [] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@77..78 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRIT_ROOT@0..78
+  0: (empty)
+  1: GRIT_VERSION@0..17
+    0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
+    1: GRIT_ENGINE_NAME@7..12
+      0: BIOME_KW@7..12 "biome" [] []
+    2: L_PAREN@12..13 "(" [] []
+    3: GRIT_DOUBLE_LITERAL@13..16
+      0: GRIT_DOUBLE@13..16 "0.1" [] []
+    4: R_PAREN@16..17 ")" [] []
+  2: GRIT_LANGUAGE_DECLARATION@17..34
+    0: LANGUAGE_KW@17..27 "language" [Newline("\n")] [Whitespace(" ")]
+    1: GRIT_BOGUS_LANGUAGE_NAME@27..33
+      0: GRIT_NAME@27..33 "python" [] []
+    2: (empty)
+    3: SEMICOLON@33..34 ";" [] []
+  3: GRIT_DEFINITION_LIST@34..77
+    0: GRIT_REWRITE@34..77
+      0: GRIT_CODE_SNIPPET@34..59
+        0: GRIT_BACKTICK_SNIPPET_LITERAL@34..59
+          0: GRIT_BACKTICK_SNIPPET@34..59 "`$var in $dict.keys()`" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: (empty)
+      2: FAT_ARROW@59..62 "=>" [] [Whitespace(" ")]
+      3: GRIT_CODE_SNIPPET@62..77
+        0: GRIT_BACKTICK_SNIPPET_LITERAL@62..77
+          0: GRIT_BACKTICK_SNIPPET@62..77 "`$var in $dict`" [] []
+  4: EOF@77..78 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+python_language.grit:2:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected language.
+  
+    1 │ engine biome(0.1)
+  > 2 │ language python;
+      │          ^^^^^^
+    3 │ 
+    4 │ `$var in $dict.keys()` => `$var in $dict`
+  
+  i Expected one of:
+  
+  - js
+  - json
+  - css
+  - grit
+  - html
+  
+```

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/marzano_pattern.grit
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/marzano_pattern.grit
@@ -1,0 +1,1 @@
+engine marzano(1.0)

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/marzano_pattern.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/marzano_pattern.grit.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_grit_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```grit
+engine marzano(1.0)
+
+```
+
+## AST
+
+```
+GritRoot {
+    bom_token: missing (optional),
+    version: GritVersion {
+        engine_token: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
+        engine_name: GritEngineName {
+            engine_kind: MARZANO_KW@7..14 "marzano" [] [],
+        },
+        l_paren_token: L_PAREN@14..15 "(" [] [],
+        version: GritDoubleLiteral {
+            value_token: GRIT_DOUBLE@15..18 "1.0" [] [],
+        },
+        r_paren_token: R_PAREN@18..19 ")" [] [],
+    },
+    language: missing (optional),
+    definitions: GritDefinitionList [],
+    eof_token: EOF@19..20 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: GRIT_ROOT@0..20
+  0: (empty)
+  1: GRIT_VERSION@0..19
+    0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
+    1: GRIT_ENGINE_NAME@7..14
+      0: MARZANO_KW@7..14 "marzano" [] []
+    2: L_PAREN@14..15 "(" [] []
+    3: GRIT_DOUBLE_LITERAL@15..18
+      0: GRIT_DOUBLE@15..18 "1.0" [] []
+    4: R_PAREN@18..19 ")" [] []
+  2: (empty)
+  3: GRIT_DEFINITION_LIST@19..19
+  4: EOF@19..20 "" [Newline("\n")] []
+
+```

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/pattern_with_version.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/pattern_with_version.grit.snap
@@ -15,7 +15,9 @@ GritRoot {
     bom_token: missing (optional),
     version: GritVersion {
         engine_token: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
-        biome_token: BIOME_KW@7..13 "biome" [] [Whitespace(" ")],
+        engine_name: GritEngineName {
+            engine_kind: BIOME_KW@7..13 "biome" [] [Whitespace(" ")],
+        },
         l_paren_token: L_PAREN@13..14 "(" [] [],
         version: GritDoubleLiteral {
             value_token: GRIT_DOUBLE@14..17 "1.0" [] [],
@@ -35,7 +37,8 @@ GritRoot {
   0: (empty)
   1: GRIT_VERSION@0..18
     0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
-    1: BIOME_KW@7..13 "biome" [] [Whitespace(" ")]
+    1: GRIT_ENGINE_NAME@7..13
+      0: BIOME_KW@7..13 "biome" [] [Whitespace(" ")]
     2: L_PAREN@13..14 "(" [] []
     3: GRIT_DOUBLE_LITERAL@14..17
       0: GRIT_DOUBLE@14..17 "1.0" [] []

--- a/crates/biome_grit_parser/tests/grit_test_suite/ok/rewrite_in_where.grit.snap
+++ b/crates/biome_grit_parser/tests/grit_test_suite/ok/rewrite_in_where.grit.snap
@@ -20,7 +20,9 @@ GritRoot {
     bom_token: missing (optional),
     version: GritVersion {
         engine_token: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")],
-        biome_token: BIOME_KW@7..12 "biome" [] [],
+        engine_name: GritEngineName {
+            engine_kind: BIOME_KW@7..12 "biome" [] [],
+        },
         l_paren_token: L_PAREN@12..13 "(" [] [],
         version: GritDoubleLiteral {
             value_token: GRIT_DOUBLE@13..16 "0.1" [] [],
@@ -89,7 +91,8 @@ GritRoot {
   0: (empty)
   1: GRIT_VERSION@0..17
     0: ENGINE_KW@0..7 "engine" [] [Whitespace(" ")]
-    1: BIOME_KW@7..12 "biome" [] []
+    1: GRIT_ENGINE_NAME@7..12
+      0: BIOME_KW@7..12 "biome" [] []
     2: L_PAREN@12..13 "(" [] []
     3: GRIT_DOUBLE_LITERAL@13..16
       0: GRIT_DOUBLE@13..16 "0.1" [] []

--- a/crates/biome_grit_syntax/src/generated/kind.rs
+++ b/crates/biome_grit_syntax/src/generated/kind.rs
@@ -44,8 +44,9 @@ pub enum GritSyntaxKind {
     SEQUENTIAL_KW,
     MULTIFILE_KW,
     ENGINE_KW,
-    BIOME_KW,
     LANGUAGE_KW,
+    BIOME_KW,
+    MARZANO_KW,
     JS_KW,
     CSS_KW,
     JSON_KW,
@@ -107,6 +108,7 @@ pub enum GritSyntaxKind {
     GRIT_FILES,
     GRIT_DEFINITION_LIST,
     GRIT_VERSION,
+    GRIT_ENGINE_NAME,
     GRIT_LANGUAGE_DECLARATION,
     GRIT_LANGUAGE_FLAVOR,
     GRIT_LANGUAGE_FLAVOR_LIST,
@@ -205,11 +207,13 @@ pub enum GritSyntaxKind {
     GRIT_BOGUS_MAP_ELEMENT,
     GRIT_BOGUS_LANGUAGE_DECLARATION,
     GRIT_BOGUS_LANGUAGE_FLAVOR_KIND,
+    GRIT_BOGUS_LANGUAGE_NAME,
     GRIT_BOGUS_LITERAL,
     GRIT_BOGUS_NAMED_ARG,
     GRIT_BOGUS_PATTERN,
     GRIT_BOGUS_PREDICATE,
     GRIT_BOGUS_VERSION,
+    GRIT_BOGUS_ENGINE_NAME,
     #[doc(hidden)]
     __LAST,
 }
@@ -279,8 +283,9 @@ impl GritSyntaxKind {
             "sequential" => SEQUENTIAL_KW,
             "multifile" => MULTIFILE_KW,
             "engine" => ENGINE_KW,
-            "biome" => BIOME_KW,
             "language" => LANGUAGE_KW,
+            "biome" => BIOME_KW,
+            "marzano" => MARZANO_KW,
             "js" => JS_KW,
             "css" => CSS_KW,
             "json" => JSON_KW,
@@ -356,8 +361,9 @@ impl GritSyntaxKind {
             SEQUENTIAL_KW => "sequential",
             MULTIFILE_KW => "multifile",
             ENGINE_KW => "engine",
-            BIOME_KW => "biome",
             LANGUAGE_KW => "language",
+            BIOME_KW => "biome",
+            MARZANO_KW => "marzano",
             JS_KW => "js",
             CSS_KW => "css",
             JSON_KW => "json",
@@ -403,4 +409,4 @@ impl GritSyntaxKind {
 }
 #[doc = r" Utility macro for creating a SyntaxKind through simple macro syntax"]
 #[macro_export]
-macro_rules ! T { [...] => { $ crate :: GritSyntaxKind :: DOT3 } ; ["$_"] => { $ crate :: GritSyntaxKind :: DOLLAR_UNDERSCORE } ; [<:] => { $ crate :: GritSyntaxKind :: MATCH } ; [;] => { $ crate :: GritSyntaxKind :: SEMICOLON } ; [,] => { $ crate :: GritSyntaxKind :: COMMA } ; ['('] => { $ crate :: GritSyntaxKind :: L_PAREN } ; [')'] => { $ crate :: GritSyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: GritSyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: GritSyntaxKind :: R_CURLY } ; ['['] => { $ crate :: GritSyntaxKind :: L_BRACK } ; [']'] => { $ crate :: GritSyntaxKind :: R_BRACK } ; [<] => { $ crate :: GritSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: GritSyntaxKind :: R_ANGLE } ; [+] => { $ crate :: GritSyntaxKind :: PLUS } ; [*] => { $ crate :: GritSyntaxKind :: STAR } ; [/] => { $ crate :: GritSyntaxKind :: SLASH } ; [%] => { $ crate :: GritSyntaxKind :: PERCENT } ; [.] => { $ crate :: GritSyntaxKind :: DOT } ; [:] => { $ crate :: GritSyntaxKind :: COLON } ; [=] => { $ crate :: GritSyntaxKind :: EQ } ; [==] => { $ crate :: GritSyntaxKind :: EQ2 } ; [=>] => { $ crate :: GritSyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: GritSyntaxKind :: BANG } ; [!=] => { $ crate :: GritSyntaxKind :: NEQ } ; [-] => { $ crate :: GritSyntaxKind :: MINUS } ; [<=] => { $ crate :: GritSyntaxKind :: LTEQ } ; [>=] => { $ crate :: GritSyntaxKind :: GTEQ } ; [+=] => { $ crate :: GritSyntaxKind :: PLUSEQ } ; ['`'] => { $ crate :: GritSyntaxKind :: BACKTICK } ; [sequential] => { $ crate :: GritSyntaxKind :: SEQUENTIAL_KW } ; [multifile] => { $ crate :: GritSyntaxKind :: MULTIFILE_KW } ; [engine] => { $ crate :: GritSyntaxKind :: ENGINE_KW } ; [biome] => { $ crate :: GritSyntaxKind :: BIOME_KW } ; [language] => { $ crate :: GritSyntaxKind :: LANGUAGE_KW } ; [js] => { $ crate :: GritSyntaxKind :: JS_KW } ; [css] => { $ crate :: GritSyntaxKind :: CSS_KW } ; [json] => { $ crate :: GritSyntaxKind :: JSON_KW } ; [grit] => { $ crate :: GritSyntaxKind :: GRIT_KW } ; [html] => { $ crate :: GritSyntaxKind :: HTML_KW } ; [typescript] => { $ crate :: GritSyntaxKind :: TYPESCRIPT_KW } ; [jsx] => { $ crate :: GritSyntaxKind :: JSX_KW } ; [js_do_not_use] => { $ crate :: GritSyntaxKind :: JS_DO_NOT_USE_KW } ; [as] => { $ crate :: GritSyntaxKind :: AS_KW } ; [limit] => { $ crate :: GritSyntaxKind :: LIMIT_KW } ; [where] => { $ crate :: GritSyntaxKind :: WHERE_KW } ; [orelse] => { $ crate :: GritSyntaxKind :: ORELSE_KW } ; [maybe] => { $ crate :: GritSyntaxKind :: MAYBE_KW } ; [after] => { $ crate :: GritSyntaxKind :: AFTER_KW } ; [before] => { $ crate :: GritSyntaxKind :: BEFORE_KW } ; [contains] => { $ crate :: GritSyntaxKind :: CONTAINS_KW } ; [until] => { $ crate :: GritSyntaxKind :: UNTIL_KW } ; [includes] => { $ crate :: GritSyntaxKind :: INCLUDES_KW } ; [if] => { $ crate :: GritSyntaxKind :: IF_KW } ; [else] => { $ crate :: GritSyntaxKind :: ELSE_KW } ; [within] => { $ crate :: GritSyntaxKind :: WITHIN_KW } ; [bubble] => { $ crate :: GritSyntaxKind :: BUBBLE_KW } ; [not] => { $ crate :: GritSyntaxKind :: NOT_KW } ; [or] => { $ crate :: GritSyntaxKind :: OR_KW } ; [and] => { $ crate :: GritSyntaxKind :: AND_KW } ; [any] => { $ crate :: GritSyntaxKind :: ANY_KW } ; [some] => { $ crate :: GritSyntaxKind :: SOME_KW } ; [every] => { $ crate :: GritSyntaxKind :: EVERY_KW } ; [private] => { $ crate :: GritSyntaxKind :: PRIVATE_KW } ; [pattern] => { $ crate :: GritSyntaxKind :: PATTERN_KW } ; [predicate] => { $ crate :: GritSyntaxKind :: PREDICATE_KW } ; [function] => { $ crate :: GritSyntaxKind :: FUNCTION_KW } ; [true] => { $ crate :: GritSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: GritSyntaxKind :: FALSE_KW } ; [undefined] => { $ crate :: GritSyntaxKind :: UNDEFINED_KW } ; [like] => { $ crate :: GritSyntaxKind :: LIKE_KW } ; [return] => { $ crate :: GritSyntaxKind :: RETURN_KW } ; [ident] => { $ crate :: GritSyntaxKind :: IDENT } ; [EOF] => { $ crate :: GritSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: GritSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: GritSyntaxKind :: HASH } ; }
+macro_rules ! T { [...] => { $ crate :: GritSyntaxKind :: DOT3 } ; ["$_"] => { $ crate :: GritSyntaxKind :: DOLLAR_UNDERSCORE } ; [<:] => { $ crate :: GritSyntaxKind :: MATCH } ; [;] => { $ crate :: GritSyntaxKind :: SEMICOLON } ; [,] => { $ crate :: GritSyntaxKind :: COMMA } ; ['('] => { $ crate :: GritSyntaxKind :: L_PAREN } ; [')'] => { $ crate :: GritSyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: GritSyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: GritSyntaxKind :: R_CURLY } ; ['['] => { $ crate :: GritSyntaxKind :: L_BRACK } ; [']'] => { $ crate :: GritSyntaxKind :: R_BRACK } ; [<] => { $ crate :: GritSyntaxKind :: L_ANGLE } ; [>] => { $ crate :: GritSyntaxKind :: R_ANGLE } ; [+] => { $ crate :: GritSyntaxKind :: PLUS } ; [*] => { $ crate :: GritSyntaxKind :: STAR } ; [/] => { $ crate :: GritSyntaxKind :: SLASH } ; [%] => { $ crate :: GritSyntaxKind :: PERCENT } ; [.] => { $ crate :: GritSyntaxKind :: DOT } ; [:] => { $ crate :: GritSyntaxKind :: COLON } ; [=] => { $ crate :: GritSyntaxKind :: EQ } ; [==] => { $ crate :: GritSyntaxKind :: EQ2 } ; [=>] => { $ crate :: GritSyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: GritSyntaxKind :: BANG } ; [!=] => { $ crate :: GritSyntaxKind :: NEQ } ; [-] => { $ crate :: GritSyntaxKind :: MINUS } ; [<=] => { $ crate :: GritSyntaxKind :: LTEQ } ; [>=] => { $ crate :: GritSyntaxKind :: GTEQ } ; [+=] => { $ crate :: GritSyntaxKind :: PLUSEQ } ; ['`'] => { $ crate :: GritSyntaxKind :: BACKTICK } ; [sequential] => { $ crate :: GritSyntaxKind :: SEQUENTIAL_KW } ; [multifile] => { $ crate :: GritSyntaxKind :: MULTIFILE_KW } ; [engine] => { $ crate :: GritSyntaxKind :: ENGINE_KW } ; [language] => { $ crate :: GritSyntaxKind :: LANGUAGE_KW } ; [biome] => { $ crate :: GritSyntaxKind :: BIOME_KW } ; [marzano] => { $ crate :: GritSyntaxKind :: MARZANO_KW } ; [js] => { $ crate :: GritSyntaxKind :: JS_KW } ; [css] => { $ crate :: GritSyntaxKind :: CSS_KW } ; [json] => { $ crate :: GritSyntaxKind :: JSON_KW } ; [grit] => { $ crate :: GritSyntaxKind :: GRIT_KW } ; [html] => { $ crate :: GritSyntaxKind :: HTML_KW } ; [typescript] => { $ crate :: GritSyntaxKind :: TYPESCRIPT_KW } ; [jsx] => { $ crate :: GritSyntaxKind :: JSX_KW } ; [js_do_not_use] => { $ crate :: GritSyntaxKind :: JS_DO_NOT_USE_KW } ; [as] => { $ crate :: GritSyntaxKind :: AS_KW } ; [limit] => { $ crate :: GritSyntaxKind :: LIMIT_KW } ; [where] => { $ crate :: GritSyntaxKind :: WHERE_KW } ; [orelse] => { $ crate :: GritSyntaxKind :: ORELSE_KW } ; [maybe] => { $ crate :: GritSyntaxKind :: MAYBE_KW } ; [after] => { $ crate :: GritSyntaxKind :: AFTER_KW } ; [before] => { $ crate :: GritSyntaxKind :: BEFORE_KW } ; [contains] => { $ crate :: GritSyntaxKind :: CONTAINS_KW } ; [until] => { $ crate :: GritSyntaxKind :: UNTIL_KW } ; [includes] => { $ crate :: GritSyntaxKind :: INCLUDES_KW } ; [if] => { $ crate :: GritSyntaxKind :: IF_KW } ; [else] => { $ crate :: GritSyntaxKind :: ELSE_KW } ; [within] => { $ crate :: GritSyntaxKind :: WITHIN_KW } ; [bubble] => { $ crate :: GritSyntaxKind :: BUBBLE_KW } ; [not] => { $ crate :: GritSyntaxKind :: NOT_KW } ; [or] => { $ crate :: GritSyntaxKind :: OR_KW } ; [and] => { $ crate :: GritSyntaxKind :: AND_KW } ; [any] => { $ crate :: GritSyntaxKind :: ANY_KW } ; [some] => { $ crate :: GritSyntaxKind :: SOME_KW } ; [every] => { $ crate :: GritSyntaxKind :: EVERY_KW } ; [private] => { $ crate :: GritSyntaxKind :: PRIVATE_KW } ; [pattern] => { $ crate :: GritSyntaxKind :: PATTERN_KW } ; [predicate] => { $ crate :: GritSyntaxKind :: PREDICATE_KW } ; [function] => { $ crate :: GritSyntaxKind :: FUNCTION_KW } ; [true] => { $ crate :: GritSyntaxKind :: TRUE_KW } ; [false] => { $ crate :: GritSyntaxKind :: FALSE_KW } ; [undefined] => { $ crate :: GritSyntaxKind :: UNDEFINED_KW } ; [like] => { $ crate :: GritSyntaxKind :: LIKE_KW } ; [return] => { $ crate :: GritSyntaxKind :: RETURN_KW } ; [ident] => { $ crate :: GritSyntaxKind :: IDENT } ; [EOF] => { $ crate :: GritSyntaxKind :: EOF } ; [UNICODE_BOM] => { $ crate :: GritSyntaxKind :: UNICODE_BOM } ; [#] => { $ crate :: GritSyntaxKind :: HASH } ; }

--- a/crates/biome_grit_syntax/src/generated/kind.rs
+++ b/crates/biome_grit_syntax/src/generated/kind.rs
@@ -213,7 +213,6 @@ pub enum GritSyntaxKind {
     GRIT_BOGUS_PATTERN,
     GRIT_BOGUS_PREDICATE,
     GRIT_BOGUS_VERSION,
-    GRIT_BOGUS_ENGINE_NAME,
     #[doc(hidden)]
     __LAST,
 }

--- a/crates/biome_grit_syntax/src/generated/macros.rs
+++ b/crates/biome_grit_syntax/src/generated/macros.rs
@@ -77,6 +77,10 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::GritDoubleLiteral::new_unchecked(node) };
                     $body
                 }
+                $crate::GritSyntaxKind::GRIT_ENGINE_NAME => {
+                    let $pattern = unsafe { $crate::GritEngineName::new_unchecked(node) };
+                    $body
+                }
                 $crate::GritSyntaxKind::GRIT_EVERY => {
                     let $pattern = unsafe { $crate::GritEvery::new_unchecked(node) };
                     $body
@@ -411,6 +415,10 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::GritBogusDefinition::new_unchecked(node) };
                     $body
                 }
+                $crate::GritSyntaxKind::GRIT_BOGUS_ENGINE_NAME => {
+                    let $pattern = unsafe { $crate::GritBogusEngineName::new_unchecked(node) };
+                    $body
+                }
                 $crate::GritSyntaxKind::GRIT_BOGUS_LANGUAGE_DECLARATION => {
                     let $pattern =
                         unsafe { $crate::GritBogusLanguageDeclaration::new_unchecked(node) };
@@ -419,6 +427,10 @@ macro_rules! map_syntax_node {
                 $crate::GritSyntaxKind::GRIT_BOGUS_LANGUAGE_FLAVOR_KIND => {
                     let $pattern =
                         unsafe { $crate::GritBogusLanguageFlavorKind::new_unchecked(node) };
+                    $body
+                }
+                $crate::GritSyntaxKind::GRIT_BOGUS_LANGUAGE_NAME => {
+                    let $pattern = unsafe { $crate::GritBogusLanguageName::new_unchecked(node) };
                     $body
                 }
                 $crate::GritSyntaxKind::GRIT_BOGUS_LITERAL => {

--- a/crates/biome_grit_syntax/src/generated/macros.rs
+++ b/crates/biome_grit_syntax/src/generated/macros.rs
@@ -415,10 +415,6 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::GritBogusDefinition::new_unchecked(node) };
                     $body
                 }
-                $crate::GritSyntaxKind::GRIT_BOGUS_ENGINE_NAME => {
-                    let $pattern = unsafe { $crate::GritBogusEngineName::new_unchecked(node) };
-                    $body
-                }
                 $crate::GritSyntaxKind::GRIT_BOGUS_LANGUAGE_DECLARATION => {
                     let $pattern =
                         unsafe { $crate::GritBogusLanguageDeclaration::new_unchecked(node) };

--- a/crates/biome_grit_syntax/src/generated/nodes.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes.rs
@@ -12208,62 +12208,6 @@ impl From<GritBogusDefinition> for SyntaxElement {
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
-pub struct GritBogusEngineName {
-    syntax: SyntaxNode,
-}
-impl GritBogusEngineName {
-    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
-    #[doc = r""]
-    #[doc = r" # Safety"]
-    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
-    #[doc = r" or a match on [SyntaxNode::kind]"]
-    #[inline]
-    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
-        Self { syntax }
-    }
-    pub fn items(&self) -> SyntaxElementChildren {
-        support::elements(&self.syntax)
-    }
-}
-impl AstNode for GritBogusEngineName {
-    type Language = Language;
-    const KIND_SET: SyntaxKindSet<Language> =
-        SyntaxKindSet::from_raw(RawSyntaxKind(GRIT_BOGUS_ENGINE_NAME as u16));
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == GRIT_BOGUS_ENGINE_NAME
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-    fn into_syntax(self) -> SyntaxNode {
-        self.syntax
-    }
-}
-impl std::fmt::Debug for GritBogusEngineName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GritBogusEngineName")
-            .field("items", &DebugSyntaxElementChildren(self.items()))
-            .finish()
-    }
-}
-impl From<GritBogusEngineName> for SyntaxNode {
-    fn from(n: GritBogusEngineName) -> SyntaxNode {
-        n.syntax
-    }
-}
-impl From<GritBogusEngineName> for SyntaxElement {
-    fn from(n: GritBogusEngineName) -> SyntaxElement {
-        n.syntax.into()
-    }
-}
-#[derive(Clone, PartialEq, Eq, Hash, Serialize)]
 pub struct GritBogusLanguageDeclaration {
     syntax: SyntaxNode,
 }

--- a/crates/biome_grit_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes_mut.rs
@@ -225,6 +225,14 @@ impl GritDoubleLiteral {
         )
     }
 }
+impl GritEngineName {
+    pub fn with_engine_kind_token(self, element: SyntaxToken) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(Some(element.into()))),
+        )
+    }
+}
 impl GritEvery {
     pub fn with_every_token(self, element: SyntaxToken) -> Self {
         Self::unwrap_cast(
@@ -318,7 +326,7 @@ impl GritLanguageDeclaration {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_name(self, element: GritLanguageName) -> Self {
+    pub fn with_name(self, element: AnyGritLanguageName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
@@ -374,7 +382,7 @@ impl GritLanguageName {
     }
 }
 impl GritLanguageSpecificSnippet {
-    pub fn with_language(self, element: GritLanguageName) -> Self {
+    pub fn with_language(self, element: AnyGritLanguageName) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
@@ -1748,10 +1756,10 @@ impl GritVersion {
                 .splice_slots(0usize..=0usize, once(Some(element.into()))),
         )
     }
-    pub fn with_biome_token(self, element: SyntaxToken) -> Self {
+    pub fn with_engine_name(self, element: GritEngineName) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into()))),
+                .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
         )
     }
     pub fn with_l_paren_token(self, element: SyntaxToken) -> Self {

--- a/xtask/codegen/gritql.ungram
+++ b/xtask/codegen/gritql.ungram
@@ -43,6 +43,8 @@ GritBogusDefinition = SyntaxElement*
 GritBogusMapElement = SyntaxElement*
 GritBogusLanguageDeclaration = SyntaxElement*
 GritBogusLanguageFlavorKind = SyntaxElement*
+GritBogusLanguageName = SyntaxElement*
+GritBogusEngineName = SyntaxElement*
 GritBogusLiteral = SyntaxElement*
 GritBogusNamedArg = SyntaxElement*
 GritBogusPattern = SyntaxElement*
@@ -62,7 +64,12 @@ AnyGritVersion =
 
 // engine biome(1.0)
 // ^^^^^^ ^^^^^^^^^^
-GritVersion = 'engine' 'biome' '(' version: GritDoubleLiteral ')'
+GritVersion =
+	'engine'
+	engine_name: GritEngineName
+	'(' version: GritDoubleLiteral ')'
+
+GritEngineName = engine_kind: ('biome' | 'marzano')
 
 AnyGritLanguageDeclaration =
     GritLanguageDeclaration
@@ -72,7 +79,7 @@ AnyGritLanguageDeclaration =
 // ^^^^^^^^ ^^^^^^^^^^^^^^ ^^^^^
 GritLanguageDeclaration =
     'language'
-    name: GritLanguageName
+    name: AnyGritLanguageName
     flavor: GritLanguageFlavor?
     ';'?
 
@@ -580,6 +587,10 @@ GritVariableList = GritVariable (',' GritVariable)* ','?
 GritName = value: 'grit_name'
 
 // These are target languages
+AnyGritLanguageName =
+    GritLanguageName
+    | GritBogusLanguageName
+
 GritLanguageName =
     language_kind: ('js' | 'css' | 'json' | 'grit' | 'html')
 
@@ -588,7 +599,7 @@ GritBacktickSnippetLiteral = value: 'grit_backtick_snippet'
 GritRawBacktickSnippetLiteral = value: 'grit_raw_backtick_snippet'
 
 GritLanguageSpecificSnippet =
-    language: GritLanguageName
+    language: AnyGritLanguageName
     snippet: 'grit_string'
 
 // a code snippet may be prefixed by a label;

--- a/xtask/codegen/gritql.ungram
+++ b/xtask/codegen/gritql.ungram
@@ -44,7 +44,6 @@ GritBogusMapElement = SyntaxElement*
 GritBogusLanguageDeclaration = SyntaxElement*
 GritBogusLanguageFlavorKind = SyntaxElement*
 GritBogusLanguageName = SyntaxElement*
-GritBogusEngineName = SyntaxElement*
 GritBogusLiteral = SyntaxElement*
 GritBogusNamedArg = SyntaxElement*
 GritBogusPattern = SyntaxElement*

--- a/xtask/codegen/src/grit_kinds_src.rs
+++ b/xtask/codegen/src/grit_kinds_src.rs
@@ -226,6 +226,5 @@ pub const GRIT_KINDS_SRC: KindsSrc = KindsSrc {
         "GRIT_BOGUS_PATTERN",
         "GRIT_BOGUS_PREDICATE",
         "GRIT_BOGUS_VERSION",
-        "GRIT_BOGUS_ENGINE_NAME",
     ],
 };

--- a/xtask/codegen/src/grit_kinds_src.rs
+++ b/xtask/codegen/src/grit_kinds_src.rs
@@ -40,8 +40,10 @@ pub const GRIT_KINDS_SRC: KindsSrc = KindsSrc {
         "sequential",
         "multifile",
         "engine",
-        "biome",
         "language",
+        // engine names:
+        "biome",
+        "marzano",
         // languages:
         "js",
         "css",
@@ -117,6 +119,7 @@ pub const GRIT_KINDS_SRC: KindsSrc = KindsSrc {
         "GRIT_FILES",
         "GRIT_DEFINITION_LIST",
         "GRIT_VERSION",
+        "GRIT_ENGINE_NAME",
         "GRIT_LANGUAGE_DECLARATION",
         "GRIT_LANGUAGE_FLAVOR",
         "GRIT_LANGUAGE_FLAVOR_LIST",
@@ -217,10 +220,12 @@ pub const GRIT_KINDS_SRC: KindsSrc = KindsSrc {
         "GRIT_BOGUS_MAP_ELEMENT",
         "GRIT_BOGUS_LANGUAGE_DECLARATION",
         "GRIT_BOGUS_LANGUAGE_FLAVOR_KIND",
+        "GRIT_BOGUS_LANGUAGE_NAME",
         "GRIT_BOGUS_LITERAL",
         "GRIT_BOGUS_NAMED_ARG",
         "GRIT_BOGUS_PATTERN",
         "GRIT_BOGUS_PREDICATE",
         "GRIT_BOGUS_VERSION",
+        "GRIT_BOGUS_ENGINE_NAME",
     ],
 };


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes https://github.com/biomejs/biome/issues/4825 to avoid panicking on unknown engine names, so Biome can be used to format GritQL files even when other backends or languages are used. Note the Biome pattern compiler is not expected to handle these other cases, just the lexer + parser + formatter.

The approach I took was to keep erroring (via bogus nodes) but to push the error down to the name itself so the content around it gets formatted. 

## Test Plan

Spec tests are added covering the problematic cases.