### PR TITLE
refactor: better handling for the lifetime extension issue

### DIFF
--- a/crates/biome_formatter/src/builders.rs
+++ b/crates/biome_formatter/src/builders.rs
@@ -2642,9 +2642,15 @@ impl<'a, Context> BestFitting<'a, Context> {
     ///
     /// You're looking for a way to create a `BestFitting` object, use the `best_fitting![least_expanded, most_expanded]` macro.
     ///
+    /// This is intended to be only used in the `best_fitting!` macro. As we can't place tail
+    /// expressions in a block for temporary lifetime extension since Rust 2024, we can't use an
+    /// `unsafe` block in the macro. Thus, this function can't be marked as unsafe, but it shouldn't
+    /// be used from outside.
+    ///
     /// ## Safety
     /// The slice must contain at least two variants.
-    pub unsafe fn from_arguments_unchecked(variants: Arguments<'a, Context>) -> Self {
+    #[doc(hidden)]
+    pub fn from_arguments_unchecked(variants: Arguments<'a, Context>) -> Self {
         assert!(
             variants.0.len() >= 2,
             "Requires at least the least expanded and most expanded variants"

--- a/crates/biome_formatter/src/macros.rs
+++ b/crates/biome_formatter/src/macros.rs
@@ -329,21 +329,8 @@ macro_rules! format {
 #[macro_export]
 macro_rules! best_fitting {
     ($least_expanded:expr, $($tail:expr),+ $(,)?) => {
-        // FIXME: Using any block in this macro causes a "temporary value dropped while borrowed"
-        //        (E0716) error since Rust 2024 edition. It seems temporary lifetime extension is
-        //        not working correctly, so it is a compiler bug?
-        $crate::macros::__macro_helper::best_fitting($crate::format_args!($least_expanded, $($tail),+))
+        BestFitting::from_arguments_unchecked($crate::format_args!($least_expanded, $($tail),+))
     };
-}
-
-#[doc(hidden)]
-pub mod __macro_helper {
-    #[inline(always)]
-    pub fn best_fitting<Context>(
-        arguments: crate::Arguments<Context>,
-    ) -> crate::BestFitting<Context> {
-        unsafe { crate::BestFitting::from_arguments_unchecked(arguments) }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up of #5224 

Per [tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html) change in Rust 2024, we can't use `unsafe` block in the `best_fitting!` macro anymore. I think hiding `BestFitting::from_arguments_checked` from documentation and using it from the macro directly is the better way to handle the problem.

## Test Plan

rustc should be happy
