### PR TITLE
fix: add missing unsafe blocks and unsafe keyword on extern blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ unused_lifetimes                       = "warn"
 unused_macro_rules                     = "warn"
 
 # Rust 2024 upgrade
+deprecated_safe_2024       = "warn"
 missing_unsafe_on_extern   = "warn"
 unsafe_attr_outside_unsafe = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ unused_import_braces                   = "warn"
 unused_lifetimes                       = "warn"
 unused_macro_rules                     = "warn"
 
+# Rust 2024 upgrade
+missing_unsafe_on_extern   = "warn"
+unsafe_attr_outside_unsafe = "warn"
+
 [workspace.lints.clippy]
 allow_attributes        = "deny"
 cargo_common_metadata   = "allow"

--- a/crates/biome_cli/tests/commands/rage.rs
+++ b/crates/biome_cli/tests/commands/rage.rs
@@ -386,7 +386,7 @@ impl TestLogDir {
         let guard = RAGE_GUARD.lock().unwrap();
         let path = env::temp_dir().join(name);
 
-        env::set_var("BIOME_LOG_PATH", &path);
+        unsafe { env::set_var("BIOME_LOG_PATH", &path) };
 
         Self {
             path: Utf8PathBuf::from_path_buf(path).unwrap(),
@@ -398,6 +398,6 @@ impl TestLogDir {
 impl Drop for TestLogDir {
     fn drop(&mut self) {
         fs::remove_dir_all(&self.path).ok();
-        env::remove_var("BIOME_LOG_PATH");
+        unsafe { env::remove_var("BIOME_LOG_PATH") };
     }
 }

--- a/crates/biome_formatter_test/src/diff_report.rs
+++ b/crates/biome_formatter_test/src/diff_report.rs
@@ -63,13 +63,13 @@ impl DiffReport {
         static ONCE: Once = Once::new();
         ONCE.call_once(|| {
             // Import the atexit function from libc
-            extern "C" {
-                fn atexit(f: extern "C" fn()) -> c_int;
+            unsafe extern "C" {
+                fn atexit(f: unsafe extern "C" fn()) -> c_int;
             }
 
             // Trampoline function into the reporter printing logic with the
             // correct extern C ABI
-            extern "C" fn print_report() {
+            unsafe extern "C" fn print_report() {
                 REPORTER.print();
             }
 

--- a/crates/biome_js_parser/src/lexer/mod.rs
+++ b/crates/biome_js_parser/src/lexer/mod.rs
@@ -511,7 +511,7 @@ impl<'src> JsLexer<'src> {
     #[inline]
     unsafe fn current_unchecked(&self) -> u8 {
         self.assert_current_char_boundary();
-        *self.source.as_bytes().get_unchecked(self.position)
+        unsafe { *self.source.as_bytes().get_unchecked(self.position) }
     }
 
     /// Advances the position by one and returns the next byte value

--- a/crates/biome_rowan/src/arc.rs
+++ b/crates/biome_rowan/src/arc.rs
@@ -53,11 +53,14 @@ impl<T> Arc<T> {
     /// It is recommended to use OffsetArc for this
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: *const T) -> Self {
-        // To find the corresponding pointer to the `ArcInner` we need
-        // to subtract the offset of the `data` field from the pointer.
-        let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
+        let ptr = unsafe {
+            // To find the corresponding pointer to the `ArcInner` we need
+            // to subtract the offset of the `data` field from the pointer.
+            let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
+            NonNull::new_unchecked(ptr as *mut ArcInner<T>)
+        };
         Arc {
-            p: ptr::NonNull::new_unchecked(ptr as *mut ArcInner<T>),
+            p: ptr,
             phantom: PhantomData,
         }
     }
@@ -77,7 +80,7 @@ impl<T: ?Sized> Arc<T> {
     // Non-inlined part of `drop`. Just invokes the destructor.
     #[inline(never)]
     unsafe fn drop_slow(&mut self) {
-        let _ = Box::from_raw(self.ptr());
+        let _ = unsafe { Box::from_raw(self.ptr()) };
     }
 
     /// Test pointer equality between the two Arcs, i.e. they must be the _same_

--- a/crates/biome_rowan/src/green/node.rs
+++ b/crates/biome_rowan/src/green/node.rs
@@ -290,8 +290,10 @@ impl GreenNode {
 
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenNodeData>) -> GreenNode {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, Slot>>(arc);
+        let arc = unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, Slot>>(arc)
+        };
         GreenNode { ptr: arc }
     }
 }

--- a/crates/biome_rowan/src/green/node_cache.rs
+++ b/crates/biome_rowan/src/green/node_cache.rs
@@ -113,7 +113,7 @@ impl IntoRawPointer for GreenToken {
     }
 
     unsafe fn from_raw(ptr: *mut Self::Pointee) -> Self {
-        GreenToken::from_raw(NonNull::new(ptr).unwrap())
+        unsafe { GreenToken::from_raw(NonNull::new(ptr).unwrap()) }
     }
 }
 
@@ -140,7 +140,7 @@ impl IntoRawPointer for GreenNode {
     }
 
     unsafe fn from_raw(ptr: *mut Self::Pointee) -> Self {
-        GreenNode::from_raw(NonNull::new(ptr).unwrap())
+        unsafe { GreenNode::from_raw(NonNull::new(ptr).unwrap()) }
     }
 }
 
@@ -434,7 +434,7 @@ impl IntoRawPointer for GreenTrivia {
     }
 
     unsafe fn from_raw(ptr: *mut Self::Pointee) -> Self {
-        GreenTrivia::from_raw(ptr)
+        unsafe { GreenTrivia::from_raw(ptr) }
     }
 }
 

--- a/crates/biome_rowan/src/green/token.rs
+++ b/crates/biome_rowan/src/green/token.rs
@@ -179,8 +179,10 @@ impl GreenToken {
 
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenTokenData>) -> GreenToken {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc);
+        let arc = unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc)
+        };
         GreenToken { ptr: arc }
     }
 }

--- a/crates/biome_rowan/src/green/trivia.rs
+++ b/crates/biome_rowan/src/green/trivia.rs
@@ -132,12 +132,15 @@ impl GreenTrivia {
     }
 
     pub(crate) unsafe fn from_raw(ptr: *mut GreenTriviaData) -> Self {
-        if let Some(ptr) = ptr.as_ref() {
-            let arc = Arc::from_raw(&ptr.data as *const ReprThin);
-            let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenTriviaHead, TriviaPiece>>(arc);
-            Self { ptr: Some(arc) }
-        } else {
-            Self { ptr: None }
+        unsafe {
+            if let Some(ptr) = ptr.as_ref() {
+                let arc = Arc::from_raw(&ptr.data as *const ReprThin);
+                let arc =
+                    mem::transmute::<Arc<ReprThin>, ThinArc<GreenTriviaHead, TriviaPiece>>(arc);
+                Self { ptr: Some(arc) }
+            } else {
+                Self { ptr: None }
+            }
         }
     }
 }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -254,15 +254,15 @@ fn markup_to_string(markup: biome_console::Markup) -> String {
 }
 
 // Check that all red / green nodes have correctly been released on exit
-extern "C" fn check_leaks() {
+unsafe extern "C" fn check_leaks() {
     if let Some(report) = biome_rowan::check_live() {
         panic!("\n{report}")
     }
 }
 pub fn register_leak_checker() {
     // Import the atexit function from libc
-    extern "C" {
-        fn atexit(f: extern "C" fn()) -> c_int;
+    unsafe extern "C" {
+        fn atexit(f: unsafe extern "C" fn()) -> c_int;
     }
 
     // Use an atomic Once to register the check_leaks function to be called

--- a/xtask/src/glue.rs
+++ b/xtask/src/glue.rs
@@ -198,13 +198,13 @@ impl Env {
     }
     fn pushenv(&mut self, var: OsString, value: OsString) {
         self.pushenv_stack.push((var.clone(), env::var_os(&var)));
-        env::set_var(var, value)
+        unsafe { env::set_var(var, value) }
     }
     fn popenv(&mut self) {
         let (var, value) = self.pushenv_stack.pop().unwrap();
         match value {
-            None => env::remove_var(var),
-            Some(value) => env::set_var(var, value),
+            None => unsafe { env::remove_var(var) },
+            Some(value) => unsafe { env::set_var(var, value) },
         }
     }
     fn cwd(&self) -> &Path {


### PR DESCRIPTION
## Summary

Part of #5196 

This pull request adds missing `unsafe` blocks inside `unsafe` functions, and `unsafe` keyword on `extern` blocks, which is required since Rust 2024.

## Test Plan

Existing tests should pass.
