### PR TITLE
feat(biome_js_formatter): introduce the new objectWrap option

### DIFF
--- a/.changeset/gentle-spies-drum.md
+++ b/.changeset/gentle-spies-drum.md
@@ -1,0 +1,20 @@
+---
+"@biomejs/biome": minor
+---
+
+Introduce a new option `objectWrap` for JS formatter.
+It does the same thing as Prettier's [Object Wrap](https://prettier.io/docs/options#object-wrap) option.
+
+For example, the following code is considered as already formatted when `objectWrap` is `preserve` (default):
+
+```js
+const obj = {
+  foo: "bar",
+};
+```
+
+However, when `objectWrap` is `collapse`, it will be formatted to the following output:
+
+```js
+const obj = { foo: "bar" };
+```

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -11,7 +11,9 @@ use biome_formatter::{
     QuoteStyle,
 };
 use biome_fs::{FileSystem, OpenOptions};
-use biome_js_formatter::context::{ArrowParentheses, QuoteProperties, Semicolons, TrailingCommas};
+use biome_js_formatter::context::{
+    ArrowParentheses, ObjectWrap, QuoteProperties, Semicolons, TrailingCommas,
+};
 use biome_json_parser::JsonParserOptions;
 use camino::Utf8Path;
 
@@ -248,6 +250,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::Configuration {
             bracket_spacing: Some(value.bracket_spacing.into()),
             jsx_quote_style: Some(jsx_quote_style),
             attribute_position: Some(AttributePosition::default()),
+            object_wrap: Some(ObjectWrap::default()), // TODO(siketyan): Prettier migration support
         };
         let js_config = biome_configuration::JsConfiguration {
             formatter: Some(js_formatter),

--- a/crates/biome_cli/src/execute/migrate/prettier.rs
+++ b/crates/biome_cli/src/execute/migrate/prettier.rs
@@ -12,7 +12,7 @@ use biome_formatter::{
 };
 use biome_fs::{FileSystem, OpenOptions};
 use biome_js_formatter::context::{
-    ArrowParentheses, ObjectWrap, QuoteProperties, Semicolons, TrailingCommas,
+    ArrowParentheses, ObjectWrap as BiomeObjectWrap, QuoteProperties, Semicolons, TrailingCommas,
 };
 use biome_json_parser::JsonParserOptions;
 use camino::Utf8Path;
@@ -58,6 +58,8 @@ pub(crate) struct PrettierConfiguration {
     arrow_parens: ArrowParens,
     /// https://prettier.io/docs/en/options#end-of-line
     end_of_line: EndOfLine,
+    /// https://prettier.io/docs/options#object-wrap
+    object_wrap: ObjectWrap,
     /// https://prettier.io/docs/en/configuration.html#configuration-overrides
     overrides: Vec<Override>,
 }
@@ -77,6 +79,7 @@ impl Default for PrettierConfiguration {
             jsx_single_quote: false,
             arrow_parens: ArrowParens::default(),
             end_of_line: EndOfLine::default(),
+            object_wrap: ObjectWrap::default(),
             overrides: vec![],
         }
     }
@@ -115,6 +118,8 @@ pub(crate) struct OverrideOptions {
     arrow_parens: Option<ArrowParens>,
     /// https://prettier.io/docs/en/options#end-of-line
     end_of_line: Option<EndOfLine>,
+    /// https://prettier.io/docs/options#object-wrap
+    object_wrap: ObjectWrap,
 }
 
 #[derive(Clone, Debug, Default, Deserializable, Eq, PartialEq)]
@@ -147,6 +152,13 @@ enum QuoteProps {
     #[deserializable(rename = "as-needed")]
     AsNeeded,
     Preserve,
+}
+
+#[derive(Clone, Debug, Default, Deserializable, Eq, PartialEq)]
+enum ObjectWrap {
+    #[default]
+    Preserve,
+    Collapse,
 }
 
 impl From<PrettierTrailingComma> for TrailingCommas {
@@ -184,6 +196,15 @@ impl From<QuoteProps> for QuoteProperties {
         match value {
             QuoteProps::AsNeeded => Self::AsNeeded,
             QuoteProps::Preserve => Self::Preserve,
+        }
+    }
+}
+
+impl From<ObjectWrap> for BiomeObjectWrap {
+    fn from(value: ObjectWrap) -> Self {
+        match value {
+            ObjectWrap::Preserve => Self::Preserve,
+            ObjectWrap::Collapse => Self::Collapse,
         }
     }
 }
