### PR TITLE
fix(cli): fix CLI flag of `bracketSpacing` option for lang-specific override

### DIFF
--- a/.changeset/funny-beans-vanish.md
+++ b/.changeset/funny-beans-vanish.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix a CLI flag `--bracket-spacing` is duplicated between the global configuration and the lang-specific override for JavaScript.

--- a/.changeset/funny-beans-vanish.md
+++ b/.changeset/funny-beans-vanish.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fix a CLI flag `--bracket-spacing` is duplicated between the global configuration and the lang-specific override for JavaScript.
+Fixed the flag `--bracket-spacing` that was duplicated between the global configuration and the language-specific override for JavaScript.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -70,6 +70,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
                               JSX elements. Defaults to auto.
+        --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
+                              brackets in object literals. Defaults to true.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -71,6 +71,8 @@ The configuration that is contained inside the file `biome.json`
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
                               JSX elements. Defaults to auto.
+        --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
+                              brackets in object literals. Defaults to true.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -53,8 +53,8 @@ Formatting options specific to the JavaScript files
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
                               JSX elements. Defaults to auto.
-        --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
-                              Defaults to true.
+        --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
+                              brackets in object literals. Defaults to true.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
 

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -103,7 +103,7 @@ pub struct JsFormatterConfiguration {
 
     // it's also a top-level configurable property.
     /// Whether to insert spaces around brackets in object literals. Defaults to true.
-    #[bpaf(long("bracket-spacing"), argument("true|false"))]
+    #[bpaf(long("javascript-formatter-bracket-spacing"), argument("true|false"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<BracketSpacing>,
 


### PR DESCRIPTION
## Summary

This pull request fixes a CLI flag `--bracket-spacing` is duplicated between the global configuration and the lang-specific override for JavaScript.

## Test Plan

Snapshot changed, existing tests should pass.
