### PR TITLE
feat(lint): support object method in noFloatingPromises

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -6,14 +6,15 @@ use biome_js_factory::make;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
     binding_ext::AnyJsBindingDeclaration, global_identifier, AnyJsClassMember, AnyJsExpression,
-    AnyTsType, JsArrowFunctionExpression, JsCallExpression, JsClassDeclaration, JsClassExpression,
-    JsClassMemberList, JsExpressionStatement, JsExtendsClause, JsFunctionDeclaration,
-    JsIdentifierExpression, JsInitializerClause, JsMethodClassMember, JsMethodObjectMember,
-    JsStaticMemberExpression, JsSyntaxKind, JsThisExpression, JsVariableDeclarator,
-    TsReturnTypeAnnotation,
+    AnyJsObjectMember, AnyTsType, JsArrowFunctionExpression, JsCallExpression, JsClassDeclaration,
+    JsClassExpression, JsClassMemberList, JsExpressionStatement, JsExtendsClause,
+    JsFunctionDeclaration, JsIdentifierExpression, JsInitializerClause, JsMethodClassMember,
+    JsMethodObjectMember, JsObjectMemberList, JsStaticMemberExpression, JsSyntaxKind,
+    JsSyntaxToken, JsThisExpression, JsVariableDeclarator, TsReturnTypeAnnotation,
 };
 use biome_rowan::{
-    AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, SyntaxNodeCast, TriviaPieceKind,
+    AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, SyntaxNodeCast, TokenText,
+    TriviaPieceKind,
 };
 
 use crate::{services::semantic::Semantic, JsRuleAction};
@@ -100,6 +101,16 @@ declare_lint_rule! {
     /// }
     /// const api = new Api();
     /// api.returnsPromise().then(() => {}).finally(() => {});
+    /// ```
+    ///
+    /// ```typescript
+    /// const obj = {
+    ///   async returnsPromise(): Promise<string> {
+    ///     return 'value';
+    ///   },
+    /// };
+    ///
+    /// obj.returnsPromise();
     /// ```
     /// ### Valid
     ///
@@ -253,6 +264,16 @@ impl Rule for NoFloatingPromises {
 /// returnsPromise().then(() => {});
 /// ```
 ///
+/// ```typescript
+/// const obj = {
+///   async returnsPromise(): Promise<string> {
+///     return 'value';
+///   },
+/// };
+///
+/// obj['returnsPromise']();
+/// ```
+///
 /// Example JavaScript code that would return `false`:
 /// ```typescript
 /// function doesNotReturnPromise() {
@@ -268,6 +289,16 @@ fn is_callee_a_promise(callee: &AnyJsExpression, model: &SemanticModel) -> Optio
         }
         AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
             is_member_expression_callee_a_promise(static_member_expr, model)
+        }
+        AnyJsExpression::JsComputedMemberExpression(computed_member_expr) => {
+            let object = computed_member_expr.object().ok()?;
+            let js_ident_expr = object.as_js_identifier_expression()?;
+            let member = computed_member_expr.member().ok()?;
+            let literal_expr = member.as_any_js_literal_expression()?;
+            let string_literal = literal_expr.as_js_string_literal_expression()?;
+            let value_token = string_literal.inner_string_text().ok()?;
+
+            is_binding_a_promise(js_ident_expr, model, Some(value_token.text()))
         }
         _ => Some(false),
     }
@@ -591,6 +622,9 @@ fn is_initializer_a_promise(
         AnyJsExpression::JsClassExpression(class_expr) => {
             find_and_check_class_member(&class_expr.members(), target_method_name?, model)
         }
+        AnyJsExpression::JsObjectExpression(object_expr) => {
+            find_and_check_object_member(&object_expr.members(), target_method_name?)
+        }
         _ => Some(false),
     }
 }
