### PR TITLE
Allow trailing commas and comments in biome.json config file JSON schema

### DIFF
--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3,6 +3,8 @@
 	"title": "Configuration",
 	"description": "The configuration that is contained inside the file `biome.json`",
 	"type": "object",
+	"allowTrailingCommas": true,
+	"allowComments": true,
 	"properties": {
 		"$schema": {
 			"description": "A field for the [JSON schema](https://json-schema.org/) specification",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

When using trailing commas or comments in the biome.json/biome.jsonc files in VS Code, warnings/errors are shown in the editor and Problems pane.

| biome.json                                                                                | biome.jsonc                                                                               |
| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| ![image](https://github.com/user-attachments/assets/1bc61dcd-c9c0-4bc4-8531-92162811482f) | ![image](https://github.com/user-attachments/assets/ff5f3298-5736-4fcb-9078-0ac990c90860) |

Apparently, these warnings/errors can be controlled by using custom VS Code JSON schema extension fields `allowTrailingComma` and `allowComments`, seen here: https://github.com/microsoft/vscode/blob/201df9b990f871fad842dc9a6211bfa84c663e53/src/vs/base/common/jsonSchema.ts#L89

A solution [suggested by a VS Code maintainer](https://github.com/microsoft/vscode/issues/102061#issuecomment-657080963) that seems to work is to use those custom fields in JSON schemas that declare they support trailing commas and comments.

VS Code does internally for its settings.json files, etc. and it would be nice if biome declared them as allowed since the biome tool allows them when parsing its JSON config file.
