### PR TITLE
test: add end-to-end tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -147,6 +147,27 @@ jobs:
         run: |
           pnpm --filter @biomejs/backend-jsonrpc run test:ci
           pnpm --filter @biomejs/js-api run test:ci
+  
+  e2e-tests:
+    name: end-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
+        with:
+          cache-base: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Biome debug binary
+        run: cargo build --bin biome
+      - name: Run tests
+        run: |
+          cd e2e-tests
+          sh test-all.sh
 
   documentation:
     name: Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Profile-*.json
 **/target
 # Ignore test files that contributors could create locally
 **/test.*
+!e2e-tests/**/test.*
 # Ignore third-party files
 **/node_modules
 **/dist

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,19 @@
+# End-to-end tests
+
+`e2e-tests` directory allows testing the Biome CLI directly.
+Each directory in `e2e-tests` is a test that represents a project using Biome.
+Every directory must include a shell script named `test.sh`.
+The exit status of the script determines if the test passed or failed.
+
+For example, the following script executes `biome lint`:
+
+```sh
+# fail if any command fail or if some variables are undefined
+set -eu
+
+cargo run --bin biome -- lint src
+
+```
+
+If the command reports lint error, then the script fails and makes the test fails.
+The working directory is always set to the directory that holds `test.sh`.

--- a/e2e-tests/relative-path/biome.json
+++ b/e2e-tests/relative-path/biome.json
@@ -1,0 +1,4 @@
+{
+    "files": { "includes": ["**"] },
+    "linter": { "rules": { "recommended": true, "suspicious": { "noDebugger": "error" } } }
+}

--- a/e2e-tests/relative-path/src/file.js
+++ b/e2e-tests/relative-path/src/file.js
@@ -1,0 +1,1 @@
+debugger;

--- a/e2e-tests/relative-path/test.sh
+++ b/e2e-tests/relative-path/test.sh
@@ -1,0 +1,3 @@
+set -eu
+
+cargo run --bin biome -- lint . 2>&1 | grep -q debugger

--- a/e2e-tests/test-all.sh
+++ b/e2e-tests/test-all.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+for x in *; do
+    if test -d "$x"; then
+        echo "Testing $x..."
+        cd "$x"
+        sh test.sh
+        cd ..
+    fi
+done


### PR DESCRIPTION
## Summary

This PR adds end-to-end tests.

A test is a directory in the `e2e-tests` directory and consists of a shell script named `test.sh`.
All tests are executed thanks to `e2e-tests/test-all.sh`.

I added a workflow in the `pull_request` action.

## Test Plan

CI must pass.
