### PR TITLE
refactor: enable `needless_lifetimes` clippy rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ allow_attributes        = "deny"
 cargo_common_metadata   = "allow"
 empty_docs              = "allow" # there are some false positives inside biome_wasm
 multiple_crate_versions = "allow"
-needless_lifetimes      = "allow"
 
 # pedantic
 assigning_clones             = "warn"

--- a/crates/biome_analyze/src/syntax.rs
+++ b/crates/biome_analyze/src/syntax.rs
@@ -109,7 +109,7 @@ mod tests {
         nodes: Vec<RawLanguageKind>,
     }
 
-    impl<'a> QueryMatcher<RawLanguage> for &'a mut BufferMatcher {
+    impl QueryMatcher<RawLanguage> for &mut BufferMatcher {
         fn match_query(&mut self, params: MatchQueryParams<RawLanguage>) {
             self.nodes.push(
                 params

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -2054,7 +2054,7 @@ mod tests {
             }
         }
 
-        impl<'a> std::fmt::Display for DiagnosticPrinter<'a> {
+        impl std::fmt::Display for DiagnosticPrinter<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 for diagnostic in self.diagnostics {
                     diagnostic.description(f)?;

--- a/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
@@ -21,6 +21,7 @@ pub(crate) struct CompilationContext<'a> {
     pub function_definition_info: BTreeMap<String, DefinitionInfo>,
 }
 
+#[expect(clippy::needless_lifetimes)]
 impl<'a> CompilationContext<'a> {
     #[cfg(test)]
     pub(crate) fn new(

--- a/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/compilation_context.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_lifetimes)]
 use grit_pattern_matcher::pattern::VariableSource;
 use grit_util::ByteRange;
 
@@ -21,7 +22,6 @@ pub(crate) struct CompilationContext<'a> {
     pub function_definition_info: BTreeMap<String, DefinitionInfo>,
 }
 
-#[expect(clippy::needless_lifetimes)]
 impl<'a> CompilationContext<'a> {
     #[cfg(test)]
     pub(crate) fn new(

--- a/crates/biome_yaml_parser/src/lexer/mod.rs
+++ b/crates/biome_yaml_parser/src/lexer/mod.rs
@@ -56,7 +56,7 @@ pub(crate) struct YamlLexer<'src> {
     context: YamlLexContext,
 }
 
-impl<'source> YamlLexer<'source> {
+impl YamlLexer<'_> {
     fn current_char(&self) -> Option<u8> {
         self.source.as_bytes().get(self.position).copied()
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR enables `needless_lifetimes` clippy rule that is default in Rust v1.84.0.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
