### PR TITLE
feat(xtask): check rustfmt version in codegen

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     env,
     fmt::Display,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 pub use crate::glue::{pushd, pushenv};
@@ -65,7 +66,13 @@ pub fn reformat_without_preamble(text: impl Display) -> Result<String> {
     Ok(format!("{output}\n"))
 }
 
+static IS_RUSTFMT_CHECKED: OnceLock<()> = OnceLock::new();
+
 pub fn ensure_rustfmt() -> Result<()> {
+    if IS_RUSTFMT_CHECKED.get().is_some() {
+        return Ok(());
+    }
+
     let out = run!("rustfmt --version")?;
     if !out.contains("stable") {
         bail!(
@@ -73,5 +80,21 @@ pub fn ensure_rustfmt() -> Result<()> {
              Please run `rustup component add rustfmt --toolchain stable` to install it.",
         )
     }
+
+    // e.g. "rustfmt 1.8.0-stable (4d91de4e48 2025-02-17)"
+    let (_, version) = out.split_once(' ').unwrap_or_default();
+    let mut version = version.split('.').flat_map(|s| str::parse::<usize>(s).ok());
+    let major = version.next();
+    let minor = version.next();
+    if major != Some(1) || minor.is_none_or(|minor| minor < 8) {
+        // `--style_edition=2024` requires 1.8.0 or later.
+        bail!(
+            "The installed rustfmt is outdated, 1.8.0 or later is required. \
+             Please run `rustup update stable` to update it.",
+        )
+    }
+
+    IS_RUSTFMT_CHECKED.get_or_init(|| ());
+
     Ok(())
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -83,7 +83,9 @@ pub fn ensure_rustfmt() -> Result<()> {
 
     // e.g. "rustfmt 1.8.0-stable (4d91de4e48 2025-02-17)"
     let (_, version) = out.split_once(' ').unwrap_or_default();
-    let mut version = version.split('.').flat_map(|s| str::parse::<usize>(s).ok());
+    let mut version = version
+        .split('.')
+        .filter_map(|s| str::parse::<usize>(s).ok());
     let major = version.next();
     let minor = version.next();
     if major != Some(1) || minor.is_none_or(|minor| minor < 8) {


### PR DESCRIPTION
## Summary

Closes #5258 

I added checking the rustfmt version before running. Plus, I added a `OnceLock` to run `rustfmt --version` only once.

## Test Plan

The codegen CI should pass.