@@ -250,7 +271,7 @@ impl TryFrom<PrettierConfiguration> for biome_configuration::Configuration {
             bracket_spacing: Some(value.bracket_spacing.into()),
             jsx_quote_style: Some(jsx_quote_style),
             attribute_position: Some(AttributePosition::default()),
-            object_wrap: Some(ObjectWrap::default()), // TODO(siketyan): Prettier migration support
+            object_wrap: Some(value.object_wrap.into()),
         };
         let js_config = biome_configuration::JsConfiguration {
             formatter: Some(js_formatter),

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 # Emitted Messages
 
@@ -71,6 +70,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
+        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
+                              possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -70,8 +70,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
-        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
-                              possible. Defaults to preserve.
+        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
+                              when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 # Emitted Messages
 
@@ -72,6 +71,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
+        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
+                              possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -71,8 +71,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
                               elements. Defaults to auto.
-        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
-                              possible. Defaults to preserve.
+        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
+                              when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 # Emitted Messages
 
@@ -56,6 +55,8 @@ Formatting options specific to the JavaScript files
                               elements. Defaults to auto.
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
+        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
+                              possible. Defaults to preserve.
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-enabled=<true|false>  Whether Biome should integrate itself with the VCS client

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -55,8 +55,8 @@ Formatting options specific to the JavaScript files
                               elements. Defaults to auto.
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
-        --object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals when
-                              possible. Defaults to preserve.
+        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
+                              when possible. Defaults to preserve.
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-enabled=<true|false>  Whether Biome should integrate itself with the VCS client

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -47,11 +46,12 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
       22 │ + → → → "bracketSameLine":·false,
       23 │ + → → → "quoteStyle":·"single",
       24 │ + → → → "attributePosition":·"auto",
-      25 │ + → → → "bracketSpacing":·true
-      26 │ + → → }
-      27 │ + → }
-      28 │ + }
-      29 │ + 
+      25 │ + → → → "bracketSpacing":·true,
+      26 │ + → → → "objectWrap":·"preserve"
+      27 │ + → → }
+      28 │ + → }
+      29 │ + }
+      30 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_end_of_line.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -50,11 +49,12 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
       21 │ + → → → "bracketSameLine":·false,
       22 │ + → → → "quoteStyle":·"single",
       23 │ + → → → "attributePosition":·"auto",
-      24 │ + → → → "bracketSpacing":·true
-      25 │ + → → }
-      26 │ + → }
-      27 │ + }
-      28 │ + 
+      24 │ + → → → "bracketSpacing":·true,
+      25 │ + → → → "objectWrap":·"preserve"
+      26 │ + → → }
+      27 │ + → }
+      28 │ + }
+      29 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -30,7 +29,8 @@ snapshot_kind: text
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_jsonc.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.jsonc`
 
@@ -47,11 +46,12 @@ biome.jsonc migrate ━━━━━━━━━━━━━━━━━━━━
       22 │ + → → → "bracketSameLine":·false,
       23 │ + → → → "quoteStyle":·"single",
       24 │ + → → → "attributePosition":·"auto",
-      25 │ + → → → "bracketSpacing":·true
-      26 │ + → → }
-      27 │ + → }
-      28 │ + }
-      29 │ + 
+      25 │ + → → → "bracketSpacing":·true,
+      26 │ + → → → "objectWrap":·"preserve"
+      27 │ + → → }
+      28 │ + → }
+      29 │ + }
+      30 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_overrides.snap
@@ -56,27 +56,28 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
       21 │ + → → → "bracketSameLine":·false,
       22 │ + → → → "quoteStyle":·"single",
       23 │ + → → → "attributePosition":·"auto",
-      24 │ + → → → "bracketSpacing":·true
-      25 │ + → → }
-      26 │ + → },
-      27 │ + → "overrides":·[
-      28 │ + → → {·"includes":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
-      29 │ + → → {
-      30 │ + → → → "includes":·["**/*.spec.js"],
-      31 │ + → → → "javascript":·{
-      32 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      33 │ + → → → }
-      34 │ + → → },
-      35 │ + → → {
-      36 │ + → → → "includes":·["**/*.ts"],
-      37 │ + → → → "javascript":·{
-      38 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
-      39 │ + → → → },
-      40 │ + → → → "formatter":·{·"indentStyle":·"space"·}
-      41 │ + → → }
-      42 │ + → ]
-      43 │ + }
-      44 │ + 
+      24 │ + → → → "bracketSpacing":·true,
+      25 │ + → → → "objectWrap":·"preserve"
+      26 │ + → → }
+      27 │ + → },
+      28 │ + → "overrides":·[
+      29 │ + → → {·"includes":·["**/*.test.js"],·"formatter":·{·"indentStyle":·"space"·}·},
+      30 │ + → → {
+      31 │ + → → → "includes":·["**/*.spec.js"],
+      32 │ + → → → "javascript":·{
+      33 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      34 │ + → → → }
+      35 │ + → → },
+      36 │ + → → {
+      37 │ + → → → "includes":·["**/*.ts"],
+      38 │ + → → → "javascript":·{
+      39 │ + → → → → "formatter":·{·"semicolons":·"always",·"quoteStyle":·"single"·}
+      40 │ + → → → },
+      41 │ + → → → "formatter":·{·"indentStyle":·"space"·}
+      42 │ + → → }
+      43 │ + → ]
+      44 │ + }
+      45 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_ignore.snap
@@ -60,11 +60,12 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
       23 │ + → → → "bracketSameLine":·false,
       24 │ + → → → "quoteStyle":·"single",
       25 │ + → → → "attributePosition":·"auto",
-      26 │ + → → → "bracketSpacing":·true
-      27 │ + → → }
-      28 │ + → }
-      29 │ + }
-      30 │ + 
+      26 │ + → → → "bracketSpacing":·true,
+      27 │ + → → → "objectWrap":·"preserve"
+      28 │ + → → }
+      29 │ + → }
+      30 │ + }
+      31 │ + 
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -30,7 +29,8 @@ snapshot_kind: text
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.jsonc`
 
@@ -30,7 +29,8 @@ snapshot_kind: text
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -30,7 +29,8 @@ snapshot_kind: text
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
@@ -30,7 +30,8 @@ expression: redactor(content)
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -30,7 +29,8 @@ snapshot_kind: text
       "bracketSameLine": false,
       "quoteStyle": "single",
       "attributePosition": "auto",
