### PR TITLE
fix(lsp): better error message when editorconfig is broken 

### DIFF
--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1365,10 +1365,7 @@ fn handle_import_named_clause_comments(
 }
 
 fn handle_array_expression(comment: DecoratedComment<JsLanguage>) -> CommentPlacement<JsLanguage> {
-    if let Some(preceding) = comment
-        .preceding_node()
-        .and_then(|node| JsArrayHole::cast_ref(node))
-    {
+    if let Some(preceding) = comment.preceding_node().and_then(JsArrayHole::cast_ref) {
         CommentPlacement::leading(preceding.into_syntax(), comment)
     } else {
         CommentPlacement::Default(comment)

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1365,7 +1365,10 @@ fn handle_import_named_clause_comments(
 }
 
 fn handle_array_expression(comment: DecoratedComment<JsLanguage>) -> CommentPlacement<JsLanguage> {
-    if let Some(preceding) = comment.preceding_node().and_then(JsArrayHole::cast_ref) {
+    if let Some(preceding) = comment
+        .preceding_node()
+        .and_then(|node| JsArrayHole::cast_ref(node))
+    {
         CommentPlacement::leading(preceding.into_syntax(), comment)
     } else {
         CommentPlacement::Default(comment)

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -105,6 +105,13 @@ impl WorkspaceError {
             verbose_advice: ProtectedFileAdvice,
         })
     }
+
+    pub fn is_editor_config_error(&self) -> bool {
+        matches!(
+            self,
+            WorkspaceError::Configuration(ConfigurationDiagnostic::EditorConfig(_))
+        )
+    }
 }
 
 impl Error for WorkspaceError {}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/3518

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested locally and confirmed that new message is shown when the `.editorconfig` is incorrect

<!-- What demonstrates that your implementation is correct? -->
