### PR TITLE
refactor(useNamingConvention): remove `enumMemberCase` option

### DIFF
--- a/.changeset/remove-enum-member-case.md
+++ b/.changeset/remove-enum-member-case.md
@@ -1,0 +1,51 @@
+---
+"@biomejs/biome": major
+---
+
+Remove the option `enumMemberCase` from the lint rule `useNamingConvention`.
+
+`enumMemberCase` is an option that allows to customize the enforced case for TypeScript's enum members.
+The option was introduced prior to the `conventions` option that allows to do the same thing.
+
+The following configuration...
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "enumMemberCase": "PascalCase"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+...must be rewritten as:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "conventions": [{
+                "selector": { "kind": "enumMember" },
+                "formats": ["PascalCase"]
+            }]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Run `biome migrate --write` to turn `enumMemberCase` into `conventions` automatically.

--- a/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_typescript.rs
@@ -161,7 +161,6 @@ impl From<NamingConventionOptions> for use_naming_convention::NamingConventionOp
             strict_case: false,
             require_ascii: false,
             conventions: conventions.into_boxed_slice(),
-            enum_member_case: use_naming_convention::Format::default(),
         }
     }
 }

--- a/crates/biome_configuration/tests/invalid/naming_convention_incorrect_options.json.snap
+++ b/crates/biome_configuration/tests/invalid/naming_convention_incorrect_options.json.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/biome_service/tests/spec_tests.rs
+source: crates/biome_configuration/tests/spec_tests.rs
 expression: naming_convention_incorrect_options.json
 ---
 naming_convention_incorrect_options.json:9:7 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -18,4 +18,3 @@ naming_convention_incorrect_options.json:9:7 deserialize ━━━━━━━�
   - strictCase
   - requireAscii
   - conventions
