### PR TITLE
feat(cli)!: rename `--javascript-attribute-position` to `--javascript-formatter-attribute-position`

### DIFF
--- a/.changeset/hot-moons-kiss.md
+++ b/.changeset/hot-moons-kiss.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+CLI flag `--javascript-attribute-position` was renamed to `--javascript-formatter-attribute-position` for consistency.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -69,7 +69,7 @@ The configuration that is contained inside the file `biome.json`
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
-                              jsx elements. Defaults to auto.
+                              JSX elements. Defaults to auto.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -68,8 +68,8 @@ The configuration that is contained inside the file `biome.json`
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
-                              elements. Defaults to auto.
+        --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
+                              jsx elements. Defaults to auto.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -70,7 +70,7 @@ The configuration that is contained inside the file `biome.json`
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
-                              jsx elements. Defaults to auto.
+                              JSX elements. Defaults to auto.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -69,8 +69,8 @@ The configuration that is contained inside the file `biome.json`
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
-                              elements. Defaults to auto.
+        --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
+                              jsx elements. Defaults to auto.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
                               when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -52,7 +52,7 @@ Formatting options specific to the JavaScript files
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
         --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
-                              jsx elements. Defaults to auto.
+                              JSX elements. Defaults to auto.
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -51,8 +51,8 @@ Formatting options specific to the JavaScript files
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
                               code. Defaults to double.
-        --javascript-attribute-position=<multiline|auto>  The attribute position style in jsx
-                              elements. Defaults to auto.
+        --javascript-formatter-attribute-position=<multiline|auto>  The attribute position style in
+                              jsx elements. Defaults to auto.
         --bracket-spacing=<true|false>  Whether to insert spaces around brackets in object literals.
                               Defaults to true.
         --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -94,7 +94,10 @@ pub struct JsFormatterConfiguration {
 
     // it's also a top-level configurable property.
     /// The attribute position style in jsx elements. Defaults to auto.
-    #[bpaf(long("javascript-attribute-position"), argument("multiline|auto"))]
+    #[bpaf(
+        long("javascript-formatter-attribute-position"),
+        argument("multiline|auto")
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attribute_position: Option<AttributePosition>,
 

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -93,7 +93,7 @@ pub struct JsFormatterConfiguration {
     pub quote_style: Option<QuoteStyle>,
 
     // it's also a top-level configurable property.
-    /// The attribute position style in jsx elements. Defaults to auto.
+    /// The attribute position style in JSX elements. Defaults to auto.
     #[bpaf(
         long("javascript-formatter-attribute-position"),
         argument("multiline|auto")

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -600,7 +600,7 @@ export interface JsFormatterConfiguration {
 	 */
 	arrowParentheses?: ArrowParentheses;
 	/**
-	 * The attribute position style in jsx elements. Defaults to auto.
+	 * The attribute position style in JSX elements. Defaults to auto.
 	 */
 	attributePosition?: AttributePosition;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1905,7 +1905,7 @@
 					]
 				},
 				"attributePosition": {
-					"description": "The attribute position style in jsx elements. Defaults to auto.",
+					"description": "The attribute position style in JSX elements. Defaults to auto.",
 					"anyOf": [
 						{ "$ref": "#/definitions/AttributePosition" },
 						{ "type": "null" }


### PR DESCRIPTION
## Summary

This pull request renames the CLI flag `--javascript-attribute-position` to `--javascript-formatter-attribute-position` to keep naming consistency.

## Test Plan

Snapshot updated, existing tests should pass.
