### PR TITLE
fix(parser): throw syntax error for import without arguments

### DIFF
--- a/.changeset/gold-buses-tap.md
+++ b/.changeset/gold-buses-tap.md
@@ -2,9 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fix [#4982](https://github.com/biomejs/biome/issues/4982), js parser should throw a syntax error for `TsImportType` when syntax `import` without arguments after.
-
-The follwing code will throw a syntax error:
+Fix [#4982](https://github.com/biomejs/biome/issues/4982), the JavaScript parser now throws a syntax error for the following code:
 
 ```ts
 type T = import;

--- a/.changeset/gold-buses-tap.md
+++ b/.changeset/gold-buses-tap.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix [#4982](https://github.com/biomejs/biome/issues/4982), js parser should throw a syntax error for `TsImportType` when syntax `import` without arguments after.
+
+The follwing code will throw a syntax error:
+
+```ts
+type T = import;
+type U = typeof import;
+```

--- a/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/ts_parse_error.rs
@@ -135,3 +135,13 @@ pub(crate) fn infer_not_allowed(p: &JsParser, range: TextRange) -> ParseDiagnost
         range,
     )
 }
+
+pub(crate) fn expected_ts_import_type_with_arguments(
+    p: &JsParser,
+    range: TextRange,
+) -> ParseDiagnostic {
+    p.err_builder(
+        format!("Expected '(', but got '{}' here", p.cur_text()),
+        range,
+    )
+}

--- a/crates/biome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/types.rs
@@ -42,6 +42,7 @@ use biome_js_syntax::JsSyntaxKind::TS_TYPE_ANNOTATION;
 use biome_js_syntax::T;
 use biome_js_syntax::{JsSyntaxKind::*, *};
 
+use super::ts_parse_error::expected_ts_import_type_with_arguments;
 use super::{expect_ts_index_signature_member, is_at_ts_index_signature_member, MemberParent};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -1165,7 +1166,8 @@ fn parse_ts_import_type(p: &mut JsParser, context: TypeContext) -> ParsedSyntax 
     p.eat(T![typeof]);
     p.expect(T![import]);
 
-    parse_ts_import_type_arguments(p, context).ok();
+    parse_ts_import_type_arguments(p, context)
+        .or_add_diagnostic(p, expected_ts_import_type_with_arguments);
 
     if p.at(T![.]) {
         let qualifier = p.start();
@@ -1731,10 +1733,6 @@ fn parse_ts_import_type_assertion_block(p: &mut JsParser) -> ParsedSyntax {
 
 fn parse_ts_import_type_arguments(p: &mut JsParser, context: TypeContext) -> ParsedSyntax {
     if !p.at(T!['(']) {
-        p.error(p.err_builder(
-            format!("Expected '(', but got '{}' here", p.cur_text()),
-            p.cur_range(),
-        ));
         return Absent;
     }
     let m = p.start();

--- a/crates/biome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/types.rs
@@ -1731,6 +1731,10 @@ fn parse_ts_import_type_assertion_block(p: &mut JsParser) -> ParsedSyntax {
 
 fn parse_ts_import_type_arguments(p: &mut JsParser, context: TypeContext) -> ParsedSyntax {
     if !p.at(T!['(']) {
+        p.error(p.err_builder(
+            format!("Expected '(', but got '{}' here", p.cur_text()),
+            p.cur_range(),
+        ));
         return Absent;
     }
     let m = p.start();

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_type_error.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_type_error.ts
@@ -2,3 +2,5 @@ type A = typeof import("a.json",{});
 type B = typeof import("a.json",{with:{[a]:"1"}});
 type C = typeof import("a.json",{with:{}}, 1);
 type D = import("a",);
+type E = import;
+type F = typeof import;

--- a/crates/biome_js_parser/tests/js_test_suite/error/import_type_error.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/import_type_error.ts.snap
@@ -10,6 +10,8 @@ type A = typeof import("a.json",{});
 type B = typeof import("a.json",{with:{[a]:"1"}});
 type C = typeof import("a.json",{with:{}}, 1);
 type D = import("a",);
+type E = import;
+type F = typeof import;
 
 ```
 
@@ -162,19 +164,51 @@ JsModule {
             },
             semicolon_token: SEMICOLON@156..157 ";" [] [],
         },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@157..163 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@163..165 "E" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@165..167 "=" [] [Whitespace(" ")],
+            ty: TsImportType {
+                typeof_token: missing (optional),
+                import_token: IMPORT_KW@167..173 "import" [] [],
+                arguments: missing (required),
+                qualifier_clause: missing (optional),
+                type_arguments: missing (optional),
+            },
+            semicolon_token: SEMICOLON@173..174 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@174..180 "type" [Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@180..182 "F" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@182..184 "=" [] [Whitespace(" ")],
+            ty: TsImportType {
+                typeof_token: TYPEOF_KW@184..191 "typeof" [] [Whitespace(" ")],
+                import_token: IMPORT_KW@191..197 "import" [] [],
+                arguments: missing (required),
+                qualifier_clause: missing (optional),
+                type_arguments: missing (optional),
+            },
+            semicolon_token: SEMICOLON@197..198 ";" [] [],
+        },
     ],
