### PR TITLE
fix(core): fix workspace scanner in LSP

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -800,6 +800,7 @@ pub(crate) trait CommandRunner: Sized {
                 project_key,
                 path: Some(project_path),
                 watch: cli_options.use_server,
+                force: false, // TODO: Maybe we'll want a CLI flag for this.
             })?;
             for diagnostic in result.diagnostics {
                 if diagnostic.severity() >= Severity::Error {

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -260,7 +260,6 @@ impl LanguageServer for LSPServer {
             params.workspace_folders,
         );
 
-        //
         let init = InitializeResult {
             capabilities: server_capabilities,
             server_info: Some(ServerInfo {

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3042,6 +3042,7 @@ export function bar() {
                 project_key,
                 path: None,
                 watch: true,
+                force: false,
             },
         )
         .await?
@@ -3253,6 +3254,7 @@ export function bar() {
                 project_key,
                 path: None,
                 watch: true,
+                force: false,
             },
         )
         .await?

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1029,6 +1029,9 @@ pub struct ScanProjectFolderParams {
     ///
     /// Does nothing if the watcher is already watching this path.
     pub watch: bool,
+
+    /// Forces scanning of the folder, even if it is already being watched.
+    pub force: bool,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -326,6 +326,7 @@ fn files_loaded_by_the_scanner_are_only_unloaded_when_the_project_is_unregistere
             project_key,
             path: None,
             watch: false,
+            force: false,
         })
         .unwrap();
 
@@ -414,6 +415,7 @@ fn too_large_files_are_tracked_but_not_parsed() {
             project_key,
             path: None,
             watch: false,
+            force: false,
         })
         .unwrap();
 
@@ -470,6 +472,7 @@ fn plugins_are_loaded_and_used_during_analysis() {
             project_key,
             path: None,
             watch: false,
+            force: false,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -28,6 +28,7 @@ fn commonjs_file_rejects_import_statement() {
             project_key,
             path: Some(BiomePath::new("/")),
             watch: false,
+            force: false,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -93,6 +93,7 @@ impl WorkspaceServer {
             project_key,
             path: Some(path.into()),
             watch: false, // It's already being watched.
+            force: true,
         })
         .map(|_| ())
     }


### PR DESCRIPTION
## Summary

Turns out the issue with the scanner in the LSP was just a footgun I ran into with Tokio: I was passing an `async` scan function to `tokio::spawn_blocking()`, which ended up doing... nothing, because nobody awaits the returned `Future`.

With that fixed, I immediately discovered that our LSP triggers 4 calls to the scanner because of some config updates it tries to process, so I implemented the functionality to not always rescan folders that are already being watched.

## Test Plan

Tests are updated and should remain green. Manually tested too.
