### PR TITLE
build: upgrade toolchain to Rust 1.85.0

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -610,7 +610,7 @@ where
 }
 
 fn range_match(filter: Option<TextRange>, range: TextRange) -> bool {
-    filter.map_or(true, |filter| filter.intersect(range).is_some())
+    filter.is_none_or(|filter| filter.intersect(range).is_some())
 }
 
 /// Signature for a suppression comment parser function
@@ -894,7 +894,7 @@ impl<'analysis> AnalysisFilter<'analysis> {
     /// Return `true` if the group `G` matches this filter
     pub fn match_group<G: RuleGroup>(&self) -> bool {
         self.match_category::<G::Category>()
-            && self.enabled_rules.map_or(true, |enabled_rules| {
+            && self.enabled_rules.is_none_or(|enabled_rules| {
                 enabled_rules.iter().any(|filter| filter.match_group::<G>())
             })
             && !self
@@ -906,7 +906,7 @@ impl<'analysis> AnalysisFilter<'analysis> {
     /// Return `true` if the rule `R` matches this filter
     pub fn match_rule<R: Rule>(&self) -> bool {
         self.match_category::<<R::Group as RuleGroup>::Category>()
-            && self.enabled_rules.map_or(true, |enabled_rules| {
+            && self.enabled_rules.is_none_or(|enabled_rules| {
                 enabled_rules.iter().any(|filter| filter.match_rule::<R>())
             })
             && !self

--- a/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
+++ b/crates/biome_grit_patterns/src/pattern_compiler/call_compiler.rs
@@ -183,7 +183,7 @@ pub(super) fn node_to_args_pairs(
                 let name = name
                     .strip_prefix(lang.metavariable_prefix())
                     .filter(|stripped| {
-                        expected_params.as_ref().map_or(true, |expected| {
+                        expected_params.as_ref().is_none_or(|expected| {
                             expected.iter().any(|exp| exp == &name || exp == stripped)
                         })
                     })

--- a/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_alt_text.rs
@@ -180,7 +180,7 @@ fn has_valid_alt_text(element: &AnyJsxElement) -> bool {
 
             attribute
                 .as_static_value()
-                .map_or(true, |value| !value.is_null_or_undefined())
+                .is_none_or(|value| !value.is_null_or_undefined())
         })
 }
 
@@ -191,7 +191,7 @@ fn has_valid_label(element: &AnyJsxElement, name_to_lookup: &str) -> bool {
             if attribute.initializer().is_none() {
                 return false;
             }
-            attribute.as_static_value().map_or(true, |value| {
+            attribute.as_static_value().is_none_or(|value| {
                 !value.is_null_or_undefined() && value.is_not_string_constant("")
             })
         })
@@ -201,11 +201,9 @@ fn is_aria_hidden(element: &AnyJsxElement) -> bool {
     element
         .find_attribute_by_name("aria-hidden")
         .is_some_and(|attribute| {
-            attribute
-                .as_static_value()
-                .map_or(true, |value| match value {
-                    StaticValue::Boolean(token) => token.text_trimmed() == "true",
-                    _ => false,
-                })
+            attribute.as_static_value().is_none_or(|value| match value {
+                StaticValue::Boolean(token) => token.text_trimmed() == "true",
+                _ => false,
+            })
         })
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_anchor_content.rs
@@ -167,7 +167,7 @@ fn has_valid_anchor_content(node: &AnyJsxElement) -> bool {
                 }
                 attribute
                     .as_static_value()
-                    .map_or(true, |attribute| !attribute.is_falsy())
+                    .is_none_or(|attribute| !attribute.is_falsy())
             })
         || node.has_spread_prop()
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_heading_content.rs
@@ -137,7 +137,7 @@ fn has_valid_heading_content(node: &AnyJsxElement) -> bool {
                 }
                 attribute
                     .as_static_value()
-                    .map_or(true, |attribute| !attribute.is_falsy())
+                    .is_none_or(|attribute| !attribute.is_falsy())
             })
         || node.has_spread_prop()
 }

--- a/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_html_lang.rs
@@ -79,7 +79,7 @@ impl Rule for UseHtmlLang {
             if let Some(lang_attribute) = element.find_attribute_by_name("lang") {
                 if !lang_attribute
                     .as_static_value()
-                    .map_or(true, |attribute| attribute.is_not_string_constant(""))
+                    .is_none_or(|attribute| attribute.is_not_string_constant(""))
                     && !element.has_trailing_spread_prop(&lang_attribute)
                 {
                     return Some(element.syntax().text_trimmed_range());

--- a/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_iframe_title.rs
@@ -85,7 +85,7 @@ impl Rule for UseIframeTitle {
             if let Some(lang_attribute) = element.find_attribute_by_name("title") {
                 if !lang_attribute
                     .as_static_value()
-                    .map_or(true, |attribute| attribute.is_not_string_constant(""))
+                    .is_none_or(|attribute| attribute.is_not_string_constant(""))
                     && !element.has_trailing_spread_prop(&lang_attribute)
                 {
                     return Some(());

--- a/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_valid_anchor.rs
@@ -162,7 +162,7 @@ impl Rule for UseValidAnchor {
                     }
 
                     let static_value = anchor_attribute.as_static_value()?;
-                    if static_value.as_string_constant().map_or(true, |const_str| {
+                    if static_value.as_string_constant().is_none_or(|const_str| {
                         const_str.is_empty()
                             || const_str.contains('#')
                             || const_str.contains("javascript:")
@@ -176,7 +176,7 @@ impl Rule for UseValidAnchor {
                     }
 
                     let static_value = anchor_attribute.as_static_value()?;
-                    if static_value.as_string_constant().map_or(true, |const_str| {
+                    if static_value.as_string_constant().is_none_or(|const_str| {
                         const_str.is_empty()
                             || const_str == "#"
                             || const_str.contains("javascript:")

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -516,7 +516,7 @@ fn capture_needs_to_be_in_the_dependency_list(
             // ... they are declared outside of the component function
             if component_function_range
                 .intersect(declaration_range)
-                .map_or(true, TextRange::is_empty)
+                .is_none_or(TextRange::is_empty)
             {
                 return false;
             }
@@ -552,7 +552,7 @@ fn capture_needs_to_be_in_the_dependency_list(
             // ... they are declared outside of the component function
             if component_function_range
                 .intersect(declaration_range)
-                .map_or(true, TextRange::is_empty)
+                .is_none_or(TextRange::is_empty)
             {
                 return false;
             }
@@ -562,7 +562,7 @@ fn capture_needs_to_be_in_the_dependency_list(
                 if declarator
                     .initializer()
                     .and_then(|initializer| initializer.expression().ok())
-                    .map_or(true, |expr| model.is_constant(&expr))
+                    .is_none_or(|expr| model.is_constant(&expr))
                 {
                     return false;
                 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_constant_binary_expression.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_constant_binary_expression.rs
@@ -599,5 +599,5 @@ fn is_undefined(model: &SemanticModel, node: &JsIdentifierExpression) -> SyntaxR
 /// Check the referenced variable is in the global scope.
 fn is_global_reference(model: &SemanticModel, node: &JsReferenceIdentifier) -> bool {
     node.binding(model)
-        .map_or(true, |b| b.scope().is_global_scope())
+        .is_none_or(|b| b.scope().is_global_scope())
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
@@ -114,7 +114,7 @@ impl Rule for NoStaticElementInteractions {
                     if let Some(value) = node.find_attribute_by_name(handler) {
                         value
                             .as_static_value()
-                            .map_or(true, |value| value.text() != "null")
+                            .is_none_or(|value| value.text() != "null")
                     } else {
                         false
                     }
@@ -153,7 +153,7 @@ fn is_hidden_from_screen_reader(node: &AnyJsxElement, element_name: &str) -> boo
     node.find_attribute_by_name("aria-hidden")
         .is_some_and(|attr| {
             attr.as_static_value()
-                .map_or(true, |val| val.text() == "true")
+                .is_none_or(|val| val.text() == "true")
         })// <div aria-hidden />
         || (element_name == "input"
             && node.find_attribute_by_name("type").is_some_and(|attr| {

--- a/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_self_closing_elements.rs
@@ -151,7 +151,7 @@ impl Rule for UseSelfClosingElements {
         let prev_token = r_angle_token.prev_token();
         let need_extra_whitespace = prev_token
             .as_ref()
-            .map_or(true, |token| !token.trailing_trivia().text().ends_with(' '));
+            .is_none_or(|token| !token.trailing_trivia().text().ends_with(' '));
 
         // drop the leading trivia of `r_angle_token`
         r_angle_token = r_angle_token.with_leading_trivia([]);

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -212,7 +212,7 @@ fn is_global_object(semantic: &SemanticModel) -> bool {
     semantic
         .scopes()
         .find(|s| s.get_binding("Object").is_some())
-        .map_or(true, |s| s.is_global_scope())
+        .is_none_or(|s| s.is_global_scope())
 }
 
 /// Checks if the given node is considered to be an access to a property of `Object.prototype`.

--- a/crates/biome_js_formatter/src/comments.rs
+++ b/crates/biome_js_formatter/src/comments.rs
@@ -1350,7 +1350,7 @@ fn handle_import_named_clause_comments(
                     // ```
                     let is_after_from_keyword = comment
                         .following_token()
-                        .map_or(true, |token| token.kind() != JsSyntaxKind::FROM_KW);
+                        .is_none_or(|token| token.kind() != JsSyntaxKind::FROM_KW);
                     if is_after_from_keyword {
                         if let Some(following_node) = comment.following_node() {
                             return CommentPlacement::leading(following_node.clone(), comment);

--- a/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
+++ b/crates/biome_js_formatter/src/js/expressions/call_arguments.rs
@@ -1073,29 +1073,28 @@ fn can_group_expression_argument(
             //     (type: ObjectType): Provider<Opts> => {}
             //   );
             // }
-            let can_group_type =
-                return_type_annotation
-                    .and_then(|rty| rty.ty().ok())
-                    .map_or(true, |any_type| match any_type {
-                        AnyTsReturnType::AnyTsType(AnyTsType::TsReferenceType(_)) => match &body {
-                            AnyJsFunctionBody::JsFunctionBody(body) => {
-                                body.statements().iter().any(|statement| match statement {
-                                    AnyJsStatement::JsEmptyStatement(s) => {
-                                        // When the body contains an empty statement, comments in
-                                        // the body will get attached to that statement rather than
-                                        // the body itself, so they need to be checked for comments
-                                        // as well to ensure that the body is still considered
-                                        // groupable when those empty statements are removed by the
-                                        // printer.
-                                        comments.has_comments(s.syntax())
-                                    }
-                                    _ => true,
-                                }) || comments.has_dangling_comments(body.syntax())
-                            }
-                            _ => false,
-                        },
-                        _ => true,
-                    });
+            let can_group_type = return_type_annotation
+                .and_then(|rty| rty.ty().ok())
+                .is_none_or(|any_type| match any_type {
+                    AnyTsReturnType::AnyTsType(AnyTsType::TsReferenceType(_)) => match &body {
+                        AnyJsFunctionBody::JsFunctionBody(body) => {
+                            body.statements().iter().any(|statement| match statement {
+                                AnyJsStatement::JsEmptyStatement(s) => {
+                                    // When the body contains an empty statement, comments in
+                                    // the body will get attached to that statement rather than
+                                    // the body itself, so they need to be checked for comments
+                                    // as well to ensure that the body is still considered
+                                    // groupable when those empty statements are removed by the
+                                    // printer.
+                                    comments.has_comments(s.syntax())
+                                }
+                                _ => true,
+                            }) || comments.has_dangling_comments(body.syntax())
+                        }
+                        _ => false,
+                    },
+                    _ => true,
+                });
 
             let can_group_body = match &body {
                 AnyJsFunctionBody::JsFunctionBody(_)

--- a/crates/biome_js_formatter/src/utils/conditional.rs
+++ b/crates/biome_js_formatter/src/utils/conditional.rs
@@ -407,30 +407,27 @@ impl FormatJsAnyConditionalRule {
                 let argument = match parent.kind() {
                     JsSyntaxKind::JS_INITIALIZER_CLAUSE => {
                         let initializer = JsInitializerClause::unwrap_cast(parent);
-                        initializer.expression().ok().map(AnyJsExpression::from)
+                        initializer.expression().ok()
                     }
                     JsSyntaxKind::JS_RETURN_STATEMENT => {
                         let return_statement = JsReturnStatement::unwrap_cast(parent);
-                        return_statement.argument().map(AnyJsExpression::from)
+                        return_statement.argument()
                     }
                     JsSyntaxKind::JS_THROW_STATEMENT => {
                         let throw_statement = JsThrowStatement::unwrap_cast(parent);
-                        throw_statement.argument().ok().map(AnyJsExpression::from)
+                        throw_statement.argument().ok()
                     }
                     JsSyntaxKind::JS_UNARY_EXPRESSION => {
                         let unary_expression = JsUnaryExpression::unwrap_cast(parent);
-                        unary_expression.argument().ok().map(AnyJsExpression::from)
+                        unary_expression.argument().ok()
                     }
                     JsSyntaxKind::JS_YIELD_ARGUMENT => {
                         let yield_argument = JsYieldArgument::unwrap_cast(parent);
-                        yield_argument.expression().ok().map(AnyJsExpression::from)
+                        yield_argument.expression().ok()
                     }
                     JsSyntaxKind::JS_ASSIGNMENT_EXPRESSION => {
                         let assignment_expression = JsAssignmentExpression::unwrap_cast(parent);
-                        assignment_expression
-                            .right()
-                            .ok()
-                            .map(AnyJsExpression::from)
+                        assignment_expression.right().ok()
                     }
                     _ => None,
                 };

--- a/crates/biome_js_syntax/src/jsx_ext.rs
+++ b/crates/biome_js_syntax/src/jsx_ext.rs
@@ -479,7 +479,7 @@ impl AnyJsxElement {
             .is_some_and(|attribute| {
                 attribute
                     .as_static_value()
-                    .map_or(true, |value| !(value.is_falsy() || value.text() == "false"))
+                    .is_none_or(|value| !(value.is_falsy() || value.text() == "false"))
                     && !self.has_trailing_spread_prop(&attribute)
             })
     }
@@ -590,7 +590,7 @@ impl AnyJsxChild {
                 let expression = expression.expression()?;
                 expression
                     .as_static_value()
-                    .map_or(true, |value| !value.is_falsy())
+                    .is_none_or(|value| !value.is_falsy())
             }
             AnyJsxChild::JsxElement(element) => {
                 let opening_element = element.opening_element().ok()?;

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1110,7 +1110,7 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
     }
 
     fn finish(mut self) -> (FxHashSet<RuleFilter<'a>>, FxHashSet<RuleFilter<'a>>) {
-        let has_only_filter = self.only.map_or(true, |only| !only.is_empty());
+        let has_only_filter = self.only.is_none_or(|only| !only.is_empty());
         let rules = self
             .settings
             .and_then(|settings| settings.as_linter_rules(self.path.expect("Path to be set")))
@@ -1310,7 +1310,7 @@ impl<'a, 'b> AssistsVisitor<'a, 'b> {
     }
 
     fn finish(mut self) -> (Vec<RuleFilter<'a>>, Vec<RuleFilter<'a>>) {
-        let has_only_filter = self.only.map_or(true, |only| !only.is_empty());
+        let has_only_filter = self.only.is_none_or(|only| !only.is_empty());
         let rules = self
             .settings
             .and_then(|settings| settings.as_assist_actions(self.path.expect("Path to be set")))

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -284,7 +284,7 @@ impl From<OverrideFormatterConfiguration> for OverrideFormatSettings {
         Self {
             enabled: conf.enabled,
             format_with_errors: conf.format_with_errors,
-            indent_style: conf.indent_style.map(Into::into),
+            indent_style: conf.indent_style,
             indent_width: conf.indent_width,
             line_ending: conf.line_ending,
             line_width: conf.line_width,
@@ -1624,7 +1624,7 @@ impl TryFrom<OverrideFormatterConfiguration> for FormatSettings {
             Some(IndentStyle::Space) => IndentStyle::Space,
             None => IndentStyle::default(),
         };
-        let indent_width = conf.indent_width.map(Into::into).unwrap_or_default();
+        let indent_width = conf.indent_width.unwrap_or_default();
 
         Ok(Self {
             enabled: conf.enabled,

--- a/crates/biome_string_case/src/lib.rs
+++ b/crates/biome_string_case/src/lib.rs
@@ -35,23 +35,23 @@ pub enum Case {
     /// ASCII numbers
     Number = 1 << 0,
     /// Alphanumeric Characters that cannot be in lowercase or uppercase (numbers and syllabary)
-    Uni = Case::Number as u16 | 1 << 1,
+    Uni = Case::Number as u16 | (1 << 1),
     /// A, B1, C42
     NumberableCapital = 1 << 2,
     /// UPPERCASE
-    Upper = Case::NumberableCapital as u16 | 1 << 3,
+    Upper = Case::NumberableCapital as u16 | (1 << 3),
     // CONSTANT_CASE
-    Constant = Case::Upper as u16 | 1 << 4,
+    Constant = Case::Upper as u16 | (1 << 4),
     /// PascalCase
-    Pascal = Case::NumberableCapital as u16 | 1 << 5,
+    Pascal = Case::NumberableCapital as u16 | (1 << 5),
     /// lowercase
-    Lower = Case::Number as u16 | 1 << 6,
+    Lower = Case::Number as u16 | (1 << 6),
     /// snake_case
-    Snake = Case::Lower as u16 | 1 << 7,
+    Snake = Case::Lower as u16 | (1 << 7),
     /// kebab-case
-    Kebab = Case::Lower as u16 | 1 << 8,
+    Kebab = Case::Lower as u16 | (1 << 8),
     // camelCase
-    Camel = Case::Lower as u16 | 1 << 9,
+    Camel = Case::Lower as u16 | (1 << 9),
     /// Unknown case
     #[default]
     Unknown = Case::Camel as u16
@@ -60,7 +60,7 @@ pub enum Case {
         | Case::Pascal as u16
         | Case::Constant as u16
         | Case::Uni as u16
-        | 1 << 10,
+        | (1 << 10),
 }
 
 impl Case {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.84.0"
+channel = "1.85.0"

--- a/xtask/coverage/src/js/test262.rs
+++ b/xtask/coverage/src/js/test262.rs
@@ -196,7 +196,7 @@ impl TestSuite for Test262TestSuite {
         if !meta
             .negative
             .as_ref()
-            .map_or(true, |negative| negative.phase == Phase::Parse)
+            .is_none_or(|negative| negative.phase == Phase::Parse)
         {
             None
         } else {


### PR DESCRIPTION
## Summary

Part of #5196 

Rust 2024 is supported since Rust 1.85.0, so we need to upgrade the toolchain first.

## Test Plan

Existing tests should pass.
