### PR TITLE
fix(core): raise an error when invalid config extension is passed

### DIFF
--- a/.changeset/biome_logs_a_warning_in_case_a_folder_contains_biomejson_and_biomejsonc_and_it_will_use_biomejson_by_default.md
+++ b/.changeset/biome_logs_a_warning_in_case_a_folder_contains_biomejson_and_biomejsonc_and_it_will_use_biomejson_by_default.md
@@ -1,0 +1,5 @@
+---
+cli: patch
+---
+
+# Biome logs a warning in case a folder contains `biome.json` and `biome.jsonc`, and it will use `biome.json` by default.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -776,6 +776,11 @@ pub(crate) trait CommandRunner: Sized {
                 cli_options.verbose,
             )?;
         }
+        if loaded_configuration.double_configuration_found {
+            console.log(markup! {
+                <Warn>"Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file."</Warn>
+            })
+        }
         info!(
             "Configuration file loaded: {:?}, diagnostics detected {}",
             loaded_configuration.file_path,

--- a/crates/biome_cli/tests/cases/config_path.rs
+++ b/crates/biome_cli/tests/cases/config_path.rs
@@ -123,3 +123,31 @@ fn raises_an_error_when_the_config_file_is_not_json() {
         result,
     ));
 }
+
+#[test]
+fn raises_an_error_for_no_configuration_file_found() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file = Utf8Path::new("file.js");
+    fs.insert(
+        file.into(),
+        r#"function name() { return "lorem" }"#.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--config-path=config", file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "raises_an_error_for_no_configuration_file_found",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -421,8 +421,6 @@ fn custom_config_file_path() {
 
 // Should throw an error when an invalid configuration path is specified
 #[test]
-// FIXME: redact snapshot for custom paths in configuration
-#[cfg(not(windows))]
 fn invalid_config_file_path() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
@@ -438,7 +436,7 @@ fn invalid_config_file_path() {
             [
                 "format",
                 "--config-path",
-                (config_path.to_string().as_str()),
+                config_path.as_str(),
                 "--write",
                 file_path.as_str(),
             ]

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/raises_a_warning_for_double_configuration_found.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/raises_a_warning_for_double_configuration_found.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `biome.jsonc`
+
+```json
+{}
+```
+
+## `file.js`
+
+```js
+function name() { return "lorem" }
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file.
+```
+
+```block
+file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - function·name()·{·return·"lorem"·}
+      1 │ + function·name()·{
+      2 │ + ········return·"lorem";
+      3 │ + }
+      4 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/raises_an_error_for_no_configuration_file_found.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/raises_an_error_for_no_configuration_file_found.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `file.js`
+
+```js
+function name() { return "lorem" }
+```
+
+# Termination Message
+
+```block
+config configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Biome couldn't find a configuration in the directory config.
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/invalid_config_file_path.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
+snapshot_kind: text
 ---
 ## `file.js`
 
@@ -11,11 +12,9 @@ content
 # Termination Message
 
 ```block
-test/biome.json internalError/fs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Cannot read file
-  
-  × Biome can't read the following file, maybe for permissions reasons or it doesn't exist: test/biome.json
+  × Biome couldn't find a configuration in the directory test.
   
 
 

--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -35,6 +35,8 @@ pub enum BiomeDiagnostic {
     /// Thrown when the program can't serialize the configuration, while saving it
     SerializationError(SerializationError),
 
+    NoConfigurationFileFound(NoConfigurationFileFound),
+
     /// Thrown when trying to **create** a new configuration file, but it exists already
     ConfigAlreadyExists(ConfigAlreadyExists),
 
@@ -121,6 +123,12 @@ impl BiomeDiagnostic {
         })
     }
 
+    pub fn no_configuration_file_found(path: &Utf8Path) -> Self {
+        Self::NoConfigurationFileFound(NoConfigurationFileFound {
+            path: path.to_string(),
+        })
+    }
+
     pub fn cant_resolve(path: impl Display, source: oxc_resolver::ResolveError) -> Self {
         Self::CantResolve(CantResolve {
             message: MessageAndDescription::from(
@@ -176,6 +184,20 @@ pub struct SerializationError;
     severity = Error
 )]
 pub struct ConfigAlreadyExists {}
+
+#[derive(Debug, Diagnostic, Serialize, Deserialize)]
+#[diagnostic(
+    category = "configuration",
+    severity = Error,
+    message(
+        message("Biome couldn't find a configuration in the directory "<Emphasis>{self.path}</Emphasis>"."),
+        description = "Biome couldn't find a configuration in the directory {path}."
+    )
+)]
+pub struct NoConfigurationFileFound {
+    #[location(resource)]
+    path: String,
+}
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]
 #[diagnostic(

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -358,6 +358,7 @@ pub struct FilesConfiguration {
     pub include: Option<Vec<Box<str>>>,
 }
 
+#[derive(Debug)]
 pub struct ConfigurationPayload {
     /// The result of the deserialization
     pub deserialized: Deserialized<Configuration>,
@@ -365,6 +366,8 @@ pub struct ConfigurationPayload {
     pub configuration_file_path: Utf8PathBuf,
     /// The base path where the external configuration in a package should be resolved from
     pub external_resolution_base_path: Utf8PathBuf,
+    /// Whether `biome.json` and `biome.jsonc` were found in the same folder
+    pub double_configuration_found: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -34,8 +34,6 @@ impl ConfigName {
     }
 }
 
-type AutoSearchResultAlias = Result<Option<AutoSearchResult>, FileSystemDiagnostic>;
-
 /// Represents the kind of filesystem entry a path points at.
 #[derive(Clone, Copy, Debug)]
 pub enum PathKind {
@@ -116,74 +114,47 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// Returns metadata about the path.
     fn path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
-    /// This method accepts a directory path (`search_dir`) and a list of filenames (`file_names`),
-    /// It looks for the files in the specified directory in the order they appear in the list.
-    /// If a file is not found in the initial directory, the search may continue into the parent
-    /// directories based on the `should_error_if_file_not_found` flag.
+    /// This method accepts a directory path (`search_dir`) and a file name `search_file`,
     ///
-    /// Behavior if files are not found in `search_dir`:
+    /// It looks for `search_file` starting from the given `search_dir`, and then it starts
+    /// navigating upwards the parent directories until it finds a file that matches `search_file` or
+    /// there aren't any more parent folders.
     ///
-    /// - If `should_error_if_file_not_found` is set to `true`, the method will return an error.
-    /// - If `should_error_if_file_not_found` is set to `false`, the method will search for the files in the parent
-    ///   directories of `search_dir` recursively until:
-    ///     - It finds a file, reads it, and returns its contents along with its path.
-    ///     - It confirms that the file doesn't exist in any of the checked directories.
-    ///
-    /// ## Errors
-    ///
-    /// The method returns an error if `should_error_if_file_not_found` is `true`,
-    /// and the file is not found or cannot be opened or read.
-    ///
-    fn auto_search(
+    /// If no file is found, the method returns `None`
+    fn auto_search_file(
         &self,
         search_dir: &Utf8Path,
-        file_names: &[&str],
-        should_error_if_file_not_found: bool,
-    ) -> AutoSearchResultAlias {
-        let mut curret_search_dir = search_dir.to_path_buf();
+        search_file: &str,
+    ) -> Option<AutoSearchResult> {
+        let mut current_search_dir = search_dir.to_path_buf();
         let mut is_searching_in_parent_dir = false;
+
         loop {
-            let mut errors: Vec<FileSystemDiagnostic> = vec![];
-
-            // Iterate all possible file names
-            for file_name in file_names {
-                let file_path = curret_search_dir.join(file_name);
-                match self.read_file_from_path(&file_path) {
-                    Ok(content) => {
-                        if is_searching_in_parent_dir {
-                            info!(
+            let file_path = current_search_dir.join(search_file);
+            match self.read_file_from_path(&file_path) {
+                Ok(content) => {
+                    if is_searching_in_parent_dir {
+                        info!(
                                 "Biome auto discovered the file at the following path that isn't in the working directory:\n{:?}",
-                                curret_search_dir
+                                current_search_dir
                             );
-                        }
-                        return Ok(Some(AutoSearchResult { content, file_path }));
                     }
-                    Err(error) => {
-                        // We don't return the error immediately because
-                        // there're multiple valid file names to search for
-                        if !is_searching_in_parent_dir && should_error_if_file_not_found {
-                            errors.push(error);
-                        }
+                    return Some(AutoSearchResult {
+                        content,
+                        file_path,
+                        directory_path: current_search_dir,
+                    });
+                }
+                _ => {
+                    if let Some(parent_search_dir) = current_search_dir.parent() {
+                        current_search_dir = Utf8PathBuf::from(parent_search_dir);
+                        is_searching_in_parent_dir = true;
+                    } else {
+                        return None;
                     }
                 }
-            }
-
-            if !is_searching_in_parent_dir && should_error_if_file_not_found {
-                if let Some(diagnostic) = errors.into_iter().next() {
-                    // We can only return one Err, so we return the first diagnostic.
-                    return Err(diagnostic);
-                }
-            }
-
-            if let Some(parent_search_dir) = curret_search_dir.parent() {
-                curret_search_dir = Utf8PathBuf::from(parent_search_dir);
-                is_searching_in_parent_dir = true;
-            } else {
-                break;
             }
         }
-
-        Ok(None)
     }
 
     /// Reads the content of a file specified by `file_path`.
@@ -247,6 +218,8 @@ pub struct AutoSearchResult {
     pub content: String,
     /// The path of the file found
     pub file_path: Utf8PathBuf,
+    /// The directory where the file was found
+    pub directory_path: Utf8PathBuf,
 }
 
 pub trait File {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -43,7 +43,7 @@ use tower_lsp::lsp_types;
 use tower_lsp::lsp_types::{Diagnostic, Url};
 use tower_lsp::lsp_types::{MessageType, Registration};
 use tower_lsp::lsp_types::{Unregistration, WorkspaceFolder};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub(crate) struct ClientInformation {
     /// The name of the client
@@ -556,6 +556,11 @@ impl Session {
                 self.client.log_message(MessageType::ERROR, message).await;
             }
             return ConfigurationStatus::Error;
+        }
+
+        if loaded_configuration.double_configuration_found {
+            warn!("Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file.");
+            self.client.log_message(MessageType::WARNING, "Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file.").await;
         }
 
         info!("Configuration loaded successfully from disk.");


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4936

I also took the opportunity to refactor the methods that we use for auto search and loading user configuration:
- the auto search now works only for one single file, instead of accepting multiple files. This reduces the cognitive complexity, it doesn't raise diagnostic and we use a single loop,
- the logic we had in the auto search regarding "should_emit_error" was introduced only when searching for configuration files, however we raise an error only when the user provide `--config-path`, which **doesn't trigger an auto-search**.
- the loading of user configuration has been moved into its own function with its own logic, which must raise an error if we can't find a configuration file
- I refactored `load_editorconfig` and reduced its cognitive complexity. We now use a more functional approach to map the fields we need to validate. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests and updated the existing ones

<!-- What demonstrates that your implementation is correct? -->