-    eof_token: EOF@157..158 "" [Newline("\n")] [],
+    eof_token: EOF@198..199 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: JS_MODULE@0..158
+0: JS_MODULE@0..199
   0: (empty)
   1: (empty)
   2: JS_DIRECTIVE_LIST@0..0
-  3: JS_MODULE_ITEM_LIST@0..157
+  3: JS_MODULE_ITEM_LIST@0..198
     0: TS_TYPE_ALIAS_DECLARATION@0..36
       0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
       1: TS_IDENTIFIER_BINDING@5..7
@@ -282,7 +316,33 @@ JsModule {
         3: (empty)
         4: (empty)
       5: SEMICOLON@156..157 ";" [] []
-  4: EOF@157..158 "" [Newline("\n")] []
+    6: TS_TYPE_ALIAS_DECLARATION@157..174
+      0: TYPE_KW@157..163 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@163..165
+        0: IDENT@163..165 "E" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@165..167 "=" [] [Whitespace(" ")]
+      4: TS_IMPORT_TYPE@167..173
+        0: (empty)
+        1: IMPORT_KW@167..173 "import" [] []
+        2: (empty)
+        3: (empty)
+        4: (empty)
+      5: SEMICOLON@173..174 ";" [] []
+    7: TS_TYPE_ALIAS_DECLARATION@174..198
+      0: TYPE_KW@174..180 "type" [Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@180..182
+        0: IDENT@180..182 "F" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@182..184 "=" [] [Whitespace(" ")]
+      4: TS_IMPORT_TYPE@184..197
+        0: TYPEOF_KW@184..191 "typeof" [] [Whitespace(" ")]
+        1: IMPORT_KW@191..197 "import" [] []
+        2: (empty)
+        3: (empty)
+        4: (empty)
+      5: SEMICOLON@197..198 ";" [] []
+  4: EOF@198..199 "" [Newline("\n")] []
 
 ```
 
@@ -332,7 +392,7 @@ import_type_error.ts:3:42 parse ━━━━━━━━━━━━━━━━
   > 3 │ type C = typeof import("a.json",{with:{}}, 1);
       │                                          ^
     4 │ type D = import("a",);
-    5 │ 
+    5 │ type E = import;
   
   i Remove ,
   
@@ -344,7 +404,8 @@ import_type_error.ts:4:20 parse ━━━━━━━━━━━━━━━━
     3 │ type C = typeof import("a.json",{with:{}}, 1);
   > 4 │ type D = import("a",);
       │                    ^
-    5 │ 
+    5 │ type E = import;
+    6 │ type F = typeof import;
   
   i Remove the trailing comma here
   
@@ -352,6 +413,28 @@ import_type_error.ts:4:20 parse ━━━━━━━━━━━━━━━━
     3 │ type C = typeof import("a.json",{with:{}}, 1);
   > 4 │ type D = import("a",);
       │                    ^
-    5 │ 
+    5 │ type E = import;
+    6 │ type F = typeof import;
+  
+import_type_error.ts:5:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected '(', but got ';' here
+  
+    3 │ type C = typeof import("a.json",{with:{}}, 1);
+    4 │ type D = import("a",);
+  > 5 │ type E = import;
+      │                ^
+    6 │ type F = typeof import;
+    7 │ 
+  
+import_type_error.ts:6:23 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected '(', but got ';' here
+  
+    4 │ type D = import("a",);
+    5 │ type E = import;
+  > 6 │ type F = typeof import;
+      │                       ^
+    7 │ 
   
 ```

--- a/crates/biome_js_parser/tests/spec_test.rs
+++ b/crates/biome_js_parser/tests/spec_test.rs
@@ -176,7 +176,7 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
 #[test]
 pub fn quick_test() {
     let code = r#"
-export { type default as CrsMeta } from './crs-meta.js';
+type T = import;
     "#;
 
     let root = parse(code, JsFileSource::ts(), JsParserOptions::default());


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

closes: #4982 

The follwing code will throw a syntax error:

```ts
type T = import;
type U = typeof import;
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I add test case for this.

<!-- What demonstrates that your implementation is correct? -->
