### PR TITLE
fix: remove usages of gen reserved keyword

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ quote                = "1.0.38"
 rayon                = "1.10.0"
 regex                = "1.11.1"
 rustc-hash           = "2.1.1"
-schemars             = { version = "0.8.21", features = ["indexmap2", "smallvec"] }
+schemars             = { version = "0.8.22", features = ["indexmap2", "smallvec"] }
 serde                = { version = "1.0.218", features = ["derive"] }
 serde_ini            = "0.2.0"
 serde_json           = "1.0.139"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unused_macro_rules                     = "warn"
 
 # Rust 2024 upgrade
 deprecated_safe_2024       = "warn"
+keyword_idents_2024        = "warn"
 missing_unsafe_on_extern   = "warn"
 unsafe_attr_outside_unsafe = "warn"
 

--- a/crates/biome_analyze/src/categories.rs
+++ b/crates/biome_analyze/src/categories.rs
@@ -375,8 +375,8 @@ impl schemars::JsonSchema for RuleCategories {
         String::from("RuleCategories")
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <Vec<RuleCategory>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <Vec<RuleCategory>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -541,8 +541,8 @@ impl schemars::JsonSchema for RuleSelector {
     fn schema_name() -> String {
         "RuleCode".to_string()
     }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 

--- a/crates/biome_configuration/src/bool.rs
+++ b/crates/biome_configuration/src/bool.rs
@@ -106,7 +106,7 @@ impl<const D: bool> schemars::JsonSchema for Bool<D> {
         "Bool".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        bool::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        bool::json_schema(generator)
     }
 }

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -363,8 +363,8 @@ impl schemars::JsonSchema for Schema {
         "Schema".into()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -96,8 +96,8 @@ impl schemars::JsonSchema for OverrideGlobs {
     fn schema_name() -> String {
         "OverrideGlobs".to_string()
     }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        Vec::<biome_glob::Glob>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        Vec::<biome_glob::Glob>::json_schema(generator)
     }
 }
 

--- a/crates/biome_diagnostics/src/display/backtrace.rs
+++ b/crates/biome_diagnostics/src/display/backtrace.rs
@@ -97,8 +97,8 @@ impl schemars::JsonSchema for Backtrace {
         String::from("Backtrace")
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <Vec<SerializedFrame>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <Vec<SerializedFrame>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_diagnostics/src/serde.rs
+++ b/crates/biome_diagnostics/src/serde.rs
@@ -365,8 +365,8 @@ impl schemars::JsonSchema for DiagnosticTags {
         String::from("DiagnosticTags")
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <Vec<DiagnosticTag>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <Vec<DiagnosticTag>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_diagnostics_categories/build.rs
+++ b/crates/biome_diagnostics_categories/build.rs
@@ -70,7 +70,7 @@ pub fn main() -> io::Result<()> {
                 String::from("Category")
             }
 
-            fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+            fn json_schema(_gen: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
                 schemars::schema::Schema::Object(schemars::schema::SchemaObject {
                     instance_type: Some(schemars::schema::InstanceType::String.into()),
                     enum_values: Some(vec![#( #enum_variants.into() ),*]),

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -138,8 +138,8 @@ impl schemars::JsonSchema for BiomePath {
         "BiomePath".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 
@@ -260,8 +260,8 @@ impl schemars::JsonSchema for FileKinds {
         String::from("FileKind")
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <Vec<FileKind>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <Vec<FileKind>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_glob/src/editorconfig.rs
+++ b/crates/biome_glob/src/editorconfig.rs
@@ -158,8 +158,8 @@ impl schemars::JsonSchema for EditorconfigGlob {
         "Glob".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 

--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -281,8 +281,8 @@ impl schemars::JsonSchema for Glob {
         "Glob".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 

--- a/crates/biome_grit_patterns/src/grit_built_in_functions.rs
+++ b/crates/biome_grit_patterns/src/grit_built_in_functions.rs
@@ -327,7 +327,7 @@ fn length_fn<'a>(
                 None => {
                     return Err(GritPatternError::new(
                         "length() requires a list or string as the first argument",
-                    ))
+                    ));
                 }
             }
         }
@@ -443,7 +443,7 @@ fn random_fn<'a>(
             Ok(ResolvedPattern::from_constant(Constant::Integer(value)))
         }
         [None, None] => {
-            let value = state.get_rng().gen::<f64>();
+            let value = state.get_rng().r#gen::<f64>();
             Ok(ResolvedPattern::from_constant(Constant::Float(value)))
         }
         _ => Err(GritPatternError::new(

--- a/crates/biome_grit_patterns/src/grit_target_language.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language.rs
@@ -80,7 +80,7 @@ macro_rules! generate_target_language {
                 "GritTargetLanguage".to_owned()
             }
 
-            fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+            fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
                 schemars::schema::Schema::Object(schemars::schema::SchemaObject {
                     enum_values: Some(vec![
                         $(serde_json::json!($name)),+

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -124,7 +124,7 @@ impl schemars::JsonSchema for DependencyAvailability {
         "DependencyAvailability".to_owned()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         use schemars::schema::*;
 
         Schema::Object(SchemaObject {

--- a/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_filenaming_convention.rs
@@ -491,8 +491,8 @@ impl schemars::JsonSchema for FilenameCases {
     fn schema_name() -> String {
         "FilenameCases".to_string()
     }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <std::collections::HashSet<FilenameCase>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <std::collections::HashSet<FilenameCase>>::json_schema(generator)
     }
 }
 impl Default for FilenameCases {

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -852,7 +852,7 @@ impl Rule for UseNamingConvention {
                         "This "<Emphasis>{format_args!("{convention_selector}")}</Emphasis>" name"{trimmed_info}" should be in "<Emphasis>{expected_case_names}</Emphasis>"."
                     },
                 ))
-            },
+            }
         }
     }
 
@@ -919,7 +919,7 @@ impl Rule for UseNamingConvention {
                 return Some(JsRuleAction::new(
                     ctx.metadata().action_category(ctx.category(), ctx.group()),
                     ctx.metadata().applicability(),
-                     markup! { "Rename this symbol in "<Emphasis>{preferred_case.to_string()}</Emphasis>"." }.to_owned(),
+                    markup! { "Rename this symbol in "<Emphasis>{preferred_case.to_string()}</Emphasis>"." }.to_owned(),
                     mutation,
                 ));
             }
@@ -1374,7 +1374,7 @@ impl Selector {
                 } else {
                     Some(Kind::IndexParameter.into())
                 }
-            },
+            }
             AnyJsBindingDeclaration::JsNamespaceImportSpecifier(_) => Some(Selector::with_scope(Kind::ImportNamespace, Scope::Global)),
             AnyJsBindingDeclaration::JsFunctionDeclaration(_)
             | AnyJsBindingDeclaration::JsFunctionExpression(_)
@@ -1854,8 +1854,8 @@ impl JsonSchema for Modifiers {
         "Modifiers".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <std::collections::HashSet<RestrictedModifier>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <std::collections::HashSet<RestrictedModifier>>::json_schema(generator)
     }
 }
 impl From<JsMethodModifierList> for Modifiers {
@@ -2049,8 +2049,8 @@ impl JsonSchema for Formats {
     fn schema_name() -> String {
         "Formats".to_string()
     }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <std::collections::HashSet<Format>>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <std::collections::HashSet<Format>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -275,7 +275,7 @@ impl JsonSchema for StableHookResult {
         "StableHookResult".to_owned()
     }
 
-    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         use schemars::schema::*;
         Schema::Object(SchemaObject {
             subschemas: Some(Box::new(SubschemaValidation {

--- a/crates/biome_js_analyze/src/utils/restricted_regex.rs
+++ b/crates/biome_js_analyze/src/utils/restricted_regex.rs
@@ -104,8 +104,8 @@ impl schemars::JsonSchema for RestrictedRegex {
         "Regex".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -76,7 +76,7 @@ use core::str;
 use crossbeam::channel::bounded;
 use enumflags2::{bitflags, BitFlags};
 #[cfg(feature = "schema")]
-use schemars::{gen::SchemaGenerator, schema::Schema};
+use schemars::{r#gen::SchemaGenerator, schema::Schema};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -496,8 +496,8 @@ impl schemars::JsonSchema for FeatureName {
         String::from("FeatureName")
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        <Vec<FeatureKind>>::json_schema(gen)
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        <Vec<FeatureKind>>::json_schema(generator)
     }
 }
 

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 use biome_js_syntax::{AnyJsDeclaration, AnyTsTupleTypeElement};
 use rustc_hash::FxHashSet;
 use schemars::{
-    gen::{SchemaGenerator, SchemaSettings},
+    r#gen::{SchemaGenerator, SchemaSettings},
     schema::{InstanceType, RootSchema, Schema, SchemaObject, SingleOrVec},
     JsonSchema,
 };
@@ -308,7 +308,7 @@ pub fn generate_type<'a>(
     match root_name {
         "Null" => return AnyTsType::TsVoidType(make::ts_void_type(make::token(T![void]))),
         "Boolean" => {
-            return AnyTsType::TsBooleanType(make::ts_boolean_type(make::token(T![boolean])))
+            return AnyTsType::TsBooleanType(make::ts_boolean_type(make::token(T![boolean])));
         }
         "String" => return AnyTsType::TsStringType(make::ts_string_type(make::token(T![string]))),
         _ => {}

--- a/crates/biome_text_size/src/schemars_impls.rs
+++ b/crates/biome_text_size/src/schemars_impls.rs
@@ -6,17 +6,17 @@
 //! bindings to the Workspace API
 
 use crate::{TextRange, TextSize};
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use schemars::{r#gen::SchemaGenerator, schema::Schema, JsonSchema};
 
 impl JsonSchema for TextSize {
     fn schema_name() -> String {
         String::from("TextSize")
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         // TextSize is represented as a raw u32, see serde_impls.rs for the
         // actual implementation
-        <u32>::json_schema(gen)
+        <u32>::json_schema(generator)
     }
 }
 
@@ -25,9 +25,9 @@ impl JsonSchema for TextRange {
         String::from("TextRange")
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         // TextSize is represented as (TextSize, TextSize), see serde_impls.rs
         // for the actual implementation
-        <(TextSize, TextSize)>::json_schema(gen)
+        <(TextSize, TextSize)>::json_schema(generator)
     }
 }

--- a/crates/biome_wasm/build.rs
+++ b/crates/biome_wasm/build.rs
@@ -7,7 +7,7 @@ use biome_js_formatter::{context::JsFormatOptions, format_node};
 use biome_rowan::AstNode;
 use biome_service::workspace_types::{generate_type, methods, ModuleQueue};
 use quote::{format_ident, quote};
-use schemars::gen::{SchemaGenerator, SchemaSettings};
+use schemars::r#gen::{SchemaGenerator, SchemaSettings};
 use std::{env, fs, io, path::PathBuf};
 
 fn main() -> io::Result<()> {

--- a/crates/tests_macros/src/lib.rs
+++ b/crates/tests_macros/src/lib.rs
@@ -179,7 +179,7 @@ impl Arguments {
         })
     }
 
-    pub fn gen(&self) -> Result<TokenStream, &str> {
+    pub fn generate(&self) -> Result<TokenStream, &str> {
         let files = self.get_all_files()?;
         let mut modules = Modules::default();
 
@@ -247,7 +247,7 @@ impl syn::parse::Parse for Arguments {
 pub fn gen_tests(input: TokenStream) -> TokenStream {
     let args = syn::parse_macro_input!(input as Arguments);
 
-    match args.gen() {
+    match args.generate() {
         Ok(tokens) => tokens,
         Err(e) => abort!(e, "{}", e),
     }

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -10,7 +10,7 @@ use biome_js_syntax::{
 use biome_rowan::AstNode;
 use biome_service::workspace_types::{generate_type, methods, ModuleQueue};
 use biome_string_case::Case;
-use schemars::gen::{SchemaGenerator, SchemaSettings};
+use schemars::r#gen::{SchemaGenerator, SchemaSettings};
 use xtask::{project_root, Mode, Result};
 use xtask_codegen::update;
 


### PR DESCRIPTION
## Summary

This is the first step of #5196, starting with an easy one :)

`gen` is now a reserved keyword since Rust 2024. All found usages were for schemars, which already supports Rust 2024 edition per https://github.com/GREsau/schemars/pull/378.

This pull request updates schemars to the latest, and removes all usages of `gen` identifiers from the project.

## Test Plan

Existing tests should pass.
