### PR TITLE
fix(lint): useArrowFunction should parenthesise the expr starting with `{`

### DIFF
--- a/.changeset/dull-clocks-rescue.md
+++ b/.changeset/dull-clocks-rescue.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the safe fix of lint rule `useArrowFunction` breaks the function body starting with `{`.

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -355,10 +355,12 @@ fn to_arrow_body(body: JsFunctionBody) -> AnyJsFunctionBody {
         // To keep comments, we keep the regular function body
         return early_result;
     }
-    if matches!(
-        return_arg,
-        AnyJsExpression::JsSequenceExpression(_) | AnyJsExpression::JsObjectExpression(_)
-    ) {
+    if matches!(return_arg, AnyJsExpression::JsSequenceExpression(_))
+        || return_arg
+            .syntax()
+            .first_token()
+            .is_some_and(|token| token.kind() == T!['{'])
+    {
         // () => (first, second)
         // () => ({ ... })
         return AnyJsFunctionBody::AnyJsExpression(make::parenthesized(return_arg).into());

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts
@@ -56,3 +56,12 @@ const withDirective = function () {
 	"use server";
 	return 0;
 }
+
+// https://github.com/biomejs/biome/issues/4967
+const needsParentheses1 = function () {
+	return { foo: "bar" }["foo"];
+}
+
+const needsParentheses2 = function () {
+	return { foo: "bar" }.foo;
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useArrowFunction/invalid.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -62,6 +61,15 @@ const binary = false + function () {};
 const withDirective = function () {
 	"use server";
 	return 0;
+}
+
+// https://github.com/biomejs/biome/issues/4967
+const needsParentheses1 = function () {
+	return { foo: "bar" }["foo"];
+}
+
+const needsParentheses2 = function () {
+	return { foo: "bar" }.foo;
 }
 
 ```
@@ -583,6 +591,7 @@ invalid.ts:55:23 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━�
   > 58 │ }
        │ ^
     59 │ 
+    60 │ // https://github.com/biomejs/biome/issues/4967
   
   i Function expressions that don't use this can be turned into arrow functions.
   
@@ -594,6 +603,65 @@ invalid.ts:55:23 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━�
        55 │ + const·withDirective·=·()·=>·{
     56 56 │   	"use server";
     57 57 │   	return 0;
+  
+
+```
+
+```
+invalid.ts:61:27 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    60 │ // https://github.com/biomejs/biome/issues/4967
+  > 61 │ const needsParentheses1 = function () {
+       │                           ^^^^^^^^^^^^^
+  > 62 │ 	return { foo: "bar" }["foo"];
+  > 63 │ }
+       │ ^
+    64 │ 
+    65 │ const needsParentheses2 = function () {
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    59 59 │   
+    60 60 │   // https://github.com/biomejs/biome/issues/4967
+    61    │ - const·needsParentheses1·=·function·()·{
+    62    │ - → return·{·foo:·"bar"·}["foo"];
+    63    │ - }
+       61 │ + const·needsParentheses1·=·()·=>·({·foo:·"bar"·}["foo"])
+    64 62 │   
+    65 63 │   const needsParentheses2 = function () {
+  
+
+```
+
+```
+invalid.ts:65:27 lint/complexity/useArrowFunction  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This function expression can be turned into an arrow function.
+  
+    63 │ }
+    64 │ 
+  > 65 │ const needsParentheses2 = function () {
+       │                           ^^^^^^^^^^^^^
+  > 66 │ 	return { foo: "bar" }.foo;
+  > 67 │ }
+       │ ^
+    68 │ 
+  
+  i Function expressions that don't use this can be turned into arrow functions.
+  
+  i Safe fix: Use an arrow function instead.
+  
+    63 63 │   }
+    64 64 │   
+    65    │ - const·needsParentheses2·=·function·()·{
+    66    │ - → return·{·foo:·"bar"·}.foo;
+    67    │ - }
+       65 │ + const·needsParentheses2·=·()·=>·({·foo:·"bar"·}.foo)
+    68 66 │   
   
 
 ```


### PR DESCRIPTION
## Summary

Closes #4967

In ECMAScript, the return value of an arrow expression that starts with `{` needs to be parenthesised to be a valid expression, even if the expression is not a `JsObjectExpression`. This pull request fixes the condition to parenthesise the expression or not.

## Test Plan

Snapshot tests added.
