### PR TITLE
test: handle relative path in cli parameter

### DIFF
--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4084,7 +4084,7 @@ fn fs_handle_relative_path_in_cli_parameter() {
     let result = run_cli_with_dyn_fs(
         Box::new(fs.create_os()),
         &mut console,
-        Args::from(["lint", "--write", fs.cli_path()].as_slice()),
+        Args::from(["lint", "--write", "."].as_slice()),
     );
 
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4069,3 +4069,29 @@ fn linter_doesnt_crash_on_malformed_code_from_issue_4723() {
         result,
     ));
 }
+
+#[test]
+fn fs_handle_relative_path_in_cli_parameter() {
+    let mut fs = biome_fs::TemporaryFs::new("fs_handle_relative_path_in_cli_parameter");
+    let mut console = BufferConsole::default();
+
+    fs.create_file("file.js", "debugger;");
+    fs.create_file("biome.json", r#"{
+        "files": { "includes": ["**"] },
+        "linter": { "rules": { "recommended": true, "suspicious": { "noDebugger": "error" } } }
+    }"#);
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint", "--write", fs.cli_path()].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "fs_handle_relative_path_in_cli_parameter",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_handle_relative_path_in_cli_parameter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_handle_relative_path_in_cli_parameter.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "files": { "includes": ["**"] },
+  "linter": {
+    "rules": { "recommended": true, "suspicious": { "noDebugger": "error" } }
+  }
+}
+```
+
+## `file.js`
+
+```js
+debugger;
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+/file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This is an unexpected use of the debugger statement.
+  
+  > 1 │ debugger;
+      │ ^^^^^^^^^
+  
+  i Unsafe fix: Remove debugger statement
+  
+    1 │ debugger;
+      │ ---------
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fs_handle_relative_path_in_cli_parameter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fs_handle_relative_path_in_cli_parameter.snap
@@ -22,9 +22,9 @@ debugger;
 # Termination Message
 
 ```block
-lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Some errors were emitted while running checks.
+  × No files were processed in the specified paths.
   
 
 
@@ -33,21 +33,5 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/file.js:1:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × This is an unexpected use of the debugger statement.
-  
-  > 1 │ debugger;
-      │ ^^^^^^^^^
-  
-  i Unsafe fix: Remove debugger statement
-  
-    1 │ debugger;
-      │ ---------
-
-```
-
-```block
-Checked 2 files in <TIME>. No fixes applied.
-Found 1 error.
+Checked 0 files in <TIME>. No fixes applied.
 ```


### PR DESCRIPTION
## Summary

This PR demonstrates a bug with our test infra that blocks me for providing a non-regression test in https://github.com/biomejs/biome/pull/5017

The first commit provides the expected snapshot that is obtained by using an absolute path as parameter of the CLI.
The second commit demonstrates that passing a relative path to the CLI makes Biome ignores files.
