### PR TITLE
fix(js-api): fix the generated types for rule domains

### DIFF
--- a/crates/biome_configuration/src/analyzer/linter/mod.rs
+++ b/crates/biome_configuration/src/analyzer/linter/mod.rs
@@ -45,8 +45,7 @@ pub struct LinterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub includes: Option<Vec<biome_glob::Glob>>,
 
-    /// An object where the keys are the names of the domains, and the values are boolean. `true` to turn-on the rules that
-    /// belong to that domain, `false` to turn them off
+    /// An object where the keys are the names of the domains, and the values are `all`, `recommended`, or `none`.
     #[bpaf(hide, pure(Default::default()))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domains: Option<FxHashMap<RuleDomain, RuleDomainValue>>,

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -350,29 +350,34 @@ pub fn generate_type<'a>(
                     property = property.with_leading_trivia(trivia);
                 }
 
-                let type_annotation = if property_str == "featuresSupported" {
+                let type_annotation = if let Some((container_type, key_type, value_type)) =
+                    match property_str.as_str() {
+                        "featuresSupported" => Some(("Map", "FeatureKind", "SupportKind")),
+                        "domains" => Some(("Record", "RuleDomain", "RuleDomainValue")),
+                        _ => None,
+                    } {
                     // HACK: force the `featuresSupported` property to be a Map<FeatureKind, SupportKind>
                     // This is a temporary workaround to fix the type annotation for this property. The
                     // better fix would be to use the `transform` feature that is available in `schemars` 1.0 to
                     // add a metadata field that we can pick up here to generate the correct type annotation.
                     // Alternatively, we could generate these types based on the actual rust types instead of the
                     // json schema.
+                    //
+                    // We also manually fix the types for some other properties as well.
                     let full_type = make::ts_reference_type(
-                        make::js_reference_identifier(make::ident("Map")).into(),
+                        make::js_reference_identifier(make::ident(container_type)).into(),
                     )
                     .with_type_arguments(make::ts_type_arguments(
                         make::token(T![<]),
                         make::ts_type_argument_list(
                             [
                                 make::ts_reference_type(
-                                    make::js_reference_identifier(make::ident("FeatureKind"))
-                                        .into(),
+                                    make::js_reference_identifier(make::ident(key_type)).into(),
                                 )
                                 .build()
                                 .into(),
                                 make::ts_reference_type(
-                                    make::js_reference_identifier(make::ident("SupportKind"))
-                                        .into(),
+                                    make::js_reference_identifier(make::ident(value_type)).into(),
                                 )
                                 .build()
                                 .into(),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -314,9 +314,9 @@ export interface JsonConfiguration {
 }
 export interface LinterConfiguration {
 	/**
-	 * An object where the keys are the names of the domains, and the values are boolean. `true` to turn-on the rules that belong to that domain, `false` to turn them off
+	 * An object where the keys are the names of the domains, and the values are `all`, `recommended`, or `none`.
 	 */
-	domains?: {};
+	domains?: Record<RuleDomain, RuleDomainValue>;
 	/**
 	 * if `false`, it disables the feature and the linter won't be executed. `true` by default
 	 */
@@ -944,7 +944,7 @@ export interface OverrideLinterConfiguration {
 	/**
 	 * List of rules
 	 */
-	domains?: {};
+	domains?: Record<RuleDomain, RuleDomainValue>;
 	/**
 	 * if `false`, it disables the feature and the linter won't be executed. `true` by default
 	 */
@@ -3834,6 +3834,11 @@ export type SupportKind =
 	| "protected"
 	| "featureNotEnabled"
 	| "fileNotSupported";
+/**
+ * Rule domains
+ */
+export type RuleDomain = "react" | "test" | "solid" | "next";
+export type RuleDomainValue = "all" | "none" | "recommended";
 export interface Workspace {
 	fileFeatures(params: SupportsFeatureParams): Promise<FileFeaturesResult>;
 	updateSettings(params: UpdateSettingsParams): Promise<void>;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2271,7 +2271,7 @@
 			"type": "object",
 			"properties": {
 				"domains": {
-					"description": "An object where the keys are the names of the domains, and the values are boolean. `true` to turn-on the rules that belong to that domain, `false` to turn them off",
+					"description": "An object where the keys are the names of the domains, and the values are `all`, `recommended`, or `none`.",
 					"type": ["object", "null"],
 					"additionalProperties": { "$ref": "#/definitions/RuleDomainValue" }
 				},

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -15,9 +15,9 @@ serde          = { workspace = true, optional = true }
 ureq           = "3.0.3"
 xtask          = { path = '../', version = "0.0" }
 
-biome_analyze         = { workspace = true, optional = true }
+biome_analyze         = { workspace = true, features = ["schema"], optional = true }
 biome_cli             = { workspace = true, optional = true }
-biome_configuration   = { workspace = true, optional = true }
+biome_configuration   = { workspace = true, features = ["schema"], optional = true }
 biome_css_analyze     = { workspace = true, optional = true }
 biome_css_syntax      = { workspace = true, optional = true }
 biome_diagnostics     = { workspace = true, optional = true }
@@ -59,6 +59,7 @@ license = ["ureq/default", "ureq/json", "serde", "serde_json"]
 schema = [
   "schemars",
   "serde_json",
+  "biome_analyze",
   "biome_rowan",
   "biome_service",
   "biome_js_syntax",

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -154,10 +154,17 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
             .build(),
         ));
     }
-    // HACK: SupportKind doesn't get picked up in the loop above, so we add it manually
+    // HACK: these types doesn't get picked up in the loop above, so we add it manually
     let support_kind_schema = SchemaGenerator::from(SchemaSettings::openapi3())
         .root_schema_for::<biome_service::workspace::SupportKind>();
     generate_type(&mut declarations, &mut queue, &support_kind_schema);
+    let rule_domain_schema = SchemaGenerator::from(SchemaSettings::openapi3())
+        .root_schema_for::<biome_analyze::RuleDomain>();
+    generate_type(&mut declarations, &mut queue, &rule_domain_schema);
+    let rule_domain_value_schema = SchemaGenerator::from(SchemaSettings::openapi3())
+        .root_schema_for::<biome_configuration::analyzer::RuleDomainValue>(
+    );
+    generate_type(&mut declarations, &mut queue, &rule_domain_value_schema);
 
     let leading_comment = [
         (


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This fixes the generated type for `domains` in the linter configuration. Now, that type gets emitted is `Record<RuleDomain, RuleDomainValue>`.

I've tested this on the website repo, and actually both an object and a `Map` work. I picked `Record` here since building `Map`s tends to be a little unergonomic.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
