### PR TITLE
fix: propagate plugin load error LSP

### DIFF
--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1617,7 +1617,6 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
 
 #[tokio::test]
 async fn plugin_load_error_show_message() -> Result<()> {
-    let factory = ServerFactory::default();
     let mut fs = MemoryFileSystem::default();
     let config = r#"{
         "css": {
@@ -1641,7 +1640,8 @@ xx"#;
         INVALID_PLUGIN_CONTENT,
     );
 
-    let (service, client) = factory.create_with_fs(None, Box::new(fs)).into_inner();
+    let factory = ServerFactory::new_with_fs(Box::new(fs));
+    let (service, client) = factory.create().into_inner();
 
     let (stream, sink) = client.split();
     let mut server = Server::new(service);

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1628,8 +1628,7 @@ async fn plugin_load_error_show_message() -> Result<()> {
         }
     }"#;
 
-    const INVALID_PLUGIN_CONTENT: &[u8] = br#"
-xx"#;
+    const INVALID_PLUGIN_CONTENT: &[u8] = br#"foo"#;
 
     fs.insert(
         Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -357,6 +357,40 @@ const CHANNEL_BUFFER_SIZE: usize = 8;
 #[derive(Debug, PartialEq, Eq)]
 enum ServerNotification {
     PublishDiagnostics(PublishDiagnosticsParams),
+    ShowMessage(ShowMessageParams),
+}
+impl ServerNotification {
+    pub fn is_publish_diagnostics(&self) -> bool {
+        matches!(self, ServerNotification::PublishDiagnostics(_))
+    }
+
+    pub fn is_show_message(&self) -> bool {
+        matches!(self, ServerNotification::ShowMessage(_))
+    }
+}
+
+async fn wait_for_notification(
+    receiver: &mut (impl futures::stream::Stream<Item = ServerNotification> + Unpin),
+    check: impl Fn(&ServerNotification) -> bool,
+) -> Option<ServerNotification> {
+    loop {
+        let notification = tokio::select! {
+            msg = receiver.next() => msg,
+            _ = sleep(Duration::from_secs(1)) => {
+                panic!("timed out waiting for the server to send diagnostics")
+            }
+        };
+
+        match notification {
+            Some(notification) => {
+                if check(&notification) {
+                    return Some(notification);
+                }
+                continue;
+            }
+            None => break None,
+        }
+    }
 }
 
 /// Basic handler for requests and notifications coming from the server for tests
@@ -372,10 +406,16 @@ where
     O: Sink<Response> + Unpin,
 {
     while let Some(req) = stream.next().await {
-        if req.method() == "textDocument/publishDiagnostics" {
-            let params = req.params().expect("invalid request");
-            let diagnostics = from_value(params.clone()).expect("invalid params");
-            let notification = ServerNotification::PublishDiagnostics(diagnostics);
+        let params = req.params().expect("invalid request").clone();
+        if let Some(notification) = match req.method() {
+            "textDocument/publishDiagnostics" => Some(ServerNotification::PublishDiagnostics(
+                from_value(params).expect("invalid params"),
+            )),
+            "window/showMessage" => Some(ServerNotification::ShowMessage(
+                from_value(params).expect("invalid params"),
+            )),
+            _ => None,
+        } {
             match notify.send(notification).await {
                 Ok(_) => continue,
                 Err(_) => break,
@@ -760,12 +800,7 @@ async fn pull_diagnostics() -> Result<()> {
 
     server.open_document("if(a == b) {}").await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -842,12 +877,7 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
 
     server.open_document("class A { #foo; #foo }").await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -904,12 +934,7 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
 
     server.open_untitled_document("if(a == b) {}").await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -1550,12 +1575,7 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
         .open_named_document(incorrect_config, url!("biome.json"), "json")
         .await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -1586,6 +1606,65 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
             }
         ))
     );
+
+    server.close_document().await?;
+
+    server.shutdown().await?;
+    reader.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn plugin_load_error_show_message() -> Result<()> {
+    let factory = ServerFactory::default();
+    let mut fs = MemoryFileSystem::default();
+    let config = r#"{
+        "css": {
+            "linter": { "enabled": true }
+        },
+        "plugins": ["./plugin"],
+        "linter": {
+            "rules": { "correctness": { "noUnknownProperty": "error" } }
+        }
+    }"#;
+
+    const INVALID_PLUGIN_CONTENT: &[u8] = br#"
+xx"#;
+
+    fs.insert(
+        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
+        config,
+    );
+    fs.insert(
+        Utf8PathBuf::from_path_buf(url!("plugin").to_file_path().unwrap()).unwrap(),
+        INVALID_PLUGIN_CONTENT,
+    );
+
+    let (service, client) = factory.create_with_fs(None, Box::new(fs)).into_inner();
+
+    let (stream, sink) = client.split();
+    let mut server = Server::new(service);
+
+    let (sender, mut receiver) = channel(CHANNEL_BUFFER_SIZE);
+    let reader = tokio::spawn(client_handler(stream, sink, sender));
+
+    server.initialize().await?;
+    server.initialized().await?;
+
+    server.load_configuration().await?;
+
+    let incorrect_config = r#"a {colr: blue;}"#;
+    server
+        .open_named_document(incorrect_config, url!("document.css"), "css")
+        .await?;
+
+    let notification = wait_for_notification(&mut receiver, |n| n.is_show_message()).await;
+
+    assert_eq!(notification, Some(ServerNotification::ShowMessage(ShowMessageParams {
+        typ: MessageType::WARNING,
+        message: "The plugin loading has failed. Biome will report only parsing errors until the file is fixed or its usage is disabled.".to_string(),
+    })));
 
     server.close_document().await?;
 
@@ -1631,12 +1710,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
         .open_named_document(incorrect_config, url!("document.css"), "css")
         .await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -1705,12 +1779,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
         )
         .await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,
@@ -2574,12 +2643,7 @@ async fn pull_diagnostics_from_manifest() -> Result<()> {
         .open_document(r#"import "lodash"; import "react"; "#)
         .await?;
 
-    let notification = tokio::select! {
-        msg = receiver.next() => msg,
-        _ = sleep(Duration::from_secs(1)) => {
-            panic!("timed out waiting for the server to send diagnostics")
-        }
-    };
+    let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
     assert_eq!(
         notification,

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -720,9 +720,9 @@ impl Session {
         self.insert_and_scan_project(project_key, path.into());
 
         if let Err(WorkspaceError::PluginErrors(error)) = result {
-            error!("Failed to load plugins: {:?}", error);
+            error!("Failed to load plugins: {error:?}");
             self.client
-                .log_message(MessageType::ERROR, format!("{:?}", error))
+                .log_message(MessageType::ERROR, format!("{error:?}"))
                 .await;
             ConfigurationStatus::PluginError
         } else if let Err(error) = result {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -721,7 +721,9 @@ impl Session {
 
         if let Err(WorkspaceError::PluginErrors(error)) = result {
             error!("Failed to load plugins: {:?}", error);
-            // self.client.log_message(MessageType::ERROR, &error).await;
+            self.client
+                .log_message(MessageType::ERROR, format!("{:?}", error))
+                .await;
             ConfigurationStatus::PluginError
         } else if let Err(error) = result {
             error!("Failed to set workspace settings: {error}");


### PR DESCRIPTION
related: https://github.com/biomejs/biome/issues/5163 https://github.com/biomejs/biome/pull/5160

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- [x] 1. When plugin load fails, report to LSP in the similar manner as configuration has errors. (currently the error text is set to: `The plugin loading has failed. Biome will report only parsing errors until the file is fixed or its usage is disabled.`)
- [x] 2. Print the diagnostics emitted by merge_with_configuration in the LSP, possibly using the error! tracing log. (looks like already logged on `crates/biome_lsp/src/session.rs 680`. TODO: check if logged in VSC)
- [x] ~~3. When plugin file changes, should try to reload the plugins~~ (currently saving config file will trigger plugin reload)

## Test Plan

- [x] test for 1 added `plugin_load_error_show_message` crates/biome_lsp/src/server.tests.rs
- [x] confirmed that errors returned by merge_with_configuration is already reported by `window/logMessage` to client and showed in VSCode `Biome` output pannel.