### PR TITLE
fix(formatter): do not break properties of type annotation in function parameters

### DIFF
--- a/.changeset/cyan-beans-yawn.md
+++ b/.changeset/cyan-beans-yawn.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed properties of object type annotation in function parameters are expanded, which is inconsistent with Prettier.
+Fix [#2406](https://github.com/biomejs/biome/issues/2406), don't expand properties of object type annotation in function parameters, which was inconsistent with Prettier.

--- a/.changeset/cyan-beans-yawn.md
+++ b/.changeset/cyan-beans-yawn.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed properties of object type annotation in function parameters are expanded, which is inconsistent with Prettier.

--- a/crates/biome_js_formatter/src/utils/object_like.rs
+++ b/crates/biome_js_formatter/src/utils/object_like.rs
@@ -2,7 +2,9 @@ use crate::prelude::*;
 use crate::JsFormatContext;
 use biome_formatter::write;
 use biome_formatter::{Format, FormatResult};
-use biome_js_syntax::{JsObjectExpression, JsSyntaxToken, TsObjectType};
+use biome_js_syntax::{
+    JsFormalParameter, JsObjectExpression, JsSyntaxToken, TsObjectType, TsTypeAnnotation,
+};
 use biome_rowan::{declare_node_union, AstNode, AstNodeList, AstSeparatedList, SyntaxResult};
 
 declare_node_union! {
@@ -61,8 +63,13 @@ impl Format<JsFormatContext> for JsObjectLike {
             )?;
         } else {
             let should_insert_space_around_brackets = f.options().bracket_spacing().value();
-            let should_expand =
-                f.options().object_wrap().is_preserve() && self.members_have_leading_newline();
+            let should_expand = f.options().object_wrap().is_preserve()
+                && self.members_have_leading_newline()
+                // const fn = ({ foo }: { foo: string }) => { ... };
+                //                      ^ do not break properties here
+                && self
+                    .parent::<TsTypeAnnotation>()
+                    .is_none_or(|node| node.parent::<JsFormalParameter>().is_none());
 
             write!(
                 f,

--- a/crates/biome_js_formatter/tests/specs/ts/object/objects.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/object/objects.ts
@@ -1,0 +1,19 @@
+let foo: {
+	bar: string;
+};
+
+const fn = ({
+	foo,
+	bar,
+}: {
+	foo: boolean;
+	bar: string;
+}) => {
+	console.log(foo, bar);
+}
+
+function fn2(foo: {
+	bar: string;
+}) {
+	console.log(foo);
+}

--- a/crates/biome_js_formatter/tests/specs/ts/object/objects.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/objects.ts.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: ts/object/objects.ts
+---
+# Input
+
+```ts
+let foo: {
+	bar: string;
+};
+
+const fn = ({
+	foo,
+	bar,
+}: {
+	foo: boolean;
+	bar: string;
+}) => {
+	console.log(foo, bar);
+}
+
+function fn2(foo: {
+	bar: string;
+}) {
+	console.log(foo);
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Object wrap: Preserve
+-----
+
+```ts
+let foo: {
+	bar: string;
+};
+
+const fn = ({ foo, bar }: { foo: boolean; bar: string }) => {
+	console.log(foo, bar);
+};
+
+function fn2(foo: { bar: string }) {
+	console.log(foo);
+}
+```


### PR DESCRIPTION
## Summary

Closes #2406

Prettier seems not breaking properties of a type annotation in function parameters. This pull request adds an exception to formatting object-like nodes to be consistent with Prettier.

## Test Plan

Snapshot tests added.