-      "bracketSpacing": true
+      "bracketSpacing": true,
+      "objectWrap": "preserve"
     }
   }
 }

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -5,7 +5,7 @@ use biome_formatter::{
     LineWidth, QuoteStyle,
 };
 use biome_js_formatter::context::{
-    trailing_commas::TrailingCommas, ArrowParentheses, QuoteProperties, Semicolons,
+    trailing_commas::TrailingCommas, ArrowParentheses, ObjectWrap, QuoteProperties, Semicolons,
 };
 use bpaf::Bpaf;
 use serde::{Deserialize, Serialize};
@@ -103,6 +103,11 @@ pub struct JsFormatterConfiguration {
     #[bpaf(long("bracket-spacing"), argument("true|false"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<BracketSpacing>,
+
+    /// Whether to enforce collapsing object literals when possible. Defaults to preserve.
+    #[bpaf(long("object-wrap"), argument("preserve|collapse"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_wrap: Option<ObjectWrap>,
 }
 
 impl JsFormatterConfiguration {
@@ -136,5 +141,9 @@ impl JsFormatterConfiguration {
 
     pub fn quote_style_resolved(&self) -> QuoteStyle {
         self.quote_style.unwrap_or_default()
+    }
+
+    pub fn object_wrap_resolved(&self) -> ObjectWrap {
+        self.object_wrap.unwrap_or_default()
     }
 }

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -105,7 +105,7 @@ pub struct JsFormatterConfiguration {
     pub bracket_spacing: Option<BracketSpacing>,
 
     /// Whether to enforce collapsing object literals when possible. Defaults to preserve.
-    #[bpaf(long("object-wrap"), argument("preserve|collapse"))]
+    #[bpaf(long("javascript-object-wrap"), argument("preserve|collapse"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_wrap: Option<ObjectWrap>,
 }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -579,8 +579,8 @@ impl FromStr for ObjectWrap {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "as-needed"  => Ok(Self::Preserve),
-            "always"  => Ok(Self::Collapse),
+            "preserve"  => Ok(Self::Preserve),
+            "contains"  => Ok(Self::Collapse),
             _ => Err("Value not supported for objectWrap. Supported values are 'preserve' and 'collapse'."),
         }
     }

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -173,6 +173,9 @@ pub struct JsFormatOptions {
 
     /// Attribute position style. By default auto.
     attribute_position: AttributePosition,
+
+    /// Whether to enforce collapsing object literals when possible. Defaults to "preserve".
+    object_wrap: ObjectWrap,
 }
 
 impl JsFormatOptions {
@@ -192,6 +195,7 @@ impl JsFormatOptions {
             bracket_spacing: BracketSpacing::default(),
             bracket_same_line: BracketSameLine::default(),
             attribute_position: AttributePosition::default(),
+            object_wrap: ObjectWrap::default(),
         }
     }
 
@@ -260,6 +264,11 @@ impl JsFormatOptions {
         self
     }
 
+    pub fn with_object_wrap(mut self, object_wrap: ObjectWrap) -> Self {
+        self.object_wrap = object_wrap;
+        self
+    }
+
     pub fn set_arrow_parentheses(&mut self, arrow_parentheses: ArrowParentheses) {
         self.arrow_parentheses = arrow_parentheses;
     }
@@ -303,8 +312,13 @@ impl JsFormatOptions {
     pub fn set_trailing_commas(&mut self, trailing_commas: TrailingCommas) {
         self.trailing_commas = trailing_commas;
     }
+
     pub fn set_attribute_position(&mut self, attribute_position: AttributePosition) {
         self.attribute_position = attribute_position;
+    }
+
+    pub fn set_object_wrap(&mut self, object_wrap: ObjectWrap) {
+        self.object_wrap = object_wrap;
     }
 
     pub fn set_semicolons(&mut self, semicolons: Semicolons) {
@@ -353,6 +367,10 @@ impl JsFormatOptions {
 
     pub fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
+    }
+
+    pub fn object_wrap(&self) -> ObjectWrap {
+        self.object_wrap
     }
 }
 
@@ -404,7 +422,8 @@ impl fmt::Display for JsFormatOptions {
         writeln!(f, "Arrow parentheses: {}", self.arrow_parentheses)?;
         writeln!(f, "Bracket spacing: {}", self.bracket_spacing.value())?;
         writeln!(f, "Bracket same line: {}", self.bracket_same_line.value())?;
-        writeln!(f, "Attribute Position: {}", self.attribute_position)
+        writeln!(f, "Attribute Position: {}", self.attribute_position)?;
+        writeln!(f, "Object wrap: {}", self.object_wrap)
     }
 }
 
@@ -528,6 +547,50 @@ impl fmt::Display for ArrowParentheses {
         match self {
             ArrowParentheses::AsNeeded => write!(f, "As needed"),
             ArrowParentheses::Always => write!(f, "Always"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserializable, Eq, Hash, Merge, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ObjectWrap {
+    #[default]
+    Preserve,
+    Collapse,
+}
+
+impl ObjectWrap {
+    pub const fn is_preserve(&self) -> bool {
+        matches!(self, Self::Preserve)
+    }
+
+    pub const fn is_collapse(&self) -> bool {
+        matches!(self, Self::Collapse)
+    }
+}
+
+impl FromStr for ObjectWrap {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "as-needed"  => Ok(Self::Preserve),
+            "always"  => Ok(Self::Collapse),
+            _ => Err("Value not supported for objectWrap. Supported values are 'preserve' and 'collapse'."),
+        }
+    }
+}
+
+impl fmt::Display for ObjectWrap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Preserve => write!(f, "Preserve"),
+            Self::Collapse => write!(f, "Collapse"),
         }
     }
 }

