### PR TITLE
fix(core): resolve extensionless imports to TS/JSX files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -75,6 +75,9 @@
       },
       "suspicious": {
         "noVar": "on"
+      },
+      "nursery": {
+        "noImportCycles": "error"
       }
     }
   },

--- a/crates/biome_dependency_graph/src/dependency_graph.rs
+++ b/crates/biome_dependency_graph/src/dependency_graph.rs
@@ -11,7 +11,7 @@ use biome_fs::{BiomePath, FileSystem, PathKind};
 use biome_js_syntax::AnyJsRoot;
 use biome_project_layout::ProjectLayout;
 use camino::{Utf8Path, Utf8PathBuf};
-use oxc_resolver::{ResolveError, ResolveOptions, ResolverGeneric};
+use oxc_resolver::{EnforceExtension, ResolveError, ResolveOptions, ResolverGeneric};
 use papaya::HashMap;
 use rustc_hash::FxBuildHasher;
 
@@ -121,8 +121,12 @@ impl DependencyGraph {
             added_or_updated_paths,
             removed_paths,
         ));
-        let resolver =
-            ResolverGeneric::new_with_cache(resolver_cache.clone(), ResolveOptions::default());
+        let resolve_options = ResolveOptions::default()
+            .with_extension(".jsx")
+            .with_extension(".ts")
+            .with_extension(".tsx")
+            .with_force_extension(EnforceExtension::Disabled);
+        let resolver = ResolverGeneric::new_with_cache(resolver_cache.clone(), resolve_options);
 
         // Make sure all directories are registered for the added/updated paths.
         let path_info = self.path_info.pin();

--- a/crates/biome_dependency_graph/src/dependency_graph.tests.rs
+++ b/crates/biome_dependency_graph/src/dependency_graph.tests.rs
@@ -186,6 +186,7 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
     );
 
     let added_paths = vec![
+        BiomePath::new(format!("{fixtures_path}/frontend/src/bar.ts")),
         BiomePath::new(format!("{fixtures_path}/frontend/src/index.ts")),
         BiomePath::new(format!(
             "{fixtures_path}/frontend/node_modules/shared/dist/index.js"
@@ -216,6 +217,14 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
         Some(&Import {
             resolved_path: Ok(Utf8PathBuf::from(format!(
                 "{fixtures_path}/shared/dist/index.js"
+            )))
+        })
+    );
+    assert_eq!(
+        file_imports.static_imports.get("./bar"),
+        Some(&Import {
+            resolved_path: Ok(Utf8PathBuf::from(format!(
+                "{fixtures_path}/frontend/src/bar.ts"
             )))
         })
     );

--- a/crates/biome_dependency_graph/src/import_visitor.rs
+++ b/crates/biome_dependency_graph/src/import_visitor.rs
@@ -50,15 +50,15 @@ impl<'a> ImportVisitor<'a> {
             return;
         };
 
-        let import = Import {
-            resolved_path: self
-                .resolver
-                .resolve(self.directory, specifier.text())
+        let specifier = specifier.text();
+        let resolved_path =
+            self.resolver
+                .resolve(self.directory, specifier)
                 .and_then(|resolution| {
                     Utf8PathBuf::from_path_buf(resolution.into_path_buf())
                         .map_err(|path| ResolveError::NotFound(path.to_string_lossy().to_string()))
-                }),
-        };
+                });
+        let import = Import { resolved_path };
 
         match node {
             AnyJsImportLike::JsModuleSource(_) => {


### PR DESCRIPTION
## Summary

Extensionless imports weren't correctly resolved yet for `.jsx`/`.ts`/`.tsx` files when building the dependency graph.

## Test Plan

Updated test.

Also enabled the `noImportCycles` rule in our repo, so it's easy to test in our own packages.
