### PR TITLE
fix(lsp): fill in missing workspaceFolders capabilities

### DIFF
--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -3,7 +3,8 @@ use biome_lsp_converters::{negotiated_encoding, PositionEncoding, WideEncoding};
 use tower_lsp::lsp_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     DocumentOnTypeFormattingOptions, OneOf, PositionEncodingKind, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncCapability, TextDocumentSyncKind, WorkspaceFoldersServerCapabilities,
+    WorkspaceServerCapabilities,
 };
 
 /// The capabilities to send from server as part of [`InitializeResult`]
@@ -93,6 +94,13 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
         document_on_type_formatting_provider: supports_on_type_formatter_dynamic_registration,
         code_action_provider,
         rename_provider: None,
+        workspace: Some(WorkspaceServerCapabilities {
+            workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                supported: Some(true),
+                change_notifications: Some(OneOf::Left(true)),
+            }),
+            ..Default::default()
+        }),
         ..Default::default()
     }
 }


### PR DESCRIPTION
## Summary

This PR fills in missing capabilities for workspace folder notifications in Biome LSP implementation.

In Zed we've reworked how language servers are initialized in https://github.com/zed-industries/zed/pull/24038 ; one of the consequences is that we no longer send out workspaceFolders in `InitializeParams`, instead opting to send out notifications when workspace folders are discovered. It works all fine and dandy with Biome (as it already supports that notification), except that we never actually send out the notification as Biome does not declare a capability for it.

The change from forelinked PR is going to land in Stable tomorrow. I've just learned about Biome breakage with new code today, but I'm sorry for the late notice regardless.

## Test Plan
Biome language server built from this commit works with latest Zed Preview.
