### PR TITLE
fix(biome_css_analyze): false positive of container name in `noMissingVarFunction`

### DIFF
--- a/.changeset/fix_nomissingvarfunction_false_positives_for_container_name.md
+++ b/.changeset/fix_nomissingvarfunction_false_positives_for_container_name.md
@@ -1,0 +1,4 @@
+---
+---
+
+# Fix [#5007](https://github.com/biomejs/biome/issues/5007) `noMissingVarFunction` false positives for `container-name`

--- a/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
@@ -123,9 +123,10 @@ declare_lint_rule! {
     }
 }
 
-pub const IGNORED_PROPERTIES: [&str; 17] = [
+pub const IGNORED_PROPERTIES: [&str; 18] = [
     "animation",
     "animation-name",
+    "container-name",
     "counter-increment",
     "counter-reset",
     "counter-set",

--- a/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
@@ -60,6 +60,11 @@ a {
     view-transition-name: --bbb;
 }
 
+@property --foo {}
+a {
+	container-name: --foo;
+}
+
 .parent {
     color: --foo;
     .child {

--- a/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css
@@ -60,9 +60,9 @@ a {
     view-transition-name: --bbb;
 }
 
-@property --foo {}
+@property --baz {}
 a {
-	container-name: --foo;
+	container-name: --baz;
 }
 
 .parent {

--- a/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noMissingVarFunction/valid.css.snap
@@ -66,6 +66,11 @@ a {
     view-transition-name: --bbb;
 }
 
+@property --baz {}
+a {
+	container-name: --baz;
+}
+
 .parent {
     color: --foo;
     .child {


### PR DESCRIPTION
closes #5007 

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
- add `container-name` to the ignored properties list

related: 
1. https://github.com/stylelint/stylelint/blob/32c9dded2b6d68ee5a435859d39b091b7f4b0a07/lib/rules/custom-property-no-missing-var-function/index.mjs#L26
2. https://developer.mozilla.org/en-US/docs/Web/CSS/container-name#formal_syntax
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
- added a test case

<!-- What demonstrates that your implementation is correct? -->
