### PR TITLE
fix(noUselessEscapeInString): use text_trimmed instead of text

### DIFF
--- a/crates/biome_css_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -61,7 +61,7 @@ impl Rule for NoUselessEscapeInString {
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
         let token = node.value_token().ok()?;
-        let text = token.text();
+        let text = token.text_trimmed();
         next_useless_escape(text, text.bytes().next()?).map(|index| (token, index))
     }
 
@@ -70,7 +70,7 @@ impl Rule for NoUselessEscapeInString {
             .text_trimmed_range()
             .start()
             .checked_add((*index as u32 + 1).into())?;
-        let escaped_char = token.text()[(1 + index)..].chars().next()?;
+        let escaped_char = token.text_trimmed()[(1 + index)..].chars().next()?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),

--- a/crates/biome_css_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.css
@@ -1,5 +1,5 @@
 .a::after {
-    content: "useless \a"
+    content: /*before*/ "useless \a" /*after*/
 }
 .b::after {
     content: "useless \'"

--- a/crates/biome_css_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.css.snap
@@ -5,7 +5,7 @@ expression: invalid.css
 # Input
 ```css
 .a::after {
-    content: "useless \a"
+    content: /*before*/ "useless \a" /*after*/
 }
 .b::after {
     content: "useless \'"
@@ -14,13 +14,13 @@ expression: invalid.css
 
 # Diagnostics
 ```
-invalid.css:2:24 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.css:2:35 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The character doesn't need to be escaped.
   
     1 │ .a::after {
-  > 2 │     content: "useless \a"
-      │                        ^
+  > 2 │     content: /*before*/ "useless \a" /*after*/
+      │                                   ^
     3 │ }
     4 │ .b::after {
   
@@ -28,8 +28,8 @@ invalid.css:2:24 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   
   i Safe fix: Unescape the character.
   
-    2 │ ····content:·"useless·\a"
-      │                       -  
+    2 │ ····content:·/*before*/·"useless·\a"·/*after*/
+      │                                  -            
 
 ```
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -72,7 +72,7 @@ impl Rule for NoUselessEscapeInString {
         match node {
             AnyString::JsStringLiteralExpression(literal) => {
                 let token = literal.value_token().ok()?;
-                let text = token.text();
+                let text = token.text_trimmed();
                 next_useless_escape(text, text.bytes().next()?).map(|index| (token, index))
             }
             AnyString::JsTemplateExpression(template) => {
@@ -85,7 +85,7 @@ impl Rule for NoUselessEscapeInString {
                             let Ok(chunk) = chunk.template_chunk_token() else {
                                 continue;
                             };
-                            if let Some(index) = next_useless_escape(chunk.text(), b'`') {
+                            if let Some(index) = next_useless_escape(chunk.text_trimmed(), b'`') {
                                 return Some((chunk, index));
                             }
                         }
@@ -113,7 +113,7 @@ impl Rule for NoUselessEscapeInString {
             .text_trimmed_range()
             .start()
             .checked_add((*index as u32 + 1).into())?;
-        let escaped_char = token.text()[(1 + index)..].chars().next()?;
+        let escaped_char = token.text_trimmed()[(1 + index)..].chars().next()?;
         Some(
             RuleDiagnostic::new(
                 rule_category!(),

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
@@ -1,7 +1,7 @@
 var s = {
-    '\a': "\a",
+    '\a': /*before*/ "\a" /*after*/,
     '\"': "\'",
-    "abc\defg": ` test ${1} \a`,
+    "abc\defg": ` test ${1} \a` /*after*/,
     // A test with unicode characters that take more than one byte
     key: "😀\😀"
 };

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
@@ -5,9 +5,9 @@ expression: invalid.js
 # Input
 ```js
 var s = {
-    '\a': "\a",
+    '\a': /*before*/ "\a" /*after*/,
     '\"': "\'",
-    "abc\defg": ` test ${1} \a`,
+    "abc\defg": ` test ${1} \a` /*after*/,
     // A test with unicode characters that take more than one byte
     key: "😀\😀"
 };
@@ -21,37 +21,37 @@ invalid.js:2:7 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━
   ! The character doesn't need to be escaped.
   
     1 │ var s = {
-  > 2 │     '\a': "\a",
+  > 2 │     '\a': /*before*/ "\a" /*after*/,
       │       ^
     3 │     '\"': "\'",
-    4 │     "abc\defg": ` test ${1} \a`,
+    4 │     "abc\defg": ` test ${1} \a` /*after*/,
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
   i Safe fix: Unescape the character.
   
-    2 │ ····'\a':·"\a",
-      │      -         
+    2 │ ····'\a':·/*before*/·"\a"·/*after*/,
+      │      -                              
 
 ```
 
 ```
-invalid.js:2:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:2:24 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The character doesn't need to be escaped.
   
     1 │ var s = {
-  > 2 │     '\a': "\a",
-      │             ^
+  > 2 │     '\a': /*before*/ "\a" /*after*/,
+      │                        ^
     3 │     '\"': "\'",
-    4 │     "abc\defg": ` test ${1} \a`,
+    4 │     "abc\defg": ` test ${1} \a` /*after*/,
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
   i Safe fix: Unescape the character.
   
-    2 │ ····'\a':·"\a",
-      │            -   
+    2 │ ····'\a':·/*before*/·"\a"·/*after*/,
+      │                       -             
 
 ```
 
@@ -61,10 +61,10 @@ invalid.js:3:7 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━
   ! The character doesn't need to be escaped.
   
     1 │ var s = {
-    2 │     '\a': "\a",
+    2 │     '\a': /*before*/ "\a" /*after*/,
   > 3 │     '\"': "\'",
       │       ^
-    4 │     "abc\defg": ` test ${1} \a`,
+    4 │     "abc\defg": ` test ${1} \a` /*after*/,
     5 │     // A test with unicode characters that take more than one byte
   
   i Only quotes that enclose the string and special characters need to be escaped.
@@ -82,10 +82,10 @@ invalid.js:3:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   ! The character doesn't need to be escaped.
   
     1 │ var s = {
-    2 │     '\a': "\a",
+    2 │     '\a': /*before*/ "\a" /*after*/,
   > 3 │     '\"': "\'",
       │             ^
-    4 │     "abc\defg": ` test ${1} \a`,
+    4 │     "abc\defg": ` test ${1} \a` /*after*/,
     5 │     // A test with unicode characters that take more than one byte
   
   i Only quotes that enclose the string and special characters need to be escaped.
@@ -102,9 +102,9 @@ invalid.js:4:10 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
 
   ! The character doesn't need to be escaped.
   
-    2 │     '\a': "\a",
+    2 │     '\a': /*before*/ "\a" /*after*/,
     3 │     '\"': "\'",
-  > 4 │     "abc\defg": ` test ${1} \a`,
+  > 4 │     "abc\defg": ` test ${1} \a` /*after*/,
       │          ^
     5 │     // A test with unicode characters that take more than one byte
     6 │     key: "😀\😀"
@@ -113,10 +113,10 @@ invalid.js:4:10 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   
   i Safe fix: Unescape the character.
   
-    2 2 │       '\a': "\a",
+    2 2 │       '\a': /*before*/ "\a" /*after*/,
     3 3 │       '\"': "\'",
-    4   │ - ····"abc\defg":·`·test·${1}·\a`,
-      4 │ + ····"abcdefg":·`·test·${1}·\a`,
+    4   │ - ····"abc\defg":·`·test·${1}·\a`·/*after*/,
+      4 │ + ····"abcdefg":·`·test·${1}·\a`·/*after*/,
     5 5 │       // A test with unicode characters that take more than one byte
     6 6 │       key: "😀\😀"
   
@@ -128,9 +128,9 @@ invalid.js:4:30 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
 
   ! The character doesn't need to be escaped.
   
-    2 │     '\a': "\a",
+    2 │     '\a': /*before*/ "\a" /*after*/,
     3 │     '\"': "\'",
-  > 4 │     "abc\defg": ` test ${1} \a`,
+  > 4 │     "abc\defg": ` test ${1} \a` /*after*/,
       │                              ^
     5 │     // A test with unicode characters that take more than one byte
     6 │     key: "😀\😀"
@@ -139,8 +139,8 @@ invalid.js:4:30 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   
   i Safe fix: Unescape the character.
   
-    4 │ ····"abc\defg":·`·test·${1}·\a`,
-      │                             -   
+    4 │ ····"abc\defg":·`·test·${1}·\a`·/*after*/,
+      │                             -             
 
 ```
 
@@ -149,7 +149,7 @@ invalid.js:6:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
 
   ! The character doesn't need to be escaped.
   
-    4 │     "abc\defg": ` test ${1} \a`,
+    4 │     "abc\defg": ` test ${1} \a` /*after*/,
     5 │     // A test with unicode characters that take more than one byte
   > 6 │     key: "😀\😀"
       │              ^^


### PR DESCRIPTION
## Summary

I thought we renamed `text` to `text_with_trivia` and `text_trimmed` to `text`.
This is the case except for tokens.
This PR fixes the `noUselessEscapeInString` rule by using `text_trimmed` instead of `text`.

## Test Plan

I added trivias in the tests.
