### PR TITLE
feat(format/html): add `css` option for whitespace sensitivity

### DIFF
--- a/crates/biome_html_formatter/src/context.rs
+++ b/crates/biome_html_formatter/src/context.rs
@@ -245,7 +245,11 @@ impl FormatOptions for HtmlFormatOptions {
 )]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum WhitespaceSensitivity {
-    /// Leading and trailing whitespace in content is considered significant for inline elements.
+    /// The formatter considers whitespace significant for elements that have an "inline" display style by default in
+    /// browser's user agent style sheets.
+    #[default]
+    Css,
+    /// Leading and trailing whitespace in content is considered significant for all elements.
     ///
     /// The formatter should leave at least one whitespace character if whitespace is present.
     /// Otherwise, if there is no whitespace, it should not add any after `>` or before `<`. In other words, if there's no whitespace, the text content should hug the tags.
@@ -256,7 +260,6 @@ pub enum WhitespaceSensitivity {
     ///     >content</b
     /// >
     /// ```
-    #[default]
     Strict,
     /// Whitespace is considered insignificant. The formatter is free to remove or add whitespace as it sees fit.
     Ignore,
@@ -265,6 +268,7 @@ pub enum WhitespaceSensitivity {
 impl fmt::Display for WhitespaceSensitivity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Css => std::write!(f, "css"),
             Self::Strict => std::write!(f, "strict"),
             Self::Ignore => std::write!(f, "ignore"),
         }
@@ -276,14 +280,19 @@ impl FromStr for WhitespaceSensitivity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "css" => Ok(Self::Css),
             "strict" => Ok(Self::Strict),
             "ignore" => Ok(Self::Ignore),
-            _ => Err("Value not supported for WhitespaceSensitivity. Supported values are 'strict' and 'ignore'."),
+            _ => Err("Value not supported for WhitespaceSensitivity. Supported values are 'css', 'strict' and 'ignore'."),
         }
     }
 }
 
 impl WhitespaceSensitivity {
+    pub const fn is_css(&self) -> bool {
+        matches!(self, Self::Css)
+    }
+
     pub const fn is_strict(&self) -> bool {
         matches!(self, Self::Strict)
     }

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -46,6 +46,8 @@ impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
                 .as_ref()
                 .is_some_and(|tag_name| tag_name.text().eq_ignore_ascii_case(tag))
         });
+        let is_whitespace_sensitive = whitespace_sensitivity.is_strict()
+            || (whitespace_sensitivity.is_css() && is_inline_tag);
 
         let content_has_leading_whitespace = children
             .syntax()
@@ -85,14 +87,10 @@ impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
         // to borrow, while the child formatters are responsible for actually printing
         // the tokens. `HtmlElementList` prints them if they are borrowed, otherwise
         // they are printed by their original formatter.
