### PR TITLE
fix: add missing `use<>` to RPIT's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unused_macro_rules                     = "warn"
 
 # Rust 2024 upgrade
 deprecated_safe_2024       = "warn"
+impl_trait_overcaptures    = "warn"
 keyword_idents_2024        = "warn"
 missing_unsafe_on_extern   = "warn"
 unsafe_attr_outside_unsafe = "warn"

--- a/crates/biome_formatter/src/comments.rs
+++ b/crates/biome_formatter/src/comments.rs
@@ -892,7 +892,7 @@ impl<L: Language> Comments<L> {
     pub fn leading_trailing_comments(
         &self,
         node: &SyntaxNode<L>,
-    ) -> impl Iterator<Item = &SourceComment<L>> {
+    ) -> impl Iterator<Item = &SourceComment<L>> + use<'_, L> {
         self.leading_comments(node)
             .iter()
             .chain(self.trailing_comments(node).iter())

--- a/crates/biome_grit_patterns/src/grit_target_node.rs
+++ b/crates/biome_grit_patterns/src/grit_target_node.rs
@@ -210,7 +210,7 @@ impl<'a> GritTargetNode<'a> {
         DescendantsIterator::new(self)
     }
 
-    pub fn named_children(&self) -> impl Iterator<Item = Self> + Clone {
+    pub fn named_children(&self) -> impl Iterator<Item = Self> + Clone + use<'a> {
         NamedChildrenIterator::new(self)
     }
 
@@ -237,7 +237,7 @@ impl<'a> GritTargetNode<'a> {
     }
 
     #[inline]
-    pub fn slots(&self) -> Option<impl Iterator<Item = GritSyntaxSlot<'a>>> {
+    pub fn slots(&self) -> Option<impl Iterator<Item = GritSyntaxSlot<'a>> + use<'a>> {
         SlotIterator::new(self)
     }
 

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -685,7 +685,7 @@ fn determine_unstable_dependency(
     }
 }
 
