### PR TITLE
feat(format/html): apply line break with multiple attributes in multiline configuration

### DIFF
--- a/crates/biome_html_formatter/src/html/lists/attribute_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/attribute_list.rs
@@ -6,7 +6,8 @@ pub(crate) struct FormatHtmlAttributeList;
 impl FormatRule<HtmlAttributeList> for FormatHtmlAttributeList {
     type Context = HtmlFormatContext;
     fn fmt(&self, node: &HtmlAttributeList, f: &mut HtmlFormatter) -> FormatResult<()> {
-        let line_break = if f.options().attribute_position() == AttributePosition::Multiline {
+        let attribute_len = node.iter().len();
+        let line_break = if f.options().attribute_position() == AttributePosition::Multiline && attribute_len > 1 {
             hard_line_break()
         } else {
             soft_line_break_or_space()

--- a/crates/biome_html_formatter/src/html/lists/attribute_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/attribute_list.rs
@@ -7,7 +7,9 @@ impl FormatRule<HtmlAttributeList> for FormatHtmlAttributeList {
     type Context = HtmlFormatContext;
     fn fmt(&self, node: &HtmlAttributeList, f: &mut HtmlFormatter) -> FormatResult<()> {
         let attribute_len = node.iter().len();
-        let line_break = if f.options().attribute_position() == AttributePosition::Multiline && attribute_len > 1 {
+        let line_break = if f.options().attribute_position() == AttributePosition::Multiline
+            && attribute_len > 1
+        {
             hard_line_break()
         } else {
             soft_line_break_or_space()

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html
@@ -1,0 +1,1 @@
+<div foo="bar" disabled bar="foo"></div>

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 211
+info: attributes/multiline/break.html
+---
+# Input
+
+```html
+<div foo="bar" disabled bar="foo"></div>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
+-----
+
+```html
+<div foo="bar" disabled bar="foo"></div>
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Multiline
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
+-----
+
+```html
+<div
+	foo="bar"
+	disabled
+	bar="foo"
+></div>
+```

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html
@@ -1,0 +1,1 @@
+<div foo="bar"></div>

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 211
+info: attributes/multiline/no-break.html
+---
+# Input
+
+```html
+<div foo="bar"></div>
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
+-----
+
+```html
+<div foo="bar"></div>
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Multiline
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
+-----
+
+```html
+<div foo="bar"></div>
+```

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/options.json
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/options.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "attributePosition": "multiline"
+  }
+}

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -52,6 +52,7 @@ impl From<HtmlFormatterConfiguration> for HtmlFormatterSettings {
             line_width: config.line_width,
             indent_width: config.indent_width,
             indent_style: config.indent_style,
+            attribute_position: config.attribute_position,
             ..Default::default()
         }
     }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Close: https://github.com/biomejs/biome/issues/4828

Previous PR: https://github.com/biomejs/biome/pull/4972

Add break if elem has multi attributes (at multiline side).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Modified test case for element with single attribute.

<!-- What demonstrates that your implementation is correct? -->
