### PR TITLE
refactor(formatter): remove non-printing related options from `FormatOptions`

### DIFF
--- a/crates/biome_css_formatter/src/context.rs
+++ b/crates/biome_css_formatter/src/context.rs
@@ -1,5 +1,5 @@
 use crate::CssCommentStyle;
-use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth, QuoteStyle};
+use biome_formatter::{prelude::*, IndentWidth, QuoteStyle};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -142,18 +142,6 @@ impl FormatOptions for CssFormatOptions {
 
     fn line_ending(&self) -> LineEnding {
         self.line_ending
-    }
-
-    fn attribute_position(&self) -> AttributePosition {
-        AttributePosition::default()
-    }
-
-    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
-        biome_formatter::BracketSameLine::default()
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        BracketSpacing::default()
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/biome_formatter/src/format_element/document.rs
+++ b/crates/biome_formatter/src/format_element/document.rs
@@ -2,8 +2,8 @@
 use super::tag::Tag;
 use crate::format_element::tag::DedentMode;
 use crate::prelude::tag::GroupMode;
-use crate::{format, write, AttributePosition, BracketSpacing};
-use crate::{prelude::*, BracketSameLine};
+use crate::prelude::*;
+use crate::{format, write};
 use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions, TransformSourceMap,
@@ -200,26 +200,12 @@ impl FormatOptions for IrFormatOptions {
         LineEnding::Lf
     }
 
-    fn attribute_position(&self) -> AttributePosition {
-        AttributePosition::default()
-    }
-
-    fn bracket_same_line(&self) -> BracketSameLine {
-        BracketSameLine::default()
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        BracketSpacing::default()
-    }
-
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions {
             indent_width: self.indent_width(),
             print_width: self.line_width().into(),
             line_ending: LineEnding::Lf,
             indent_style: IndentStyle::Space,
-            attribute_position: self.attribute_position(),
-            bracket_spacing: self.bracket_spacing(),
         }
     }
 }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -718,15 +718,6 @@ pub trait FormatOptions {
     /// The type of line ending.
     fn line_ending(&self) -> LineEnding;
 
-    /// The attribute position.
-    fn attribute_position(&self) -> AttributePosition;
-
-    /// Whether to put the `>` of a multi-line HTML or JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
-    fn bracket_same_line(&self) -> BracketSameLine;
-
-    /// Whether to insert spaces around brackets in object literals. Defaults to true.
-    fn bracket_spacing(&self) -> BracketSpacing;
-
     /// Derives the print options from the these format options
     fn as_print_options(&self) -> PrinterOptions;
 }
@@ -775,9 +766,6 @@ pub struct SimpleFormatOptions {
     pub indent_width: IndentWidth,
     pub line_width: LineWidth,
     pub line_ending: LineEnding,
-    pub attribute_position: AttributePosition,
-    pub bracket_same_line: BracketSameLine,
-    pub bracket_spacing: BracketSpacing,
 }
 
 impl FormatOptions for SimpleFormatOptions {
@@ -797,26 +785,12 @@ impl FormatOptions for SimpleFormatOptions {
         self.line_ending
     }
 
-    fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> BracketSameLine {
-        self.bracket_same_line
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        self.bracket_spacing
-    }
-
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions::default()
             .with_indent_style(self.indent_style)
             .with_indent_width(self.indent_width)
             .with_print_width(self.line_width.into())
             .with_line_ending(self.line_ending)
-            .with_attribute_position(self.attribute_position)
-            .with_bracket_spacing(self.bracket_spacing)
     }
 }
 

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -705,6 +705,11 @@ pub trait FormatContext {
 }
 
 /// Options customizing how the source code should be formatted.
+///
+/// **Note**: This trait should **only** contain the essential abstractions required for the printing phase.  
+/// For example, do not add a `fn bracket_spacing(&self) -> BracketSpacing` method here,  
+/// as the [BracketSpacing] option is not needed during the printing phase
+/// and enforcing its implementation for all structs using this trait is unnecessary.
 pub trait FormatOptions {
     /// The indent style.
     fn indent_style(&self) -> IndentStyle;

--- a/crates/biome_formatter/src/printer/printer_options/mod.rs
+++ b/crates/biome_formatter/src/printer/printer_options/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    AttributePosition, BracketSpacing, FormatOptions, IndentStyle, IndentWidth, LineEnding,
-    LineWidth,
-};
+use crate::{FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth};
 
 /// Options that affect how the [crate::Printer] prints the format tokens
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,12 +15,6 @@ pub struct PrinterOptions {
 
     /// Whether the printer should use tabs or spaces to indent code and if spaces, by how many.
     pub indent_style: IndentStyle,
-
-    /// The attribute position style
-    pub attribute_position: AttributePosition,
-
-    /// Whether to insert spaces around brackets in object literals. Defaults to true.
-    pub bracket_spacing: BracketSpacing,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -63,7 +54,6 @@ where
             .with_indent_width(options.indent_width())
             .with_print_width(options.line_width().into())
             .with_line_ending(options.line_ending())
-            .with_bracket_spacing(options.bracket_spacing())
     }
 }
 
