### PR TITLE
feat(lsp)!: remove `--config-path` from lsp-proxy and daemon

### DIFF
--- a/.changeset/chubby-cameras-argue.md
+++ b/.changeset/chubby-cameras-argue.md
@@ -3,8 +3,11 @@
 ---
 
 Removed `--config-path` argument from `biome lsp-proxy` and `biome start` commands.
+The option was overriding the configuration path for all workspaces opened in the Biome daemon, which led configuration
+mismatch problem when multiple projects are opened in some editors or IDEs.
 
-If you are using one of our official plugins for IDEs or editors, just update it to the latest version.
+If you are using one of our official plugins for IDEs or editors, it is recommended to update it to the latest version
+of the plugin, or you will get unexpected behavior.
 
 If you are a developer of a plugin, please update your plugin to use `workspace/configuration` response instead of
 using `--config-path` argument. Biome's LSP will resolve a configuration in the workspace automatically, so it is

--- a/.changeset/chubby-cameras-argue.md
+++ b/.changeset/chubby-cameras-argue.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": major
+---
+
+Removed `--config-path` argument from `biome lsp-proxy` and `biome start` commands.
+
+If you are using one of our official plugins for IDEs or editors, just update it to the latest version.
+
+If you are a developer of a plugin, please update your plugin to use `workspace/configuration` response instead of
+using `--config-path` argument. Biome's LSP will resolve a configuration in the workspace automatically, so it is
+recommended to keep it empty unless you are using a custom configuration path.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -96,10 +96,6 @@ pub enum BiomeCommand {
             fallback(biome_fs::ensure_cache_dir().join("biome-logs")),
         )]
         log_path: Utf8PathBuf,
-        /// Allows to set a custom file path to the configuration file,
-        /// or a custom directory path to find `biome.json` or `biome.jsonc`
-        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
-        config_path: Option<Utf8PathBuf>,
     },
 
     /// Stops the Biome daemon server process.
@@ -379,10 +375,6 @@ pub enum BiomeCommand {
             fallback(biome_fs::ensure_cache_dir().join("biome-logs")),
         )]
         log_path: Utf8PathBuf,
-        /// Allows to set a custom file path to the configuration file,
-        /// or a custom directory path to find `biome.json` or `biome.jsonc`
-        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
-        config_path: Option<Utf8PathBuf>,
         /// Bogus argument to make the command work with vscode-languageclient
         #[bpaf(long("stdio"), hide, hide_usage, switch)]
         stdio: bool,
