### PR TITLE
chore: stabilise tests on macOS

### DIFF
--- a/crates/biome_cli/src/commands/daemon.rs
+++ b/crates/biome_cli/src/commands/daemon.rs
@@ -80,7 +80,7 @@ pub(crate) fn run_server(
 ) -> Result<(), CliDiagnostic> {
     setup_tracing_subscriber(log_path.as_deref(), log_file_name_prefix.as_deref());
 
-    let (mut watcher, instruction_channel) = WorkspaceWatcher::new()?;
+    let (mut watcher, instruction_channel, _) = WorkspaceWatcher::new()?;
 
     let rt = Runtime::new()?;
     let factory = ServerFactory::new(stop_on_disconnect, instruction_channel.sender.clone());


### PR DESCRIPTION
## Summary

This should hopefully stabilise the watcher tests on macOS. I did find FSEvents on Mac to be _very_ unstable, to the point that tests would sometimes receive FS events for fixture preparation that happened even before the watcher was enabled. In the debugger I'm also still seeing weird effects... but at least when running `cargo tests`, it does appear stable. Fingers crossed...

## Test Plan

CI should be green.
