### PR TITLE
ci: rebrand nightly releases as preview releases

### DIFF
--- a/.github/actions/build-cli/action.yml
+++ b/.github/actions/build-cli/action.yml
@@ -1,0 +1,83 @@
+name: Build Biome CLI
+description: Build the Biome CLI
+inputs:
+  version:
+    description: The version of Biome
+    required: true
+    default: "0.0.0"
+  code-target:
+    description: The OS code target
+    required: true
+  target:
+    description: The OS target
+    required: true
+  os:
+    description: The OS name
+    required: true
+
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Install Node.js
+      uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      with:
+        node-version: 20
+
+    - name: Install Rust toolchain
+      run: rustup target add ${{ inputs.target }}
+
+    - name: Install arm64 toolchain
+      if: inputs.code-target == 'linux-arm64' || inputs.code-target == 'linux-arm64-musl'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu
+
+    - name: Install musl toolchain
+      if: inputs.code-target == 'linux-x64-musl' || inputs.code-target == 'linux-arm64-musl'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+
+    - name: Audit crates.io dependencies
+      if: inputs.code-target == 'linux-x64'
+      run: cargo audit
+
+    - name: Set jemalloc page size for linux-arm64
+      if: inputs.code-target == 'linux-arm64'
+      run: |
+        echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
+
+    # Build the CLI binary
+    - name: Build binaries
+      run: cargo build -p biome_cli --release --target ${{ inputs.target }}
+      env:
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        # Strip all debug symbols from the resulting binaries
+        RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
+        # Inline the version of the npm package in the CLI binary
+        BIOME_VERSION: ${{ inputs.version }}
+
+    # Copy the CLI binary and rename it to include the name of the target platform
+    - name: Copy CLI binary
+      if: inputs.os == 'windows-2022'
+      run: |
+        mkdir dist
+        cp target/${{ inputs.target }}/release/biome.exe ./dist/biome-${{ inputs.code-target }}.exe
+    - name: Copy CLI binary
+      if: inputs.os != 'windows-2022'
+      run: |
+        mkdir dist
+        cp target/${{ inputs.target }}/release/biome ./dist/biome-${{ inputs.code-target }}
+
+    # Upload the CLI binary as a build artifact
+    - name: Upload CLI artifact
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      with:
+        name: cli-${{ inputs.target }}
+        path: ./dist/biome-*
+      if-no-files-found: error

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,97 @@
+name: Preview releases
+on:
+  workflow_dispatch:
+
+jobs:
+  build-binaries:
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            target: x86_64-pc-windows-msvc
+            code-target: win32-x64
+          - os: windows-2022
+            target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-gnu
+            code-target: linux-arm64
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            code-target: linux-x64-musl
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            code-target: linux-arm64-musl
+          - os: macos-14
+            target: x86_64-apple-darwin
+            code-target: darwin-x64
+          - os: macos-14
+            target: aarch64-apple-darwin
+            code-target: darwin-arm64
+
+    name: Package ${{ matrix.code-target }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Run build
+        uses: ./.github/actions/build
+        with:
+          os: ${{ matrix.os }}
+          target: ${{ matrix.target }}
+          code-target: ${{ matrix.code-target }}
+          version: ${{ env.cli-version }}
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs:
+      - build-binaries
+    environment: npm-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: cli-*
+          merge-multiple: true
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: wasm-*
+          merge-multiple: true
+          path: packages/@biomejs
+
+      - name: Install Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Pin Corepack 0.20
+        run: |
+          echo "Before: corepack => $(corepack --version || echo 'not installed')"
+          npm install -g corepack@0.20
+          echo "After : corepack => $(corepack --version)"
+          corepack enable
+          pnpm --version
+
+      - name: Generate npm packages
+        run: node packages/@biomejs/biome/scripts/generate-packages.mjs
+
+      - name: Run changesets version
+        run: pnpm exec changeset version --snapshot preview
+
+      - name: Publish version
+        run: pnpm exec changeset publish  --tag preview
+        env:
+          # Needs access to publish to npm
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -6,9 +6,9 @@ on:
       - main
       - next
     paths: # Only run when changes are made to js code
-      - 'editors/**'
-      #     - 'crates/**'
-      - 'packages/@biomejs/js-api/**'
+      - 'packages/@biomejs/**'
+      - 'packages/aria-data/**'
+      - 'packages/tailwindcss-config-analyzer/**'
 
 # Cancel jobs when the PR is updated
 concurrency:
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-      - name: Run Biome Format
+      - name: Run Biome CI check
         run: |
           pnpm i
           pnpm run ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,68 +107,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      - name: Run build
+        uses: ./.github/actions/build-cli
         with:
-          node-version: 20
-
-      - name: Install Rust toolchain
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Install arm64 toolchain
-        if: matrix.code-target == 'linux-arm64' || matrix.code-target == 'linux-arm64-musl'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Install musl toolchain
-        if: matrix.code-target == 'linux-x64-musl' || matrix.code-target == 'linux-arm64-musl'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y musl-tools
-
-      - name: Audit crates.io dependencies
-        if: matrix.code-target == 'linux-x64'
-        run: cargo audit
-
-      - name: Set jemalloc page size for linux-arm64
-        if: matrix.code-target == 'linux-arm64'
-        run: |
-          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
-
-      # Build the CLI binary
-      - name: Build binaries
-        run: cargo build -p biome_cli --release --target ${{ matrix.target }}
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
-          # Strip all debug symbols from the resulting binaries
-          RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
-          # Inline the version of the npm package in the CLI binary
-          BIOME_VERSION: ${{ env.cli-version }}
-
-      # Copy the CLI binary and rename it to include the name of the target platform
-      - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
-        run: |
-          mkdir dist
-          cp target/${{ matrix.target }}/release/biome.exe ./dist/biome-${{ matrix.code-target }}.exe
-      - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
-        run: |
-          mkdir dist
-          cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}
-
-      # Upload the CLI binary as a build artifact
-      - name: Upload CLI artifact
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: cli-${{ matrix.target }}
-          path: ./dist/biome-*
-          if-no-files-found: error
+          os: ${{ matrix.os }}
+          target: ${{ matrix.target }}
+          code-target: ${{ matrix.code-target }}
+          version: ${{ env.cli-version }}
 
   build-wasm:
     name: Build WASM


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR does the following:
- creates a new workflow called `preview.yml` which we can use to create **Preview releases**. Preview releases are the "new nightlies", where a preview release is only built upon a workflow dispatch and approval of a core contributors. While nightly releases are good, they use a lot of compute time in the CI and don't publish all of them.
- it moves the shared logic for building the binaries inside a composite job, so we don't repeat ourselves 
- preview releases and prod releases will have two separate workflows/files

This new preview workflow relies on the the [changeset snapshot release](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md). They have their own naming convention, but I believe it's fine. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Proof read. I will test it once we will merge `next` to `main`

<!-- What demonstrates that your implementation is correct? -->