@@ -507,10 +499,6 @@ pub enum BiomeCommand {
 
         #[bpaf(long("stop-on-disconnect"), hide_usage)]
         stop_on_disconnect: bool,
-        /// Allows to set a custom file path to the configuration file,
-        /// or a custom directory path to find `biome.json` or `biome.jsonc`
-        #[bpaf(env("BIOME_CONFIG_PATH"), long("config-path"), argument("PATH"))]
-        config_path: Option<Utf8PathBuf>,
     },
     #[bpaf(command("__print_socket"), hide)]
     PrintSocket,

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -66,10 +66,9 @@ impl<'app> CliSession<'app> {
             }
             BiomeCommand::Clean => commands::clean::clean(self),
             BiomeCommand::Start {
-                config_path,
                 log_path,
                 log_prefix_name,
-            } => commands::daemon::start(self, config_path, Some(log_path), Some(log_prefix_name)),
+            } => commands::daemon::start(self, Some(log_path), Some(log_prefix_name)),
             BiomeCommand::Stop => commands::daemon::stop(self),
             BiomeCommand::Check {
                 write,
@@ -210,11 +209,10 @@ impl<'app> CliSession<'app> {
             BiomeCommand::Explain { doc } => commands::explain::explain(self, doc),
             BiomeCommand::Init(emit_jsonc) => commands::init::init(self, emit_jsonc),
             BiomeCommand::LspProxy {
-                config_path,
                 log_path,
                 log_prefix_name,
                 ..
-            } => commands::daemon::lsp_proxy(config_path, Some(log_path), Some(log_prefix_name)),
+            } => commands::daemon::lsp_proxy(Some(log_path), Some(log_prefix_name)),
             BiomeCommand::Migrate {
                 cli_options,
                 write,
@@ -253,12 +251,10 @@ impl<'app> CliSession<'app> {
             ),
             BiomeCommand::RunServer {
                 stop_on_disconnect,
-                config_path,
                 log_path,
                 log_prefix_name,
             } => commands::daemon::run_server(
                 stop_on_disconnect,
-                config_path,
                 Some(log_path),
                 Some(log_prefix_name),
             ),

--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -219,10 +219,7 @@ pub(crate) async fn print_socket() -> io::Result<()> {
 
 /// Start listening on the global pipe and accepting connections with the
 /// provided [ServerFactory]
-pub(crate) async fn run_daemon(
-    factory: ServerFactory,
-    config_path: Option<Utf8PathBuf>,
-) -> io::Result<Infallible> {
+pub(crate) async fn run_daemon(factory: ServerFactory) -> io::Result<Infallible> {
     let mut prev_server = ServerOptions::new()
         .first_pipe_instance(true)
         .create(get_pipe_name())?;
@@ -232,7 +229,7 @@ pub(crate) async fn run_daemon(
         let mut next_server = ServerOptions::new().create(get_pipe_name())?;
         swap(&mut prev_server, &mut next_server);
 
-        let connection = factory.create(config_path.clone());
+        let connection = factory.create();
         let span = tracing::trace_span!("run_server");
         tokio::spawn(run_server(connection, next_server).instrument(span.or_current()));
     }

--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -68,7 +68,6 @@ const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 /// Spawn the daemon server process in the background
 fn spawn_daemon(
     stop_on_disconnect: bool,
-    config_path: Option<Utf8PathBuf>,
     log_path: Option<Utf8PathBuf>,
     log_file_name_prefix: Option<String>,
 ) -> io::Result<()> {
@@ -81,9 +80,6 @@ fn spawn_daemon(
         cmd.arg("--stop-on-disconnect");
     }
 
-    if let Some(config_path) = config_path {
-        cmd.arg(format!("--config-path={}", config_path.as_str()));
-    }
     if let Some(log_path) = log_path {
         cmd.arg(format!("--log-path={}", log_path.as_str()));
     }
@@ -183,7 +179,6 @@ impl AsyncWrite for ClientWriteHalf {
 /// to be started
 pub(crate) async fn ensure_daemon(
     stop_on_disconnect: bool,
-    config_path: Option<Utf8PathBuf>,
     log_path: Option<Utf8PathBuf>,
     log_file_name_prefix: Option<String>,
 ) -> io::Result<bool> {
@@ -195,7 +190,6 @@ pub(crate) async fn ensure_daemon(
             Ok(None) => {
                 spawn_daemon(
                     stop_on_disconnect,
-                    config_path.clone(),
                     log_path.clone(),
                     log_file_name_prefix.clone(),
                 )?;
@@ -212,7 +206,7 @@ pub(crate) async fn ensure_daemon(
 /// Ensure the server daemon is running and ready to receive connections and
 /// print the global pipe name in the standard output
 pub(crate) async fn print_socket() -> io::Result<()> {
-    ensure_daemon(true, None, None, None).await?;
+    ensure_daemon(true, None, None).await?;
     println!("{}", get_pipe_name());
     Ok(())
 }

--- a/crates/biome_cli/tests/main.rs
+++ b/crates/biome_cli/tests/main.rs
@@ -360,7 +360,7 @@ pub(crate) fn run_cli_with_dyn_fs(
     };
 
     let factory = ServerFactory::new_with_fs(Box::new(OsFileSystem::default()));
-    let connection = factory.create(None);
+    let connection = factory.create();
 
     let runtime = Runtime::new().expect("failed to create runtime");
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lsp_proxy/lsp_proxy_help.snap
@@ -1,23 +1,20 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Emitted Messages
 
 ```block
 Acts as a server for the Language Server Protocol over stdin/stdout.
 
-Usage: lsp-proxy [--config-path=PATH]
+Usage: lsp-proxy 
 
 Available options:
         --log-prefix-name=STRING  Allows to change the prefix applied to the file name of the logs.
-                            [env:BIOME_LOG_PREFIX_NAME: N/A]
-                            [default: server.log]
-        --log-path=PATH     Allows to change the folder where logs are stored.
-                            [env:BIOME_LOG_PATH: N/A]
-        --config-path=PATH  Allows to set a custom file path to the configuration file, or a custom
-                            directory path to find `biome.json` or `biome.jsonc`
-                            [env:BIOME_CONFIG_PATH: N/A]
-    -h, --help              Prints help information
+                         [env:BIOME_LOG_PREFIX_NAME: N/A]
+                         [default: server.log]
+        --log-path=PATH  Allows to change the folder where logs are stored.
+                         [env:BIOME_LOG_PATH: N/A]
+    -h, --help           Prints help information
 
 ```

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -13,7 +13,6 @@ use biome_service::workspace::{
     CloseProjectParams, OpenProjectParams, RageEntry, RageParams, RageResult,
 };
 use biome_service::{WatcherInstruction, WorkspaceServer};
-use camino::Utf8PathBuf;
 use crossbeam::channel::{Sender, bounded};
 use futures::FutureExt;
 use futures::future::ready;
@@ -592,17 +591,13 @@ impl ServerFactory {
     }
 
     /// Creates a new [ServerConnection] from this factory.
-    pub fn create(&self, config_path: Option<Utf8PathBuf>) -> ServerConnection {
+    pub fn create(&self) -> ServerConnection {
         let workspace = self.workspace.clone();
 
         let session_key = SessionKey(self.next_session_key.fetch_add(1, Ordering::Relaxed));
 
         let mut builder = LspService::build(move |client| {
-            let mut session =
-                Session::new(session_key, client, workspace, self.cancellation.clone());
-            if let Some(path) = config_path {
-                session.set_config_path(path);
-            }
+            let session = Session::new(session_key, client, workspace, self.cancellation.clone());
             let handle = Arc::new(session);
 
             let mut sessions = self.sessions.lock().unwrap();

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -396,7 +396,7 @@ where
 #[tokio::test]
 async fn basic_lifecycle() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -506,7 +506,7 @@ const EXPECTED_CST: &str = "0: JS_MODULE@0..57
 #[tokio::test]
 async fn document_lifecycle() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -566,7 +566,7 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
 
     // First connection:
     {
-        let (service, client) = factory.create(None).into_inner();
+        let (service, client) = factory.create().into_inner();
         let (stream, sink) = client.split();
         let mut server = Server::new(service);
 
@@ -618,7 +618,7 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
 
     // Second connection, the document will still be there:
     {
-        let (service, client) = factory.create(None).into_inner();
+        let (service, client) = factory.create().into_inner();
         let (stream, sink) = client.split();
         let mut server = Server::new(service);
 
@@ -666,7 +666,7 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
 #[tokio::test]
 async fn document_no_extension() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -737,7 +737,7 @@ async fn document_no_extension() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -819,7 +819,7 @@ async fn pull_diagnostics() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -881,7 +881,7 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics_from_new_file() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -963,7 +963,7 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
 #[tokio::test]
 async fn pull_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1142,7 +1142,7 @@ async fn pull_quick_fixes() -> Result<()> {
 #[tokio::test]
 async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1224,7 +1224,7 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
 #[tokio::test]
 async fn pull_biome_quick_fixes() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1320,7 +1320,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 #[tokio::test]
 async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1520,7 +1520,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 #[tokio::test]
 async fn pull_diagnostics_for_rome_json() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1602,7 +1602,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
     );
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
 
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
@@ -1673,7 +1673,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
 #[tokio::test]
 async fn no_code_actions_for_ignored_json_files() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1757,7 +1757,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
 #[tokio::test]
 async fn pull_code_actions_with_import_sorting() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -1970,7 +1970,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
     );
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2045,7 +2045,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
 #[tokio::test]
 async fn pull_refactors() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2155,7 +2155,7 @@ async fn pull_refactors() -> Result<()> {
 #[tokio::test]
 async fn pull_fix_all() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2258,7 +2258,7 @@ async fn pull_fix_all() -> Result<()> {
 #[tokio::test]
 async fn change_document_remove_line() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2343,7 +2343,7 @@ isSpreadAssignment;
 #[tokio::test]
 async fn format_with_syntax_errors() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2392,7 +2392,7 @@ async fn format_with_syntax_errors() -> Result<()> {
 #[tokio::test]
 async fn format_jsx_in_javascript_file() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2470,7 +2470,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
     );
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2528,7 +2528,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
 #[ignore = "Find a way to retrieve the last notification sent"]
 async fn pull_diagnostics_from_manifest() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2633,7 +2633,7 @@ async fn pull_diagnostics_from_manifest() -> Result<()> {
 #[tokio::test]
 async fn server_shutdown() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2658,7 +2658,7 @@ async fn server_shutdown() -> Result<()> {
 #[tokio::test]
 async fn multiple_projects() -> Result<()> {
     let factory = ServerFactory::default();
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2794,7 +2794,7 @@ async fn pull_source_assist_action() -> Result<()> {
     );
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -2999,7 +2999,7 @@ export function bar() {
         watcher.run(workspace.as_ref());
     });
 
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
@@ -3210,7 +3210,7 @@ export function bar() {
         watcher.run(workspace.as_ref());
     });
 
-    let (service, client) = factory.create(None).into_inner();
+    let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 


### PR DESCRIPTION
Part of #5089 

## Summary

This pull request removes `--config-path` option from `biome lsp-proxy` and `biome start` commands.

## Test Plan

Snapshots updated.