### PR TITLE
fix(format/html): enforce whitespace sensitivity for siblings in HtmlElementList

### DIFF
--- a/crates/biome_html_formatter/src/utils/metadata.rs
+++ b/crates/biome_html_formatter/src/utils/metadata.rs
@@ -1,3 +1,8 @@
+use biome_html_syntax::AnyHtmlElement;
+use biome_rowan::AstNode;
+
+use crate::HtmlFormatter;
+
 /// HTML tags that have an "inline" layout by default.
 ///
 /// In HTML, The inline layout treats the element as if it were a single line of text. This means that the element does not start on a new line, and only takes up as much width as necessary.
@@ -12,3 +17,29 @@ pub const HTML_INLINE_TAGS: &[&str] = &[
     // TODO: this is incomplete. derive this from the HTML spec.
     "b", "i", "u", "span", "a", "strong", "em", "small", "big",
 ];
+
+/// Whether or not an element should be considered whitespace sensitive, considering the element's tag name and the
+/// formatter's whitespace sensitivity options.
+pub(crate) fn is_element_whitespace_sensitive(f: &HtmlFormatter, element: &AnyHtmlElement) -> bool {
+    let name = match element {
+        AnyHtmlElement::HtmlElement(element) => {
+            element.opening_element().and_then(|element| element.name())
+        }
+        AnyHtmlElement::HtmlSelfClosingElement(element) => element.name(),
+        _ => return false,
+    };
+
+    let is_inline_element = if let Ok(name) = name {
+        let Ok(Some(tag_name)) = name.trim_trivia().map(|t| t.value_token()).transpose() else {
+            return false;
+        };
+        HTML_INLINE_TAGS
+            .iter()
+            .any(|tag| tag_name.text().eq_ignore_ascii_case(tag))
+    } else {
+        false
+    };
+
+    let sensitivity = f.options().whitespace_sensitivity();
+    sensitivity.is_css() && is_inline_element || sensitivity.is_strict()
+}

--- a/crates/biome_html_formatter/src/utils/metadata.rs
+++ b/crates/biome_html_formatter/src/utils/metadata.rs
@@ -18,7 +18,7 @@ pub const HTML_INLINE_TAGS: &[&str] = &[
     "b", "i", "u", "span", "a", "strong", "em", "small", "big",
 ];
 
-/// Whether or not an element should be considered whitespace sensitive, considering the element's tag name and the
+/// Whether an element should be considered whitespace sensitive, considering the element's tag name and the
 /// formatter's whitespace sensitivity options.
 pub(crate) fn is_element_whitespace_sensitive(f: &HtmlFormatter, element: &AnyHtmlElement) -> bool {
     let name = match element {

--- a/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html
+++ b/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html
@@ -1,0 +1,14 @@
+Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
+sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
+feugiat ac.<b
+  attribute="really long for this example"
+  actually="so long it should break and become multiline"
+  >Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
+  augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
+  vestibulum nulla.</b
+>Donec maximus euismod egestas. Sed tempus semper efficitur. Suspendisse maximus
+ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
+  attribute="really long for this example"
+  actually="so long it should break and become multiline"
+/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+viverra libero quis lacus euismod, ut consequat ante convallis.

--- a/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html.snap
@@ -1,0 +1,58 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: long-inline-elements.html
+---
+# Input
+
+```html
+Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
+sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
+feugiat ac.<b
+  attribute="really long for this example"
+  actually="so long it should break and become multiline"
+  >Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
+  augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
+  vestibulum nulla.</b
+>Donec maximus euismod egestas. Sed tempus semper efficitur. Suspendisse maximus
+ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
+  attribute="really long for this example"
+  actually="so long it should break and become multiline"
+/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+viverra libero quis lacus euismod, ut consequat ante convallis.
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+-----
+
+```html
+Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
+sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
+feugiat ac.<b
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+	>Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
+	augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
+	vestibulum nulla.</b
+>Donec maximus euismod egestas. Sed tempus semper efficitur. Suspendisse maximus
+ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+viverra libero quis lacus euismod, ut consequat ante convallis.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This attempts to handle whitespace sensitivity cases where there's inline elements in a long chunk of text.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related: #4927

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a new test.