-fn into_member_iter(node: &JsSyntaxNode) -> impl Iterator<Item = String> {
+fn into_member_iter(node: &JsSyntaxNode) -> impl Iterator<Item = String> + use<> {
     let mut vec = vec![];
     let mut next = Some(node.clone());
 

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -62,7 +62,7 @@ impl TryFrom<AnyJsExpression> for AnyJsFunctionExpression {
 impl ReactCallWithDependencyResult {
     /// Returns all [Reference] captured by the closure argument of the React hook.
     /// See [react_hook_with_dependency].
-    pub fn all_captures(&self, model: &SemanticModel) -> impl Iterator<Item = Capture> {
+    pub fn all_captures(&self, model: &SemanticModel) -> impl Iterator<Item = Capture> + use<> {
         self.closure_node
             .as_ref()
             .and_then(|node| AnyJsFunctionExpression::try_from(node.clone()).ok())
@@ -80,7 +80,7 @@ impl ReactCallWithDependencyResult {
 
     /// Returns all dependencies of a React hook.
     /// See [react_hook_with_dependency]
-    pub fn all_dependencies(&self) -> impl Iterator<Item = AnyJsExpression> {
+    pub fn all_dependencies(&self) -> impl Iterator<Item = AnyJsExpression> + use<> {
         self.dependencies_node
             .as_ref()
             .and_then(|x| Some(x.as_js_array_expression()?.elements().into_iter()))

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -262,7 +262,7 @@ impl Closure {
     /// }";
     /// assert!(model.closure(function_f).all_captures(), &["a"]);
     /// ```
-    pub fn all_captures(&self) -> impl Iterator<Item = Capture> {
+    pub fn all_captures(&self) -> impl Iterator<Item = Capture> + use<> {
         let scope = &self.data.scopes[self.scope_id.index()];
 
         let scopes = scope.children.clone();
@@ -292,7 +292,7 @@ impl Closure {
     /// }";
     /// assert!(model.closure(function_f).children(), &["g"]);
     /// ```
-    pub fn children(&self) -> impl Iterator<Item = Closure> {
+    pub fn children(&self) -> impl Iterator<Item = Closure> + use<> {
         let scope = &self.data.scopes[self.scope_id.index()];
         ChildrenIter {
             data: self.data.clone(),
@@ -315,7 +315,7 @@ impl Closure {
     /// }";
     /// assert!(model.closure(function_f).descendents(), &["f", "g", "h"]);
     /// ```
-    pub fn descendents(&self) -> impl Iterator<Item = Closure> {
+    pub fn descendents(&self) -> impl Iterator<Item = Closure> + use<> {
         let scopes = vec![self.scope_id];
         DescendentsIter {
             data: self.data.clone(),

--- a/crates/biome_js_semantic/src/semantic_model/scope.rs
+++ b/crates/biome_js_semantic/src/semantic_model/scope.rs
@@ -47,13 +47,13 @@ impl Scope {
 
     /// Returns all parents of this scope. Starting with the current
     /// [Scope].
-    pub fn ancestors(&self) -> impl Iterator<Item = Scope> {
+    pub fn ancestors(&self) -> impl Iterator<Item = Scope> + use<> {
         std::iter::successors(Some(self.clone()), |scope| scope.parent())
     }
 
     /// Returns all descendents of this scope in breadth-first order. Starting with the current
     /// [Scope].
-    pub fn descendents(&self) -> impl Iterator<Item = Scope> {
+    pub fn descendents(&self) -> impl Iterator<Item = Scope> + use<> {
         let mut q = VecDeque::new();
         q.push_back(self.id);
 

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -673,7 +673,7 @@ impl JsTemplateExpression {
     /// The string chunks of the template. aka:
     /// `foo ${bar} foo` breaks down into:
     /// `QUASIS ELEMENT{EXPR} QUASIS`
-    pub fn quasis(&self) -> impl Iterator<Item = JsSyntaxToken> {
+    pub fn quasis(&self) -> impl Iterator<Item = JsSyntaxToken> + use<> {
         self.syntax()
             .children_with_tokens()
             .filter_map(NodeOrToken::into_token)

--- a/crates/biome_rowan/src/cursor/element.rs
+++ b/crates/biome_rowan/src/cursor/element.rs
@@ -52,7 +52,7 @@ impl SyntaxElement {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/crates/biome_rowan/src/cursor/node.rs
+++ b/crates/biome_rowan/src/cursor/node.rs
@@ -162,7 +162,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), SyntaxNode::parent)
     }
 
@@ -266,7 +266,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), move |node| match direction {
             Direction::Next => node.next_sibling(),
             Direction::Prev => node.prev_sibling(),
@@ -277,7 +277,7 @@ impl SyntaxNode {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let me: SyntaxElement = self.clone().into();
         iter::successors(Some(me), move |el| match direction {
             Direction::Next => el.next_sibling_or_token(),
@@ -286,7 +286,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         self.preorder().filter_map(|event| match event {
             WalkEvent::Enter(node) => Some(node),
             WalkEvent::Leave(_) => None,
@@ -297,7 +297,7 @@ impl SyntaxNode {
     pub fn descendants_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         self.preorder_with_tokens(direction)
             .filter_map(|event| match event {
                 WalkEvent::Enter(it) => Some(it),
@@ -897,7 +897,7 @@ impl<'a> Siblings<'a> {
     /// For example, the preceding siblings of the if statement's condition are:
     /// * opening parentheses: (
     /// * if keyword: if
-    pub fn previous(&self) -> impl Iterator<Item = Child<'a>> {
+    pub fn previous(&self) -> impl Iterator<Item = Child<'a>> + use<'a> {
         let mut slots = self.parent.slots().enumerate();
 
         // Navigate to the start slot from the back so that calling `next_back` (or rev().next()) returns

--- a/crates/biome_rowan/src/cursor/token.rs
+++ b/crates/biome_rowan/src/cursor/token.rs
@@ -126,7 +126,7 @@ impl SyntaxToken {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         std::iter::successors(self.parent(), SyntaxNode::parent)
     }
 
@@ -141,7 +141,7 @@ impl SyntaxToken {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let next = move |el: &SyntaxElement| match direction {
             Direction::Next => el.next_sibling_or_token(),
             Direction::Prev => el.prev_sibling_or_token(),

--- a/crates/biome_rowan/src/syntax/element.rs
+++ b/crates/biome_rowan/src/syntax/element.rs
@@ -63,7 +63,7 @@ impl<L: Language> SyntaxElement<L> {
         }
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/crates/biome_rowan/src/syntax/node.rs
+++ b/crates/biome_rowan/src/syntax/node.rs
@@ -261,7 +261,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.index()
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -328,24 +328,27 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.last_token().map(SyntaxToken::from)
     }
 
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.siblings(direction).map(SyntaxNode::from)
     }
 
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement<L>> {
+    ) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw
             .siblings_with_tokens(direction)
             .map(SyntaxElement::from)
     }
 
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.descendants().map(SyntaxNode::from)
     }
 
-    pub fn descendants_tokens(&self, direction: Direction) -> impl Iterator<Item = SyntaxToken<L>> {
+    pub fn descendants_tokens(
+        &self,
+        direction: Direction,
+    ) -> impl Iterator<Item = SyntaxToken<L>> + use<L> {
         self.descendants_with_tokens(direction)
             .filter_map(|x| x.as_token().cloned())
     }
@@ -353,7 +356,7 @@ impl<L: Language> SyntaxNode<L> {
     pub fn descendants_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement<L>> {
+    ) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw
             .descendants_with_tokens(direction)
             .map(NodeOrToken::from)

--- a/crates/biome_rowan/src/syntax/token.rs
+++ b/crates/biome_rowan/src/syntax/token.rs
@@ -152,7 +152,7 @@ impl<L: Language> SyntaxToken<L> {
         self.raw.parent().map(SyntaxNode::from)
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -166,7 +166,7 @@ impl<L: Language> SyntaxToken<L> {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement<L>> {
+    ) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw
             .siblings_with_tokens(direction)
             .map(SyntaxElement::from)
@@ -433,7 +433,9 @@ impl<L: Language> SyntaxToken<L> {
     }
 
     /// Return whitespace that juxtapose the token until the first non-whitespace item.
-    pub fn indentation_trivia_pieces(&self) -> impl ExactSizeIterator<Item = SyntaxTriviaPiece<L>> {
+    pub fn indentation_trivia_pieces(
+        &self,
+    ) -> impl ExactSizeIterator<Item = SyntaxTriviaPiece<L>> + use<L> {
         let leading_trivia = self.leading_trivia().pieces();
         let skip_count = leading_trivia.len()
             - leading_trivia

--- a/crates/biome_rowan/src/syntax_node_text.rs
+++ b/crates/biome_rowan/src/syntax_node_text.rs
@@ -140,11 +140,11 @@ impl SyntaxNodeText {
         }
     }
 
-    fn tokens_with_ranges(&self) -> impl FusedIterator<Item = (SyntaxToken, TextRange)> {
+    fn tokens_with_ranges(&self) -> impl FusedIterator<Item = (SyntaxToken, TextRange)> + use<> {
         SyntaxNodeTokenWithRanges::new(self)
     }
 
-    pub fn chars(&self) -> impl FusedIterator<Item = char> {
+    pub fn chars(&self) -> impl FusedIterator<Item = char> + use<> {
         SyntaxNodeTextChars::new(self)
     }
 }

--- a/xtask/codegen/src/generate_analyzer.rs
+++ b/xtask/codegen/src/generate_analyzer.rs
@@ -334,7 +334,7 @@ fn update_graphql_registry_builder(analyzers: BTreeMap<&'static str, TokenStream
 }
 
 /// Returns file paths of the given directory.
-fn list_entry_paths(dir: &Path) -> Result<impl Iterator<Item = PathBuf>> {
+fn list_entry_paths(dir: &Path) -> Result<impl Iterator<Item = PathBuf> + use<>> {
     Ok(fs2::read_dir(dir)
         .context("A directory is expected")?
         .filter_map(|entry| entry.ok())


### PR DESCRIPTION
## Summary

Part of #5196 

In Rust 2024 edition, we need to add `use<>` notation to control which lifetime is captured in RPIT's (return-position impl Trait). This pull request adds these notations based on the `impl_trait_overcaptures` lint rule, before upgrading to 2024.

ref: https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html

## Test Plan

Existing tests should pass.
