### PR TITLE
fix(lint): allow single spaces in useConsistentCurlyBraces rule

### DIFF
--- a/.changeset/fancy-coins-cross.md
+++ b/.changeset/fancy-coins-cross.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Allow single spaces in `useConsistentCurlyBraces` rule.

--- a/.changeset/fancy-coins-cross.md
+++ b/.changeset/fancy-coins-cross.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Allow single spaces in `useConsistentCurlyBraces` rule.
+Allowed single spaces in `useConsistentCurlyBraces` rule.

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_curly_braces.rs
@@ -339,7 +339,9 @@ fn handle_attr_init_clause(
     match node {
         AnyJsxAttributeValue::AnyJsxTag(_) => Some(CurlyBraceResolution::AddBraces),
         AnyJsxAttributeValue::JsxExpressionAttributeValue(node) => {
-            if has_curly_braces && contains_string_literal(&node) {
+            if has_curly_braces && contains_single_space(&node) {
+                None
+            } else if has_curly_braces && contains_string_literal(&node) {
                 Some(CurlyBraceResolution::RemoveBraces)
             } else if !has_curly_braces && contains_jsx_tag(&node) {
                 Some(CurlyBraceResolution::AddBraces)
@@ -353,18 +355,25 @@ fn handle_attr_init_clause(
 
 fn handle_jsx_child(child: &AnyJsxChild, has_curly_braces: bool) -> Option<CurlyBraceResolution> {
     match child {
-        AnyJsxChild::JsxExpressionChild(child) => child
-            .expression()
-            .as_ref()
-            .and_then(|node| node.as_any_js_literal_expression())
-            .and_then(|node| node.as_js_string_literal_expression())
-            .and({
-                if has_curly_braces {
-                    Some(CurlyBraceResolution::RemoveBraces)
-                } else {
-                    None
+        AnyJsxChild::JsxExpressionChild(child) => {
+            if let Some(AnyJsExpression::AnyJsLiteralExpression(
+                AnyJsLiteralExpression::JsStringLiteralExpression(literal),
+            )) = child.expression().as_ref()
+            {
+                // Don't suggest removing braces for single space
+                if literal
+                    .inner_string_text()
+                    .is_ok_and(|text| text.text() == " ")
+                {
+                    return None;
                 }
-            }),
+
+                if has_curly_braces {
+                    return Some(CurlyBraceResolution::RemoveBraces);
+                }
+            }
+            None
+        }
         AnyJsxChild::JsxText(_) => None,
         _ => None,
     }
@@ -374,8 +383,7 @@ fn has_curly_braces(node: &AnyJsxCurlyQuery) -> bool {
     match node {
         AnyJsxCurlyQuery::JsxAttributeInitializerClause(node) => {
             node.value()
-                .map(|node| matches!(node, AnyJsxAttributeValue::JsxExpressionAttributeValue(attr) if attr.l_curly_token().is_ok() || attr.r_curly_token().is_ok()))
-                .unwrap_or(false)
+                .is_ok_and(|node| matches!(node, AnyJsxAttributeValue::JsxExpressionAttributeValue(attr) if attr.l_curly_token().is_ok() || attr.r_curly_token().is_ok()))
         }
         AnyJsxCurlyQuery::AnyJsxChild(node) => match node {
             AnyJsxChild::JsxExpressionChild(node) => node.l_curly_token().is_ok() || node.r_curly_token().is_ok(),
@@ -399,4 +407,15 @@ fn contains_string_literal(node: &JsxExpressionAttributeValue) -> bool {
 fn contains_jsx_tag(node: &JsxExpressionAttributeValue) -> bool {
     node.expression()
         .is_ok_and(|expr| matches!(expr, AnyJsExpression::JsxTagExpression(_)))
+}
+
+fn contains_single_space(node: &JsxExpressionAttributeValue) -> bool {
+    node.expression().is_ok_and(|expr| {
+        matches!(
+            expr,
+            AnyJsExpression::AnyJsLiteralExpression(
+                AnyJsLiteralExpression::JsStringLiteralExpression(literal)
+            ) if literal.inner_string_text().is_ok_and(|text| text.text() == " ")
+        )
+    })
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/valid.jsx
@@ -19,4 +19,6 @@ let baz = 4;
 <Foo><Bar /></Foo>
 
 <Foo>{/*comment*/}Hello world{/*comment*/}</Foo>
+
+<Foo>{' '}</Foo>
 </>

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentCurlyBraces/valid.jsx.snap
@@ -25,6 +25,8 @@ let baz = 4;
 <Foo><Bar /></Foo>
 
 <Foo>{/*comment*/}Hello world{/*comment*/}</Foo>
+
+<Foo>{' '}</Foo>
 </>
 
 ```


### PR DESCRIPTION
Fixes #4154

Update `useConsistentCurlyBraces` rule to ignore single spaces and newline characters in React components.