@@ -729,12 +763,16 @@ fn check_this_expression(
         .syntax()
         .ancestors()
         .skip(1)
-        .find_map(|ancestor| {
-            if ancestor.kind() == JsSyntaxKind::JS_CLASS_MEMBER_LIST {
+        .find_map(|ancestor| match ancestor.kind() {
+            JsSyntaxKind::JS_CLASS_MEMBER_LIST => {
                 let class_member_list = JsClassMemberList::cast(ancestor)?;
-                return find_and_check_class_member(&class_member_list, target_name, model);
+                find_and_check_class_member(&class_member_list, target_name, model)
             }
-            None
+            JsSyntaxKind::JS_OBJECT_MEMBER_LIST => {
+                let object_member_list = JsObjectMemberList::cast(ancestor)?;
+                find_and_check_object_member(&object_member_list, target_name)
+            }
+            _ => None,
         })
 }
 
@@ -866,6 +904,73 @@ fn is_ts_type_a_promise(any_ts_type: &AnyTsType) -> Option<bool> {
             let identifier = name.as_js_reference_identifier()?;
 
             Some(identifier.has_name("Promise"))
+        }
+        _ => None,
+    }
+}
+
+/// Finds a object method or property by matching the given name and checks if it is a promise.
+///
+/// This function searches for a object method or property in the given `JsObjectMemberList`
+/// by matching the provided `target_name`. If a matching member is found, it checks if the member
+/// is a promise.
+///
+/// # Arguments
+///
+/// * `object_member_list` - A reference to a `JsObjectMemberList` representing the object members to search in.
+/// * `target_name` - The name of the method or property to search for.
+/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
+///
+/// # Returns
+///
+/// * `Some(true)` if the class member is a promise.
+/// * `Some(false)` if the class member is not a promise.
+/// * `None` if there is an error in the process or if the class member is not found.
+///
+fn find_and_check_object_member(
+    object_member_list: &JsObjectMemberList,
+    target_name: &str,
+) -> Option<bool> {
+    fn extract_member_name(member: &AnyJsObjectMember) -> Option<TokenText> {
+        match member {
+            AnyJsObjectMember::JsPropertyObjectMember(property) => property.name().ok()?.name(),
+            AnyJsObjectMember::JsMethodObjectMember(method) => method.name().ok()?.name(),
+            _ => None,
+        }
+    }
+
+    fn is_async_or_promise(
+        async_token: &Option<JsSyntaxToken>,
+        return_type: Option<TsReturnTypeAnnotation>,
+    ) -> bool {
+        async_token.is_some() || is_return_type_a_promise(return_type).unwrap_or_default()
+    }
+
+    let object_member = object_member_list.iter().find_map(|member| {
+        let member = member.ok()?;
+        (extract_member_name(&member)? == target_name).then_some(member)
+    })?;
+
+    match object_member {
+        AnyJsObjectMember::JsMethodObjectMember(method) => Some(is_async_or_promise(
+            &method.async_token(),
+            method.return_type_annotation(),
+        )),
+        AnyJsObjectMember::JsPropertyObjectMember(property) => {
+            let value = property.value().ok()?;
+            match value {
+                AnyJsExpression::JsArrowFunctionExpression(arrow_func) => {
+                    Some(is_async_or_promise(
+                        &arrow_func.async_token(),
+                        arrow_func.return_type_annotation(),
+                    ))
+                }
+                AnyJsExpression::JsFunctionExpression(func_expr) => Some(is_async_or_promise(
+                    &func_expr.async_token(),
+                    func_expr.return_type_annotation(),
+                )),
+                _ => None,
+            }
         }
         _ => None,
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -265,3 +265,35 @@ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
 invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
 	.then(() => {})
 	.finally(() => {});
+invalidTestClassExpression.returnsPromiseProperty
+	.then(() => {})
+	.finally(() => {});
+
+const invalidTestObject = {
+	returnsPromiseArrowFunction: async (): Promise<string> => {
+		return "value";
+	},
+
+	returnsPromiseFunction: async function (): Promise<string> {
+		return "value";
+	},
+
+	async returnsPromiseMethod(): Promise<string> {
+		return "value";
+	},
+
+	someMethod() {
+		this.returnsPromiseArrowFunction();
+		this.returnsPromiseFunction().then(() => {});
+		this.returnsPromiseMethod();
+	},
+};
+async function testInvalidObejctMethodCalls(): Promise<void> {
+	invalidTestObject.returnsPromiseArrowFunction();
+	invalidTestObject.returnsPromiseFunction().then(() => {});
+	invalidTestObject
+		.returnsPromiseMethod()
+		.then(() => {})
+		.finally(() => {});
+	invalidTestObject["returnsPromiseMethod"]();
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -271,6 +271,38 @@ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
 invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
 	.then(() => {})
 	.finally(() => {});
+invalidTestClassExpression.returnsPromiseProperty
+	.then(() => {})
+	.finally(() => {});
+
+const invalidTestObject = {
+	returnsPromiseArrowFunction: async (): Promise<string> => {
+		return "value";
+	},
+
+	returnsPromiseFunction: async function (): Promise<string> {
+		return "value";
+	},
+
+	async returnsPromiseMethod(): Promise<string> {
+		return "value";
+	},
+
+	someMethod() {
+		this.returnsPromiseArrowFunction();
+		this.returnsPromiseFunction().then(() => {});
+		this.returnsPromiseMethod();
+	},
+};
+async function testInvalidObejctMethodCalls(): Promise<void> {
+	invalidTestObject.returnsPromiseArrowFunction();
+	invalidTestObject.returnsPromiseFunction().then(() => {});
+	invalidTestObject
+		.returnsPromiseMethod()
+		.then(() => {})
+		.finally(() => {});
+	invalidTestObject["returnsPromiseMethod"]();
+}
 
 ```
 
@@ -1232,9 +1264,168 @@ invalid.ts:265:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
   > 266 │ 	.then(() => {})
   > 267 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    268 │ 
+    268 │ invalidTestClassExpression.returnsPromiseProperty
+    269 │ 	.then(() => {})
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
+
+```
+
+```
+invalid.ts:268:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    266 │ 	.then(() => {})
+    267 │ 	.finally(() => {});
+  > 268 │ invalidTestClassExpression.returnsPromiseProperty
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 269 │ 	.then(() => {})
+  > 270 │ 	.finally(() => {});
+        │ 	^^^^^^^^^^^^^^^^^^^
+    271 │ 
+    272 │ const invalidTestObject = {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:286:3 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    285 │ 	someMethod() {
+  > 286 │ 		this.returnsPromiseArrowFunction();
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    287 │ 		this.returnsPromiseFunction().then(() => {});
+    288 │ 		this.returnsPromiseMethod();
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:287:3 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    285 │ 	someMethod() {
+    286 │ 		this.returnsPromiseArrowFunction();
+  > 287 │ 		this.returnsPromiseFunction().then(() => {});
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    288 │ 		this.returnsPromiseMethod();
+    289 │ 	},
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:288:3 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    286 │ 		this.returnsPromiseArrowFunction();
+    287 │ 		this.returnsPromiseFunction().then(() => {});
+  > 288 │ 		this.returnsPromiseMethod();
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    289 │ 	},
+    290 │ };
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:292:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    290 │ };
+    291 │ async function testInvalidObejctMethodCalls(): Promise<void> {
+  > 292 │ 	invalidTestObject.returnsPromiseArrowFunction();
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    293 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+    294 │ 	invalidTestObject
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    292 │ → await·invalidTestObject.returnsPromiseArrowFunction();
+        │   ++++++                                                
+
+```
+
+```
+invalid.ts:293:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    291 │ async function testInvalidObejctMethodCalls(): Promise<void> {
+    292 │ 	invalidTestObject.returnsPromiseArrowFunction();
+  > 293 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    294 │ 	invalidTestObject
+    295 │ 		.returnsPromiseMethod()
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    293 │ → await·invalidTestObject.returnsPromiseFunction().then(()·=>·{});
+        │   ++++++                                                          
+
+```
+
+```
+invalid.ts:294:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    292 │ 	invalidTestObject.returnsPromiseArrowFunction();
+    293 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+  > 294 │ 	invalidTestObject
+        │ 	^^^^^^^^^^^^^^^^^
+  > 295 │ 		.returnsPromiseMethod()
+  > 296 │ 		.then(() => {})
+  > 297 │ 		.finally(() => {});
+        │ 		^^^^^^^^^^^^^^^^^^^
+    298 │ 	invalidTestObject["returnsPromiseMethod"]();
+    299 │ }
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    294 │ → await·invalidTestObject
+        │   ++++++                 
+
+```
+
+```
+invalid.ts:298:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    296 │ 		.then(() => {})
+    297 │ 		.finally(() => {});
+  > 298 │ 	invalidTestObject["returnsPromiseMethod"]();
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    299 │ }
+    300 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    298 │ → await·invalidTestObject["returnsPromiseMethod"]();
+        │   ++++++                                            
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
@@ -190,3 +190,29 @@ async function testUnnamedClassExpressionMethodCalls(): Promise<string> {
   unnamedValidClassExpression.returnsPromiseProperty.catch(() => { });
   return unnamedValidClassExpression.returnsPromiseArrowFunction();
 }
+
+const validTestObject = {
+  returnsPromiseArrowFunction: async (): Promise<string> => {
+    return 'value';
+  },
+
+  returnsPromiseFunction: async function (): Promise<string> {
+    return 'value';
+  },
+
+  async returnsPromiseMethod(): Promise<string> {
+    return 'value';
+  },
+
+  async someMethod() {
+		await this.returnsPromiseArrowFunction();
+		this.returnsPromiseFunction().then(() => {}, () => {}).finally(() => {});
+		this.returnsPromiseMethod().catch(() => {});
+	},
+}
+async function testValidObejctMethodCalls(): Promise<string> {
+  await validTestObject.returnsPromiseArrowFunction();
+  validTestObject.returnsPromiseFunction().catch(() => { });
+  validTestObject.returnsPromiseMethod().then(() => { }, () => { }).finally(() => { });
+  return validTestObject['returnsPromiseMethod']();
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
@@ -196,4 +196,30 @@ async function testUnnamedClassExpressionMethodCalls(): Promise<string> {
   unnamedValidClassExpression.returnsPromiseProperty.catch(() => { });
   return unnamedValidClassExpression.returnsPromiseArrowFunction();
 }
+
+const validTestObject = {
+  returnsPromiseArrowFunction: async (): Promise<string> => {
+    return 'value';
+  },
+
+  returnsPromiseFunction: async function (): Promise<string> {
+    return 'value';
+  },
+
+  async returnsPromiseMethod(): Promise<string> {
+    return 'value';
+  },
+
+  async someMethod() {
+		await this.returnsPromiseArrowFunction();
+		this.returnsPromiseFunction().then(() => {}, () => {}).finally(() => {});
+		this.returnsPromiseMethod().catch(() => {});
+	},
+}
+async function testValidObejctMethodCalls(): Promise<string> {
+  await validTestObject.returnsPromiseArrowFunction();
+  validTestObject.returnsPromiseFunction().catch(() => { });
+  validTestObject.returnsPromiseMethod().then(() => { }, () => { }).finally(() => { });
+  return validTestObject['returnsPromiseMethod']();
+}
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
https://github.com/biomejs/biome/issues/4956
This pull request introduces the support for object methods in `noFloatingPromises`

### Example of invalid code:
calling an async method in the same object using `this`
```
const obj = {
  returnsPromiseArrowFunction: async (): Promise<string> => {
    return "value";
  },

  returnsPromiseFunction: async function (): Promise<string> {
    return "value";
  },

  async returnsPromiseMethod(): Promise<string> {
    return "value";
  },

  someMethod() {
    this.returnsPromiseArrowFunction();  // diagnostic here
    this.returnsPromiseFunction().then(() => {});  // diagnostic here
    this.returnsPromiseMethod();  // diagnostic here
  }
};
```

calling an async method from outside
```
const obj = {
  returnsPromiseArrowFunction: async (): Promise<string> => {
    return "value";
  },

  returnsPromiseFunction: async function (): Promise<string> {
    return "value";
  },

  async returnsPromiseMethod(): Promise<string> {
    return "value";
  },
};

obj.returnsPromiseArrowFunction();  // diagnostic here
obj.returnsPromiseFunction().then(() => {});  // diagnostic here
obj['returnsPromiseMethod']();  // diagnostic here
```

### Example of valid code:
```
const obj = {
  returnsPromiseArrowFunction: async (): Promise<string> => {
    return "value";
  },

  returnsPromiseFunction: async function (): Promise<string> {
    return "value";
  },

  async returnsPromiseMethod(): Promise<string> {
    return "value";
  },

  async someMethod() {
    await this.returnsPromiseArrowFunction();
    this.returnsPromiseFunction().then(() => {}, () => {});
    this.returnsPromiseMethod().catch(() => {});
  }
};

await obj.returnsPromiseArrowFunction();
await obj['returnsPromiseFunction']();
```