@@ -91,18 +81,6 @@ impl PrinterOptions {
         self
     }
 
-    pub fn with_attribute_position(mut self, attribute_position: AttributePosition) -> Self {
-        self.attribute_position = attribute_position;
-
-        self
-    }
-
-    pub fn with_bracket_spacing(mut self, bracket_spacing: BracketSpacing) -> Self {
-        self.bracket_spacing = bracket_spacing;
-
-        self
-    }
-
     pub(crate) fn indent_style(&self) -> IndentStyle {
         self.indent_style
     }
@@ -116,16 +94,6 @@ impl PrinterOptions {
     pub(super) const fn line_ending(&self) -> LineEnding {
         self.line_ending
     }
-
-    #[expect(dead_code)]
-    pub(crate) fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    #[expect(dead_code)]
-    pub(crate) fn bracket_spacing(&self) -> BracketSpacing {
-        self.bracket_spacing
-    }
 }
 
 impl Default for PrinterOptions {
@@ -135,8 +103,6 @@ impl Default for PrinterOptions {
             print_width: PrintWidth::default(),
             indent_style: Default::default(),
             line_ending: LineEnding::Lf,
-            attribute_position: AttributePosition::default(),
-            bracket_spacing: BracketSpacing::default(),
         }
     }
 }

--- a/crates/biome_graphql_formatter/src/context.rs
+++ b/crates/biome_graphql_formatter/src/context.rs
@@ -1,7 +1,5 @@
 use crate::GraphqlCommentStyle;
-use biome_formatter::{
-    prelude::*, AttributePosition, BracketSameLine, BracketSpacing, IndentWidth, QuoteStyle,
-};
+use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth, QuoteStyle};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -137,6 +135,10 @@ impl GraphqlFormatOptions {
         self.bracket_spacing = bracket_spacing;
     }
 
+    pub fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
+
     pub fn quote_style(&self) -> QuoteStyle {
         self.quote_style
     }
