### PR TITLE
fix(lint): support some of wrapped hook calls in useExhaustiveDependencies

### DIFF
--- a/.changeset/fix_1597_useexhaustivedependencies_now_consider_react_hooks_stable_within_parentheses_or_type_assertions.md
+++ b/.changeset/fix_1597_useexhaustivedependencies_now_consider_react_hooks_stable_within_parentheses_or_type_assertions.md
@@ -1,0 +1,5 @@
+---
+biome_js_analyze: patch
+---
+
+# Fix #1597, useExhaustiveDependencies now consider React hooks stable within parentheses or type assertions

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -476,25 +476,27 @@ pub fn is_binding_react_stable(
 
 /// Unwrap the expression to a call expression without changing the result of the expression,
 /// such as type assertions.
-fn unwrap_to_call_expression(expression: AnyJsExpression) -> Option<JsCallExpression> {
-    match expression {
-        AnyJsExpression::JsCallExpression(expr) => Some(expr),
-        AnyJsExpression::JsParenthesizedExpression(expr) => {
-            expr.expression().ok().and_then(unwrap_to_call_expression)
+fn unwrap_to_call_expression(mut expression: AnyJsExpression) -> Option<JsCallExpression> {
+    loop {
+        match expression {
+            AnyJsExpression::JsCallExpression(expr) => return Some(expr),
+            AnyJsExpression::JsParenthesizedExpression(expr) => {
+                expression = expr.expression().ok()?;
+            }
+            AnyJsExpression::JsSequenceExpression(expr) => {
+                expression = expr.right().ok()?;
+            }
+            AnyJsExpression::TsAsExpression(expr) => {
+                expression = expr.expression().ok()?;
+            }
+            AnyJsExpression::TsSatisfiesExpression(expr) => {
+                expression = expr.expression().ok()?;
+            }
+            AnyJsExpression::TsNonNullAssertionExpression(expr) => {
+                expression = expr.expression().ok()?;
+            }
+            _ => return None,
         }
-        AnyJsExpression::JsSequenceExpression(expr) => {
-            expr.right().ok().and_then(unwrap_to_call_expression)
-        }
-        AnyJsExpression::TsAsExpression(expr) => {
-            expr.expression().ok().and_then(unwrap_to_call_expression)
-        }
-        AnyJsExpression::TsSatisfiesExpression(expr) => {
-            expr.expression().ok().and_then(unwrap_to_call_expression)
-        }
-        AnyJsExpression::TsNonNullAssertionExpression(expr) => {
-            expr.expression().ok().and_then(unwrap_to_call_expression)
-        }
-        _ => None,
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.ts
@@ -1,6 +1,6 @@
 /* should not generate diagnostics */
 
-import { useEffect } from "react";
+import { type MutableRefObject, useEffect, useRef } from "react";
 
 // capturing declarations
 function overloaded(s: string): string;
@@ -45,4 +45,21 @@ export function MyComponent3({ outer }: { outer: string[] }) {
 			const a: (typeof outer)[number] = "foo";
 			console.log(a)
 		}, []);
+}
+
+// useRef's are still considered as stable even if there's any type assertion
+export function MyComponent4() {
+    const parenthesizedRef = (((useRef())));
+    const sequenceRef = (doSomething(), useRef());
+    const nonNullAssertedRef = useRef()!;
+    const castedRef = useRef() as MutableRefObject<HTMLElement>;
+    const satisfiedRef = useRef() satisfies MutableRefObject<HTMLElement>;
+
+    useEffect(() => {
+        console.log(parenthesizedRef.current);
+        console.log(sequenceRef.current);
+        console.log(nonNullAssertedRef.current);
+        console.log(castedRef.current.innerHTML);
+        console.log(satisfiedRef.current.innerHTML);
+    }, []);
 }

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/valid.ts.snap
@@ -6,7 +6,7 @@ expression: valid.ts
 ```ts
 /* should not generate diagnostics */
 
-import { useEffect } from "react";
+import { type MutableRefObject, useEffect, useRef } from "react";
 
 // capturing declarations
 function overloaded(s: string): string;
@@ -53,6 +53,21 @@ export function MyComponent3({ outer }: { outer: string[] }) {
 		}, []);
 }
 
+// useRef's are still considered as stable even if there's any type assertion
+export function MyComponent4() {
+    const parenthesizedRef = (((useRef())));
+    const sequenceRef = (doSomething(), useRef());
+    const nonNullAssertedRef = useRef()!;
+    const castedRef = useRef() as MutableRefObject<HTMLElement>;
+    const satisfiedRef = useRef() satisfies MutableRefObject<HTMLElement>;
+
+    useEffect(() => {
+        console.log(parenthesizedRef.current);
+        console.log(sequenceRef.current);
+        console.log(nonNullAssertedRef.current);
+        console.log(castedRef.current.innerHTML);
+        console.log(satisfiedRef.current.innerHTML);
+    }, []);
+}
+
 ```
-
-


### PR DESCRIPTION
## Summary

Fixes #1597 (except more edge cases)

This pull request adds support of some different styles of hook calls that are considered as "stable", including:

- Parenthesized calls `(useRef())`
- Sequencial calls with a comma operator `(doSomething(), useRef())`
- Calls with a TS Non-null assertion `useRef()!`
- Calls with a TS `as` operator `useRef() as T`
- Calls with a TS `satisfies` operator `useRef() satisfies T`

Note this _doesn't_ cover all of edge cases.

## Test Plan

Tests added.
