### PR TITLE
fix(cli): rename `--javascript-object-wrap` to `--javascript-formatter-object-wrap`

### DIFF
--- a/.changeset/gentle-spies-drum.md
+++ b/.changeset/gentle-spies-drum.md
@@ -18,3 +18,5 @@ However, when `objectWrap` is `collapse`, it will be formatted to the following 
 ```js
 const obj = { foo: "bar" };
 ```
+
+This option is also available in a CLI flag `--javascript-formatter-object-wrap=<preserve|collapse>`.

--- a/.changeset/sour-coats-shake.md
+++ b/.changeset/sour-coats-shake.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+CLI flag `--javascript-object-wrap` has been renamed to `--javascript-formatter-object-wrap` to keep consistency in flags.

--- a/.changeset/sour-coats-shake.md
+++ b/.changeset/sour-coats-shake.md
@@ -1,5 +1,0 @@
----
-"@biomejs/biome": patch
----
-
-CLI flag `--javascript-object-wrap` has been renamed to `--javascript-formatter-object-wrap` to keep consistency in flags.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -72,8 +72,8 @@ The configuration that is contained inside the file `biome.json`
                               JSX elements. Defaults to auto.
         --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
                               brackets in object literals. Defaults to true.
-        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
-                              when possible. Defaults to preserve.
+        --javascript-formatter-object-wrap=<preserve|collapse>  Whether to enforce collapsing object
+                              literals when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -73,8 +73,8 @@ The configuration that is contained inside the file `biome.json`
                               JSX elements. Defaults to auto.
         --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
                               brackets in object literals. Defaults to true.
-        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
-                              when possible. Defaults to preserve.
+        --javascript-formatter-object-wrap=<preserve|collapse>  Whether to enforce collapsing object
+                              literals when possible. Defaults to preserve.
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super
                               languages) files.
         --javascript-assist-enabled=<true|false>  Control the assist for JavaScript (and its super

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -55,8 +55,8 @@ Formatting options specific to the JavaScript files
                               JSX elements. Defaults to auto.
         --javascript-formatter-bracket-spacing=<true|false>  Whether to insert spaces around
                               brackets in object literals. Defaults to true.
-        --javascript-object-wrap=<preserve|collapse>  Whether to enforce collapsing object literals
-                              when possible. Defaults to preserve.
+        --javascript-formatter-object-wrap=<preserve|collapse>  Whether to enforce collapsing object
+                              literals when possible. Defaults to preserve.
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-enabled=<true|false>  Whether Biome should integrate itself with the VCS client

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -108,7 +108,10 @@ pub struct JsFormatterConfiguration {
     pub bracket_spacing: Option<BracketSpacing>,
 
     /// Whether to enforce collapsing object literals when possible. Defaults to preserve.
-    #[bpaf(long("javascript-object-wrap"), argument("preserve|collapse"))]
+    #[bpaf(
+        long("javascript-formatter-object-wrap"),
+        argument("preserve|collapse")
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_wrap: Option<ObjectWrap>,
 }


### PR DESCRIPTION
## Summary

Follow-up of #5068 
Split from #5082 

I renamed the CLI flag to keep consistency in formatter related flags.

## Test Plan

CLI snapshots are updated to reflect the change.
