### PR TITLE
fix(js/linter): use text_trimmed instead of text

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
@@ -100,7 +100,7 @@ impl Rule for NoUselessCatch {
             .as_js_identifier_binding()?
             .name_token()
             .ok()?;
-        let catch_err_name = catch_binding_err.text();
+        let catch_err_name = catch_binding_err.text_trimmed();
 
         let first_statement = catch_body_statements.first()?;
         let js_throw_statement = first_statement.as_js_throw_statement()?;

--- a/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_nonoctal_decimal_escape.rs
@@ -89,7 +89,7 @@ impl Rule for NoNonoctalDecimalEscape {
         let Some(token) = node.value_token().ok() else {
             return result.into_boxed_slice();
         };
-        let text = token.text();
+        let text = token.text_trimmed();
         if !is_octal_escape_sequence(text) {
             return result.into_boxed_slice();
         }
@@ -207,7 +207,7 @@ impl Rule for NoNonoctalDecimalEscape {
         let node = ctx.query();
         let prev_token = node.value_token().ok()?;
         let replaced = safe_replace_by_range(
-            prev_token.text().to_string(),
+            prev_token.text_trimmed().to_string(),
             replace_string_range.clone(),
             replace_to,
         )?;

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -316,8 +316,8 @@ fn is_callee_a_promise(callee: &AnyJsExpression, model: &SemanticModel) -> Optio
             let member = computed_member_expr.member().ok()?;
             let literal_expr = member.as_any_js_literal_expression()?;
             let string_literal = literal_expr.as_js_string_literal_expression()?;
-            let value_token = string_literal.inner_string_text().ok()?;
-            let value_text = value_token.text();
+            let value_token_text = string_literal.inner_string_text().ok()?;
+            let value_text = value_token_text.text();
 
             match object {
                 AnyJsExpression::JsIdentifierExpression(js_ident_expr) => {

--- a/crates/biome_js_analyze/src/lint/nursery/no_secrets.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_secrets.rs
@@ -95,7 +95,7 @@ impl Rule for NoSecrets {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let token = node.value_token().ok()?;
-        let text = token.text();
+        let text = token.text_trimmed();
 
         if text.len() < MIN_PATTERN_LEN {
             return None;

--- a/crates/biome_js_analyze/src/lint/nursery/no_template_curly_in_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_template_curly_in_string.rs
@@ -56,7 +56,7 @@ impl Rule for NoTemplateCurlyInString {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let token = node.value_token().ok()?;
-        let text = token.text();
+        let text = token.text_trimmed();
 
         let mut byte_iter = text.bytes().enumerate();
         while let Some((i, byte)) = byte_iter.next() {

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_string_raw.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_string_raw.rs
@@ -91,7 +91,7 @@ fn can_remove_string_raw(node: &JsTemplateExpression) -> bool {
             AnyJsTemplateElement::JsTemplateElement(_) => false,
             AnyJsTemplateElement::JsTemplateChunkElement(chunk) => {
                 match chunk.template_chunk_token() {
-                    Ok(token) => token.text().contains('\\'),
+                    Ok(token) => token.text_trimmed().contains('\\'),
                     Err(_) => {
                         // if found an error, return `true` means `String.raw` can't remove
                         true

--- a/crates/biome_js_analyze/src/lint/nursery/use_parse_int_radix.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_parse_int_radix.rs
@@ -23,9 +23,21 @@ declare_lint_rule! {
     ///
     /// ```js,expect_diagnostic
     /// parseInt("071");
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
     /// parseInt(someValue);
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
     /// parseInt("071", "abc");
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
     /// parseInt("071", 37);
+    /// ```
+    ///
+    /// ```js,expect_diagnostic
     /// parseInt();
     /// ```
     ///
@@ -58,12 +70,12 @@ impl Rule for UseParseIntRadix {
 
         let object_name = call_expression.callee().ok()?.get_callee_object_name()?;
 
-        if !matches!(object_name.text(), "Number" | "parseInt") {
+        if !matches!(object_name.text_trimmed(), "Number" | "parseInt") {
             return None;
         }
 
         let member_name = call_expression.callee().ok()?.get_callee_member_name()?;
-        if member_name.text() != "parseInt" {
+        if member_name.text_trimmed() != "parseInt" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_shouty_constants.rs
@@ -174,7 +174,7 @@ impl Rule for NoShoutyConstants {
                         JsReferenceIdentifier::cast_ref(state.reference.syntax())?
                             .value_token()
                             .ok()?
-                            .text(),
+                            .text_trimmed(),
                         [],
                         [],
                     ),

--- a/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_unused_template_literal.rs
@@ -83,7 +83,7 @@ impl Rule for NoUnusedTemplateLiteral {
                 AnyJsTemplateElement::JsTemplateChunkElement(ele) => {
                     // Safety: if `ele.template_chunk_token()` is `Err` variant, [can_convert_to_string_lit] should return false,
                     // thus `run` will return None
-                    acc += ele.template_chunk_token().unwrap().text();
+                    acc += ele.template_chunk_token().unwrap().text_trimmed();
                     acc
                 }
                 AnyJsTemplateElement::JsTemplateElement(_) => {
@@ -127,7 +127,7 @@ fn can_convert_to_string_literal(node: &JsTemplateExpression) -> bool {
                     Ok(token) => {
                         // if token text has any special character
                         token
-                            .text()
+                            .text_trimmed()
                             .bytes()
                             .any(|byte| matches!(byte, b'\n' | b'\'' | b'"'))
                     }

--- a/crates/biome_js_analyze/src/lint/style/use_for_of.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_for_of.rs
@@ -295,7 +295,7 @@ fn is_less_than_length_expression(binary_expression: &JsBinaryExpression) -> Opt
 
     Some(
         matches!(operator, JsBinaryOperator::LessThan)
-            && member.value_token().ok()?.text() == "length"
+            && member.value_token().ok()?.text_trimmed() == "length"
             && !matches!(object.syntax().kind(), JsSyntaxKind::JS_THIS_EXPRESSION),
     )
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misleading_character_class.rs
@@ -146,7 +146,7 @@ impl Rule for NoMisleadingCharacterClass {
         }
         let node = ctx.query();
         let prev_token = node.value_token().ok()?;
-        let text = prev_token.text();
+        let text = prev_token.text_trimmed();
         let next_token = JsSyntaxToken::new_detached(
             JsSyntaxKind::JS_REGEX_LITERAL,
             &format!("{text}u"),

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
@@ -240,7 +240,7 @@ fn is_exception_for_expect(node: &AnyJsExpression) -> Option<bool> {
 
     let parent = node.syntax().parent()?;
     let last_token = parent.last_token()?;
-    let last_token_text = last_token.text();
+    let last_token_text = last_token.text_trimmed();
 
     let member = node.get_callee_member_name()?;
     let member_text = member.text_trimmed();

--- a/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_suspicious_semicolon_in_jsx.rs
@@ -96,9 +96,9 @@ fn has_suspicious_semicolon(node: &JsxChildList) -> Option<TextRange> {
         let jsx_text = c.as_jsx_text()?;
         let jsx_text_value = jsx_text.value_token().ok()?;
         // We should also check for \r and \r\n
-        if jsx_text_value.text().starts_with(";\n")
-            || jsx_text_value.text().starts_with(";\r")
-            || jsx_text_value.text().starts_with(";\r\n")
+        if jsx_text_value.text_trimmed().starts_with(";\n")
+            || jsx_text_value.text_trimmed().starts_with(";\r")
+            || jsx_text_value.text_trimmed().starts_with(";\r\n")
         {
             return Some(jsx_text_value.text_range());
         }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
@@ -189,7 +189,7 @@ fn process_js_method_object_member(node: &JsMethodObjectMember) -> Option<RuleSt
     match member_name {
         AnyJsObjectMemberName::JsComputedMemberName(expr) => match expr.expression().ok()? {
             AnyJsExpression::AnyJsLiteralExpression(lit) => {
-                if lit.value_token().ok()?.text() == "then" {
+                if lit.value_token().ok()?.text_trimmed() == "then" {
                     return Some(RuleState {
                         range: node.name().ok()?.range(),
                         message: NoThenPropertyMessage::Object,
@@ -199,7 +199,7 @@ fn process_js_method_object_member(node: &JsMethodObjectMember) -> Option<RuleSt
             AnyJsExpression::JsTemplateExpression(lit) => {
                 for l in lit.elements() {
                     if let AnyJsTemplateElement::JsTemplateChunkElement(chunk) = l {
-                        if chunk.template_chunk_token().ok()?.text() == "then" {
+                        if chunk.template_chunk_token().ok()?.text_trimmed() == "then" {
                             return Some(RuleState {
                                 range: node.name().ok()?.range(),
                                 message: NoThenPropertyMessage::Object,
@@ -239,7 +239,7 @@ fn process_js_class_member(node: &AnyJsClassMember) -> Option<RuleState> {
 fn process_js_computed_member_name(node: &JsComputedMemberName) -> Option<RuleState> {
     match node.expression().ok()? {
         AnyJsExpression::AnyJsLiteralExpression(expr) => {
-            if expr.value_token().ok()?.text() == "\"then\"" {
+            if expr.value_token().ok()?.text_trimmed() == "\"then\"" {
                 return Some(RuleState {
                     range: expr.range(),
                     message: NoThenPropertyMessage::Object,
@@ -249,7 +249,7 @@ fn process_js_computed_member_name(node: &JsComputedMemberName) -> Option<RuleSt
         AnyJsExpression::JsTemplateExpression(lit) => {
             for l in lit.elements() {
                 if let AnyJsTemplateElement::JsTemplateChunkElement(chunk) = l {
-                    if chunk.template_chunk_token().ok()?.text() == "then" {
+                    if chunk.template_chunk_token().ok()?.text_trimmed() == "then" {
                         return Some(RuleState {
                             range: chunk.range(),
                             message: NoThenPropertyMessage::Object,

--- a/crates/biome_js_analyze/tests/specs/style/noShoutyConstants/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noShoutyConstants/invalid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -187,9 +186,8 @@ invalid.js:26:7 lint/style/noShoutyConstants  FIXABLE  ━━━━━━━━�
     26    │ - const·D·="D";
     27 25 │   export const e = {
     28    │ - → D
-       26 │ + → 
-       27 │ + → D:"D"
-    29 28 │   };
+       26 │ + → D:"D"
+    29 27 │   };
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noMisleadingCharacterClass/invalid.js.snap
@@ -543,12 +543,7 @@ invalid.js:29:5 lint/suspicious/noMisleadingCharacterClass  FIXABLE  ━━━�
   
   i Safe fix: Add unicode u flag to regex
   
-    27 27 │   var r = /[\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F466}]/u;
-    28 28 │   
-    29    │ - /[\]👍]/;
-       29 │ + 
-       30 │ + 
-       31 │ + /[\]👍]/u;
-  
+    29 │ /[\]👍]/u;
+       │         + 
 
 ```


### PR DESCRIPTION
## Summary

This PR fixes several js lint rules that wrongly use `text` instead of `text_trimmed`.

## Test Plan

CI must pass.
