### PR TITLE
fix(core): don't build control flow graph inside bogus nodes

### DIFF
--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4047,3 +4047,30 @@ fn linter_doesnt_crash_on_malformed_code_from_issue_4623() {
         result,
     ));
 }
+
+#[test]
+fn linter_doesnt_crash_on_malformed_code_from_issue_4723() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+
+    fs.insert(
+        Utf8PathBuf::from("issue4723.js"),
+        r#"   if ndpato{      (){   if asCmesnen{   }
+  if     '&
+  else"#
+            .as_bytes(),
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["lint", "issue4723.js"].as_slice()),
+    );
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "linter_doesnt_crash_on_malformed_code_from_issue_4723",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/linter_doesnt_crash_on_malformed_code_from_issue_4723.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/linter_doesnt_crash_on_malformed_code_from_issue_4723.snap
@@ -1,0 +1,161 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `issue4723.js`
+
+```js
+   if ndpato{      (){   if asCmesnen{   }
+  if     '&
+  else
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+issue4723.js:1:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `(` but instead found `ndpato`
+  
+  > 1 │    if ndpato{      (){   if asCmesnen{   }
+      │       ^^^^^^
+    2 │   if     '&
+    3 │   else
+  
+  i Remove ndpato
+  
+
+```
+
+```block
+issue4723.js:1:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead found `{`
+  
+  > 1 │    if ndpato{      (){   if asCmesnen{   }
+      │             ^
+    2 │   if     '&
+    3 │   else
+  
+  i Remove {
+  
+
+```
+
+```block
+issue4723.js:1:22 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `=>` but instead found `{`
+  
+  > 1 │    if ndpato{      (){   if asCmesnen{   }
+      │                      ^
+    2 │   if     '&
+    3 │   else
+  
+  i Remove {
+  
+
+```
+
+```block
+issue4723.js:1:29 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `(` but instead found `asCmesnen`
+  
+  > 1 │    if ndpato{      (){   if asCmesnen{   }
+      │                             ^^^^^^^^^
+    2 │   if     '&
+    3 │   else
+  
+  i Remove asCmesnen
+  
+
+```
+
+```block
+issue4723.js:1:38 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead found `{`
+  
+  > 1 │    if ndpato{      (){   if asCmesnen{   }
+      │                                      ^
+    2 │   if     '&
+    3 │   else
+  
+  i Remove {
+  
+
+```
+
+```block
+issue4723.js:2:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × unterminated string literal
+  
+    1 │    if ndpato{      (){   if asCmesnen{   }
+  > 2 │   if     '&
+      │          ^^
+    3 │   else
+  
+  i 
+  
+    1 │    if ndpato{      (){   if asCmesnen{   }
+  > 2 │   if     '&
+      │          ^^
+    3 │   else
+  
+  i The closing quote must be on the same line.
+  
+
+```
+
+```block
+issue4723.js:3:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × expected `)` but instead found `else`
+  
+    1 │    if ndpato{      (){   if asCmesnen{   }
+    2 │   if     '&
+  > 3 │   else
+      │   ^^^^
+  
+  i Remove else
+  
+
+```
+
+```block
+issue4723.js:3:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a statement but instead found the end of the file.
+  
+    1 │    if ndpato{      (){   if asCmesnen{   }
+    2 │   if     '&
+  > 3 │   else
+      │       
+  
+  i Expected a statement here.
+  
+    1 │    if ndpato{      (){   if asCmesnen{   }
+    2 │   if     '&
+  > 3 │   else
+      │       
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 8 errors.
+```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -26187,6 +26187,7 @@ impl From<CssValueAtRuleGenericValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyCssBogusNode = CssBogus | CssBogusAtRule | CssBogusBlock | CssBogusCustomIdentifier | CssBogusDeclarationItem | CssBogusDocumentMatcher | CssBogusFontFamilyName | CssBogusFontFeatureValuesItem | CssBogusKeyframesItem | CssBogusKeyframesName | CssBogusLayer | CssBogusMediaQuery | CssBogusPageSelectorPseudo | CssBogusParameter | CssBogusProperty | CssBogusPropertyValue | CssBogusPseudoClass | CssBogusPseudoElement | CssBogusRule | CssBogusScopeRange | CssBogusSelector | CssBogusSubSelector | CssBogusUnicodeRangeValue | CssBogusUrlModifier | CssUnknownAtRuleComponentList | CssValueAtRuleGenericValue }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct CssBracketedValueList {
     syntax_list: SyntaxList,

--- a/crates/biome_formatter/src/diagnostics.rs
+++ b/crates/biome_formatter/src/diagnostics.rs
@@ -55,9 +55,9 @@ impl From<SyntaxError> for FormatError {
 impl From<&SyntaxError> for FormatError {
     fn from(syntax_error: &SyntaxError) -> Self {
         match syntax_error {
-            SyntaxError::MissingRequiredChild | SyntaxError::UnexpectedMetavariable => {
-                FormatError::SyntaxError
-            }
+            SyntaxError::MissingRequiredChild
+            | SyntaxError::UnexpectedBogusNode
+            | SyntaxError::UnexpectedMetavariable => FormatError::SyntaxError,
         }
     }
 }

--- a/crates/biome_graphql_syntax/src/generated/nodes.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes.rs
@@ -7969,6 +7969,7 @@ impl From<GraphqlBogusValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyGraphqlBogusNode = GraphqlBogus | GraphqlBogusDefinition | GraphqlBogusSelection | GraphqlBogusType | GraphqlBogusValue }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct GraphqlArgumentDefinitionList {
     syntax_list: SyntaxList,

--- a/crates/biome_grit_patterns/src/errors.rs
+++ b/crates/biome_grit_patterns/src/errors.rs
@@ -12,14 +12,11 @@ pub enum CompileError {
     /// Indicates the (top-level) pattern could not be parsed.
     ParsePatternError(ParseDiagnostic),
 
-    /// Used for missing syntax nodes.
-    MissingSyntaxNode,
+    /// Used for syntax errors.
+    SyntaxError(SyntaxError),
 
     /// A built-in function call was discovered in an unexpected context.
     UnexpectedBuiltinCall(String),
-
-    /// A metavariables was discovered in an unexpected context.
-    UnexpectedMetavariable,
 
     /// If a function with the same name is defined multiple times.
     DuplicateFunctionDefinition(String),
@@ -95,14 +92,17 @@ impl Diagnostic for CompileError {
                 fmt.write_markup(markup! { "Error parsing pattern: " })?;
                 diagnostic.message(fmt)
             }
-            CompileError::MissingSyntaxNode => {
+            CompileError::SyntaxError(SyntaxError::MissingRequiredChild) => {
                 fmt.write_markup(markup! { "A syntax node was missing" })
+            }
+            CompileError::SyntaxError(SyntaxError::UnexpectedBogusNode) => {
+                fmt.write_markup(markup! { "Unexpected bogus node" })
+            }
+            CompileError::SyntaxError(SyntaxError::UnexpectedMetavariable) => {
+                fmt.write_markup(markup! { "Unexpected metavariable" })
             }
             CompileError::UnexpectedBuiltinCall(name) => {
                 fmt.write_markup(markup! { "Unexpected call to built-in: "{{name}}"()" })
-            }
-            CompileError::UnexpectedMetavariable => {
-                fmt.write_markup(markup! { "Unexpected metavariable" })
             }
             CompileError::DuplicateFunctionDefinition(name) => {
                 fmt.write_markup(markup! { "Duplicate function definition: "{{name}} })
@@ -202,10 +202,7 @@ impl Diagnostic for CompileError {
 
 impl From<SyntaxError> for CompileError {
     fn from(error: SyntaxError) -> Self {
-        match error {
-            SyntaxError::MissingRequiredChild => Self::MissingSyntaxNode,
-            SyntaxError::UnexpectedMetavariable => Self::UnexpectedMetavariable,
-        }
+        Self::SyntaxError(error)
     }
 }
 

--- a/crates/biome_grit_syntax/src/generated/nodes.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes.rs
@@ -13575,6 +13575,7 @@ impl From<GritBogusVersion> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyGritBogusNode = GritBogus | GritBogusContainer | GritBogusDefinition | GritBogusLanguageDeclaration | GritBogusLanguageFlavorKind | GritBogusLanguageName | GritBogusLiteral | GritBogusMapElement | GritBogusNamedArg | GritBogusPattern | GritBogusPredicate | GritBogusVersion }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct GritDefinitionList {
     syntax_list: SyntaxList,

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -1825,6 +1825,7 @@ impl From<HtmlBogusElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyHtmlBogusNode = HtmlBogus | HtmlBogusAttribute | HtmlBogusElement }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct HtmlAttributeList {
     syntax_list: SyntaxList,

--- a/crates/biome_js_analyze/src/services/control_flow/nodes.rs
+++ b/crates/biome_js_analyze/src/services/control_flow/nodes.rs
@@ -1,4 +1,5 @@
 mod block;
+mod bogus;
 mod break_stmt;
 mod continue_stmt;
 mod do_while;
@@ -15,6 +16,7 @@ mod variable;
 mod while_stmt;
 
 pub(super) use block::*;
+pub(super) use bogus::*;
 pub(super) use break_stmt::*;
 pub(super) use continue_stmt::*;
 pub(super) use do_while::*;

--- a/crates/biome_js_analyze/src/services/control_flow/nodes/bogus.rs
+++ b/crates/biome_js_analyze/src/services/control_flow/nodes/bogus.rs
@@ -1,0 +1,22 @@
+use biome_js_syntax::JsBogusStatement;
+use biome_rowan::{SyntaxError, SyntaxResult};
+
+use crate::services::control_flow::{
+    visitor::{NodeVisitor, StatementStack},
+    FunctionBuilder,
+};
+
+/// Bogus visitor.
+///
+/// The bogus visitor merely acts to abort control flow analysis inside broken
+/// code, which could otherwise mess with assumptions made inside other
+/// visitors.
+pub(in crate::services::control_flow) struct BogusVisitor;
+
+impl NodeVisitor for BogusVisitor {
+    type Node = JsBogusStatement;
+
+    fn enter(_: Self::Node, _: &mut FunctionBuilder, _: StatementStack) -> SyntaxResult<Self> {
+        Err(SyntaxError::UnexpectedBogusNode)
+    }
+}

--- a/crates/biome_js_analyze/src/services/control_flow/nodes/bogus.rs
+++ b/crates/biome_js_analyze/src/services/control_flow/nodes/bogus.rs
@@ -1,4 +1,4 @@
-use biome_js_syntax::JsBogusStatement;
+use biome_js_syntax::AnyJsBogusNode;
 use biome_rowan::{SyntaxError, SyntaxResult};
 
 use crate::services::control_flow::{
@@ -14,7 +14,7 @@ use crate::services::control_flow::{
 pub(in crate::services::control_flow) struct BogusVisitor;
 
 impl NodeVisitor for BogusVisitor {
-    type Node = JsBogusStatement;
+    type Node = AnyJsBogusNode;
 
     fn enter(_: Self::Node, _: &mut FunctionBuilder, _: StatementStack) -> SyntaxResult<Self> {
         Err(SyntaxError::UnexpectedBogusNode)

--- a/crates/biome_js_analyze/src/services/control_flow/visitor.rs
+++ b/crates/biome_js_analyze/src/services/control_flow/visitor.rs
@@ -125,6 +125,7 @@ declare_visitor! {
         return_stmt: ReturnVisitor,
         throw: ThrowVisitor,
         variable: VariableVisitor,
+        bogus: BogusVisitor,
     }
 }
 

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -42632,6 +42632,7 @@ impl From<TsBogusType> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyJsBogusNode = JsBogus | JsBogusAssignment | JsBogusBinding | JsBogusExpression | JsBogusImportAssertionEntry | JsBogusMember | JsBogusNamedImportSpecifier | JsBogusParameter | JsBogusStatement | TsBogusType }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsArrayAssignmentPatternElementList {
     syntax_list: SyntaxList,

--- a/crates/biome_json_syntax/src/generated/nodes.rs
+++ b/crates/biome_json_syntax/src/generated/nodes.rs
@@ -1178,6 +1178,7 @@ impl From<JsonBogusValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyJsonBogusNode = JsonBogus | JsonBogusValue }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct JsonArrayElementList {
     syntax_list: SyntaxList,

--- a/crates/biome_markdown_syntax/src/generated/nodes.rs
+++ b/crates/biome_markdown_syntax/src/generated/nodes.rs
@@ -2644,6 +2644,7 @@ impl From<MdBogus> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyMdBogusNode = MdBogus }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct MdBlockList {
     syntax_list: SyntaxList,

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -747,6 +747,9 @@ pub enum SyntaxError {
     /// Error thrown when a mandatory node is not found
     MissingRequiredChild,
 
+    /// Error thrown when a bogus node is encountered in an unexpected position
+    UnexpectedBogusNode,
+
     /// Error thrown when a metavariable node is found in an unexpected context
     UnexpectedMetavariable,
 }
@@ -755,7 +758,8 @@ impl Display for SyntaxError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         match self {
             SyntaxError::MissingRequiredChild => fmt.write_str("missing required child"),
-            SyntaxError::UnexpectedMetavariable => fmt.write_str("unexpectedd metavariable node"),
+            SyntaxError::UnexpectedBogusNode => fmt.write_str("unexpected bogus node"),
+            SyntaxError::UnexpectedMetavariable => fmt.write_str("unexpected metavariable node"),
         }
     }
 }
@@ -828,6 +832,7 @@ pub mod support {
             match &self.0 {
                 Ok(node) => std::fmt::Debug::fmt(node, f),
                 Err(SyntaxError::MissingRequiredChild) => f.write_str("missing (required)"),
+                Err(SyntaxError::UnexpectedBogusNode) => f.write_str("bogus node"),
                 Err(SyntaxError::UnexpectedMetavariable) => f.write_str("metavariable"),
             }
         }

--- a/crates/biome_yaml_syntax/src/generated/nodes.rs
+++ b/crates/biome_yaml_syntax/src/generated/nodes.rs
@@ -1811,6 +1811,7 @@ impl From<YamlBogusValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+biome_rowan::declare_node_union! { pub AnyYamlBogusNode = YamlBogus | YamlBogusValue }
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct YamlArrayInlineList {
     syntax_list: SyntaxList,


### PR DESCRIPTION
## Summary

Fixes #4723 by adding a `BogusVisitor` to our control flow graph builder. The original panic was caused by a broken assumption due to the presence of a bogus statement between the if statement and its else clause. I think the safer alternative is to just skip bogus branches from analysis.

To aid with this, codegen now generate an `Any*BogusNode` for every language as well.

## Test Plan

Added test case.