### PR TITLE
ci: move `test-node-api` job to a new `pull_request_node.yml` workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -102,52 +102,6 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-  test-node-api:
-    name: Test node.js API
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Free Disk Space
-        uses: ./.github/actions/free-disk-space
-      - name: Install toolchain
-        uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
-        with:
-          cache-target: release
-          cache-base: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build main binary
-        run: cargo build -p biome_cli --release
-      - name: Install Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: 20
-      - name: Cache pnpm modules
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-
-      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build TypeScript code
-        run: |
-          pnpm --filter @biomejs/backend-jsonrpc i
-          pnpm --filter @biomejs/backend-jsonrpc run build
-          pnpm --filter @biomejs/js-api run build:wasm-bundler
-          pnpm --filter @biomejs/js-api run build:wasm-node
-          pnpm --filter @biomejs/js-api run build:wasm-web
-          pnpm --filter @biomejs/js-api i
-          pnpm --filter @biomejs/js-api run build
-      - name: Run JS tests
-        run: |
-          pnpm --filter @biomejs/backend-jsonrpc run test:ci
-          pnpm --filter @biomejs/js-api run test:ci
-  
   e2e-tests:
     name: End-to-end tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -8,6 +8,8 @@ on:
       - 'packages/@biomejs/**'
       - 'packages/aria-data/**'
       - 'packages/tailwindcss-config-analyzer/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
 
 # Cancel jobs when the PR is updated
 concurrency:

--- a/.github/workflows/pull_request_node.yml
+++ b/.github/workflows/pull_request_node.yml
@@ -1,0 +1,70 @@
+# Jobs run on pull request for Node.js APIs
+name: Pull request Node.js
+on:
+  pull_request:
+    branches:
+      - main
+    paths: # Only run when changes are made to Rust crates or Node.js packages
+      - "crates/**"
+      - "packages/@biomejs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "rust-toolchain.toml"
+
+# Cancel jobs when the PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  RUST_LOG: info
+  RUST_BACKTRACE: 1
+
+jobs:
+  test-node-api:
+    name: Test Node.js API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@e013866c4215f77c925f42f60257dec7dd18836e # v1.2.1
+        with:
+          cache-target: release
+          cache-base: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build main binary
+        run: cargo build -p biome_cli --release
+      - name: Install Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 20
+      - name: Cache pnpm modules
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build TypeScript code
+        run: |
+          pnpm --filter @biomejs/backend-jsonrpc i
+          pnpm --filter @biomejs/backend-jsonrpc run build
+          pnpm --filter @biomejs/js-api run build:wasm-bundler
+          pnpm --filter @biomejs/js-api run build:wasm-node
+          pnpm --filter @biomejs/js-api run build:wasm-web
+          pnpm --filter @biomejs/js-api i
+          pnpm --filter @biomejs/js-api run build
+      - name: Run JS tests
+        run: |
+          pnpm --filter @biomejs/backend-jsonrpc run test:ci
+          pnpm --filter @biomejs/js-api run test:ci


### PR DESCRIPTION
## Summary

From https://github.com/biomejs/biome/pull/5190#issuecomment-2677793625

Testing Node.js API should be triggered on either Rust files or JS/TS files are changed. I added a new workflow `pull_request_node.yml` and moved the job.

Plus, I added `package.json` and `pnpm-lock.yaml` files to the trigger of `pull_request_js.yml` so any package updates will trigger the workflow.

## Test Plan

Unfortunately this PR doesn't have any changes to trigger the workflow, but we can check in #5190 after merged this. At least existing CIs shouldn't be an error on the analysing phase.
