### PR TITLE
fix(core): fix symlink handling

### DIFF
--- a/crates/biome_dependency_graph/src/dependency_graph.tests.rs
+++ b/crates/biome_dependency_graph/src/dependency_graph.tests.rs
@@ -181,7 +181,7 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
             )
             .into_deserialized()
             .expect("package.json must parse")
-            .with_path(path)
+            .with_path_and_canonicalized_path(path, format!("{fixtures_path}/shared/package.json"))
         },
     );
 
@@ -214,10 +214,8 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
     assert_eq!(
         file_imports.static_imports.get("shared"),
         Some(&Import {
-            // FIXME: This should really have pointed towards the target of the
-            //        symlink.
             resolved_path: Ok(Utf8PathBuf::from(format!(
-                "{fixtures_path}/frontend/node_modules/shared/dist/index.js"
+                "{fixtures_path}/shared/dist/index.js"
             )))
         })
     );

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -233,6 +233,13 @@ impl FileSystem for MemoryFileSystem {
         Ok(cb())
     }
 
+    fn read_link(&self, _path: &Utf8Path) -> io::Result<Utf8PathBuf> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "memory FS doesn't support symlinks",
+        ))
+    }
+
     fn resolve_configuration(
         &self,
         _specifier: &str,

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -124,6 +124,10 @@ impl FileSystem for OsFileSystem {
         }
     }
 
+    fn read_link(&self, path: &Utf8Path) -> io::Result<Utf8PathBuf> {
+        path.read_link_utf8()
+    }
+
     fn resolve_configuration(
         &self,
         specifier: &str,


### PR DESCRIPTION
## Summary

Fix #4941. We can now handle symlinks when resolving the dependency graph, which should allow us to handle many monorepo situations.

Also used `Utf8Path` a bit more internally, as I think I managed to work around some of the conversions I was struggling with.

## Test Plan

Updated test case.
