### PR TITLE
fix(parser): don't apply `jsxEverywhere` to `.ts` files

### DIFF
--- a/.changeset/add_new_option_javascriptjsxeverywhere.md
+++ b/.changeset/add_new_option_javascriptjsxeverywhere.md
@@ -2,8 +2,10 @@
 "@biomejs/biome": minor
 ---
 
-Add new option `javascript.parser.jsxEverywhere`. This new option allows to control whether Biome should expect JSX syntax in `.js`/`.ts` files.
+Add new option `javascript.parser.jsxEverywhere`. This new option allows to control whether Biome should expect JSX syntax in `.js`/`.mjs`/`.cjs` files.
 
-When `jsxEverywhere` is set to `false`, having JSX syntax like `<div></div>` inside `.js`/`.ts` files will result in a **parsing error**.
+When `jsxEverywhere` is set to `false`, having JSX syntax like `<div></div>` inside `.js`/`.mjs`/`.cjs` files will result in a **parsing error**.
+
+Despite the name of the option, JSX is never supported inside `.ts` files. This is because TypeScript generics syntax may conflict with JSX in such files.
 
 This option defaults to `true`.

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -50,7 +50,8 @@ The configuration that is contained inside the file `biome.json`
                               Configuration in `biome.json` will override `.editorconfig`
                               configuration.
                               Default: `false`.
-        --jsx-everywhere=<true|false>  When enabled, files like `.js`/`.ts` can contain JSX syntax.
+        --jsx-everywhere=<true|false>  When enabled, files like `.js`/`.mjs`/`.cjs` may contain JSX
+                              syntax.
                               Defaults to `true`.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its
                               super languages) files.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -51,7 +51,8 @@ The configuration that is contained inside the file `biome.json`
                               Configuration in `biome.json` will override `.editorconfig`
                               configuration.
                               Default: `false`.
-        --jsx-everywhere=<true|false>  When enabled, files like `.js`/`.ts` can contain JSX syntax.
+        --jsx-everywhere=<true|false>  When enabled, files like `.js`/`.mjs`/`.cjs` may contain JSX
+                              syntax.
                               Defaults to `true`.
         --javascript-formatter-enabled=<true|false>  Control the formatter for JavaScript (and its
                               super languages) files.

--- a/crates/biome_configuration/src/javascript/mod.rs
+++ b/crates/biome_configuration/src/javascript/mod.rs
@@ -70,7 +70,9 @@ pub struct JsParserConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grit_metavariables: Option<JsGritMetavariable>,
 
-    /// When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.
+    /// When enabled, files like `.js`/`.mjs`/`.cjs` may contain JSX syntax.
+    ///
+    /// Defaults to `true`.
     #[bpaf(long("jsx-everywhere"), argument("true|false"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jsx_everywhere: Option<JsxEverywhere>,

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -552,7 +552,7 @@ fn parse(
     }
 
     let mut file_source = file_source.to_js_file_source().unwrap_or_default();
-    if jsx_everywhere {
+    if jsx_everywhere && !file_source.is_typescript() {
         file_source = file_source.with_variant(LanguageVariant::Jsx);
     }
     let parse = biome_js_parser::parse_js_with_cache(text, file_source, options, cache);
@@ -1028,3 +1028,7 @@ fn rename(
         ))
     }
 }
+
+#[cfg(test)]
+#[path = "javascript.tests.rs"]
+mod tests;

--- a/crates/biome_service/src/file_handlers/javascript.tests.rs
+++ b/crates/biome_service/src/file_handlers/javascript.tests.rs
@@ -1,0 +1,41 @@
+use biome_configuration::bool::Bool;
+use biome_configuration::javascript::JsParserConfiguration;
+use biome_configuration::{Configuration, JsConfiguration};
+use biome_fs::BiomePath;
+
+use crate::settings::Settings;
+
+use super::*;
+
+#[test]
+fn correctly_parses_ts_generics_with_jsx_everywhere() {
+    let js_conf = JsConfiguration {
+        parser: Some(JsParserConfiguration {
+            jsx_everywhere: Some(Bool(true)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let configuration = Configuration {
+        javascript: Some(js_conf),
+        ..Default::default()
+    };
+    let mut settings = Settings::default();
+    settings
+        .merge_with_configuration(configuration, None)
+        .expect("valid configuration");
+
+    let source = r#"
+const f = <T1>(arg1: T1) => <T2>(arg2: T2) => {
+    return { arg1, arg2 };
+}
+"#;
+    let result = parse(
+        &BiomePath::new("file.test"),
+        DocumentFileSource::Js(JsFileSource::ts()),
+        source,
+        settings.into(),
+        &mut NodeCache::default(),
+    );
+    assert!(!result.any_parse.has_errors());
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -650,7 +650,9 @@ export interface JsParserConfiguration {
 	 */
 	gritMetavariables?: Bool;
 	/**
-	 * When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.
+	* When enabled, files like `.js`/`.mjs`/`.cjs` may contain JSX syntax.
+
+Defaults to `true`. 
 	 */
 	jsxEverywhere?: Bool;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1990,7 +1990,7 @@
 					"anyOf": [{ "$ref": "#/definitions/Bool" }, { "type": "null" }]
 				},
 				"jsxEverywhere": {
-					"description": "When enabled, files like `.js`/`.ts` can contain JSX syntax. Defaults to `true`.",
+					"description": "When enabled, files like `.js`/`.mjs`/`.cjs` may contain JSX syntax.\n\nDefaults to `true`.",
 					"anyOf": [{ "$ref": "#/definitions/Bool" }, { "type": "null" }]
 				},
 				"unsafeParameterDecoratorsEnabled": {


### PR DESCRIPTION
## Summary

`.jsxEverywhere` should make an exception for `.ts` files to avoid conflicts with TS generics.

I've updated the original changeset.

## Test Plan

Test added. Also manually tested.