-  - enumMemberCase

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -339,7 +339,6 @@ declare_lint_rule! {
     ///     "options": {
     ///         "strictCase": false,
     ///         "requireAscii": false,
-    ///         "enumMemberCase": "CONSTANT_CASE",
     ///         "conventions": [
     ///             {
     ///                 "selector": {
@@ -402,17 +401,6 @@ declare_lint_rule! {
     ///
     /// **Default:** `true`
     ///
-    /// ### enumMemberCase
-    ///
-    /// By default, the rule enforces the naming convention followed by the [TypeScript Compiler team](https://www.typescriptlang.org/docs/handbook/enums.html):
-    /// an `enum` member is in [`PascalCase`].
-    ///
-    /// You can enforce another convention by setting `enumMemberCase` option.
-    /// The supported cases are: [`PascalCase`], [`CONSTANT_CASE`], and [`camelCase`].
-    ///
-    /// **This option will be deprecated in the future.**
-    /// **Use the [`conventions`](#conventions-since-v180) option instead.**
-    ///
     /// ### conventions (Since v1.8.0)
     ///
     /// The `conventions` option allows applying custom conventions.
@@ -445,6 +433,7 @@ declare_lint_rule! {
     ///   - `typeLike`: classes, enums, type aliases, and interfaces
     ///   - `class`
     ///   - `enum`
+    ///   - `enumMember`
     ///   - `interface`
     ///   - `typeAlias`
     ///   - `function`: named function declarations and expressions
@@ -504,8 +493,9 @@ declare_lint_rule! {
     ///
     /// In the following example, we check the following conventions:
     ///
-    /// - A private property starts with `_` and consists of at least two characters
+    /// - A private property starts with `_` and consists of at least two characters.
     /// - The captured name (the name without the leading `_`) is in [`camelCase`].
+    /// - An enum member is in [`PascalCase`] or [`CONSTANT_CASE`].
     ///
     /// ```json,options
     /// {
@@ -518,6 +508,12 @@ declare_lint_rule! {
     ///                 },
     ///                 "match": "_(.+)",
     ///                 "formats": ["camelCase"]
+    ///             },
+    ///             {
+    ///                 "selector": {
+    ///                     "kind": "enumMember"
+    ///                 },
+    ///                 "formats": ["PascalCase", "CONSTANT_CASE"]
     ///             }
     ///         ]
     ///     }
@@ -765,7 +761,7 @@ impl Rule for UseNamingConvention {
                 });
             }
         }
-        let default_convention = node_selector.default_convention(options);
+        let default_convention = node_selector.default_convention();
         // We only tim the name if it was not trimmed yet
         if is_not_trimmed {
             let (prefix_len, trimmed_name) = trim_underscore_dollar(name);
@@ -1035,10 +1031,6 @@ pub struct NamingConventionOptions {
     /// Custom conventions.
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
     pub conventions: Box<[Convention]>,
-
-    /// Allowed cases for _TypeScript_ `enum` member names.
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub enum_member_case: Format,
 }
 impl Default for NamingConventionOptions {
     fn default() -> Self {
@@ -1046,7 +1038,6 @@ impl Default for NamingConventionOptions {
             strict_case: true,
             require_ascii: true,
             conventions: Vec::new().into_boxed_slice(),
-            enum_member_case: Format::default(),
         }
     }
 }
@@ -1088,7 +1079,7 @@ impl DeserializableValidator for Convention {
         if self.formats.is_empty() && self.matching.is_none() {
             ctx.report(
                 DeserializationDiagnostic::new(
-                    "At least one field among `format` and `match` must be set.",
+                    "At least one field among `formats` and `match` must be set.",
                 )
                 .with_range(range),
             );
@@ -1499,7 +1490,7 @@ impl Selector {
 
     /// Returns the list of default [Case] for `self`.
     /// The preferred case comes first in the list.
-    fn default_convention(self, options: &NamingConventionOptions) -> Convention {
+    fn default_convention(self) -> Convention {
         let kind = self.kind;
         match kind {
             Kind::TypeProperty if self.modifiers.contains(Modifier::Readonly) => Convention {
@@ -1572,7 +1563,7 @@ impl Selector {
             Kind::EnumMember => Convention {
                 selector: kind.into(),
                 matching: None,
-                formats: Formats(Case::from(options.enum_member_case).into()),
+                formats: Formats(Case::Pascal.into()),
             },
             Kind::Variable | Kind::Const | Kind::Var | Kind::Let => Convention {
                 selector: kind.into(),

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/malformedOptions.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/malformedOptions.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: malformedOptions.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -10,23 +9,22 @@ snapshot_kind: text
 
 # Diagnostics
 ```
-malformedOptions.options:9:25 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+malformedOptions.options:9:7 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Found an unknown value `kebab-case`.
+  × Found an unknown key `enumMemberCase`.
   
      7 │ 					"level": "error",
      8 │ 					"options": {
    > 9 │ 						"enumMemberCase": "kebab-case"
-       │ 						                  ^^^^^^^^^^^^
+       │ 						^^^^^^^^^^^^^^^^
     10 │ 					}
     11 │ 				}
   
-  i Accepted values:
+  i Known keys:
   
-  - camelCase
-  - CONSTANT_CASE
-  - PascalCase
-  - snake_case
+  - strictCase
+  - requireAscii
+  - conventions
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validEnumMemberCamelCase.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validEnumMemberCamelCase.options.json
@@ -6,8 +6,11 @@
 				"useNamingConvention": {
 					"level": "error",
 					"options": {
-						"enumMemberCase": "camelCase",
-						"strictCase": true
+						"strictCase": true,
+						"conventions": [{
+							"selector": { "kind": "enumMember" },
+							"formats": ["camelCase"]
+						}]
 					}
 				}
 			}

--- a/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validEnumMemberConstantCase.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/useNamingConvention/validEnumMemberConstantCase.options.json
@@ -6,7 +6,10 @@
 				"useNamingConvention": {
 					"level": "error",
 					"options": {
-						"enumMemberCase": "CONSTANT_CASE"
+						"conventions": [{
+							"selector": { "kind": "enumMember" },
+							"formats": ["CONSTANT_CASE"]
+						}]
 					}
 				}
 			}

--- a/crates/biome_migrate/src/analyzers.rs
+++ b/crates/biome_migrate/src/analyzers.rs
@@ -10,6 +10,7 @@ use crate::analyzers::trailing_comma::TrailingComma;
 use crate::analyzers::use_while::UseWhile;
 use biome_analyze::{GroupCategory, RegistryVisitor, RuleCategory, RuleGroup};
 use biome_json_syntax::JsonLanguage;
+use use_naming_convention_enum_member_case::UseNamingConventionEnumMemberCase;
 
 mod all;
 mod deleted_rules;
@@ -20,6 +21,7 @@ mod organize_imports;
 mod schema;
 mod style_rules;
 mod trailing_comma;
+mod use_naming_convention_enum_member_case;
 mod use_while;
 
 pub(crate) struct MigrationGroup;
@@ -45,6 +47,7 @@ impl RuleGroup for MigrationGroup {
         registry.record_rule::<OrganizeImports>();
         registry.record_rule::<Includes>();
         registry.record_rule::<TrailingComma>();
+        registry.record_rule::<UseNamingConventionEnumMemberCase>();
     }
 }
 

--- a/crates/biome_migrate/src/analyzers/use_naming_convention_enum_member_case.rs
+++ b/crates/biome_migrate/src/analyzers/use_naming_convention_enum_member_case.rs
@@ -1,0 +1,152 @@
+use crate::{declare_migration, MigrationAction};
+use biome_analyze::context::RuleContext;
+use biome_analyze::{Ast, Rule, RuleAction, RuleDiagnostic};
+use biome_console::markup;
+use biome_diagnostics::{category, Applicability};
+use biome_json_factory::make;
+use biome_json_syntax::{AnyJsonValue, JsonMember, JsonMemberList, T};
+use biome_rowan::{AstNode, AstSeparatedList, AstSeparatedListExt, BatchMutationExt, TokenText};
+
+declare_migration! {
+    pub(crate) UseNamingConventionEnumMemberCase {
+        version: "2.0.0",
+        name: "useNamingConventionEnumMemberCase",
+    }
+}
+
+impl Rule for UseNamingConventionEnumMemberCase {
+    type Query = Ast<JsonMember>;
+    type State = TokenText;
+    type Signals = Option<Self::State>;
+    type Options = ();
+
+    fn run(ctx: &RuleContext<Self>) -> Self::Signals {
+        let node = ctx.query();
+        let name = node.name().ok()?;
+        let text = name.inner_string_text().ok()?;
+        if text.text() == "enumMemberCase" {
+            let value = node.value().ok()?;
+            let value = value.as_json_string_value()?.inner_string_text().ok()?;
+            if matches!(
+                value.text(),
+                "camelCase" | "CONSTANT_CASE" | "PascalCase" | "snake_case"
+            ) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let node = ctx.query();
+        let name = node.name().ok()?;
+        Some(RuleDiagnostic::new(
+            category!("migrate"),
+            name.range(),
+            markup! {
+                "The option "<Emphasis>"enumMemberCase"</Emphasis>" has ben removed."
+            }
+            .to_owned(),
+        ))
+    }
+
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<MigrationAction> {
+        let selector_kind = make::json_member(
+            make::json_member_name(make::json_string_literal("kind")),
+            make::token(T![:]),
+            make::json_string_value(make::json_string_literal("enumMember")).into(),
+        );
+        let selector = make::json_member(
+            make::json_member_name(make::json_string_literal("selector")),
+            make::token(T![:]),
+            make::json_object_value(
+                make::token(T!['{']),
+                make::json_member_list([selector_kind], []),
+                make::token(T!['}']),
+            )
+            .into(),
+        );
+        let formats = make::json_member(
+            make::json_member_name(make::json_string_literal("formats")),
+            make::token(T![:]),
+            make::json_array_value(
+                make::token(T!['[']),
+                make::json_array_element_list(
+                    [make::json_string_value(make::json_string_literal(state.text())).into()],
+                    [],
+                ),
+                make::token(T![']']),
+            )
+            .into(),
+        );
+        let enum_member_convention = make::json_object_value(
+            make::token(T!['{']),
+            make::json_member_list([selector, formats], [make::token(T![,])]),
+            make::token(T!['}']),
+        );
+
+        let node = ctx.query();
+        let parent = node.parent::<JsonMemberList>()?;
+        let conventions = parent.into_iter().find_map(|member| {
+            let member = member.ok()?;
+            let member_name = member.name().ok()?.inner_string_text().ok()?;
+            if member_name.text() == "conventions" {
+                if let Ok(AnyJsonValue::JsonArrayValue(conventions)) = member.value() {
+                    return Some(conventions);
+                }
+            }
+            None
+        });
+        let mut mutation = ctx.root().begin();
+        if let Some(conventions) = conventions {
+            let conventions = conventions.elements();
+            let new_conventions = if conventions.is_empty() {
+                make::json_array_element_list([enum_member_convention.into()], [])
+            } else {
+                conventions.clone().splice(
+                    0..0,
+                    [(enum_member_convention.into(), Some(make::token(T![,])))],
+                )
+            };
+            mutation.replace_node(conventions, new_conventions);
+            mutation.remove_node(node.clone());
+            if let Some(trailing_comma) = node
+                .syntax()
+                .last_token()
+                .and_then(|ignore_last_token| ignore_last_token.next_token())
+                .filter(|next_token| next_token.kind() == T![,])
+            {
+                mutation.remove_token(trailing_comma);
+            } else if let Some(leading_comma) = node
+                .syntax()
+                .first_token()
+                .and_then(|ignore_last_token| ignore_last_token.prev_token())
+                .filter(|prev_token| prev_token.kind() == T![,])
+            {
+                mutation.remove_token(leading_comma);
+            }
+        } else {
+            let conventions_array = make::json_array_value(
+                make::token(T!['[']),
+                make::json_array_element_list([enum_member_convention.into()], []),
+                make::token(T![']']),
+            );
+            let conventions = make::json_member(
+                make::json_member_name(make::json_string_literal("conventions")),
+                make::token(T![:]),
+                conventions_array.into(),
+            );
+            mutation.replace_node(node.clone(), conventions);
+        }
+
+        Some(RuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            Applicability::Always,
+            markup! {
+                "Use "<Emphasis>"conventions"</Emphasis>" instead of "<Emphasis>"enumMemberCase"</Emphasis>"."
+            }
+            .to_owned(),
+            mutation,
+        ))
+    }
+}

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid.json
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid.json
@@ -1,0 +1,14 @@
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "enumMemberCase": "PascalCase"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid.json.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: invalid.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "enumMemberCase": "PascalCase"
+          }
+        }
+      }
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid.json:8:13 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The option enumMemberCase has ben removed.
+  
+     6 │           "level": "on",
+     7 │           "options": {
+   > 8 │             "enumMemberCase": "PascalCase"
+       │             ^^^^^^^^^^^^^^^^
+     9 │           }
+    10 │         }
+  
+  i Safe fix: Use conventions instead of enumMemberCase.
+  
+     6  6 │             "level": "on",
+     7  7 │             "options": {
+     8    │ - ············"enumMemberCase":·"PascalCase"
+        8 │ + ············"conventions":[{"selector":{"kind":"enumMember"},"formats":["PascalCase"]}]
+     9  9 │             }
+    10 10 │           }
+  
+
+```

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_conventions.json
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_conventions.json
@@ -1,0 +1,15 @@
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "enumMemberCase": "camelCase",
+            "conventions": [{ "selector": { "kind": "let" }, "formats": ["camelCase"] }]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_conventions.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_conventions.json.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: invalid_with_conventions.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "enumMemberCase": "camelCase",
+            "conventions": [{ "selector": { "kind": "let" }, "formats": ["camelCase"] }]
+          }
+        }
+      }
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid_with_conventions.json:8:13 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The option enumMemberCase has ben removed.
+  
+     6 │           "level": "on",
+     7 │           "options": {
+   > 8 │             "enumMemberCase": "camelCase",
+       │             ^^^^^^^^^^^^^^^^
+     9 │             "conventions": [{ "selector": { "kind": "let" }, "formats": ["camelCase"] }]
+    10 │           }
+  
+  i Safe fix: Use conventions instead of enumMemberCase.
+  
+     6  6 │             "level": "on",
+     7  7 │             "options": {
+     8    │ - ············"enumMemberCase":·"camelCase",
+     9    │ - ············"conventions":·[{·"selector":·{·"kind":·"let"·},·"formats":·["camelCase"]·}]
+        8 │ + ············"conventions":·[{"selector":{"kind":"enumMember"},"formats":["camelCase"]},{·"selector":·{·"kind":·"let"·},·"formats":·["camelCase"]·}]
+    10  9 │             }
+    11 10 │           }
+  
+
+```

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_empty_conventions.json
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_empty_conventions.json
@@ -1,0 +1,15 @@
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "conventions": [],
+            "enumMemberCase": "CONSTANT_CASE"
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_empty_conventions.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/invalid_with_empty_conventions.json.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: invalid_with_empty_conventions.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "conventions": [],
+            "enumMemberCase": "CONSTANT_CASE"
+          }
+        }
+      }
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid_with_empty_conventions.json:9:13 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The option enumMemberCase has ben removed.
+  
+     7 │           "options": {
+     8 │             "conventions": [],
+   > 9 │             "enumMemberCase": "CONSTANT_CASE"
+       │             ^^^^^^^^^^^^^^^^
+    10 │           }
+    11 │         }
+  
+  i Safe fix: Use conventions instead of enumMemberCase.
+  
+     6  6 │             "level": "on",
+     7  7 │             "options": {
+     8    │ - ············"conventions":·[],
+     9    │ - ············"enumMemberCase":·"CONSTANT_CASE"
+        8 │ + ············"conventions":·[{"selector":{"kind":"enumMember"},"formats":["CONSTANT_CASE"]}]
+    10  9 │             }
+    11 10 │           }
+  
+
+```

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/valid.json
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/valid.json
@@ -1,0 +1,14 @@
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "requireAscii": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/valid.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/useNamingConventionEnumMemberCase/valid.json.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: valid.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      "style": {
+        "useNamingConvention": {
+          "level": "on",
+          "options": {
+            "requireAscii": true
+          }
+        }
+      }
+    }
+  }
+}
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2821,10 +2821,6 @@ export interface NamingConventionOptions {
 	 */
 	conventions: Convention[];
 	/**
-	 * Allowed cases for _TypeScript_ `enum` member names.
-	 */
-	enumMemberCase: Format;
-	/**
 	 * If `false`, then non-ASCII characters are allowed.
 	 */
 	requireAscii: boolean;
@@ -2906,14 +2902,6 @@ export interface Convention {
 	 */
 	selector: Selector;
 }
-/**
- * Supported cases.
- */
-export type Format =
-	| "camelCase"
-	| "CONSTANT_CASE"
-	| "PascalCase"
-	| "snake_case";
 export type StableHookResult = boolean | number[];
 /**
  * Supported cases for file names.
@@ -2939,6 +2927,14 @@ export interface Selector {
 	 */
 	scope: Scope;
 }
+/**
+ * Supported cases.
+ */
+export type Format =
+	| "camelCase"
+	| "CONSTANT_CASE"
+	| "PascalCase"
+	| "snake_case";
 export type Kind =
 	| "class"
 	| "enum"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2290,10 +2290,6 @@
 					"type": "array",
 					"items": { "$ref": "#/definitions/Convention" }
 				},
-				"enumMemberCase": {
-					"description": "Allowed cases for _TypeScript_ `enum` member names.",
-					"allOf": [{ "$ref": "#/definitions/Format" }]
-				},
 				"requireAscii": {
 					"description": "If `false`, then non-ASCII characters are allowed.",
 					"type": "boolean"


### PR DESCRIPTION
## Summary

Remove the `enumMemberCase` option from the `useNamingConvention` lint rule.
I added a migration rule to convert `enumMemberCase` into `conventions`.

## Test Plan

I added migration tests and updated `useNamingConvention` tests.