--- a/crates/biome_js_formatter/src/utils/object_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_like.rs
@@ -61,7 +61,9 @@ impl Format<JsFormatContext> for JsObjectLike {
             )?;
         } else {
             let should_insert_space_around_brackets = f.options().bracket_spacing().value();
-            let should_expand = self.members_have_leading_newline();
+            let should_expand =
+                f.options().object_wrap().is_preserve() && self.members_have_leading_newline();
+
             write!(
                 f,
                 [group(&soft_block_indent_with_maybe_space(

--- a/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/array_nested.js.snap
@@ -70,6 +70,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/binding_pattern.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/empty_lines.js.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spaces.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/spread.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/es5/array_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/es5/array_trailing_commas.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/array/trailing-comma/es5/array_trailing_comma.js
+info: js/module/array/trailing-commas/es5/array_trailing_commas.js
 ---
 # Input
 
@@ -39,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -72,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/none/array_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/array/trailing-commas/none/array_trailing_commas.js.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
-info: js/module/array/trailing-comma/none/array_trailing_comma.js
+info: js/module/array/trailing-commas/none/array_trailing_commas.js
 ---
 # Input
 
@@ -39,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -72,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow-comments.js.snap
@@ -50,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -91,6 +92,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_chain_comments.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -75,6 +76,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_function.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -66,6 +67,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_nested.js.snap
@@ -56,6 +56,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -103,6 +104,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/arrow_test_callback.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -63,6 +64,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/assignment_binding_line_break.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/assignment_binding_line_break.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -66,6 +67,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/call.js.snap
@@ -73,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -147,6 +148,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/curried_indents.js.snap
@@ -72,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -140,6 +141,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/currying.js.snap
@@ -79,6 +79,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -170,6 +171,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/arrow/params.js.snap
@@ -355,6 +355,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -683,6 +684,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/array-assignment-holes.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment.js.snap
@@ -198,6 +198,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/assignment/assignment_ignore.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array-binding-holes.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -52,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/array_binding.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -59,6 +60,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/identifier_binding.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -57,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/nested_bindings.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/nested_bindings.js.snap
@@ -80,6 +80,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -199,6 +200,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/binding/object_binding.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -67,6 +68,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/bom_character.js.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call/call_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/call_chain.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call/simple_arguments.js.snap
@@ -113,6 +113,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/call_expression.js.snap
@@ -98,6 +98,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class.js.snap
@@ -99,6 +99,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/class_comments.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/class/private_method.js.snap
@@ -45,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments.js.snap
@@ -115,6 +115,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/import_exports.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/import_exports.js.snap
@@ -43,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/comments/nested_comments/nested_comments.js.snap
@@ -36,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -67,6 +68,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/test_declaration.js.snap
@@ -55,6 +55,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/declarations/variable_declaration.js.snap
@@ -294,6 +294,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_call_decorator.js.snap
@@ -121,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_mixed.js.snap
@@ -121,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_members_simple.js.snap
@@ -121,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple.js.snap
@@ -77,6 +77,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/class_simple_call_decorator.js.snap
@@ -77,6 +77,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_1.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_2.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_3.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/export_default_4.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/expression.js.snap
@@ -50,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/decorators/multiline.js.snap
@@ -45,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/each/each.js.snap
@@ -95,6 +95,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/bracket-spacing/export_bracket_spacing.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/bracket-spacing/export_bracket_spacing.js
-snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -100,6 +100,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/class_clause.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/expression_clause.js.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/from_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/from_clause.js
-snapshot_kind: text
 ---
 # Input
 
@@ -35,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/function_clause.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_clause.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/named_from_clause.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/export/named_from_clause.js
-snapshot_kind: text
 ---
 # Input
 
@@ -50,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/es5/export_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/es5/export_trailing_commas.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -60,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/none/export_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/trailing-commas/none/export_trailing_commas.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -60,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/export/variable_declaration.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_expression.js.snap
@@ -63,6 +63,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binary_range_expression.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/binaryish_expression.js.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/call_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/call_arguments.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/computed-member-expression.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/conditional_expression.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/import_meta_expression/import_meta_expression.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -63,6 +64,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/literal_expression.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/logical_expression.js.snap
@@ -141,6 +141,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/complex_arguments.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/computed.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/inline-merge.js.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/multi_line.js.snap
@@ -102,6 +102,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/member-chain/static_member_regex.js.snap
@@ -53,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/nested_conditional_expression/nested_conditional_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/nested_conditional_expression/nested_conditional_expression.js.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -75,6 +76,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/new_expression.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/post_update_expression.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/pre_update_expression.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/sequence_expression.js.snap
@@ -62,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/static_member_expression.js.snap
@@ -49,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/this_expression.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/expression/unary_expression_verbatim_argument.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function.js.snap
@@ -61,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_args.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/function/function_comments.js.snap
@@ -68,6 +68,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/ident.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bare_import.js.snap
@@ -52,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/bracket-spacing/import_bracket_spacing.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/bracket-spacing/import_bracket_spacing.js
-snapshot_kind: text
 ---
 # Input
 
@@ -60,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -108,6 +108,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/default_import.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/default_import.js
-snapshot_kind: text
 ---
 # Input
 
@@ -41,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_call.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/import_specifiers.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/import/import_specifiers.js
-snapshot_kind: text
 ---
 # Input
 
@@ -62,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/named_import_clause.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/namespace_import.js.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/es5/import_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/es5/import_trailing_commas.js.snap
@@ -59,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -120,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/none/import_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/import/trailing-commas/none/import_trailing_commas.js.snap
@@ -59,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -120,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-1.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/4/example-2.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -84,6 +85,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-1.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-2.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/indent-width/8/example-2.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -84,6 +85,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter-with-trailing-spaces.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/interpreter_with_empty_line.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/block_stmt_err.js.snap
@@ -39,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/invalid/if_stmt_err.js.snap
@@ -45,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/cr/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/cr/line_ending.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -84,6 +85,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/crlf/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/crlf/line_ending.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -84,6 +85,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/newlines.js.snap
@@ -107,6 +107,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/class.js.snap
@@ -147,6 +147,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -284,6 +285,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue2006.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -66,6 +67,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/no-semi.js.snap
@@ -109,6 +109,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -221,6 +222,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/private-field.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -58,6 +59,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons-asi.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -52,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/semicolons_range.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/number/number_with_space.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/bracket-spacing/object_bracket_spacing.js.snap
@@ -51,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -90,6 +91,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/computed_member.js.snap
@@ -48,6 +48,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/getter_setter.js.snap
@@ -36,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/numeric-property.js.snap
@@ -66,6 +66,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js
@@ -1,0 +1,17 @@
+const a = { already: "collapsed" };
+
+const b = {
+	needs: "to",
+	be: "collapsed",
+};
+
+const c = { very: "long", object: "literal", with: "many", properties: "it", needs: "to", be: "expanded"  };
+
+const d = {
+	very: "long",
+	object: "literal",
+	but: "it",
+	is: "already",
+	expanded: "so",
+	do: "nothing",
+};

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js
@@ -1,17 +1,17 @@
-const a = { already: "collapsed" };
-
-const b = {
-	needs: "to",
-	be: "collapsed",
+const a = {
+	name1: "value1",
+	name2: "value2",
 };
 
-const c = { very: "long", object: "literal", with: "many", properties: "it", needs: "to", be: "expanded"  };
+const b = { name1: "value1",
+	name2: "value2",
+};
+
+const c = {
+	name1: "value1", name2: "value2",
+};
 
 const d = {
-	very: "long",
-	object: "literal",
-	but: "it",
-	is: "already",
-	expanded: "so",
-	do: "nothing",
-};
+	name1: "value1", name2: "value2", };
+
+const e = { name1: "value1", name2: "value2", };

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js.snap
@@ -5,23 +5,23 @@ info: js/module/object/object-wrap/object-wrap-collapse.js
 # Input
 
 ```js
-const a = { already: "collapsed" };
-
-const b = {
-	needs: "to",
-	be: "collapsed",
+const a = {
+	name1: "value1",
+	name2: "value2",
 };
 
-const c = { very: "long", object: "literal", with: "many", properties: "it", needs: "to", be: "expanded"  };
+const b = { name1: "value1",
+	name2: "value2",
+};
+
+const c = {
+	name1: "value1", name2: "value2",
+};
 
 const d = {
-	very: "long",
-	object: "literal",
-	but: "it",
-	is: "already",
-	expanded: "so",
-	do: "nothing",
-};
+	name1: "value1", name2: "value2", };
+
+const e = { name1: "value1", name2: "value2", };
 
 ```
 
@@ -50,30 +50,24 @@ Object wrap: Preserve
 -----
 
 ```js
-const a = { already: "collapsed" };
-
-const b = {
-	needs: "to",
-	be: "collapsed",
+const a = {
+	name1: "value1",
+	name2: "value2",
 };
 
+const b = { name1: "value1", name2: "value2" };
+
 const c = {
-	very: "long",
-	object: "literal",
-	with: "many",
-	properties: "it",
-	needs: "to",
-	be: "expanded",
+	name1: "value1",
+	name2: "value2",
 };
 
 const d = {
-	very: "long",
-	object: "literal",
-	but: "it",
-	is: "already",
-	expanded: "so",
-	do: "nothing",
+	name1: "value1",
+	name2: "value2",
 };
+
+const e = { name1: "value1", name2: "value2" };
 ```
 
 ## Output 1
@@ -96,25 +90,13 @@ Object wrap: Collapse
 -----
 
 ```js
-const a = { already: "collapsed" };
+const a = { name1: "value1", name2: "value2" };
 
-const b = { needs: "to", be: "collapsed" };
+const b = { name1: "value1", name2: "value2" };
 
-const c = {
-	very: "long",
-	object: "literal",
-	with: "many",
-	properties: "it",
-	needs: "to",
-	be: "expanded",
-};
+const c = { name1: "value1", name2: "value2" };
 
-const d = {
-	very: "long",
-	object: "literal",
-	but: "it",
-	is: "already",
-	expanded: "so",
-	do: "nothing",
-};
+const d = { name1: "value1", name2: "value2" };
+
+const e = { name1: "value1", name2: "value2" };
 ```

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/object-wrap-collapse.js.snap
@@ -1,0 +1,120 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/object/object-wrap/object-wrap-collapse.js
+---
+# Input
+
+```js
+const a = { already: "collapsed" };
+
+const b = {
+	needs: "to",
+	be: "collapsed",
+};
+
+const c = { very: "long", object: "literal", with: "many", properties: "it", needs: "to", be: "expanded"  };
+
+const d = {
+	very: "long",
+	object: "literal",
+	but: "it",
+	is: "already",
+	expanded: "so",
+	do: "nothing",
+};
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Object wrap: Preserve
+-----
+
+```js
+const a = { already: "collapsed" };
+
+const b = {
+	needs: "to",
+	be: "collapsed",
+};
+
+const c = {
+	very: "long",
+	object: "literal",
+	with: "many",
+	properties: "it",
+	needs: "to",
+	be: "expanded",
+};
+
+const d = {
+	very: "long",
+	object: "literal",
+	but: "it",
+	is: "already",
+	expanded: "so",
+	do: "nothing",
+};
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Object wrap: Collapse
+-----
+
+```js
+const a = { already: "collapsed" };
+
+const b = { needs: "to", be: "collapsed" };
+
+const c = {
+	very: "long",
+	object: "literal",
+	with: "many",
+	properties: "it",
+	needs: "to",
+	be: "expanded",
+};
+
+const d = {
+	very: "long",
+	object: "literal",
+	but: "it",
+	is: "already",
+	expanded: "so",
+	do: "nothing",
+};
+```

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object-wrap/options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "objectWrap": "collapse"
+    }
+  }
+}

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object.js.snap
@@ -61,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/object_comments.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/octal_literals_key.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_object_member.js.snap
@@ -117,6 +117,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/es5/object_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/es5/object_trailing_commas.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -70,6 +71,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/none/object_trailing_commas.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/trailing-commas/none/object_trailing_commas.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -70,6 +71,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/parentheses.js.snap
@@ -52,6 +52,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/parentheses/range_parentheses_binary.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol.js.snap
@@ -39,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/range/range_parenthesis_after_semicol_1.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/script.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/block_statement.js.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/continue_stmt.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/do_while.js.snap
@@ -43,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/empty_blocks.js.snap
@@ -58,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_in.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_loop.js.snap
@@ -46,6 +46,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/for_of.js.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_chain.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/if_else.js.snap
@@ -98,6 +98,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return.js.snap
@@ -54,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/return_verbatim_argument.js.snap
@@ -54,6 +54,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/statement.js.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch.js.snap
@@ -80,6 +80,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/switch_comment.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/switch_comment.js.snap
@@ -47,6 +47,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/throw.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/try_catch_finally.js.snap
@@ -55,6 +55,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/statement/while_loop.js.snap
@@ -55,6 +55,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/directives.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -57,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/parentheses_token.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -52,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/properties_quotes.js.snap
@@ -72,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -137,6 +138,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quotePreserve/string.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quotePreserve/string.js
-snapshot_kind: text
 ---
 # Input
 
@@ -88,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -173,6 +173,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/directives.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/directives.js.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -57,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/parentheses_token.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/parentheses_token.js.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -52,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/properties_quotes.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/properties_quotes.js.snap
@@ -72,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -137,6 +138,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/string.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/string/quoteSingle/string.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: js/module/string/quoteSingle/string.js
-snapshot_kind: text
 ---
 # Input
 
@@ -88,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js
@@ -173,6 +173,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/suppression.js.snap
@@ -58,6 +58,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/template/template.js.snap
@@ -100,6 +100,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/with.js.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/script_with_bom.js.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/script/with.js.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```js

--- a/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/arrow_function.jsx.snap
@@ -69,6 +69,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_escape.jsx.snap
@@ -44,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attribute_position/attribute_position.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attribute_position/attribute_position.jsx.snap
@@ -56,6 +56,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -115,6 +116,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Multiline
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/attributes.jsx.snap
@@ -105,6 +105,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/bracket_same_line/bracket_same_line.jsx.snap
@@ -72,6 +72,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -136,6 +137,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: true
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/comments.jsx.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/conditional.jsx.snap
@@ -78,6 +78,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/element.jsx.snap
@@ -359,6 +359,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/fragment.jsx.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/multiline_jsx_string/multiline_jsx_string.jsx.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/new-lines.jsx.snap
@@ -79,6 +79,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/parentheses_range.jsx.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_double/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_double/quote_style.jsx.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_single/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_double_string_single/quote_style.jsx.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_double/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_double/quote_style.jsx.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_single/quote_style.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/quote_style/jsx_single_string_single/quote_style.jsx.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx
@@ -61,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/self_closing.jsx.snap
@@ -50,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/smoke.jsx.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/jsx/text_children.jsx.snap
+++ b/crates/biome_js_formatter/tests/specs/jsx/text_children.jsx.snap
@@ -130,6 +130,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```jsx

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/arrow_parentheses.ts.snap
@@ -42,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -76,6 +77,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/long_arrow_parentheses_with_line_break.ts.snap
@@ -44,6 +44,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -80,6 +81,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow/parameter_default_binding_line_break.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow/parameter_default_binding_line_break.ts.snap
@@ -49,6 +49,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -84,6 +85,7 @@ Arrow parentheses: As needed
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/arrow_chain.ts.snap
@@ -40,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/as_assignment.ts.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment.ts.snap
@@ -42,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/assignment_comments.ts.snap
@@ -50,6 +50,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/property_assignment_comments.ts.snap
@@ -62,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/assignment/type_assertion_assignment.ts.snap
@@ -43,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/binding/definite_variable.ts.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/call_expression.ts.snap
@@ -62,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/accessor.ts.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/assigment_layout.ts.snap
@@ -36,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/constructor_parameter.ts.snap
@@ -73,6 +73,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/implements_clause.ts.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/readonly_ambient_property.ts.snap
@@ -39,6 +39,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/es5/class_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/es5/class_trailing_commas.ts.snap
@@ -40,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -86,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/none/class_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/class/trailing_commas/none/class_trailing_commas.ts.snap
@@ -40,6 +40,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -86,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/class.ts.snap
@@ -88,6 +88,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/declare_function.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/global_declaration.ts.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/interface.ts.snap
@@ -76,6 +76,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declaration/variable_declaration.ts.snap
@@ -116,6 +116,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/declare.ts.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decoartors.ts.snap
@@ -287,6 +287,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/decorators/class_members.ts.snap
@@ -123,6 +123,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_es5/enum_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_es5/enum_trailing_commas.ts.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -60,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_none/enum_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/enum/trailing_commas_none/enum_trailing_commas.ts.snap
@@ -34,6 +34,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -60,6 +61,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/as_expression.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/bracket-spacing/expression_bracket_spacing.ts.snap
@@ -96,6 +96,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -213,6 +214,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/non_null_expression.ts.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_assertion_expression.ts.snap
@@ -35,6 +35,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_expression.ts.snap
@@ -135,6 +135,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/expression/type_member.ts.snap
@@ -78,6 +78,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_100/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_100/function_parameters.ts.snap
@@ -62,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -118,6 +119,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_120/function_parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/parameters/line_width_120/function_parameters.ts.snap
@@ -62,6 +62,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -118,6 +119,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/es5/function_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/es5/function_trailing_commas.ts.snap
@@ -66,6 +66,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -126,6 +127,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/none/function_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/function/trailing_commas/none/function_trailing_commas.ts.snap
@@ -66,6 +66,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -126,6 +127,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/issue1511.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/issue1511.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/export_clause.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/module/export_clause.ts
-snapshot_kind: text
 ---
 # Input
 
@@ -54,6 +53,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/external_module_reference.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/import_type/import_types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/import_type/import_types.ts.snap
@@ -51,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -87,6 +88,7 @@ Arrow parentheses: Always
 Bracket spacing: false
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/module_declaration.ts.snap
@@ -33,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/module/qualified_module_name.ts.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/class.ts.snap
@@ -81,6 +81,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -154,6 +155,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/non-null.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -56,6 +57,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/statements.ts.snap
@@ -43,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -77,6 +78,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/no-semi/types.ts.snap
@@ -42,6 +42,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -80,6 +81,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/object-wrap-collapse.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/object-wrap-collapse.ts
@@ -1,0 +1,35 @@
+type A = {
+	name1: "value1",
+	name2: "value2",
+};
+
+const a: A = {
+	name1: "value1",
+	name2: "value2",
+};
+
+type B = { name1: "value1",
+	name2: "value2",
+};
+
+const b: B = { name1: "value1",
+	name2: "value2",
+};
+
+type C = {
+	name1: "value1", name2: "value2",
+};
+
+const c: C = {
+	name1: "value1", name2: "value2",
+};
+
+type D = {
+	name1: "value1", name2: "value2", };
+
+const d: D = {
+	name1: "value1", name2: "value2", };
+
+type E = { name1: "value1", name2: "value2", };
+
+const e: E = { name1: "value1", name2: "value2", };

--- a/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/object-wrap-collapse.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/object-wrap-collapse.ts.snap
@@ -1,0 +1,149 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/object/object-wrap/object-wrap-collapse.ts
+---
+# Input
+
+```ts
+type A = {
+	name1: "value1",
+	name2: "value2",
+};
+
+const a: A = {
+	name1: "value1",
+	name2: "value2",
+};
+
+type B = { name1: "value1",
+	name2: "value2",
+};
+
+const b: B = { name1: "value1",
+	name2: "value2",
+};
+
+type C = {
+	name1: "value1", name2: "value2",
+};
+
+const c: C = {
+	name1: "value1", name2: "value2",
+};
+
+type D = {
+	name1: "value1", name2: "value2", };
+
+const d: D = {
+	name1: "value1", name2: "value2", };
+
+type E = { name1: "value1", name2: "value2", };
+
+const e: E = { name1: "value1", name2: "value2", };
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Object wrap: Preserve
+-----
+
+```ts
+type A = {
+	name1: "value1";
+	name2: "value2";
+};
+
+const a: A = {
+	name1: "value1",
+	name2: "value2",
+};
+
+type B = { name1: "value1"; name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = {
+	name1: "value1";
+	name2: "value2";
+};
+
+const c: C = {
+	name1: "value1",
+	name2: "value2",
+};
+
+type D = {
+	name1: "value1";
+	name2: "value2";
+};
+
+const d: D = {
+	name1: "value1",
+	name2: "value2",
+};
+
+type E = { name1: "value1"; name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Object wrap: Collapse
+-----
+
+```ts
+type A = { name1: "value1"; name2: "value2" };
+
+const a: A = { name1: "value1", name2: "value2" };
+
+type B = { name1: "value1"; name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = { name1: "value1"; name2: "value2" };
+
+const c: C = { name1: "value1", name2: "value2" };
+
+type D = { name1: "value1"; name2: "value2" };
+
+const d: D = { name1: "value1", name2: "value2" };
+
+type E = { name1: "value1"; name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+```

--- a/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/options.json
+++ b/crates/biome_js_formatter/tests/specs/ts/object/object-wrap/options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "objectWrap": "collapse"
+    }
+  }
+}

--- a/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_es5/object_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_es5/object_trailing_commas.ts.snap
@@ -51,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -93,6 +94,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_none/object_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/trailing_commas_none/object_trailing_commas.ts.snap
@@ -51,6 +51,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -93,6 +94,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/issue-1356/parameter_type_annotation_semicolon.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/issue-1356/parameter_type_annotation_semicolon.ts.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -69,6 +70,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parameters/parameters.ts.snap
@@ -31,6 +31,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/parenthesis.ts.snap
@@ -38,6 +38,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/simple_arguments.ts.snap
@@ -76,6 +76,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/empty_block.ts.snap
@@ -30,6 +30,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/statement/enum_statement.ts.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/quotePreserve/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/quotePreserve/parameter_quotes.ts.snap
@@ -64,6 +64,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -120,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/string/quoteSingle/parameter_quotes.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/string/quoteSingle/parameter_quotes.ts.snap
@@ -64,6 +64,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -120,6 +121,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/suppressions.ts.snap
@@ -36,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/conditional.ts.snap
@@ -45,6 +45,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type.ts.snap
@@ -37,6 +37,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/import_type_with_resolution_mode.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/import_type_with_resolution_mode.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: ts/type/import_type_with_resolution_mode.ts
-snapshot_kind: text
 ---
 # Input
 
@@ -34,6 +33,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_intersection.ts.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/injfer_in_union.ts.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/intersection_type.ts.snap
@@ -87,6 +87,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/mapped_type.ts.snap
@@ -36,6 +36,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/qualified_name.ts.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/template_type.ts.snap
@@ -32,6 +32,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/es5/type_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/es5/type_trailing_commas.ts.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -73,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/none/type_trailing_commas.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/trailing-commas/none/type_trailing_commas.ts.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -73,6 +74,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/type/union_type.ts.snap
@@ -278,6 +278,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/ts/union/nested_union/nested_union.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/union/nested_union/nested_union.ts.snap
@@ -41,6 +41,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts
@@ -74,6 +75,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```ts

--- a/crates/biome_js_formatter/tests/specs/tsx/arrow/issue-2736.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/arrow/issue-2736.tsx.snap
@@ -48,6 +48,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```tsx

--- a/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/smoke.tsx.snap
@@ -29,6 +29,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```tsx

--- a/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
+++ b/crates/biome_js_formatter/tests/specs/tsx/type_param.tsx.snap
@@ -43,6 +43,7 @@ Arrow parentheses: Always
 Bracket spacing: true
 Bracket same line: false
 Attribute Position: Auto
+Object wrap: Preserve
 -----
 
 ```tsx

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -43,7 +43,9 @@ use biome_js_analyze::{
     analyze, analyze_with_inspect_matcher, ControlFlowGraph, JsAnalyzerServices,
 };
 use biome_js_formatter::context::trailing_commas::TrailingCommas;
-use biome_js_formatter::context::{ArrowParentheses, JsFormatOptions, QuoteProperties, Semicolons};
+use biome_js_formatter::context::{
+    ArrowParentheses, JsFormatOptions, ObjectWrap, QuoteProperties, Semicolons,
+};
 use biome_js_formatter::format_node;
 use biome_js_parser::JsParserOptions;
 use biome_js_semantic::{semantic_model, SemanticModelOptions};
@@ -76,6 +78,7 @@ pub struct JsFormatterSettings {
     pub indent_style: Option<IndentStyle>,
     pub enabled: Option<JsFormatterEnabled>,
     pub attribute_position: Option<AttributePosition>,
+    pub object_wrap: Option<ObjectWrap>,
 }
 
 impl From<JsFormatterConfiguration> for JsFormatterSettings {
@@ -95,6 +98,7 @@ impl From<JsFormatterConfiguration> for JsFormatterSettings {
             indent_width: value.indent_width,
             indent_style: value.indent_style,
             line_ending: value.line_ending,
+            object_wrap: value.object_wrap,
         }
     }
 }
