### PR TITLE
fix: repair explosive memory leak in GritQL parser

### DIFF
--- a/crates/biome_grit_parser/src/lexer/mod.rs
+++ b/crates/biome_grit_parser/src/lexer/mod.rs
@@ -180,7 +180,7 @@ impl<'src> GritLexer<'src> {
     fn lex_token(&mut self, current: u8) -> GritSyntaxKind {
         match current {
             b'\n' | b'\r' => {
-                debug_assert!(self.consume_newline());
+                assert!(self.consume_newline());
                 NEWLINE
             }
             b'\t' | b' ' => self.consume_whitespaces(),

--- a/crates/biome_grit_parser/src/lexer/mod.rs
+++ b/crates/biome_grit_parser/src/lexer/mod.rs
@@ -180,7 +180,7 @@ impl<'src> GritLexer<'src> {
     fn lex_token(&mut self, current: u8) -> GritSyntaxKind {
         match current {
             b'\n' | b'\r' => {
-                assert!(self.consume_newline());
+                self.consume_newline();
                 NEWLINE
             }
             b'\t' | b' ' => self.consume_whitespaces(),

--- a/crates/biome_grit_parser/src/parser/mod.rs
+++ b/crates/biome_grit_parser/src/parser/mod.rs
@@ -3,6 +3,7 @@ mod literals;
 mod parse_error;
 mod patterns;
 mod predicates;
+mod tests;
 
 use crate::constants::*;
 use crate::token_source::GritTokenSource;

--- a/crates/biome_grit_parser/src/parser/tests.rs
+++ b/crates/biome_grit_parser/src/parser/tests.rs
@@ -1,0 +1,11 @@
+#![cfg(test)]
+
+use crate::parse_grit;
+
+/// This pattern should be parseable, but previously caused explosive memory usage
+#[test]
+fn parse_language_declaration() {
+    let code = "language js\n";
+    let parse = parse_grit(code);
+    assert!(parse.diagnostics().is_empty());
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes https://github.com/biomejs/biome/issues/5032 to prevent the parser from consuming infinite memory.

We previously only consumed new-lines in debug builds: https://github.com/biomejs/biome/pull/5033/files#diff-15e627641974e3cc1e6efc62bdc4b632ca41315fa8cc7b5bf3dd50c40df65d3eL183

This of course is very problematic when trying to use the parser in a released build.

## Test Plan

Since this behavior only shows up in release builds, I don't have a simple way to run the tests unless we want to switch CI to use the `--release` profile for running tests.