### PR TITLE
fix(lint): don't crash on malformed JSX

### DIFF
--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4005,3 +4005,45 @@ fn linter_finds_nested_package_json_for_no_undeclared_dependencies_inversed() {
         result,
     ));
 }
+
+#[test]
+fn linter_doesnt_crash_on_malformed_code_from_issue_4623() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+
+    fs.insert(
+        Utf8Path::new("biome.json").into(),
+        r#"{
+    "linter": {
+        "rules": {
+            "recommended": false,
+            "suspicious": {
+                "noCommentText": "on"
+            }
+        }
+    }
+}"#
+        .as_bytes(),
+    );
+
+    fs.insert(
+        Utf8PathBuf::from("issue4623.js"),
+        r#"<b
+ //
+}"#
+        .as_bytes(),
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "issue4623.js"].as_slice()),
+    );
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "linter_doesnt_crash_on_malformed_code_from_issue_4623",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/linter_doesnt_crash_on_malformed_code_from_issue_4623.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/linter_doesnt_crash_on_malformed_code_from_issue_4623.snap
@@ -1,0 +1,98 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": false,
+      "suspicious": {
+        "noCommentText": "on"
+      }
+    }
+  }
+}
+```
+
+## `issue4623.js`
+
+```js
+<b
+ //
+}
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+issue4623.js:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
+  
+    1 │ <b
+    2 │  //
+  > 3 │ }
+      │ ^
+  
+
+```
+
+```block
+issue4623.js:3:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `<` but instead the file ends
+  
+    1 │ <b
+    2 │  //
+  > 3 │ }
+      │  
+  
+  i the file ends here
+  
+    1 │ <b
+    2 │  //
+  > 3 │ }
+      │  
+  
+
+```
+
+```block
+issue4623.js:2:2 lint/suspicious/noCommentText  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Wrap comments inside children within braces.
+  
+    1 │ <b
+  > 2 │  //
+      │  ^^
+    3 │ }
+  
+  i Unsafe fix: Wrap the comments with braces
+  
+    1 1 │   <b
+    2 2 │    //
+      3 │ + 
+      4 │ + ·{/*··*/}
+    3 5 │   }
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 3 errors.
+```

--- a/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_comment_text.rs
@@ -6,7 +6,7 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_factory::make;
 use biome_js_syntax::{AnyJsxChild, JsSyntaxKind, JsSyntaxToken, JsxText};
-use biome_rowan::{AstNode, BatchMutationExt, TextRange, TextSize};
+use biome_rowan::{BatchMutationExt, TextRange, TextSize};
 use std::ops::Range;
 
 declare_lint_rule! {
@@ -128,7 +128,7 @@ impl Rule for NoCommentText {
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, range: &Self::State) -> Option<RuleDiagnostic> {
-        let node_range_start = ctx.query().range().start();
+        let node_range_start = ctx.query().value_token().ok()?.text_range().start();
         Some(RuleDiagnostic::new(
             rule_category!(),
             TextRange::new(

--- a/crates/biome_rowan/src/cursor/element.rs
+++ b/crates/biome_rowan/src/cursor/element.rs
@@ -1,6 +1,6 @@
 use crate::cursor::{SyntaxNode, SyntaxToken};
 use crate::green::{GreenElement, GreenElementRef};
-use crate::{NodeOrToken, RawSyntaxKind, TokenAtOffset};
+use crate::{NodeOrToken, RawSyntaxKind};
 use biome_text_size::{TextRange, TextSize};
 use std::iter;
 
@@ -83,14 +83,6 @@ impl SyntaxElement {
         match self {
             NodeOrToken::Node(it) => it.prev_sibling_or_token(),
             NodeOrToken::Token(it) => it.prev_sibling_or_token(),
-        }
-    }
-
-    pub(super) fn token_at_offset(&self, offset: TextSize) -> TokenAtOffset<SyntaxToken> {
-        assert!(self.text_range().start() <= offset && offset <= self.text_range().end());
-        match self {
-            NodeOrToken::Token(token) => TokenAtOffset::Single(token.clone()),
-            NodeOrToken::Node(node) => node.token_at_offset(offset),
         }
     }
 

--- a/crates/biome_rowan/src/cursor/node.rs
+++ b/crates/biome_rowan/src/cursor/node.rs
@@ -5,6 +5,7 @@ use crate::{
     WalkEvent,
 };
 use biome_text_size::{TextRange, TextSize};
+use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
 use std::ops;
@@ -319,36 +320,43 @@ impl SyntaxNode {
     }
 
     pub fn token_at_offset(&self, offset: TextSize) -> TokenAtOffset<SyntaxToken> {
-        // TODO: this could be faster if we first drill-down to node, and only
-        // then switch to token search. We should also replace explicit
-        // recursion with a loop.
-        let range = self.text_range();
-        assert!(
-            range.start() <= offset && offset <= range.end(),
-            "Bad offset: range {range:?} offset {offset:?}"
-        );
-        if range.is_empty() {
-            return TokenAtOffset::None;
-        }
-
-        let mut children = self.children_with_tokens().filter(|child| {
-            let child_range = child.text_range();
-            !child_range.is_empty() && child_range.contains_inclusive(offset)
-        });
-
-        let left = children.next().unwrap();
-        let right = children.next();
-        assert!(children.next().is_none());
-
-        if let Some(right) = right {
-            match (left.token_at_offset(offset), right.token_at_offset(offset)) {
-                (TokenAtOffset::Single(left), TokenAtOffset::Single(right)) => {
-                    TokenAtOffset::Between(left, right)
-                }
-                _ => unreachable!(),
+        let mut node = Cow::Borrowed(self);
+        loop {
+            let range = node.text_range();
+            if range.is_empty() || offset < range.start() || offset > range.end() {
+                return TokenAtOffset::None;
             }
-        } else {
-            left.token_at_offset(offset)
+
+            let mut children = node.children_with_tokens().filter(|child| {
+                let child_range = child.text_range();
+                !child_range.is_empty() && child_range.contains_inclusive(offset)
+            });
+
+            let left = children.next().unwrap();
+            let right = children.next();
+            assert!(children.next().is_none());
+
+            if let Some(right) = right {
+                let token_at_offset =
+                    |node: NodeOrToken<SyntaxNode, SyntaxToken>| -> TokenAtOffset<SyntaxToken> {
+                        match node {
+                            NodeOrToken::Token(token) => TokenAtOffset::Single(token),
+                            NodeOrToken::Node(node) => node.token_at_offset(offset),
+                        }
+                    };
+
+                return match (token_at_offset(left), token_at_offset(right)) {
+                    (TokenAtOffset::Single(left), TokenAtOffset::Single(right)) => {
+                        TokenAtOffset::Between(left, right)
+                    }
+                    _ => TokenAtOffset::None,
+                };
+            }
+
+            match left {
+                NodeOrToken::Node(left) => node = Cow::Owned(left),
+                NodeOrToken::Token(left) => return TokenAtOffset::Single(left),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #4623 and resolves a TODO in `cursor/node.rs`.

The real fix is in `no_comment_text.rs`, where I replaced `ctx.query().range().start()` with `ctx.query().value_token().ok()?.text_range().start()`. The reason this works is that `ctx.query().range()` can return a range _with a higher starting offset_ than `ctx.query().value_token().ok()?.text_range()`, due to trimming in the former. I am not really happy with this fix, since it seems like a very easy mistake to make and there's no type safety to protect against this. It's also not really intuitive, so I'm open to better suggestions.

## Test Plan

Test case added.
