### PR TITLE
ci: reduce max build jobs on cargo to mitigate OOM

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Compile
         timeout-minutes: 15
         run: cargo codspeed build --features codspeed -p xtask_bench
+        env:
+          CARGO_BUILD_JOBS: 3  # Default is 4 (equals to the vCPU count of the runner), which leads OOM on cargo build
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@513a19673a831f139e8717bf45ead67e47f00044 # v3.2.0


### PR DESCRIPTION
## Summary

Benchmark CI is failing randomly, and it seems killed as Out-of-Memory (e.g. https://github.com/biomejs/biome/actions/runs/13453650349/job/37592835454).
`cargo codspeed build` invokes a `cargo build` command in it, so it can accept `CARGO_BUILD_JOBS` environment variable to limit how many jobs to be run in parallel.

I tried limiting the jobs in the different branch, and it seems mitigating the issue (at least it succeeded twice in this run: https://github.com/biomejs/biome/actions/runs/13451944211).

Let's try reducing the number of parallel jobs to see the issue to be resolved for now.

## Test Plan

~Benchmark CI will run on this pull request, and all PRs after merged.~
All PRs including parser, formatter, or analyzer changes will run the Benchmark workflow, let's see it keeps failing or not after merged.