@@ -157,18 +159,6 @@ impl FormatOptions for GraphqlFormatOptions {
 
     fn line_ending(&self) -> LineEnding {
         self.line_ending
-    }
-
-    fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> BracketSameLine {
-        BracketSameLine::default()
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        self.bracket_spacing
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/biome_graphql_formatter/src/graphql/value/object_value.rs
+++ b/crates/biome_graphql_formatter/src/graphql/value/object_value.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{format_args, write, FormatOptions};
+use biome_formatter::{format_args, write};
 use biome_graphql_syntax::{GraphqlObjectValue, GraphqlObjectValueFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/context.rs
+++ b/crates/biome_grit_formatter/src/context.rs
@@ -61,6 +61,7 @@ pub struct GritFormatOptions {
     line_ending: LineEnding,
     line_width: LineWidth,
     attribute_position: AttributePosition,
+    bracket_spacing: BracketSpacing,
     _file_source: GritFileSource,
 }
 
@@ -72,6 +73,7 @@ impl GritFormatOptions {
             indent_width: IndentWidth::default(),
             line_ending: LineEnding::default(),
             line_width: LineWidth::default(),
+            bracket_spacing: BracketSpacing::default(),
             attribute_position: AttributePosition::default(),
         }
     }
@@ -115,6 +117,10 @@ impl GritFormatOptions {
     pub fn attribute_position(&self) -> AttributePosition {
         self.attribute_position
     }
+
+    pub fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
 }
 
 impl Display for GritFormatOptions {
@@ -142,18 +148,6 @@ impl FormatOptions for GritFormatOptions {
 
     fn line_ending(&self) -> LineEnding {
         self.line_ending
-    }
-
-    fn attribute_position(&self) -> biome_formatter::AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
-        biome_formatter::BracketSameLine::default()
-    }
-
-    fn bracket_spacing(&self) -> biome_formatter::BracketSpacing {
-        BracketSpacing::default()
     }
 
     fn as_print_options(&self) -> biome_formatter::prelude::PrinterOptions {

--- a/crates/biome_grit_formatter/src/grit/auxiliary/like.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/like.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritLike, GritLikeFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritLike;

--- a/crates/biome_grit_formatter/src/grit/auxiliary/map.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/map.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritMap, GritMapFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritMap;

--- a/crates/biome_grit_formatter/src/grit/auxiliary/sequential.rs
+++ b/crates/biome_grit_formatter/src/grit/auxiliary/sequential.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritSequential, GritSequentialFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/patterns/curly_pattern.rs
+++ b/crates/biome_grit_formatter/src/grit/patterns/curly_pattern.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritCurlyPattern, GritCurlyPatternFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritCurlyPattern;

--- a/crates/biome_grit_formatter/src/grit/patterns/pattern_any.rs
+++ b/crates/biome_grit_formatter/src/grit/patterns/pattern_any.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPatternAny, GritPatternAnyFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/patterns/pattern_or.rs
+++ b/crates/biome_grit_formatter/src/grit/patterns/pattern_or.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPatternOr, GritPatternOrFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/patterns/pattern_or_else.rs
+++ b/crates/biome_grit_formatter/src/grit/patterns/pattern_or_else.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPatternOrElse, GritPatternOrElseFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/predicates/predicate_and.rs
+++ b/crates/biome_grit_formatter/src/grit/predicates/predicate_and.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPredicateAnd, GritPredicateAndFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/predicates/predicate_any.rs
+++ b/crates/biome_grit_formatter/src/grit/predicates/predicate_any.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPredicateAny, GritPredicateAnyFields};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/biome_grit_formatter/src/grit/predicates/predicate_curly.rs
+++ b/crates/biome_grit_formatter/src/grit/predicates/predicate_curly.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use biome_formatter::write;
-use biome_formatter::FormatOptions;
 use biome_grit_syntax::{GritPredicateCurly, GritPredicateCurlyFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritPredicateCurly;

--- a/crates/biome_grit_formatter/src/grit/predicates/predicate_or.rs
+++ b/crates/biome_grit_formatter/src/grit/predicates/predicate_or.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{write, FormatOptions};
+use biome_formatter::write;
 use biome_grit_syntax::{GritPredicateOr, GritPredicateOrFields};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatGritPredicateOr;

--- a/crates/biome_html_formatter/src/context.rs
+++ b/crates/biome_html_formatter/src/context.rs
@@ -2,9 +2,8 @@ use std::{fmt, rc::Rc, str::FromStr};
 
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
-    printer::PrinterOptions, AttributePosition, BracketSameLine, BracketSpacing, CstFormatContext,
-    FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
-    TransformSourceMap,
+    printer::PrinterOptions, AttributePosition, BracketSameLine, CstFormatContext, FormatContext,
+    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, TransformSourceMap,
 };
 use biome_html_syntax::{HtmlFileSource, HtmlLanguage};
 
@@ -195,18 +194,6 @@ impl FormatOptions for HtmlFormatOptions {
 
     fn line_width(&self) -> LineWidth {
         self.line_width
-    }
-
-    fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> BracketSameLine {
-        self.bracket_same_line
-    }
-
-    fn bracket_spacing(&self) -> biome_formatter::BracketSpacing {
-        BracketSpacing::default()
     }
 
     fn as_print_options(&self) -> biome_formatter::prelude::PrinterOptions {

--- a/crates/biome_js_formatter/src/context.rs
+++ b/crates/biome_js_formatter/src/context.rs
@@ -391,18 +391,6 @@ impl FormatOptions for JsFormatOptions {
         self.line_ending
     }
 
-    fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
-        self.bracket_same_line
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        self.bracket_spacing
-    }
-
     fn as_print_options(&self) -> PrinterOptions {
         PrinterOptions::from(self)
     }

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -2,7 +2,7 @@ use crate::comments::{FormatJsonLeadingComment, JsonComments};
 use crate::JsonCommentStyle;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::separated::TrailingSeparator;
-use biome_formatter::{prelude::*, AttributePosition, BracketSpacing, IndentWidth};
+use biome_formatter::{prelude::*, BracketSpacing, IndentWidth};
 use biome_formatter::{
     CstFormatContext, FormatContext, FormatOptions, IndentStyle, LineEnding, LineWidth,
     TransformSourceMap,
@@ -64,7 +64,6 @@ pub struct JsonFormatOptions {
     indent_width: IndentWidth,
     line_ending: LineEnding,
     line_width: LineWidth,
-    attribute_position: AttributePosition,
     /// Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "none".
     trailing_commas: TrailingCommas,
     expand: Expand,
@@ -214,6 +213,10 @@ impl JsonFormatOptions {
         self.expand = expand;
     }
 
+    pub fn bracket_spacing(&self) -> BracketSpacing {
+        self.bracket_spacing
+    }
+
     pub(crate) fn to_trailing_separator(&self) -> TrailingSeparator {
         match self.trailing_commas {
             TrailingCommas::None => TrailingSeparator::Omit,
@@ -245,18 +248,6 @@ impl FormatOptions for JsonFormatOptions {
 
     fn line_ending(&self) -> LineEnding {
         self.line_ending
-    }
-
-    fn attribute_position(&self) -> AttributePosition {
-        self.attribute_position
-    }
-
-    fn bracket_same_line(&self) -> biome_formatter::BracketSameLine {
-        biome_formatter::BracketSameLine::default()
-    }
-
-    fn bracket_spacing(&self) -> BracketSpacing {
-        self.bracket_spacing
     }
 
     fn as_print_options(&self) -> PrinterOptions {

--- a/crates/biome_json_formatter/src/json/value/object_value.rs
+++ b/crates/biome_json_formatter/src/json/value/object_value.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use biome_formatter::{format_args, write, FormatContext, FormatOptions};
+use biome_formatter::{format_args, write, FormatContext};
 use biome_json_syntax::JsonObjectValue;
 use biome_rowan::AstNode;
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Remove non-printing related options like `bracket_spacing` from `FormatOptions`

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

CI passes
