### PR TITLE
refactor(formatter): preserve useless escapes

### DIFF
--- a/.changeset/preserve-useless-escapes.md
+++ b/.changeset/preserve-useless-escapes.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": major
+---
+
+[Prettier 3.4](https://prettier.io/blog/2024/11/26/3.4.0.html) introduced a change in their normalization process of string literals: it no longer unescapes useless escape sequences.
+Biome now matches the new behavior of Prettier when formatting code.
+This affects the JSON and JavaScript formatters.

--- a/crates/biome_formatter/src/token/string.rs
+++ b/crates/biome_formatter/src/token/string.rs
@@ -88,7 +88,7 @@ pub fn normalize_string(
                             false
                         }
                         0xE2 => {
-                            // Prserve escaping of Unicode characters U+2028 and U+2029
+                            // Preserve escaping of Unicode characters U+2028 and U+2029
                             !(matches!(bytes.next(), Some((_, 0x80)))
                                 && matches!(bytes.next(), Some((_, 0xA8 | 0xA9))))
                         }
@@ -98,7 +98,7 @@ pub fn normalize_string(
                             // So we ignore the current slash and we continue
                             // to the next iteration
                             //
-                            // We always unescape alternate quots regardless of `is_escape_preserved`.
+                            // We always unescape alternate quotes regardless of `is_escape_preserved`.
                             escaped == alternate_quote
                                 || (escaped != preferred_quote && !is_escape_preserved)
                         }

--- a/crates/biome_js_formatter/src/utils/string_utils.rs
+++ b/crates/biome_js_formatter/src/utils/string_utils.rs
@@ -319,7 +319,11 @@ impl<'token> LiteralStringNormaliser<'token> {
 
     fn normalise_string_literal(&self, string_information: StringInformation) -> Cow<'token, str> {
         let preferred_quote = string_information.preferred_quote;
-        let polished_raw_content = self.normalize_string(&string_information);
+        let polished_raw_content = normalize_string(
+            self.raw_content(),
+            string_information.preferred_quote.into(),
+            true,
+        );
 
         match polished_raw_content {
             Cow::Borrowed(raw_content) => self.swap_quotes(raw_content, &string_information),
@@ -331,15 +335,6 @@ impl<'token> LiteralStringNormaliser<'token> {
                 Cow::Owned(s)
             }
         }
-    }
-
-    fn normalize_string(&self, string_information: &StringInformation) -> Cow<'token, str> {
-        let is_escape_preserved = self.token.token.kind() == JSX_STRING_LITERAL;
-        normalize_string(
-            self.raw_content(),
-            string_information.preferred_quote.into(),
-            is_escape_preserved,
-        )
     }
 
     /// Returns the string without its quotes.

