### PR TITLE
fix(linter): allow escaping at the start of a regex group

### DIFF
--- a/.changeset/naming-conventions-regex-allow-char-escaping-at-start-of-regex-groups.md
+++ b/.changeset/naming-conventions-regex-allow-char-escaping-at-start-of-regex-groups.md
@@ -5,11 +5,10 @@
 The lint rules `useNamingConvention` and `useFilenamingConvention` now accepts character escapes at the start of a regex group.
 
 The rules `useNamingConvention` and `useFilenamingConvention` provides some options that allow matching names against a regular expression.
-Previously, escaped character at the start of a regex group reported an error.
+Previously, an escaped character at the start of a regex group reported an error.
 They are now accepted.
 
-For example, the following configuration used to emit en error.
-It no longer raised an error.
+For example, the following configuration is now valid doesn't emit an error anymore.
 
 ```json
 {

--- a/.changeset/naming-conventions-regex-allow-char-escaping-at-start-of-regex-groups.md
+++ b/.changeset/naming-conventions-regex-allow-char-escaping-at-start-of-regex-groups.md
@@ -1,0 +1,36 @@
+---
+"@biomejs/biome": patch
+---
+
+The lint rules `useNamingConvention` and `useFilenamingConvention` now accepts character escapes at the start of a regex group.
+
+The rules `useNamingConvention` and `useFilenamingConvention` provides some options that allow matching names against a regular expression.
+Previously, escaped character at the start of a regex group reported an error.
+They are now accepted.
+
+For example, the following configuration used to emit en error.
+It no longer raised an error.
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "conventions": [
+              {
+                "selector": {
+                  "kind": "let"
+                },
+                "match": "(\\n.*)"
+              },
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
@@ -120,7 +120,9 @@ declare_lint_rule! {
     /// - Non-capturing groups `(?:)`
     /// - Case-insensitive groups `(?i:)` and case-sensitive groups `(?-i:)`
     /// - A limited set of escaped characters including all special characters
-    ///   and regular string escape characters `\f`, `\n`, `\r`, `\t`, `\v`
+    ///   and regular string escape characters `\f`, `\n`, `\r`, `\t`, `\v`.
+    ///   Note that you can also escape special characters using character classes.
+    ///   For example, `\$` and `[$]` are two valid patterns that escape `$`.
     ///
     /// ### filenameCases
     ///

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -667,7 +667,9 @@ declare_lint_rule! {
     /// - Non-capturing groups `(?:)`
     /// - Case-insensitive groups `(?i:)` and case-sensitive groups `(?-i:)`
     /// - A limited set of escaped characters including all special characters
-    ///   and regular string escape characters `\f`, `\n`, `\r`, `\t`, `\v`
+    ///   and regular string escape characters `\f`, `\n`, `\r`, `\t`, `\v`.
+    ///   Note that you can also escape special characters using character classes.
+    ///   For example, `\$` and `[$]` are two valid patterns that escape `$`.
     ///
     /// [case]: https://en.wikipedia.org/wiki/Naming_convention_(programming)#Examples_of_multiple-word_identifier_formats
     /// [`camelCase`]: https://en.wikipedia.org/wiki/Camel_case

--- a/crates/biome_js_analyze/src/utils/restricted_regex.rs
+++ b/crates/biome_js_analyze/src/utils/restricted_regex.rs
@@ -233,11 +233,10 @@ fn validate_restricted_regex(pattern: &str) -> Result<(), RestrictedRegexError> 
                 }
             }
             b'(' if !is_in_char_class => {
-                match it.next() {
-                    Some((_, b'[')) => {
-                        is_in_char_class = true;
-                    }
-                    Some((_, b'?')) => match it.next() {
+                let mut lookahead = it.clone();
+                if let Some((_, b'?')) = lookahead.next() {
+                    it.next();
+                    match it.next() {
                         Some((i, b'P' | b'=' | b'!' | b'<')) => {
                             return if c == b'P'
                                 || (c == b'<' && !matches!(it.next(), Some((_, b'=' | b'!'))))
@@ -292,8 +291,7 @@ fn validate_restricted_regex(pattern: &str) -> Result<(), RestrictedRegexError> 
                                 }
                             }
                         }
-                    },
-                    _ => {}
+                    }
                 }
             }
             _ => {}
@@ -331,5 +329,6 @@ mod tests {
         assert!(validate_restricted_regex("[A-Z][^a-z]").is_ok());
         assert!(validate_restricted_regex(r"\n\t\v\f").is_ok());
         assert!(validate_restricted_regex("([^_])").is_ok());
+        assert!(validate_restricted_regex(r"(\$)").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/5173

The issue comes from the regex validator.
Only escapes sequence at the start of capturing regex group were ignored.

## Test Plan

I added a test.