### PR TITLE
feat(core): watcher + LSP improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/biome_cli/src/service/unix.rs
+++ b/crates/biome_cli/src/service/unix.rs
@@ -196,11 +196,11 @@ pub(crate) async fn print_socket() -> io::Result<()> {
 pub(crate) async fn run_daemon(factory: ServerFactory) -> io::Result<Infallible> {
     let path = get_socket_name();
 
-    info!("Trying to connect to socket {}", path.as_str());
+    info!("Trying to connect to socket {path}");
 
     // Try to remove the socket file if it already exists
     if path.exists() {
-        info!("Remove socket folder {}", path.as_str());
+        info!("Remove socket {path}");
         fs::remove_file(&path)?;
     }
 

--- a/crates/biome_dependency_graph/src/dependency_graph.rs
+++ b/crates/biome_dependency_graph/src/dependency_graph.rs
@@ -149,7 +149,7 @@ impl DependencyGraph {
                     .is_err()
                 {
                     break;
-                };
+                }
                 parent = path.parent();
             }
         }

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::diagnostics::LspError;
 use crate::utils::apply_document_changes;
 use crate::{documents::Document, session::Session};
@@ -19,7 +21,7 @@ use tracing::{debug, error, field, info};
     )
 )]
 pub(crate) async fn did_open(
-    session: &Session,
+    session: &Arc<Session>,
     params: lsp_types::DidOpenTextDocumentParams,
 ) -> Result<(), LspError> {
     let url = params.text_document.uri;
@@ -41,7 +43,7 @@ pub(crate) async fn did_open(
                 path: parent_path.clone(),
                 open_uninitialized: true,
             })?;
-            session.insert_project(parent_path, project_key);
+            session.insert_and_scan_project(project_key, parent_path);
             project_key
         }
     };

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -70,6 +70,7 @@ schemars                = { workspace = true, optional = true }
 serde                   = { workspace = true, features = ["derive"] }
 serde_json              = { workspace = true, features = ["raw_value"] }
 smallvec                = { workspace = true, features = ["serde"] }
+tokio                   = { workspace = true, features = ["sync"] }
 tracing                 = { workspace = true, features = ["attributes", "log"] }
 
 [dev-dependencies]

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -24,6 +24,11 @@ pub use file_handlers::JsFormatterSettings;
 pub use workspace::{Workspace, WorkspaceServer};
 pub use workspace_watcher::{WatcherInstruction, WorkspaceWatcher};
 
+/// Path entries that should be ignored in the workspace, even by the scanner.
+///
+/// These cannot (yet) be configured.
+const IGNORE_ENTRIES: &[&[u8]] = &[b".git", b".timestamp", b".DS_Store"];
+
 /// This is the main entrypoint of the application.
 pub struct App<'app> {
     /// A reference to the internal workspace

--- a/crates/biome_service/src/workspace/document.rs
+++ b/crates/biome_service/src/workspace/document.rs
@@ -1,0 +1,36 @@
+use biome_parser::AnyParse;
+
+use crate::diagnostics::FileTooLarge;
+
+#[derive(Clone, Debug)]
+pub(crate) struct Document {
+    /// Document content.
+    pub(crate) content: String,
+
+    /// The version of the document.
+    ///
+    /// A version is only specified when the document is opened by a client,
+    /// typically through the LSP. Documents that are only opened by the scanner
+    /// do not have a version.
+    pub(crate) version: Option<i32>,
+
+    /// The index of where the original file source is saved.
+    /// Use `WorkspaceServer#file_sources` to retrieve the file source that belongs to the document.
+    pub(crate) file_source_index: usize,
+
+    /// The result of the parser (syntax tree + diagnostics).
+    /// Types explained:
+    /// - `Option`: if the file can be read
+    /// - `Result`: if the file is read, but the  file is too large
+    /// - `AnyParse`: the result of the parsed file
+    pub(crate) syntax: Option<Result<AnyParse, FileTooLarge>>,
+
+    /// If `true`, this indicates the document has been opened by the scanner,
+    /// and should be unloaded only when the project is unregistered.
+    ///
+    /// Note the file can still *also* be opened explicitly by a client such as
+    /// the LSP Proxy. In that case `version` will be `Some` and
+    /// `opened_by_scanner` will be `true`, and the document will only be
+    /// unloaded when both are unset.
+    pub(super) opened_by_scanner: bool,
+}

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -1,5 +1,6 @@
 use biome_fs::MemoryFileSystem;
 use crossbeam::channel::bounded;
+use tokio::sync::watch;
 
 use super::*;
 
@@ -12,8 +13,9 @@ fn commonjs_file_rejects_import_statement() {
     fs.insert(Utf8PathBuf::from("/project/a.js"), FILE_CONTENT);
     fs.insert(Utf8PathBuf::from("/project/package.json"), MANIFEST_CONTENT);
 
-    let (tx, _) = bounded(0);
-    let workspace = WorkspaceServer::new(Box::new(fs), tx);
+    let (watcher_tx, _) = bounded(0);
+    let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
+    let workspace = WorkspaceServer::new(Box::new(fs), watcher_tx, service_data_tx);
     let project_key = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/"),

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -15,11 +15,11 @@ use biome_fs::{FileSystemDiagnostic, PathKind};
 use camino::Utf8Path;
 use papaya::{Compute, Operation};
 
-use crate::{WorkspaceError, workspace_watcher::WatcherSignalKind};
+use crate::{IGNORE_ENTRIES, WorkspaceError, workspace_watcher::WatcherSignalKind};
 
 use super::{
-    FileContent, OpenFileParams, ScanProjectFolderParams, Workspace, WorkspaceServer,
-    scanner::IGNORE_ENTRIES, server::Document,
+    FileContent, OpenFileParams, ScanProjectFolderParams, ServiceDataNotification, Workspace,
+    WorkspaceServer, document::Document,
 };
 
 impl WorkspaceServer {
@@ -63,7 +63,7 @@ impl WorkspaceServer {
 
         if path
             .components()
-            .any(|component| IGNORE_ENTRIES.contains(&component.as_str()))
+            .any(|component| IGNORE_ENTRIES.contains(&component.as_os_str().as_encoded_bytes()))
         {
             return Ok(());
         }
@@ -190,6 +190,11 @@ impl WorkspaceServer {
         self.open_path_through_watcher(to)?;
 
         Ok(())
+    }
+
+    /// Used by the watcher to indicate it has stopped.
+    pub fn watcher_stopped(&self) {
+        let _ = self.notification_tx.send(ServiceDataNotification::Stop);
     }
 }
 


### PR DESCRIPTION
## Summary

This implements various improvements for making the watcher and the LSP play nicer together. Specifically:

* Made sure terminating the LSP proxy also terminates the daemon process (it hung on an pending channel loop).
* Made sure we always scan the project folder when registering it.
* Changed the channel mechanism for watcher updates to become "service data notifications". The LSP now also listens to this and updates diagnostics for all open documents when it receives a notification. This ensures that if you have multiple open documents, and make or break a cyclic dependency in one of them, they'll all update together.

Unfortunately it doesn't resolve my main issue with the LSP yet: Cyclic dependencies aren't detected until _after_ you've run the CLI with `--use-server` at least once. I'm still investigating that one.

## Test Plan

Manually tested. Tests should remain green.
