### PR TITLE
chore: fix windows specific script errors

### DIFF
--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -63,7 +63,7 @@ async fn try_connect() -> io::Result<NamedPipeClient> {
 
 /// Process creation flag from the Win32 API, ensures the process is created
 /// in its own group and will not be killed when the parent process exits
-const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 
 /// Spawn the daemon server process in the background
 fn spawn_daemon(

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -813,7 +813,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
 
     #[cfg(target_os = "windows")]
     {
-        check_windows_symlink!(symlink_dir(&subdir2_path, &subdir1_path.join("symlink1")));
+        check_windows_symlink!(symlink_dir(&subdir2_path, subdir1_path.join("symlink1")));
         check_windows_symlink!(symlink_dir(subdir1_path, subdir2_path.join("symlink2")));
     }
 

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -178,15 +178,6 @@ const APPLY_ATTRIBUTE_POSITION_AFTER: &str = r#"<Foo
 </Foo>;
 "#;
 
-const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
-    return { a, b }
-  }"#;
-
-const DEFAULT_CONFIGURATION_AFTER: &str = "function f() {
-      return { a, b };
-}
-";
-
 const CUSTOM_CONFIGURATION_BEFORE: &str = r#"function f() {
   return { a, b }
 }"#;

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -178,6 +178,17 @@ const APPLY_ATTRIBUTE_POSITION_AFTER: &str = r#"<Foo
 </Foo>;
 "#;
 
+#[cfg(not(windows))]
+const DEFAULT_CONFIGURATION_BEFORE: &str = r#"function f() {
+    return { a, b }
+  }"#;
+
+#[cfg(not(windows))]
+const DEFAULT_CONFIGURATION_AFTER: &str = "function f() {
+      return { a, b };
+}
+";
+
 const CUSTOM_CONFIGURATION_BEFORE: &str = r#"function f() {
   return { a, b }
 }"#;

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -847,7 +847,7 @@ fn fs_error_infinite_symlink_expansion_to_dirs() {
 
     #[cfg(target_os = "windows")]
     {
-        check_windows_symlink!(symlink_dir(&subdir2_path, &subdir1_path.join("symlink1")));
+        check_windows_symlink!(symlink_dir(&subdir2_path, subdir1_path.join("symlink1")));
         check_windows_symlink!(symlink_dir(subdir1_path, subdir2_path.join("symlink2")));
     }
 

--- a/justfile
+++ b/justfile
@@ -115,7 +115,8 @@ _touch file:
 
 [windows]
 _touch file:
-  (gci {{file}}).LastWriteTime = Get-Date
+  powershell -Command "(Get-Item {{file}}).LastWriteTime = Get-Date"
+
 
 # Run tests of all crates
 test:


### PR DESCRIPTION
## Summary

This PR aims to solve the errors thrown by `just l` and `just _touch` on Windows systems. 

### `just l`

The linter succeeds in CI but not locally on my Windows machine. This is because it seems to not lint code with the `#[cfg(target_os = "windows")]` directive as the runner OS is Linux. In the future I suggest using a matrix runner in CI that runs the same linter workflow on both Windows and Unix so every OS is covered.

These were the fixes I had to implement on my local Windows machine, as recommend by the linter:

- Removed unnecessary explicit references (`&`)
- Added `#[cfg(not(windows))]` to Linux only variables, avoiding unused variable errors
- Wrote hexadecimal with equally sized groups of digits

### `just _touch`

Made the script call `powershell` explicitly, this allows the user to use either CMD, Powershell, or any other shell of their choice on Windows and still have the command called by Powershell under the hood.

Fixes other scripts by extension, like `test-lintrule` and `test-transform`, that relied on `just _touch` to function correctly.  

## Test Plan

Changes made do not require tests.
