### PR TITLE
feat(lint): support promise in function argument for `noFloatingPromises`

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -1070,10 +1070,5 @@ fn find_and_check_object_member(
 /// `JsFormalParameter`. It returns `Some(JsFormalParameter)` if a `JsFormalParameter` is found,
 /// otherwise it returns `None`.
 fn find_js_formal_parameter(node: &SyntaxNode<JsLanguage>) -> Option<JsFormalParameter> {
-    node.ancestors()
-        .skip(1)
-        .find_map(|ancestor| match ancestor.kind() {
-            JsSyntaxKind::JS_FORMAL_PARAMETER => ancestor.cast::<JsFormalParameter>(),
-            _ => None,
-        })
+    node.ancestors().skip(1).find_map(JsFormalParameter::cast)
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -383,14 +383,14 @@ fn is_binding_a_promise(
         AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(js_obj_binding) => {
             // function foo({ bar }: Type)
             let value_token = reference.value_token().ok()?;
-            let js_formal_param = find_js_format_parameter(js_obj_binding.syntax())?;
+            let js_formal_param = find_js_formal_parameter(js_obj_binding.syntax())?;
             let type_annotation = js_formal_param.type_annotation()?;
             let any_ts_type = type_annotation.ty().ok()?;
             is_ts_type_a_promise(&any_ts_type, model, Some(value_token.text_trimmed()))
         }
         AnyJsBindingDeclaration::JsObjectBindingPatternRest(js_obj_binding) => {
             // function foo({ bar, ...rest }: Type)
-            let js_formal_param = find_js_format_parameter(js_obj_binding.syntax())?;
+            let js_formal_param = find_js_formal_parameter(js_obj_binding.syntax())?;
             let type_annotation = js_formal_param.type_annotation()?;
             let any_ts_type = type_annotation.ty().ok()?;
             is_ts_type_a_promise(&any_ts_type, model, target_method_name)
@@ -1069,7 +1069,7 @@ fn find_and_check_object_member(
 /// This function traverses up the syntax tree from the given `SyntaxNode` to find the nearest
 /// `JsFormalParameter`. It returns `Some(JsFormalParameter)` if a `JsFormalParameter` is found,
 /// otherwise it returns `None`.
-fn find_js_format_parameter(node: &SyntaxNode<JsLanguage>) -> Option<JsFormalParameter> {
+fn find_js_formal_parameter(node: &SyntaxNode<JsLanguage>) -> Option<JsFormalParameter> {
     node.ancestors()
         .skip(1)
         .find_map(|ancestor| match ancestor.kind() {

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -297,3 +297,35 @@ async function testInvalidObejctMethodCalls(): Promise<void> {
 		.finally(() => {});
 	invalidTestObject["returnsPromiseMethod"]();
 }
+
+type Props = {
+	a: string;
+	returnsPromise: () => Promise<void>;
+};
+async function testCallingReturnsPromise(props: Props) {
+	props.returnsPromise().then(() => {});
+}
+const testDestructuringAndCallingReturnsPromise = async ({
+	returnsPromise,
+}: Props) => {
+	returnsPromise();
+};
+async function testPassingReturnsPromiseDirectly(
+	returnsPromise: () => Promise<void>
+) {
+	returnsPromise();
+}
+async function testCallingReturnsPromiseFromObject(props: {
+	returnsPromise: () => Promise<void>;
+}) {
+	props.returnsPromise();
+}
+async function testDestructuringAndCallingReturnsPromiseFromRest({
+	a,
+	...rest
+}: Props) {
+	rest
+		.returnsPromise()
+		.then(() => {})
+		.finally(() => {});
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -304,6 +304,38 @@ async function testInvalidObejctMethodCalls(): Promise<void> {
 	invalidTestObject["returnsPromiseMethod"]();
 }
 
+type Props = {
+	a: string;
+	returnsPromise: () => Promise<void>;
+};
+async function testCallingReturnsPromise(props: Props) {
+	props.returnsPromise().then(() => {});
+}
+const testDestructuringAndCallingReturnsPromise = async ({
+	returnsPromise,
+}: Props) => {
+	returnsPromise();
+};
+async function testPassingReturnsPromiseDirectly(
+	returnsPromise: () => Promise<void>
+) {
+	returnsPromise();
+}
+async function testCallingReturnsPromiseFromObject(props: {
+	returnsPromise: () => Promise<void>;
+}) {
+	props.returnsPromise();
+}
+async function testDestructuringAndCallingReturnsPromiseFromRest({
+	a,
+	...rest
+}: Props) {
+	rest
+		.returnsPromise()
+		.then(() => {})
+		.finally(() => {});
+}
+
 ```
 
 # Diagnostics
@@ -1427,5 +1459,114 @@ invalid.ts:298:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━
   
     298 │ → await·invalidTestObject["returnsPromiseMethod"]();
         │   ++++++                                            
+
+```
+
+```
+invalid.ts:306:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    304 │ };
+    305 │ async function testCallingReturnsPromise(props: Props) {
+  > 306 │ 	props.returnsPromise().then(() => {});
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    307 │ }
+    308 │ const testDestructuringAndCallingReturnsPromise = async ({
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    306 │ → await·props.returnsPromise().then(()·=>·{});
+        │   ++++++                                      
+
+```
+
+```
+invalid.ts:311:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    309 │ 	returnsPromise,
+    310 │ }: Props) => {
+  > 311 │ 	returnsPromise();
+        │ 	^^^^^^^^^^^^^^^^^
+    312 │ };
+    313 │ async function testPassingReturnsPromiseDirectly(
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    311 │ → await·returnsPromise();
+        │   ++++++                 
+
+```
+
+```
+invalid.ts:316:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    314 │ 	returnsPromise: () => Promise<void>
+    315 │ ) {
+  > 316 │ 	returnsPromise();
+        │ 	^^^^^^^^^^^^^^^^^
+    317 │ }
+    318 │ async function testCallingReturnsPromiseFromObject(props: {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    316 │ → await·returnsPromise();
+        │   ++++++                 
+
+```
+
+```
+invalid.ts:321:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    319 │ 	returnsPromise: () => Promise<void>;
+    320 │ }) {
+  > 321 │ 	props.returnsPromise();
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^
+    322 │ }
+    323 │ async function testDestructuringAndCallingReturnsPromiseFromRest({
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    321 │ → await·props.returnsPromise();
+        │   ++++++                       
+
+```
+
+```
+invalid.ts:327:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    325 │ 	...rest
+    326 │ }: Props) {
+  > 327 │ 	rest
+        │ 	^^^^
+  > 328 │ 		.returnsPromise()
+  > 329 │ 		.then(() => {})
+  > 330 │ 		.finally(() => {});
+        │ 		^^^^^^^^^^^^^^^^^^^
+    331 │ }
+    332 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    327 │ → await·rest
+        │   ++++++    
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
@@ -216,3 +216,32 @@ async function testValidObejctMethodCalls(): Promise<string> {
   validTestObject.returnsPromiseMethod().then(() => { }, () => { }).finally(() => { });
   return validTestObject['returnsPromiseMethod']();
 }
+
+type Props = {
+  a: string;
+  returnsPromise: () => Promise<void>;
+};
+async function testCallingReturnsPromise(props: Props) {
+  props.returnsPromise().then(() => { }, () => {});
+}
+const testDestructuringAndCallingReturnsPromise = async ({
+  returnsPromise,
+}: Props) => {
+  await returnsPromise();
+}
+async function testPassingReturnsPromiseDirectly(
+	returnsPromise: () => Promise<void>
+) {
+	returnsPromise().catch(() => {});
+}
+async function testCallingReturnsPromiseFromObject(props: {
+  returnsPromise: () => Promise<void>;
+}) {
+  await props.returnsPromise();
+}
+async function testDestructuringAndCallingReturnsPromiseFromRest({
+  a,
+  ...rest
+}: Props) {
+  rest.returnsPromise().catch(() => {}).finally(() => {});
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
@@ -222,4 +222,34 @@ async function testValidObejctMethodCalls(): Promise<string> {
   validTestObject.returnsPromiseMethod().then(() => { }, () => { }).finally(() => { });
   return validTestObject['returnsPromiseMethod']();
 }
+
+type Props = {
+  a: string;
+  returnsPromise: () => Promise<void>;
+};
+async function testCallingReturnsPromise(props: Props) {
+  props.returnsPromise().then(() => { }, () => {});
+}
+const testDestructuringAndCallingReturnsPromise = async ({
+  returnsPromise,
+}: Props) => {
+  await returnsPromise();
+}
+async function testPassingReturnsPromiseDirectly(
+	returnsPromise: () => Promise<void>
+) {
+	returnsPromise().catch(() => {});
+}
+async function testCallingReturnsPromiseFromObject(props: {
+  returnsPromise: () => Promise<void>;
+}) {
+  await props.returnsPromise();
+}
+async function testDestructuringAndCallingReturnsPromiseFromRest({
+  a,
+  ...rest
+}: Props) {
+  rest.returnsPromise().catch(() => {}).finally(() => {});
+}
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary
https://github.com/biomejs/biome/issues/4956
This pull request introduces the support for promise call in function argument for `noFloatingPromises`

### Example of invalid code:
```
type Props = {
  a: string;
  returnsPromise: () => Promise<void>;
};

async function testCallingReturnsPromise(props: Props) {
  props.returnsPromise().then(() => {});
}

const testDestructuringAndCallingReturnsPromise = async ({
  returnsPromise,
}: Props) => {
  returnsPromise();
};

async function testPassingReturnsPromiseDirectly(
  returnsPromise: () => Promise<void>
) {
  returnsPromise();
}

async function testCallingReturnsPromiseFromObject(props: {
  returnsPromise: () => Promise<void>;
}) {
  props.returnsPromise();
}

async function testDestructuringAndCallingReturnsPromiseFromRest({ a, ...rest }: Props) {
  rest.returnsPromise().then(() => {}).finally(() => {});
}

```

### Example of valid code:
```
type Props = {
  a: string;
  returnsPromise: () => Promise<void>;
};

async function testCallingReturnsPromise(props: Props) {
  props.returnsPromise().then(() => {}).catch(() => {});
}

```