@@ -243,7 +247,8 @@ impl ServiceLanguage for JsLanguage {
                 .and_then(|l| l.attribute_position)
                 .or(global.and_then(|g| g.attribute_position))
                 .unwrap_or_default(),
-        );
+        )
+        .with_object_wrap(language.and_then(|l| l.object_wrap).unwrap_or_default());
 
         if let Some(overrides) = overrides {
             overrides.override_js_format_options(path, options)

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -636,6 +636,10 @@ export interface JsFormatterConfiguration {
 	 */
 	lineWidth?: LineWidth;
 	/**
+	 * Whether to enforce collapsing object literals when possible. Defaults to preserve.
+	 */
+	objectWrap?: ObjectWrap;
+	/**
 	 * When properties in objects are quoted. Defaults to asNeeded.
 	 */
 	quoteProperties?: QuoteProperties;
@@ -858,6 +862,7 @@ Note that this is only necessary for inline elements. Block elements do not have
 	 */
 export type WhitespaceSensitivity = "css" | "strict" | "ignore";
 export type ArrowParentheses = "always" | "asNeeded";
+export type ObjectWrap = "preserve" | "collapse";
 export type QuoteProperties = "asNeeded" | "preserve";
 export type Semicolons = "always" | "asNeeded";
 /**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1949,6 +1949,10 @@
 					"description": "What's the max width of a line applied to JavaScript (and its super languages) files. Defaults to 80.",
 					"anyOf": [{ "$ref": "#/definitions/LineWidth" }, { "type": "null" }]
 				},
+				"objectWrap": {
+					"description": "Whether to enforce collapsing object literals when possible. Defaults to preserve.",
+					"anyOf": [{ "$ref": "#/definitions/ObjectWrap" }, { "type": "null" }]
+				},
 				"quoteProperties": {
 					"description": "When properties in objects are quoted. Defaults to asNeeded.",
 					"anyOf": [
@@ -2915,6 +2919,7 @@
 			},
 			"additionalProperties": false
 		},
+		"ObjectWrap": { "type": "string", "enum": ["preserve", "collapse"] },
 		"Options": {
 			"type": "object",
 			"properties": {


### PR DESCRIPTION
## Summary

Prettier 3.5 introduced a new [Object Wrap](https://prettier.io/docs/options#object-wrap) option. This improves code consistency, so it will be great if Biome also support this option.

This pull request introduces the `objectWrap` option to enforce collapsing object literals when possible.

## Test Plan

Snapshot test cases added.
