### PR TITLE
chore: eliminate some warnings on release build

### DIFF
--- a/crates/biome_formatter/src/comments/map.rs
+++ b/crates/biome_formatter/src/comments/map.rs
@@ -248,6 +248,7 @@ impl<K: std::hash::Hash + Eq, V> CommentsMap<K, V> {
     }
 
     /// Returns an iterator over the parts of all keys.
+    #[cfg(debug_assertions)]
     pub fn all_parts(&self) -> impl Iterator<Item = &V> {
         self.index
             .values()

--- a/crates/biome_formatter/src/group_id.rs
+++ b/crates/biome_formatter/src/group_id.rs
@@ -1,60 +1,70 @@
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
-pub struct DebugGroupId {
-    value: NonZeroU32,
-    name: &'static str,
-}
+#[cfg(debug_assertions)]
+mod debug {
+    use super::*;
 
-impl DebugGroupId {
-    fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
-        Self {
-            value,
-            name: debug_name,
+    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+    pub struct GroupId {
+        pub(super) value: NonZeroU32,
+        name: &'static str,
+    }
+
+    impl GroupId {
+        pub(super) fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
+            Self {
+                value,
+                name: debug_name,
+            }
+        }
+    }
+
+    impl std::fmt::Debug for GroupId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "#{}-{}", self.name, self.value)
         }
     }
 }
 
-impl std::fmt::Debug for DebugGroupId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}-{}", self.name, self.value)
+#[cfg(not(debug_assertions))]
+mod release {
+    use super::*;
+
+    /// Unique identification for a group.
+    ///
+    /// See [crate::Formatter::group_id] on how to get a unique id.
+    #[repr(transparent)]
+    #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+    pub struct GroupId {
+        pub(super) value: NonZeroU32,
+    }
+
+    impl GroupId {
+        /// Creates a new unique group id with the given debug name (only stored in debug builds)
+        #[cfg_attr(debug_assertions, expect(unused))]
+        pub(super) fn new(value: NonZeroU32, _: &'static str) -> Self {
+            Self { value }
+        }
+    }
+
+    impl std::fmt::Debug for GroupId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "#{}", self.value)
+        }
     }
 }
 
-/// Unique identification for a group.
-///
-/// See [crate::Formatter::group_id] on how to get a unique id.
-#[repr(transparent)]
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
-pub struct ReleaseGroupId {
-    value: NonZeroU32,
-}
-
-impl ReleaseGroupId {
-    /// Creates a new unique group id with the given debug name (only stored in debug builds)
-    #[expect(unused)]
-    fn new(value: NonZeroU32, _: &'static str) -> Self {
-        Self { value }
-    }
-}
+#[cfg(not(debug_assertions))]
+pub type GroupId = release::GroupId;
+#[cfg(debug_assertions)]
+pub type GroupId = debug::GroupId;
 
 impl From<GroupId> for u32 {
     fn from(id: GroupId) -> Self {
         id.value.get()
     }
 }
-
-impl std::fmt::Debug for ReleaseGroupId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "#{}", self.value)
-    }
-}
-
-#[cfg(not(debug_assertions))]
-pub type GroupId = ReleaseGroupId;
-#[cfg(debug_assertions)]
-pub type GroupId = DebugGroupId;
 
 /// Builder to construct unique group ids that are unique if created with the same builder.
 pub(super) struct UniqueGroupIdBuilder {

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -706,8 +706,8 @@ pub trait FormatContext {
 
 /// Options customizing how the source code should be formatted.
 ///
-/// **Note**: This trait should **only** contain the essential abstractions required for the printing phase.  
-/// For example, do not add a `fn bracket_spacing(&self) -> BracketSpacing` method here,  
+/// **Note**: This trait should **only** contain the essential abstractions required for the printing phase.
+/// For example, do not add a `fn bracket_spacing(&self) -> BracketSpacing` method here,
 /// as the [BracketSpacing] option is not needed during the printing phase
 /// and enforcing its implementation for all structs using this trait is unnecessary.
 pub trait FormatOptions {
@@ -1934,14 +1934,15 @@ impl<Context> FormatState<Context> {
         self.group_id_builder.group_id(debug_name)
     }
 
+    #[cfg(not(debug_assertions))]
+    #[inline]
+    pub fn track_token<L: Language>(&mut self, _token: &SyntaxToken<L>) {}
+
     /// Tracks the given token as formatted
+    #[cfg(debug_assertions)]
     #[inline]
     pub fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>) {
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                self.printed_tokens.track_token(token);
-            }
-        }
+        self.printed_tokens.track_token(token);
     }
 
     #[cfg(not(debug_assertions))]
@@ -1968,14 +1969,15 @@ impl<Context> FormatState<Context> {
         self.printed_tokens.is_disabled()
     }
 
+    #[cfg(not(debug_assertions))]
+    #[inline]
+    pub fn assert_formatted_all_tokens<L: Language>(&self, _root: &SyntaxNode<L>) {}
+
     /// Asserts in debug builds that all tokens have been printed.
+    #[cfg(debug_assertions)]
     #[inline]
     pub fn assert_formatted_all_tokens<L: Language>(&self, root: &SyntaxNode<L>) {
-        cfg_if::cfg_if! {
-            if #[cfg(debug_assertions)] {
-                self.printed_tokens.assert_all_tracked(root);
-            }
-        }
+        self.printed_tokens.assert_all_tracked(root);
     }
 }
 


### PR DESCRIPTION
## Summary

Resolved these warnings on `cargo check -p biome_cli --release`:

```
warning: unused variable: `token`
    --> crates/biome_formatter/src/lib.rs:1939:48
     |
1939 |     pub fn track_token<L: Language>(&mut self, token: &SyntaxToken<L>) {
     |                                                ^^^^^ help: if this is intentional, prefix it with an underscore: `_token`
     |
     = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `root`
    --> crates/biome_formatter/src/lib.rs:1973:60
     |
1973 |     pub fn assert_formatted_all_tokens<L: Language>(&self, root: &SyntaxNode<L>) {
     |                                                            ^^^^ help: if this is intentional, prefix it with an underscore: `_root`

warning: method `all_parts` is never used
   --> crates/biome_formatter/src/comments/map.rs:251:12
    |
61  | impl<K: std::hash::Hash + Eq, V> CommentsMap<K, V> {
    | -------------------------------------------------- method in this implementation
...
251 |     pub fn all_parts(&self) -> impl Iterator<Item = &V> {
    |            ^^^^^^^^^
    |
    = note: requested on the command line with `-W dead-code`

warning: associated function `new` is never used
  --> crates/biome_formatter/src/group_id.rs:11:8
   |
10 | impl DebugGroupId {
   | ----------------- associated function in this implementation
11 |     fn new(value: NonZeroU32, debug_name: &'static str) -> Self {
   |        ^^^

warning: this lint expectation is unfulfilled
  --> crates/biome_formatter/src/group_id.rs:36:14
   |
36 |     #[expect(unused)]
   |              ^^^^^^
   |
   = note: `#[warn(unfulfilled_lint_expectations)]` on by default

warning: `biome_formatter` (lib) generated 5 warnings
```

## Test Plan

CI should pass