-        let should_borrow_opening_r_angle = whitespace_sensitivity.is_strict()
-            && is_inline_tag
-            && !children.is_empty()
-            && !content_has_leading_whitespace;
-        let should_borrow_closing_tag = whitespace_sensitivity.is_strict()
-            && is_inline_tag
-            && !children.is_empty()
-            && !content_has_trailing_whitespace;
+        let should_borrow_opening_r_angle =
+            is_whitespace_sensitive && !children.is_empty() && !content_has_leading_whitespace;
+        let should_borrow_closing_tag =
+            is_whitespace_sensitive && !children.is_empty() && !content_has_trailing_whitespace;
 
         let borrowed_r_angle = if should_borrow_opening_r_angle {
             opening_element.r_angle_token().ok()

--- a/crates/biome_html_formatter/tests/specs/html/attributes/break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/break.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/break.html.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 211
 info: attributes/multiline/break.html
 ---
 # Input
@@ -24,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 
@@ -41,7 +40,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Multiline
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/multiline/no-break.html.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-assertion_line: 211
 info: attributes/multiline/no-break.html
 ---
 # Input
@@ -24,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 
@@ -41,7 +40,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Multiline
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/no-break.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/no-break.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/self-closing.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/attributes/single-quotes.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/attributes/single-quotes.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/bracket-same-line/element.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/bracket-same-line/element.html.snap
@@ -31,7 +31,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 
@@ -54,7 +54,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: true
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/bracket-same-line/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/bracket-same-line/self-closing.html.snap
@@ -29,7 +29,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 
@@ -52,7 +52,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: true
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/empty-extra-lines.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/empty-extra-lines.html.snap
@@ -25,7 +25,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-dont-hug-content-2.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-dont-hug-content-2.html.snap
@@ -25,7 +25,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-dont-hug-content.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-dont-hug-content.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-longer-w-attr.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-longer-w-attr.html.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: elements/inline/tags-hug-content-longer.html
+info: elements/inline/tags-hug-content-longer-w-attr.html
 ---
 # Input
 
@@ -22,7 +22,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-w-attr.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content-w-attr.html.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: elements/inline/tags-hug-content.html
+info: elements/inline/tags-hug-content-w-attr.html
 ---
 # Input
 
@@ -22,7 +22,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/inline/tags-hug-content.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/pre-with-brackets.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/pre-with-brackets.html.snap
@@ -32,7 +32,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/pre-with-braille.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/pre-with-braille.html.snap
@@ -54,7 +54,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/pre.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/pre.html.snap
@@ -35,7 +35,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case0.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case0.html.snap
@@ -28,7 +28,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case1.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case1.html.snap
@@ -30,7 +30,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case2.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case2.html.snap
@@ -28,7 +28,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case3.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case3.html.snap
@@ -28,7 +28,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/elements/spacing/case4.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/elements/spacing/case4.html.snap
@@ -25,7 +25,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/example.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/example.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/long-content.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/long-content.html.snap
@@ -23,7 +23,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/many-children.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/many-children.html.snap
@@ -26,7 +26,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
@@ -25,7 +25,7 @@ Line ending: LF
 Line width: 80
 Attribute Position: Auto
 Bracket same line: false
-Whitespace sensitivity: strict
+Whitespace sensitivity: css
 Indent script and style: false
 -----
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -856,7 +856,7 @@ As a consequence of this, the formatter must format blocks that look like this (
 
 Note that this is only necessary for inline elements. Block elements do not have this restriction. 
 	 */
-export type WhitespaceSensitivity = "strict" | "ignore";
+export type WhitespaceSensitivity = "css" | "strict" | "ignore";
 export type ArrowParentheses = "always" | "asNeeded";
 export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -5025,7 +5025,12 @@
 			"description": "Whitespace sensitivity for HTML formatting.\n\nThe following two cases won't produce the same output:\n\n|                |      html      |    output    | | -------------- | :------------: | :----------: | | with spaces    | `1<b> 2 </b>3` | 1<b> 2 </b>3 | | without spaces |  `1<b>2</b>3`  |  1<b>2</b>3  |\n\nThis happens because whitespace is significant in inline elements.\n\nAs a consequence of this, the formatter must format blocks that look like this (assume a small line width, <20): ```html <span>really long content</span> ``` as this, where the content hugs the tags: ```html <span >really long content</span > ```\n\nNote that this is only necessary for inline elements. Block elements do not have this restriction.",
 			"oneOf": [
 				{
-					"description": "Leading and trailing whitespace in content is considered significant for inline elements.\n\nThe formatter should leave at least one whitespace character if whitespace is present. Otherwise, if there is no whitespace, it should not add any after `>` or before `<`. In other words, if there's no whitespace, the text content should hug the tags.\n\nExample of text hugging the tags: ```html <b >content</b > ```",
+					"description": "The formatter considers whitespace significant for elements that have an \"inline\" display style by default in browser's user agent style sheets.",
+					"type": "string",
+					"enum": ["css"]
+				},
+				{
+					"description": "Leading and trailing whitespace in content is considered significant for all elements.\n\nThe formatter should leave at least one whitespace character if whitespace is present. Otherwise, if there is no whitespace, it should not add any after `>` or before `<`. In other words, if there's no whitespace, the text content should hug the tags.\n\nExample of text hugging the tags: ```html <b >content</b > ```",
 					"type": "string",
 					"enum": ["strict"]
 				},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This adds a `css` option for whitespace sensitivity to the HTML formattter. This option does what `strict` previously did, where it considers which elements are "inline" to determine whether or not to apply whitespace sensitivity rules. The `strict` option now considers *all* elements to be whitespace sensitive, matching prettier's behavior.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related: #4927

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should pass.
