### PR TITLE
feat: add plugin suppression

### DIFF
--- a/crates/biome_analyze/src/diagnostics.rs
+++ b/crates/biome_analyze/src/diagnostics.rs
@@ -26,7 +26,7 @@ pub struct AnalyzerDiagnostic {
 impl From<RuleDiagnostic> for AnalyzerDiagnostic {
     fn from(rule_diagnostic: RuleDiagnostic) -> Self {
         Self {
-            kind: DiagnosticKind::Rule(rule_diagnostic),
+            kind: DiagnosticKind::Rule(Box::new(rule_diagnostic)),
             code_suggestion_list: vec![],
         }
     }
@@ -35,7 +35,7 @@ impl From<RuleDiagnostic> for AnalyzerDiagnostic {
 #[derive(Debug)]
 enum DiagnosticKind {
     /// It holds various info related to diagnostics emitted by the rules
-    Rule(RuleDiagnostic),
+    Rule(Box<RuleDiagnostic>),
     /// We have raw information to create a basic [Diagnostic]
     Raw(Error),
 }

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -721,7 +721,7 @@ pub enum AnalyzerSuppressionKind<'a> {
     Rule(&'a str),
     /// A suppression to be evaluated by a specific rule eg. `// biome-ignore lint/correctness/useExhaustiveDependencies(foo)`
     RuleInstance(&'a str, &'a str),
-    /// A suppression disabling a plugin eg. `// biome-ignore plugin/my-plugin`
+    /// A suppression disabling a plugin eg. `// lint/biome-ignore plugin/my-plugin`
     Plugin(Option<&'a str>),
 }
 

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -738,7 +738,7 @@ pub fn to_analyzer_suppressions(
     for (key, subcategory, value) in suppression.categories {
         if key == category!("lint") {
             result.push(AnalyzerSuppression::everything().with_variant(&suppression.kind));
-        } else if key == category!("plugin") {
+        } else if key == category!("lint/plugin") {
             let suppression = AnalyzerSuppression::plugin(subcategory)
                 .with_ignore_range(ignore_range)
                 .with_variant(&suppression.kind);

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1231,6 +1231,7 @@ pub trait Rule: RuleMeta + Sized {
 pub struct RuleDiagnostic {
     #[category]
     pub(crate) category: &'static Category,
+    pub(crate) subcategory: Option<String>,
     #[location(span)]
     pub(crate) span: Option<TextRange>,
     #[message]
@@ -1309,6 +1310,7 @@ impl RuleDiagnostic {
         let message = markup!({ title }).to_owned();
         Self {
             category,
+            subcategory: None,
             span: span.as_span(),
             message: MessageAndDescription::from(message),
             tags: DiagnosticTags::empty(),
@@ -1407,6 +1409,11 @@ impl RuleDiagnostic {
 
     pub fn advices(&self) -> &RuleAdvice {
         &self.rule_advice
+    }
+
+    pub fn subcategory(mut self, subcategory: String) -> Self {
+        self.subcategory = Some(subcategory);
+        self
     }
 }
 

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -7,7 +7,7 @@ use biome_diagnostics::category;
 use biome_rowan::{TextRange, TextSize};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-const PLUGIN_RULE_FILTER: RuleFilter<'static> = RuleFilter::Group("plugin");
+const PLUGIN_LINT_RULE_FILTER: RuleFilter<'static> = RuleFilter::Group("lint/plugin");
 
 #[derive(Debug, Default)]
 pub struct TopLevelSuppression {
@@ -54,7 +54,7 @@ impl TopLevelSuppression {
         // The absence of a filter means that it's a suppression all
         match filter {
             None => self.suppress_all = true,
-            Some(PLUGIN_RULE_FILTER) => self.insert_plugin(&suppression.kind),
+            Some(PLUGIN_LINT_RULE_FILTER) => self.insert_plugin(&suppression.kind),
             Some(filter) => self.insert(filter),
         }
         self.comment_range = comment_range;
@@ -166,7 +166,7 @@ impl RangeSuppressions {
         text_range: TextRange,
         already_suppressed: Option<TextRange>,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
-        if let Some(PLUGIN_RULE_FILTER) = filter {
+        if let Some(PLUGIN_LINT_RULE_FILTER) = filter {
             return Err(AnalyzerSuppressionDiagnostic::new(
                 category!("suppressions/incorrect"),
                 text_range,
@@ -322,7 +322,7 @@ impl<'analyzer> Suppressions<'analyzer> {
                         suppression.suppressed_instances.clear();
                         suppression.suppressed_plugins.clear();
                     }
-                    Some(PLUGIN_RULE_FILTER) => {
+                    Some(PLUGIN_LINT_RULE_FILTER) => {
                         if let Some(plugin_name) = plugin_name {
                             suppression.suppressed_plugins.insert(plugin_name);
                             suppression.suppress_all_plugins = false;
@@ -354,7 +354,7 @@ impl<'analyzer> Suppressions<'analyzer> {
             None => {
                 suppression.suppress_all = true;
             }
-            Some(PLUGIN_RULE_FILTER) => {
+            Some(PLUGIN_LINT_RULE_FILTER) => {
                 if let Some(plugin_name) = plugin_name {
                     suppression.suppressed_plugins.insert(plugin_name);
                 } else {
@@ -383,7 +383,7 @@ impl<'analyzer> Suppressions<'analyzer> {
             AnalyzerSuppressionKind::Everything => return Ok(None),
             AnalyzerSuppressionKind::Rule(rule) => rule,
             AnalyzerSuppressionKind::RuleInstance(rule, _) => rule,
-            AnalyzerSuppressionKind::Plugin(_) => return Ok(Some(PLUGIN_RULE_FILTER)),
+            AnalyzerSuppressionKind::Plugin(_) => return Ok(Some(PLUGIN_LINT_RULE_FILTER)),
         };
 
         let group_rule = rule.split_once('/');

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -72,7 +72,7 @@ impl CommentStyle for CssCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _)| key == category!("format"))
+            .any(|(key, _, _)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_css_formatter/src/comments.rs
+++ b/crates/biome_css_formatter/src/comments.rs
@@ -72,7 +72,7 @@ impl CommentStyle for CssCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _, _)| key == category!("format"))
+            .any(|(key, ..)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -388,6 +388,7 @@ define_categories! {
     "lint/security",
     "lint/style",
     "lint/suspicious",
+    "lint/plugin",
 
     // Suppression comments
     "suppressions/parse",

--- a/crates/biome_diagnostics_categories/src/lib.rs
+++ b/crates/biome_diagnostics_categories/src/lib.rs
@@ -58,7 +58,6 @@ struct CategoryVisitor;
 
 #[cfg(feature = "serde")]
 fn deserialize_parse<E: serde::de::Error>(code: &str) -> Result<&'static Category, E> {
-    println!("called deserialize_parse");
     code.parse().map_err(|()| {
         serde::de::Error::custom(format_args!("failed to deserialize category from {code}"))
     })

--- a/crates/biome_diagnostics_categories/src/lib.rs
+++ b/crates/biome_diagnostics_categories/src/lib.rs
@@ -58,6 +58,7 @@ struct CategoryVisitor;
 
 #[cfg(feature = "serde")]
 fn deserialize_parse<E: serde::de::Error>(code: &str) -> Result<&'static Category, E> {
+    println!("called deserialize_parse");
     code.parse().map_err(|()| {
         serde::de::Error::custom(format_args!("failed to deserialize category from {code}"))
     })

--- a/crates/biome_graphql_formatter/src/comments.rs
+++ b/crates/biome_graphql_formatter/src/comments.rs
@@ -68,7 +68,7 @@ impl CommentStyle for GraphqlCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _, _)| key == category!("format"))
+            .any(|(key, ..)| key == category!("format"))
     }
 
     fn get_comment_kind(_comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_graphql_formatter/src/comments.rs
+++ b/crates/biome_graphql_formatter/src/comments.rs
@@ -68,7 +68,7 @@ impl CommentStyle for GraphqlCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _)| key == category!("format"))
+            .any(|(key, _, _)| key == category!("format"))
     }
 
     fn get_comment_kind(_comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_html_formatter/src/comments.rs
+++ b/crates/biome_html_formatter/src/comments.rs
@@ -88,7 +88,7 @@ impl CommentStyle for HtmlCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _, _)| key == category!("format"))
+            .any(|(key, ..)| key == category!("format"))
     }
 
     fn get_comment_kind(_comment: &SyntaxTriviaPieceComments<HtmlLanguage>) -> CommentKind {

--- a/crates/biome_html_formatter/src/comments.rs
+++ b/crates/biome_html_formatter/src/comments.rs
@@ -88,7 +88,7 @@ impl CommentStyle for HtmlCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _)| key == category!("format"))
+            .any(|(key, _, _)| key == category!("format"))
     }
 
     fn get_comment_kind(_comment: &SyntaxTriviaPieceComments<HtmlLanguage>) -> CommentKind {

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit
@@ -1,0 +1,6 @@
+`Object.assign($args)` where {
+    register_diagnostic(
+        span = $args,
+        message = "Prefer object spread instead of `Object.assign()`"
+    )
+}

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
@@ -12,6 +12,14 @@ Object.assign({ foo: 'bar'}, baz);
 Object.assign({}, {foo: 'bar'});
 // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
 
+// if no name is specified, should suppress all plugins
+// biome-ignore plugin: reason
+Object.assign({}, foo);
+
+// only suppress specified plugin
+// biome-ignore plugin/anotherPlugin: reason
+Object.assign({ foo: 'bar'}, baz);
+
 ```
 
 # Diagnostics
@@ -42,6 +50,7 @@ preferObjectSpreadSuppression.grit:6:1 suppressions/incorrect ━━━━━━
   > 6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     7 │ 
+    8 │ // if no name is specified, should suppress all plugins
   
   i Remove this suppression.
   
@@ -58,6 +67,34 @@ preferObjectSpreadSuppression.grit:5:15 plugin ━━━━━━━━━━━
       │               ^^^^^^^^^^^^^^^^
     6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
     7 │ 
+  
+
+```
+
+```
+preferObjectSpreadSuppression.grit:14:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer object spread instead of `Object.assign()`
+  
+    12 │ // only suppress specified plugin
+    13 │ // biome-ignore plugin/anotherPlugin: reason
+  > 14 │ Object.assign({ foo: 'bar'}, baz);
+       │               ^^^^^^^^^^^^^^^^^^
+    15 │ 
+  
+
+```
+
+```
+preferObjectSpreadSuppression.grit:13:1 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
+  
+    12 │ // only suppress specified plugin
+  > 13 │ // biome-ignore plugin/anotherPlugin: reason
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │ Object.assign({ foo: 'bar'}, baz);
+    15 │ 
   
 
 ```

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
@@ -5,19 +5,19 @@ expression: preferObjectSpreadSuppression.grit
 ---
 # Input
 ```js
-// biome-ignore plugin/preferObjectSpreadSuppression: reason
+// biome-ignore lint/plugin/preferObjectSpreadSuppression: reason
 Object.assign({ foo: 'bar'}, baz);
 
-// biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+// biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
 Object.assign({}, {foo: 'bar'});
-// biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+// biome-ignore-end lint/plugin/preferObjectSpreadSuppression: reason
 
 // if no name is specified, should suppress all plugins
-// biome-ignore plugin: reason
+// biome-ignore lint/plugin: reason
 Object.assign({}, foo);
 
 // only suppress specified plugin
-// biome-ignore plugin/anotherPlugin: reason
+// biome-ignore lint/plugin/anotherPlugin: reason
 Object.assign({ foo: 'bar'}, baz);
 
 ```
@@ -30,10 +30,10 @@ preferObjectSpreadSuppression.grit:4:1 suppressions/incorrect ━━━━━━
   
     2 │ Object.assign({ foo: 'bar'}, baz);
     3 │ 
-  > 4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 4 │ // biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     5 │ Object.assign({}, {foo: 'bar'});
-    6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+    6 │ // biome-ignore-end lint/plugin/preferObjectSpreadSuppression: reason
   
   i Remove this suppression.
   
@@ -45,10 +45,10 @@ preferObjectSpreadSuppression.grit:6:1 suppressions/incorrect ━━━━━━
 
   ! Found a biome-ignore-<range> suppression on plugin. This is not supported. See https://github.com/biomejs/biome/issues/5175
   
-    4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+    4 │ // biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
     5 │ Object.assign({}, {foo: 'bar'});
-  > 6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 6 │ // biome-ignore-end lint/plugin/preferObjectSpreadSuppression: reason
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     7 │ 
     8 │ // if no name is specified, should suppress all plugins
   
@@ -62,10 +62,10 @@ preferObjectSpreadSuppression.grit:5:15 plugin ━━━━━━━━━━━
 
   ! Prefer object spread instead of `Object.assign()`
   
-    4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+    4 │ // biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
   > 5 │ Object.assign({}, {foo: 'bar'});
       │               ^^^^^^^^^^^^^^^^
-    6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+    6 │ // biome-ignore-end lint/plugin/preferObjectSpreadSuppression: reason
     7 │ 
   
 
@@ -77,7 +77,7 @@ preferObjectSpreadSuppression.grit:14:15 plugin ━━━━━━━━━━�
   ! Prefer object spread instead of `Object.assign()`
   
     12 │ // only suppress specified plugin
-    13 │ // biome-ignore plugin/anotherPlugin: reason
+    13 │ // biome-ignore lint/plugin/anotherPlugin: reason
   > 14 │ Object.assign({ foo: 'bar'}, baz);
        │               ^^^^^^^^^^^^^^^^^^
     15 │ 
@@ -91,8 +91,8 @@ preferObjectSpreadSuppression.grit:13:1 suppressions/unused ━━━━━━�
   ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
   
     12 │ // only suppress specified plugin
-  > 13 │ // biome-ignore plugin/anotherPlugin: reason
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 13 │ // biome-ignore lint/plugin/anotherPlugin: reason
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     14 │ Object.assign({ foo: 'bar'}, baz);
     15 │ 
   

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 366
+expression: preferObjectSpreadSuppression.grit
+---
+# Input
+```js
+// biome-ignore plugin/preferObjectSpreadSuppression: reason
+Object.assign({ foo: 'bar'}, baz);
+
+```

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
@@ -8,4 +8,56 @@ expression: preferObjectSpreadSuppression.grit
 // biome-ignore plugin/preferObjectSpreadSuppression: reason
 Object.assign({ foo: 'bar'}, baz);
 
+// biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+Object.assign({}, {foo: 'bar'});
+// biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+
+```
+
+# Diagnostics
+```
+preferObjectSpreadSuppression.grit:4:1 suppressions/incorrect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Found a biome-ignore-<range> suppression on plugin. This is not supported. See https://github.com/biomejs/biome/issues/5175
+  
+    2 │ Object.assign({ foo: 'bar'}, baz);
+    3 │ 
+  > 4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ Object.assign({}, {foo: 'bar'});
+    6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+  
+  i Remove this suppression.
+  
+
+```
+
+```
+preferObjectSpreadSuppression.grit:6:1 suppressions/incorrect ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Found a biome-ignore-<range> suppression on plugin. This is not supported. See https://github.com/biomejs/biome/issues/5175
+  
+    4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+    5 │ Object.assign({}, {foo: 'bar'});
+  > 6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i Remove this suppression.
+  
+
+```
+
+```
+preferObjectSpreadSuppression.grit:5:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Prefer object spread instead of `Object.assign()`
+  
+    4 │ // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+  > 5 │ Object.assign({}, {foo: 'bar'});
+      │               ^^^^^^^^^^^^^^^^
+    6 │ // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+    7 │ 
+  
+
 ```

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
@@ -1,0 +1,2 @@
+// biome-ignore plugin/preferObjectSpreadSuppression: reason
+Object.assign({ foo: 'bar'}, baz);

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
@@ -1,2 +1,6 @@
 // biome-ignore plugin/preferObjectSpreadSuppression: reason
 Object.assign({ foo: 'bar'}, baz);
+
+// biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+Object.assign({}, {foo: 'bar'});
+// biome-ignore-end plugin/preferObjectSpreadSuppression: reason

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
@@ -4,3 +4,11 @@ Object.assign({ foo: 'bar'}, baz);
 // biome-ignore-start plugin/preferObjectSpreadSuppression: reason
 Object.assign({}, {foo: 'bar'});
 // biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+
+// if no name is specified, should suppress all plugins
+// biome-ignore plugin: reason
+Object.assign({}, foo);
+
+// only suppress specified plugin
+// biome-ignore plugin/anotherPlugin: reason
+Object.assign({ foo: 'bar'}, baz);

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.js
@@ -1,14 +1,14 @@
-// biome-ignore plugin/preferObjectSpreadSuppression: reason
+// biome-ignore lint/plugin/preferObjectSpreadSuppression: reason
 Object.assign({ foo: 'bar'}, baz);
 
-// biome-ignore-start plugin/preferObjectSpreadSuppression: reason
+// biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
 Object.assign({}, {foo: 'bar'});
-// biome-ignore-end plugin/preferObjectSpreadSuppression: reason
+// biome-ignore-end lint/plugin/preferObjectSpreadSuppression: reason
 
 // if no name is specified, should suppress all plugins
-// biome-ignore plugin: reason
+// biome-ignore lint/plugin: reason
 Object.assign({}, foo);
 
 // only suppress specified plugin
-// biome-ignore plugin/anotherPlugin: reason
+// biome-ignore lint/plugin/anotherPlugin: reason
 Object.assign({ foo: 'bar'}, baz);

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit
@@ -1,0 +1,6 @@
+`Object.assign($args)` where {
+    register_diagnostic(
+        span = $args,
+        message = "Prefer object spread instead of `Object.assign()`"
+    )
+}

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit.snap
@@ -5,7 +5,7 @@ expression: preferObjectSpreadSuppressionAll.grit
 ---
 # Input
 ```js
-// biome-ignore-all plugin/preferObjectSpreadSuppressionAll: reason
+// biome-ignore-all lint/plugin/preferObjectSpreadSuppressionAll: reason
 
 console.log("foo");
 

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.grit.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 366
+expression: preferObjectSpreadSuppressionAll.grit
+---
+# Input
+```js
+// biome-ignore-all plugin/preferObjectSpreadSuppressionAll: reason
+
+console.log("foo");
+
+Object.assign({ foo: 'bar'}, baz);
+
+```

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.js
@@ -1,4 +1,4 @@
-// biome-ignore-all plugin/preferObjectSpreadSuppressionAll: reason
+// biome-ignore-all lint/plugin/preferObjectSpreadSuppressionAll: reason
 
 console.log("foo");
 

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.js
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppressionAll.js
@@ -1,0 +1,5 @@
+// biome-ignore-all plugin/preferObjectSpreadSuppressionAll: reason
+
+console.log("foo");
+
+Object.assign({ foo: 'bar'}, baz);

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -332,8 +332,11 @@ fn run_plugin_test(input: &'static str, _: &str, _: &str, _: &str) {
         Err(err) => panic!("Cannot load plugin: {err:?}"),
     };
 
+    // Enable at least 1 rule so that PhaseRunner will be called
+    // which is necessary to parse and store supression comments
+    let rule_filter = RuleFilter::Rule("nursery", "noCommonJs");
     let filter = AnalysisFilter {
-        enabled_rules: Some(&[]),
+        enabled_rules: Some(slice::from_ref(&rule_filter)),
         ..AnalysisFilter::default()
     };
 

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -80,7 +80,7 @@ impl CommentStyle for JsCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _)| key == category!("format"))
+            .any(|(key, _, _)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -80,7 +80,7 @@ impl CommentStyle for JsCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _, _)| key == category!("format"))
+            .any(|(key, ..)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<JsLanguage>) -> CommentKind {

--- a/crates/biome_json_formatter/src/comments.rs
+++ b/crates/biome_json_formatter/src/comments.rs
@@ -69,7 +69,7 @@ impl CommentStyle for JsonCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _, _)| key == category!("format"))
+            .any(|(key, ..)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_json_formatter/src/comments.rs
+++ b/crates/biome_json_formatter/src/comments.rs
@@ -69,7 +69,7 @@ impl CommentStyle for JsonCommentStyle {
         parse_suppression_comment(text)
             .filter_map(Result::ok)
             .flat_map(|suppression| suppression.categories)
-            .any(|(key, _)| key == category!("format"))
+            .any(|(key, _, _)| key == category!("format"))
     }
 
     fn get_comment_kind(comment: &SyntaxTriviaPieceComments<Self::Language>) -> CommentKind {

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -20,7 +20,7 @@ use crate::{AnalyzerPlugin, PluginDiagnostic};
 #[derive(Clone, Debug)]
 pub struct AnalyzerGritPlugin {
     grit_query: Rc<GritQuery>,
- }
+}
 
 impl AnalyzerGritPlugin {
     pub fn load(fs: &dyn FileSystem, path: &Utf8Path) -> Result<Self, PluginDiagnostic> {

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -20,7 +20,7 @@ use crate::{AnalyzerPlugin, PluginDiagnostic};
 #[derive(Clone, Debug)]
 pub struct AnalyzerGritPlugin {
     grit_query: Rc<GritQuery>,
-}
+ }
 
 impl AnalyzerGritPlugin {
     pub fn load(fs: &dyn FileSystem, path: &Utf8Path) -> Result<Self, PluginDiagnostic> {
@@ -65,6 +65,7 @@ impl AnalyzerPlugin for AnalyzerGritPlugin {
                     .verbose()
                 })
                 .chain(result.diagnostics)
+                .map(|diagnos| diagnos.subcategory(name.to_string()))
                 .collect(),
             Err(error) => vec![RuleDiagnostic::new(
                 category!("plugin"),

--- a/crates/biome_suppression/src/lib.rs
+++ b/crates/biome_suppression/src/lib.rs
@@ -20,8 +20,9 @@ pub struct Suppression<'a> {
     /// List of categories for this suppression
     ///
     /// Categories are a pair of the category name +
+    /// an optional dynamic subcategory name +
     /// an optional category value
-    pub categories: Vec<(&'a Category, Option<&'a str>)>,
+    pub categories: Vec<(&'a Category, Option<&'a str>, Option<&'a str>)>,
     /// Reason for this suppression comment to exist
     pub reason: &'a str,
 
@@ -252,15 +253,10 @@ fn parse_suppression_line(
 
         let (category, rest) = line.split_at(separator);
         let category = category.trim_end();
-        let category: Option<&'static Category> = if !category.is_empty() {
-            let category = category.parse().map_err(|()| SuppressionDiagnostic {
-                message: SuppressionDiagnosticKind::ParseCategory(category.into()),
-                span: TextRange::at(offset_from(base, category), TextSize::of(category)),
-            })?;
-            Some(category)
-        } else {
-            None
-        };
+        let (category, subcategory) = parse_category(category).map_err(|()| SuppressionDiagnostic {
+            message: SuppressionDiagnosticKind::ParseCategory(category.into()),
+            span: TextRange::at(offset_from(base, category), TextSize::of(category)),
+        })?;
 
         // Skip over and match the separator
         let (separator, rest) = rest.split_at(1);
@@ -269,7 +265,7 @@ fn parse_suppression_line(
             // Colon token: stop parsing categories
             ":" => {
                 if let Some(category) = category {
-                    categories.push((category, None));
+                    categories.push((category, subcategory, None));
                 }
 
                 line = rest.trim_start();
@@ -292,14 +288,14 @@ fn parse_suppression_line(
                 let (value, rest) = rest.split_at(paren);
                 let value = value.trim();
 
-                categories.push((category, Some(value)));
+                categories.push((category, subcategory, Some(value)));
 
                 line = rest.strip_prefix(')').unwrap().trim_start();
             }
             // Whitespace: push a category without value
             _ => {
                 if let Some(category) = category {
-                    categories.push((category, None));
+                    categories.push((category, subcategory, None));
                 }
 
                 line = rest.trim_start();
@@ -314,6 +310,18 @@ fn parse_suppression_line(
         kind,
         range,
     })
+}
+
+fn parse_category(category: &str) -> Result<(Option<&Category>, Option<&str>), ()> {
+    if category.is_empty() {
+        return Ok((None, None));
+    }
+    if let Some(rest) = category.strip_prefix("plugin/") {
+        return Ok(("plugin".parse().ok(), Some(rest)));
+    }
+    let category = category.parse()?;
+    // can create dynamic category here
+    Ok((Some(category), None))
 }
 
 /// Returns the byte offset of `substr` within `base`
@@ -353,7 +361,7 @@ mod tests_suppression_kinds {
             parse_suppression_comment("// biome-ignore format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -367,7 +375,7 @@ mod tests_suppression_kinds {
             parse_suppression_comment("// biome-ignore-all format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -381,7 +389,7 @@ mod tests_suppression_kinds {
             parse_suppression_comment("// biome-ignore-start format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::RangeStart,
                 range: TextRange::new(TextSize::from(3), TextSize::from(21))
@@ -395,7 +403,7 @@ mod tests_suppression_kinds {
             parse_suppression_comment("// biome-ignore-end format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::RangeEnd,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -418,7 +426,7 @@ mod tests_biome_ignore_inline {
         assert_eq!(
             parse_suppression_comment("// biome-ignore parse: explanation1").collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation1",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -429,7 +437,7 @@ mod tests_biome_ignore_inline {
             parse_suppression_comment("/** biome-ignore parse: explanation2 */")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation2",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(4), TextSize::from(16))
@@ -444,7 +452,7 @@ mod tests_biome_ignore_inline {
             )
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation3",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(24), TextSize::from(36))
@@ -460,7 +468,7 @@ mod tests_biome_ignore_inline {
             )
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation4",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(50), TextSize::from(62))
@@ -472,7 +480,7 @@ mod tests_biome_ignore_inline {
         assert_eq!(
             parse_suppression_comment("/* biome-ignore format: explanation").collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -482,7 +490,7 @@ mod tests_biome_ignore_inline {
         assert_eq!(
             parse_suppression_comment("/* biome-ignore format: explanation *").collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -492,7 +500,7 @@ mod tests_biome_ignore_inline {
         assert_eq!(
             parse_suppression_comment("/* biome-ignore format: explanation /").collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -507,8 +515,8 @@ mod tests_biome_ignore_inline {
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("foo")),
-                    (category!("parse"), Some("dog"))
+                    (category!("parse"), None, Some("foo")),
+                    (category!("parse"), None, Some("dog"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
@@ -521,8 +529,8 @@ mod tests_biome_ignore_inline {
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("bar")),
-                    (category!("parse"), Some("cat"))
+                    (category!("parse"), None, Some("bar")),
+                    (category!("parse"), None, Some("cat"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
@@ -539,8 +547,8 @@ mod tests_biome_ignore_inline {
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("yes")),
-                    (category!("parse"), Some("frog"))
+                    (category!("parse"), None, Some("yes")),
+                    (category!("parse"), None, Some("frog"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
@@ -558,8 +566,8 @@ mod tests_biome_ignore_inline {
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("wow")),
-                    (category!("parse"), Some("fish"))
+                    (category!("parse"), None, Some("wow")),
+                    (category!("parse"), None, Some("fish"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
@@ -574,7 +582,7 @@ mod tests_biome_ignore_inline {
             parse_suppression_comment("// biome-ignore format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::Classic,
                 range: TextRange::new(TextSize::from(3), TextSize::from(15))
@@ -655,7 +663,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("// biome-ignore-all parse: explanation1")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation1",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -666,7 +674,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("/** biome-ignore-all parse: explanation2 */")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation2",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(4), TextSize::from(20))
@@ -681,7 +689,7 @@ mod tests_biome_ignore_toplevel {
             )
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation3",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(24), TextSize::from(40))
@@ -697,7 +705,7 @@ mod tests_biome_ignore_toplevel {
             )
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("parse"), None)],
+                categories: vec![(category!("parse"), None, None)],
                 reason: "explanation4",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(50), TextSize::from(66))
@@ -710,7 +718,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("/* biome-ignore-all format: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -721,7 +729,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("/* biome-ignore-all format: explanation *")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -732,7 +740,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("/* biome-ignore-all format: explanation /")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None)],
+                categories: vec![(category!("format"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))
@@ -747,8 +755,8 @@ mod tests_biome_ignore_toplevel {
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("foo")),
-                    (category!("parse"), Some("dog"))
+                    (category!("parse"), None, Some("foo")),
+                    (category!("parse"), None, Some("dog"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::All,
@@ -761,8 +769,8 @@ mod tests_biome_ignore_toplevel {
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("bar")),
-                    (category!("parse"), Some("cat"))
+                    (category!("parse"), None, Some("bar")),
+                    (category!("parse"), None, Some("cat"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::All,
@@ -779,8 +787,8 @@ mod tests_biome_ignore_toplevel {
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("yes")),
-                    (category!("parse"), Some("frog"))
+                    (category!("parse"), None, Some("yes")),
+                    (category!("parse"), None, Some("frog"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::All,
@@ -798,8 +806,8 @@ mod tests_biome_ignore_toplevel {
             .collect::<Vec<_>>(),
             vec![Ok(Suppression {
                 categories: vec![
-                    (category!("parse"), Some("wow")),
-                    (category!("parse"), Some("fish"))
+                    (category!("parse"), None, Some("wow")),
+                    (category!("parse"), None, Some("fish"))
                 ],
                 reason: "explanation",
                 kind: SuppressionKind::All,
@@ -814,7 +822,7 @@ mod tests_biome_ignore_toplevel {
             parse_suppression_comment("// biome-ignore-all format lint: explanation")
                 .collect::<Vec<_>>(),
             vec![Ok(Suppression {
-                categories: vec![(category!("format"), None), (category!("lint"), None)],
+                categories: vec![(category!("format"), None, None), (category!("lint"), None, None)],
                 reason: "explanation",
                 kind: SuppressionKind::All,
                 range: TextRange::new(TextSize::from(3), TextSize::from(19))

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3547,6 +3547,7 @@ export type Category =
 	| "lint/security"
 	| "lint/style"
 	| "lint/suspicious"
+	| "lint/plugin"
 	| "suppressions/parse"
 	| "suppressions/unknownGroup"
 	| "suppressions/unknownRule"


### PR DESCRIPTION
task: https://github.com/biomejs/biome/issues/4667

# Plugin Suppression

changes are split into 2 parts:

1. during the existing workflow for lint suppression, we need to add new fields to record suppression for plugins
2. during plugin evaluation, we need to handle each diagnosis, suppress it if matched

## Part 1: Changes to data structs in each step of existing lint suppression workflow

plugin suppression reuse most of the existing lint suppression workflow, but new fields are added to handle dynamic plugin names that users input.

### Step 1: parse comment string to Suppression<'a>

file: crates/biome_suppression/src/lib.rs

each suppression comment is parse a single Suppression<'a>

here, a new 'subcategory' is added to the parse result

In the case for plugin, category will be 'plugin', and subcategory will be the custom plugin name that users input

```git
#[derive(Debug, PartialEq, Eq)]
pub struct Suppression<'a> {
    // ...
-   pub categories: Vec<(&'a Category, Option<&'a str>)>, // Vec<(category, value)>
+   pub categories: Vec<(&'a Category, Option<&'a str>, Option<&'a str>)>, // Vec<(category, subcategory, value)>
}
```

### Step 2: Suppression<'a> processed into AnalyzerSuppression

file: crates/biome_analyze/src/lib.rs

Suppression<'a> is then processed into AnalyzerSuppression

previously AnalyzerSuppression.kind has 3 variants: `Everything, Rule(&'a str), RuleInstance(&'a str, &'a str)`
a new variant `Plugin(&'a str)` is added for plugin

```git
pub struct AnalyzerSuppression<'a> {
    /// The kind of suppression
    pub(crate) kind: AnalyzerSuppressionKind<'a>,

    /// The range where the `biome-ignore` comment is placed inside the whole text
    pub(crate) ignore_range: Option<TextRange>,

    /// The kind of `biome-ignore` comment used for this suppression
    pub(crate) variant: AnalyzerSuppressionVariant,
}

pub enum AnalyzerSuppressionKind<'a> {
    /// A suppression disabling all lints eg. `// biome-ignore lint`
    Everything,
    /// A suppression disabling a specific rule eg. `// biome-ignore lint/complexity/useWhile`
    Rule(&'a str),
    /// A suppression to be evaluated by a specific rule eg. `// biome-ignore lint/correctness/useExhaustiveDependencies(foo)`
    RuleInstance(&'a str, &'a str),
+    /// A suppression disabling a plugin eg. `// biome-ignore plugin/my-plugin`
+    Plugin(&'a str),
}
```

### Step 3: AnalyzerSuppression pushed to PhaseRunner.suppression

see crates/biome_analyze/src/suppressions.rs

#### top level suppression, new field `plugins` is added

```
pub struct TopLevelSuppression {
    /// Whether this suppression suppresses all filters
    pub(crate) suppress_all: bool,
    /// Filters for the current suppression
    pub(crate) filters: FxHashSet<RuleFilter<'static>>,
+   /// Current suppressed plugins
+   pub(crate) plugins: FxHashSet<String>,
    /// The range of the comment
    pub(crate) comment_range: TextRange,

    /// The range covered by the current suppression.
    /// Eventually, it should hit the entire document
    pub(crate) range: TextRange,
}
```

#### for line suppression, new field `suppressed_plugins` is added

```
pub(crate) struct LineSuppression {
    /// Line index this comment is suppressing lint rules for
    pub(crate) line_index: usize,
    /// Range of source text covered by the suppression comment
    pub(crate) comment_span: TextRange,
    /// Range of source text this comment is suppressing lint rules for
    pub(crate) text_range: TextRange,
    /// Set to true if this comment has set the `suppress_all` flag to true
    /// (must be restored to false on expiration)
    pub(crate) suppress_all: bool,
    /// List of all the rules this comment has started suppressing (must be
    /// removed from the suppressed set on expiration)
    pub(crate) suppressed_rules: FxHashSet<RuleFilter<'static>>,
    /// List of all the rule instances this comment has started suppressing.
    pub(crate) suppressed_instances: FxHashMap<String, RuleFilter<'static>>,
+   /// List of plugins this comment has started suppressing
+   pub(crate) suppressed_plugins: FxHashSet<String>,
    /// Set to `true` when a signal matching this suppression was emitted and
    /// suppressed
    pub(crate) did_suppress_signal: bool,
    /// Set to `true` when this line suppresses a signal that was already suppressed by another entity e.g. top-level suppression
    pub(crate) already_suppressed: Option<TextRange>,
}
```

#### for range suppression

range suppression for plugin is not supported, and an error is reported if there is a range suppression for plugin

the reason it's not supported is because plugin is run after lint phases.
During lint phase, range suppressions are dynamiclly updated while parsing `// biome-range-start` and `// biome-range-end`.

after lint phases are finished, all range suppressions have empty filters.

### Why not reuse current Category/RuleFilter to avoid adding new fileds

in optimal cases, we can treat `plugin/xxx` same as `lint/xxx` to avoid adding new fields and making changes to exising workflow.

however, currently it's not implemented as such because step 1 and 3 of above section both require pre-register static string and codegen, thus doesn't allow for dynamic values.
but for plugin, it must allow user to use dynamic plugin names.

step 1:
Suppression<'a> stores &'a Category instead of arbitrary string

```rs
#[derive(Debug)]
pub struct Category {
    name: &'static str,
    link: Option<&'static str>,
}
```

but we cannot init a new `Category` outside of the `biome_diagnostics_categories` crate, which serves as a registry for all known diagnostic categories (currently this registry is fully static and generated at compile time).

step 3:

filter is required to be a RuleFilter<'static>

```rs
pub enum RuleFilter<'a> {
    Group(&'a str),
    Rule(&'a str, &'a str),
}
```

see `map_to_rule_filter` in `crates/biome_analyze/src/suppressions.rs`, this requires the group/rule to be registered in MetadataRegistry, which is currently done during codegen using `declare_lint_group!`

due to these 2 reasons, it will be troublesome to fit in the new plugin suppression into existing flow without adding new fields.

## Part 2: Handle plugin diagnosis

Plugins are run after exiting lint runners are finished.

During plugin evaluation, everytime there is a diagnosis, we will check to see if it is suppressed

see crates/biome_analyze/src/lib.rs, most logic is copied from `flush_matches`, except for:

1. top level suppression is matched using `plugins`
2. line suppression is matched using `suppressed_plugins`
3. range suppression is not supported and thus skipped
