### PR TITLE
ci: fix `udeps` workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,7 +74,12 @@ jobs:
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space
       - name: Install toolchain
-        run: rustup toolchain install nightly
+        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        with:
+          channel: nightly
+          cache: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install udeps
         run: cargo install cargo-udeps --locked
       - name: Detect unused dependencies using udeps


### PR DESCRIPTION
## Summary

Fixing `cargo-udeps` issue:

```
error: toolchain '1.85.0-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.85.0-x86_64-unknown-linux-gnu` to install it
```

See: https://github.com/biomejs/biome/actions/runs/13633509173/job/38106518433

## Test Plan

CI should be green again.