--- a/crates/biome_js_formatter/tests/specs/prettier/js/quote-props/objects.js.prettier-snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/quote-props/objects.js.prettier-snap
@@ -97,6 +97,6 @@ Object.entries({
 };
 
 a = {
-  a: 1,
+  "\a": 1,
   b: 2,
 };

--- a/crates/biome_js_formatter/tests/specs/prettier/js/quotes/strings.js.prettier-snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/quotes/strings.js.prettier-snap
@@ -35,20 +35,20 @@
 // Unnecessary escapes.
 ("'");
 ('"');
-("a");
-("a");
-("hola");
-("hola");
+("\a");
+("\a");
+("hol\a");
+("hol\a");
 ("hol\\a (the a is not escaped)");
 ("hol\\a (the a is not escaped)");
-("multiple a unnecessary a escapes");
-("multiple a unnecessary a escapes");
-("unnecessarily escaped character preceded by escaped backslash \\a");
-("unnecessarily escaped character preceded by escaped backslash \\a");
+("multiple \a unnecessary \a escapes");
+("multiple \a unnecessary \a escapes");
+("unnecessarily escaped character preceded by escaped backslash \\\a");
+("unnecessarily escaped character preceded by escaped backslash \\\a");
 ("unescaped character preceded by two escaped backslashes       \\\\a");
 ("unescaped character preceded by two escaped backslashes       \\\\a");
-("aa"); // consecutive unnecessarily escaped characters
-("aa"); // consecutive unnecessarily escaped characters
+("\a\a"); // consecutive unnecessarily escaped characters
+("\a\a"); // consecutive unnecessarily escaped characters
 ("escaped \u2030 ‰ (should not stay escaped)");
 
 // Meaningful escapes

--- a/crates/biome_js_formatter/tests/specs/prettier/js/strings/non-octal-eight-and-nine.js.prettier-snap
+++ b/crates/biome_js_formatter/tests/specs/prettier/js/strings/non-octal-eight-and-nine.js.prettier-snap
@@ -1,7 +1,7 @@
 // https://github.com/babel/babel/pull/11852
 
-"8", "9";
+"\8", "\9";
 () => {
   "use strict";
-  "8", "9";
+  "\8", "\9";
 };

--- a/crates/biome_json_formatter/src/format_string.rs
+++ b/crates/biome_json_formatter/src/format_string.rs
@@ -16,7 +16,7 @@ impl Format<JsonFormatContext> for CleanedStringLiteralText<'_> {
         let content = self.token.text_trimmed();
         let raw_content = &content[1..content.len() - 1];
 
-        let text = match normalize_string(raw_content, Quote::Double, false) {
+        let text = match normalize_string(raw_content, Quote::Double, true) {
             Cow::Borrowed(_) => Cow::Borrowed(content),
             Cow::Owned(raw_content) => Cow::Owned(std::format!(
                 "{}{}{}",

--- a/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/object/string.json.snap
@@ -34,14 +34,14 @@ Object wrap: Preserve
 
 ```json
 {
-	"/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
-	"/ & /": "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
-	"slash": "/ & /"
+	"\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
+	"/ & \/": "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
+	"slash": "/ & \/"
 }
 ```
 
 # Lines exceeding max width of 80 characters
 ```
-    2: 	"/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
-    3: 	"/ & /": "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
+    2: 	"\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string",
+    3: 	"/ & \/": "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?",
 ```

--- a/crates/biome_json_formatter/tests/specs/prettier/json/json/pass1.json.prettier-snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/json/pass1.json.prettier-snap
@@ -19,7 +19,7 @@
     "quote": "\"",
     "backslash": "\\",
     "controls": "\b\f\n\r\t",
-    "slash": "/ & /",
+    "slash": "/ & \/",
     "alpha": "abcdefghijklmnopqrstuvwyz",
     "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
     "digit": "0123456789",
@@ -43,7 +43,7 @@
     "compact": [1, 2, 3, 4, 5, 6, 7],
     "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
     "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
-    "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
   },
   0.5,
   98.6,

--- a/crates/biome_json_formatter/tests/specs/prettier/json/json/pass1.json.snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/json/pass1.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/json/pass1.json
 ---
-
 # Input
 
 ```json
@@ -107,7 +106,7 @@ info: json/json/pass1.json
     "quote": "\"",
     "backslash": "\\",
     "controls": "\b\f\n\r\t",
-    "slash": "/ & /",
+    "slash": "/ & \/",
     "alpha": "abcdefghijklmnopqrstuvwyz",
     "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
     "digit": "0123456789",
@@ -131,7 +130,7 @@ info: json/json/pass1.json
     "compact": [1, 2, 3, 4, 5, 6, 7],
     "jsontext": "{\"object with 1 member\":[\"array with 1 element\"]}",
     "quotes": "&#34; \u0022 %22 0x22 034 &#x22;",
-    "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+    "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
   },
   0.5,
   98.6,
@@ -150,7 +149,5 @@ info: json/json/pass1.json
 
 # Lines exceeding max width of 80 characters
 ```
-   46:     "/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+   46:     "\/\\\"\uCAFE\uBABE\uAB98\uFCDE\ubcda\uef4A\b\f\n\r\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
 ```
-
-


### PR DESCRIPTION
## Summary

Part of https://github.com/biomejs/biome/issues/1090
This PR ensures that our formatter matches the behavior of Prettier 3.4+ by preserving useless escape sequences.

## Test Plan

I updated the corresponding Prettier snapshots.