### PR TITLE
fix(lsp): order of code actions

### DIFF
--- a/.changeset/pretty-buttons-taste.md
+++ b/.changeset/pretty-buttons-taste.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+When pulling code actions from the LSP, now the first choice suggested by the client will be the safe fix.

--- a/crates/biome_analyze/src/categories.rs
+++ b/crates/biome_analyze/src/categories.rs
@@ -36,8 +36,8 @@ impl Display for RuleCategory {
 }
 
 /// Actions that suppress rules should start with this string
-pub const SUPPRESSION_INLINE_ACTION_CATEGORY: &str = "quickfix.suppressRule.inline";
-pub const SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY: &str = "quickfix.suppressRule.topLevel";
+pub const SUPPRESSION_INLINE_ACTION_CATEGORY: &str = "quickfix.suppressRule.inline.biome";
+pub const SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY: &str = "quickfix.suppressRule.topLevel.biome";
 
 /// The category of a code action, this type maps directly to the
 /// [CodeActionKind] type in the Language Server Protocol specification

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1210,7 +1210,7 @@ pub trait Rule: RuleMeta + Sized {
 
             Some(SuppressAction {
                 mutation,
-                message: markup! { "Suppress rule " {rule_category} }.to_owned(),
+                message: markup! { "Suppress rule " {rule_category} " for this line."}.to_owned(),
             })
         } else {
             None

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -65,12 +65,14 @@ pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCa
                     // quickfix.suppressRule
                     CodeActionKind::from(SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY),
                     CodeActionKind::from(SUPPRESSION_INLINE_ACTION_CATEGORY),
-                    CodeActionKind::from("source.fixAll.biome"),
+                    // import sorting
                     CodeActionKind::from("source.organizeImports.biome"),
+                    // general refactors
                     CodeActionKind::from("refactor.biome"),
                     CodeActionKind::from("refactor.extract.biome"),
                     CodeActionKind::from("refactor.inline.biome"),
                     CodeActionKind::from("refactor.rewrite.biome"),
+                    // source actions
                     CodeActionKind::from("source.biome"),
                 ]),
                 ..Default::default()

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1066,7 +1066,7 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let expected_inline_suppression_action =
         lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from("Suppress rule lint/suspicious/noCompareNegZero"),
+            title: String::from("Suppress rule lint/suspicious/noCompareNegZero for this line."),
             kind: Some(lsp::CodeActionKind::new(
                 "quickfix.suppressRule.inline.biome",
             )),
@@ -1125,9 +1125,9 @@ async fn pull_quick_fixes() -> Result<()> {
     assert_eq!(
         res,
         vec![
-            expected_top_level_suppression_action,
+            expected_code_action,
             expected_inline_suppression_action,
-            expected_code_action
+            expected_top_level_suppression_action,
         ]
     );
 
@@ -1446,7 +1446,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 
     let expected_inline_suppression_action =
         lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from("Suppress rule lint/suspicious/noDoubleEquals"),
+            title: String::from("Suppress rule lint/suspicious/noDoubleEquals for this line."),
             kind: Some(lsp::CodeActionKind::new(
                 "quickfix.suppressRule.inline.biome",
             )),
@@ -1503,9 +1503,9 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     assert_eq!(
         res,
         vec![
-            expected_toplevel_suppression_action,
-            expected_inline_suppression_action,
             expected_code_action,
+            expected_inline_suppression_action,
+            expected_toplevel_suppression_action,
         ]
     );
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/5058

This PR contains two fixes:
- It changes the order of the code actions provided to the LSP client, and now the safe fix is at the first position. Check the screenshot later.
- It removes `source.fixAll.biome` from the fixed filters that are sent to the code actions method. The fix all filter is only opt-in, and it prevented from showing the suppressions code actions 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the tests. Manually tested with Zed

<img width="818" alt="Screenshot 2025-03-03 at 19 47 41" src="https://github.com/user-attachments/assets/2d129d83-0d3d-48f8-b4da-0b620e55c399" />


<!-- What demonstrates that your implementation is correct? -->
