### PR TITLE
feat(lsp): allow overriding the configuration path from LSP workspaces

### DIFF
--- a/.changeset/funny-planes-care.md
+++ b/.changeset/funny-planes-care.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": minor
+---
+
+LSP clients can now override the configuration path for each workspace, by responding to
+`workspace/configuration` requests.

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -22,6 +22,9 @@ pub struct WorkspaceSettings {
     /// Only run Biome if a `biome.json` configuration file exists.
     pub require_configuration: Option<bool>,
 
+    /// Path to the configuration file to prefer over the default `biome.json`.
+    pub configuration_path: Option<String>,
+
     /// Experimental settings
     pub experimental: Option<ExperimentalSettings>,
 }
@@ -31,9 +34,6 @@ pub struct WorkspaceSettings {
 pub struct ExperimentalSettings {
     /// Enable experimental symbol renaming
     pub rename: Option<bool>,
-
-    /// Path to the configuration file to prefer over the default `biome.json`.
-    pub configuration_path: Option<String>,
 }
 
 /// The `biome.*` extension settings
@@ -77,9 +77,8 @@ impl ExtensionSettings {
 
     pub(crate) fn configuration_path(&self) -> Option<Utf8PathBuf> {
         self.settings
-            .experimental
-            .as_ref()
-            .and_then(|e| e.configuration_path.as_deref())
+            .configuration_path
+            .as_deref()
             .map(|config_path| Utf8PathBuf::from_str(config_path).unwrap()) // infallible
     }
 }

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -1,3 +1,6 @@
+use std::str::FromStr;
+
+use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::{Error, Value};
 use tracing::debug;
@@ -28,6 +31,9 @@ pub struct WorkspaceSettings {
 pub struct ExperimentalSettings {
     /// Enable experimental symbol renaming
     pub rename: Option<bool>,
+
+    /// Path to the configuration file to prefer over the default `biome.json`.
+    pub configuration_path: Option<String>,
 }
 
 /// The `biome.*` extension settings
@@ -67,5 +73,13 @@ impl ExtensionSettings {
 
     pub(crate) fn requires_configuration(&self) -> bool {
         self.settings.require_configuration.unwrap_or_default()
+    }
+
+    pub(crate) fn configuration_path(&self) -> Option<Utf8PathBuf> {
+        self.settings
+            .experimental
+            .as_ref()
+            .and_then(|e| e.configuration_path.as_deref())
+            .map(|config_path| Utf8PathBuf::from_str(config_path).unwrap()) // infallible
     }
 }

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -275,10 +275,8 @@ impl LanguageServer for LSPServer {
 
         info!("Attempting to load the configuration from 'biome.json' file");
 
-        futures::join!(
-            self.session.load_extension_settings(),
-            self.session.load_workspace_settings(),
-        );
+        self.session.load_extension_settings().await;
+        self.session.load_workspace_settings().await;
 
         let msg = format!("Server initialized with PID: {}", std::process::id());
         self.session
@@ -299,8 +297,8 @@ impl LanguageServer for LSPServer {
     #[tracing::instrument(level = "debug", skip(self))]
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
         let _ = params;
-        self.session.load_workspace_settings().await;
         self.session.load_extension_settings().await;
+        self.session.load_workspace_settings().await;
         self.setup_capabilities().await;
         self.session.update_all_diagnostics().await;
     }


### PR DESCRIPTION
## Summary

As the first step of #5089, this pull request adds a new option `experimental.configurationPath` to the response of `workspace/configuration` request. It will affect when loading workspace configurations, preferred over the default `biome.json` in the workspace.

## Test Plan

Existing tests should pass.

For the new option, I tested my modified build of biome-intellij with `workspace/configuration` support added. I could confirm that two projects work in parallel with different Biome configurations.
