### PR TITLE
fix(wasm): add missing `RuleDomain` and `RuleDomainValue` types to the generated declaration

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -479,7 +479,7 @@ impl RuleSourceKind {
 }
 
 /// Rule domains
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(

--- a/crates/biome_configuration/src/analyzer/linter/mod.rs
+++ b/crates/biome_configuration/src/analyzer/linter/mod.rs
@@ -8,6 +8,7 @@ use bpaf::Bpaf;
 pub use rules::*;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 pub type LinterEnabled = Bool<true>;
 
@@ -36,7 +37,7 @@ pub struct LinterConfiguration {
     /// An object where the keys are the names of the domains, and the values are `all`, `recommended`, or `none`.
     #[bpaf(hide, pure(Default::default()))]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub domains: Option<FxHashMap<RuleDomain, RuleDomainValue>>,
+    pub domains: Option<RuleDomains>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize, Merge)]
@@ -49,6 +50,38 @@ pub enum RuleDomainValue {
     None,
     /// It enables only the recommended rules for this domain
     Recommended,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize, Merge)]
+pub struct RuleDomains(FxHashMap<RuleDomain, RuleDomainValue>);
+
+impl Deref for RuleDomains {
+    type Target = FxHashMap<RuleDomain, RuleDomainValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for RuleDomains {
+    fn schema_name() -> String {
+        "RuleDomains".to_string()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::Object.into()),
+            object: Some(Box::new(ObjectValidation {
+                property_names: Some(Box::new(generator.subschema_for::<RuleDomain>())),
+                additional_properties: Some(Box::new(generator.subschema_for::<RuleDomainValue>())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
 }
 
 impl LinterConfiguration {

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -1,19 +1,17 @@
 use crate::analyzer::assist::AssistEnabled;
-use crate::analyzer::{LinterEnabled, RuleDomainValue};
+use crate::analyzer::{LinterEnabled, RuleDomains};
 use crate::formatter::{FormatWithErrorsEnabled, FormatterEnabled};
 use crate::html::HtmlConfiguration;
 use crate::{
     CssConfiguration, GraphqlConfiguration, GritConfiguration, JsConfiguration, JsonConfiguration,
     Rules,
 };
-use biome_analyze::RuleDomain;
 use biome_deserialize_macros::{Deserializable, Merge};
 use biome_formatter::{
     AttributePosition, BracketSameLine, BracketSpacing, Expand, IndentStyle, IndentWidth,
     LineEnding, LineWidth,
 };
 use bpaf::Bpaf;
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
@@ -184,8 +182,8 @@ pub struct OverrideLinterConfiguration {
 
     /// List of rules
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(pure(FxHashMap::default()), optional, hide)]
-    pub domains: Option<FxHashMap<RuleDomain, RuleDomainValue>>,
+    #[bpaf(pure(Default::default()), optional, hide)]
+    pub domains: Option<RuleDomains>,
 }
 
 #[derive(Bpaf, Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]

--- a/crates/biome_configuration/tests/invalid/domains.json
+++ b/crates/biome_configuration/tests/invalid/domains.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "../../../../packages/@biomejs/biome/configuration_schema.json",
   "linter": {
     "domains": {
       "DO_NOT_EXISTS": true

--- a/crates/biome_configuration/tests/invalid/domains.json
+++ b/crates/biome_configuration/tests/invalid/domains.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../../packages/@biomejs/biome/configuration_schema.json",
   "linter": {
     "domains": {
       "DO_NOT_EXISTS": true

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1,8 +1,8 @@
 use crate::WorkspaceError;
 use crate::workspace::DocumentFileSource;
-use biome_analyze::{AnalyzerOptions, AnalyzerRules, RuleDomain};
+use biome_analyze::{AnalyzerOptions, AnalyzerRules};
 use biome_configuration::analyzer::assist::{Actions, AssistConfiguration, AssistEnabled};
-use biome_configuration::analyzer::{LinterEnabled, RuleDomainValue};
+use biome_configuration::analyzer::{LinterEnabled, RuleDomains};
 use biome_configuration::bool::Bool;
 use biome_configuration::diagnostics::InvalidIgnorePattern;
 use biome_configuration::formatter::{FormatWithErrorsEnabled, FormatterEnabled};
@@ -41,7 +41,6 @@ use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use camino::{Utf8Path, Utf8PathBuf};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use rustc_hash::FxHashMap;
 use std::borrow::Cow;
 use std::ops::Deref;
 use tracing::instrument;
@@ -177,10 +176,7 @@ impl Settings {
     }
 
     /// Extract the domains applied to the given `path`, by looking that the base `domains`, and the once applied by `overrides`
-    pub fn as_linter_domains(
-        &self,
-        path: &Utf8Path,
-    ) -> Option<Cow<FxHashMap<RuleDomain, RuleDomainValue>>> {
+    pub fn as_linter_domains(&self, path: &Utf8Path) -> Option<Cow<RuleDomains>> {
         let mut result = self.linter.domains.as_ref().map(Cow::Borrowed);
         let overrides = &self.override_settings;
         for pattern in overrides.patterns.iter() {
@@ -309,7 +305,7 @@ pub struct LinterSettings {
     pub includes: Includes,
 
     /// Rule domains
-    pub domains: Option<FxHashMap<RuleDomain, RuleDomainValue>>,
+    pub domains: Option<RuleDomains>,
 }
 
 impl LinterSettings {
@@ -328,7 +324,7 @@ pub struct OverrideLinterSettings {
     pub rules: Option<Rules>,
 
     /// List of domains
-    pub domains: Option<FxHashMap<RuleDomain, RuleDomainValue>>,
+    pub domains: Option<RuleDomains>,
 }
 
 /// Linter settings for the entire workspace

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -56,9 +56,10 @@ fn instance_type<'a>(
         // If the instance type is an object, generate a TS object type with the corresponding properties
         InstanceType::Object => {
             let object = schema.object.as_deref().unwrap();
-            AnyTsType::from(make::ts_object_type(
-                make::token(T!['{']),
-                make::ts_type_member_list(object.properties.iter().map(|(property, schema)| {
+            let properties = object
+                .properties
+                .iter()
+                .map(|(property, schema)| {
                     let (ts_type, optional, description) = schema_type(queue, root_schema, schema);
                     assert!(!optional, "optional nested types are not supported");
 
@@ -80,9 +81,69 @@ fn instance_type<'a>(
                         .with_type_annotation(make::ts_type_annotation(make::token(T![:]), ts_type))
                         .build(),
                     )
-                })),
-                make::token(T!['}']),
-            ))
+                })
+                .collect::<Vec<_>>();
+
+            let properties_type = (!properties.is_empty()).then(|| {
+                make::ts_object_type(
+                    make::token(T!['{']),
+                    make::ts_type_member_list(properties),
+                    make::token(T!['}']),
+                )
+                .into()
+            });
+
+            // If `additionalProperties` is not empty, add a `Record<K, V>` type
+            let additional_properties_type =
+                object.additional_properties.as_deref().map(|schema| {
+                    // If `propertyNames` is not empty, use as the key type
+                    let key_type = object
+                        .property_names
+                        .as_deref()
+                        .map(|schema| {
+                            let (ts_type, optional, _) = schema_type(queue, root_schema, schema);
+                            assert!(!optional, "optional nested types are not supported");
+                            ts_type
+                        })
+                        .unwrap_or_else(|| {
+                            // Otherwise, use `string` as the key type
+                            make::ts_reference_type(
+                                make::js_reference_identifier(make::ident("string")).into(),
+                            )
+                            .build()
+                            .into()
+                        });
+
+                    let value_type = {
+                        let (ts_type, optional, _) = schema_type(queue, root_schema, schema);
+                        assert!(!optional, "optional nested types are not supported");
+                        ts_type
+                    };
+
+                    make::ts_reference_type(
+                        make::js_reference_identifier(make::ident("Record")).into(),
+                    )
+                    .with_type_arguments(make::ts_type_arguments(
+                        make::token(T![<]),
+                        make::ts_type_argument_list([key_type, value_type], [make::token(T![,])]),
+                        make::token(T![>]),
+                    ))
+                    .build()
+                    .into()
+                });
+
+            // If both `properties` and `additionalProperties` are provided, turn into an
+            // intersection type. Pick one for the final type otherwise.
+            let result = [properties_type, additional_properties_type]
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+
+            let separators = (0..result.len().saturating_sub(1)).map(|_| make::token(T![&]));
+
+            make::ts_intersection_type(make::ts_intersection_type_element_list(result, separators))
+                .build()
+                .into()
         }
         // If the instance type is an array, generate a TS array type with the corresponding item type
         InstanceType::Array => {
@@ -319,16 +380,20 @@ pub fn generate_type<'a>(
     while let Some((name, schema)) = queue.pop_front() {
         // Detect if the type being emitted is an object, emit it as an
         // interface definition if that's the case
-        let is_interface = schema.instance_type.as_ref().map_or_else(
-            || schema.object.is_some(),
-            |instance_type| {
-                if let SingleOrVec::Single(instance_type) = instance_type {
-                    matches!(**instance_type, InstanceType::Object)
-                } else {
-                    false
-                }
-            },
-        );
+        let is_interface = schema.object.as_deref().is_some_and(|object| {
+            object
+                .additional_properties
+                .as_deref()
+                .is_none_or(|additional_properties| {
+                    matches!(additional_properties, Schema::Bool(false))
+                })
+        }) && schema.instance_type.as_ref().map_or(true, |instance_type| {
+            if let SingleOrVec::Single(instance_type) = instance_type {
+                matches!(**instance_type, InstanceType::Object)
+            } else {
+                false
+            }
+        });
 
         if is_interface {
             let mut members = Vec::new();
@@ -353,7 +418,6 @@ pub fn generate_type<'a>(
                 let type_annotation = if let Some((container_type, key_type, value_type)) =
                     match property_str.as_str() {
                         "featuresSupported" => Some(("Map", "FeatureKind", "SupportKind")),
-                        "domains" => Some(("Record", "RuleDomain", "RuleDomainValue")),
                         _ => None,
                     } {
                     // HACK: force the `featuresSupported` property to be a Map<FeatureKind, SupportKind>

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3530,20 +3530,17 @@ export type DiagnosticTags = DiagnosticTag[];
 See the [Visitor] trait for additional documentation on all the supported advice types. 
 	 */
 export type Advice =
-	| ({ log: [LogCategory, MarkupBuf] } & Record<string, never>)
-	| ({ list: MarkupBuf[] } & Record<string, never>)
-	| ({ frame: Location } & Record<string, never>)
-	| ({ diff: TextEdit } & Record<string, never>)
-	| ({ backtrace: [MarkupBuf, Backtrace] } & Record<string, never>)
-	| ({ command: string } & Record<string, never>)
-	| ({ group: [MarkupBuf, Advices] } & Record<string, never>);
+	| { log: [LogCategory, MarkupBuf] }
+	| { list: MarkupBuf[] }
+	| { frame: Location }
+	| { diff: TextEdit }
+	| { backtrace: [MarkupBuf, Backtrace] }
+	| { command: string }
+	| { group: [MarkupBuf, Advices] };
 /**
  * Represents the resource a diagnostic is associated with.
  */
-export type Resource_for_String =
-	| "argv"
-	| "memory"
-	| ({ file: string } & Record<string, never>);
+export type Resource_for_String = "argv" | "memory" | { file: string };
 export type TextRange = [TextSize, TextSize];
 export interface MarkupNodeBuf {
 	content: string;
@@ -3583,10 +3580,10 @@ export type MarkupElement =
 	| "Debug"
 	| "Trace"
 	| "Inverse"
-	| ({ Hyperlink: { href: string } } & Record<string, never>);
+	| { Hyperlink: { href: string } };
 export type CompressedOp =
-	| ({ diffOp: DiffOp } & Record<string, never>)
-	| ({ equalLines: { line_count: number } } & Record<string, never>);
+	| { diffOp: DiffOp }
+	| { equalLines: { line_count: number } };
 /**
  * Serializable representation of a backtrace frame.
  */
@@ -3595,9 +3592,9 @@ export interface BacktraceFrame {
 	symbols: BacktraceSymbol[];
 }
 export type DiffOp =
-	| ({ equal: { range: TextRange } } & Record<string, never>)
-	| ({ insert: { range: TextRange } } & Record<string, never>)
-	| ({ delete: { range: TextRange } } & Record<string, never>);
+	| { equal: { range: TextRange } }
+	| { insert: { range: TextRange } }
+	| { delete: { range: TextRange } };
 /**
  * Serializable representation of a backtrace frame symbol.
  */
@@ -3635,12 +3632,12 @@ export type FileContent =
 export type DocumentFileSource =
 	| "Ignore"
 	| "Unknown"
-	| ({ Js: JsFileSource } & Record<string, never>)
-	| ({ Json: JsonFileSource } & Record<string, never>)
-	| ({ Css: CssFileSource } & Record<string, never>)
-	| ({ Graphql: GraphqlFileSource } & Record<string, never>)
-	| ({ Html: HtmlFileSource } & Record<string, never>)
-	| ({ Grit: GritFileSource } & Record<string, never>);
+	| { Js: JsFileSource }
+	| { Json: JsonFileSource }
+	| { Css: CssFileSource }
+	| { Graphql: GraphqlFileSource }
+	| { Html: HtmlFileSource }
+	| { Grit: GritFileSource };
 export interface JsFileSource {
 	/**
 	 * Used to mark if the source is being used for an Astro, Svelte or Vue file
@@ -3671,7 +3668,7 @@ export interface GritFileSource {
 export type EmbeddingKind = "Astro" | "Vue" | "Svelte" | "None";
 export type Language =
 	| "javaScript"
-	| ({ typeScript: { definition_file: boolean } } & Record<string, never>);
+	| { typeScript: { definition_file: boolean } };
 /**
  * Is the source file an ECMAScript Module or Script. Changes the parsing semantic.
  */
@@ -3781,10 +3778,10 @@ export interface CodeAction {
 [CodeActionKind]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind 
 	 */
 export type ActionCategory =
-	| ({ quickFix: string } & Record<string, never>)
-	| ({ refactor: RefactorKind } & Record<string, never>)
-	| ({ source: SourceActionKind } & Record<string, never>)
-	| ({ other: OtherActionCategory } & Record<string, never>);
+	| { quickFix: string }
+	| { refactor: RefactorKind }
+	| { source: SourceActionKind }
+	| { other: OtherActionCategory };
 /**
  * A Suggestion that is provided by Biome's linter, and can be reported to the user, and can be automatically applied if it has the right [`Applicability`].
  */
@@ -3805,7 +3802,7 @@ export type RefactorKind =
 	| "extract"
 	| "inline"
 	| "rewrite"
-	| ({ other: string } & Record<string, never>);
+	| { other: string };
 /**
  * The sub-category of a source code action
  */
@@ -3813,11 +3810,11 @@ export type SourceActionKind =
 	| "fixAll"
 	| "none"
 	| "organizeImports"
-	| ({ other: string } & Record<string, never>);
+	| { other: string };
 export type OtherActionCategory =
 	| "inlineSuppression"
 	| "toplevelSuppression"
-	| ({ generic: string } & Record<string, never>);
+	| { generic: string };
 /**
  * Indicates how a tool should manage this suggestion.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2264,8 +2264,7 @@
 			"properties": {
 				"domains": {
 					"description": "An object where the keys are the names of the domains, and the values are `all`, `recommended`, or `none`.",
-					"type": ["object", "null"],
-					"additionalProperties": { "$ref": "#/definitions/RuleDomainValue" }
+					"anyOf": [{ "$ref": "#/definitions/RuleDomains" }, { "type": "null" }]
 				},
 				"enabled": {
 					"description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
@@ -3101,8 +3100,7 @@
 			"properties": {
 				"domains": {
 					"description": "List of rules",
-					"type": ["object", "null"],
-					"additionalProperties": { "$ref": "#/definitions/RuleDomainValue" }
+					"anyOf": [{ "$ref": "#/definitions/RuleDomains" }, { "type": "null" }]
 				},
 				"enabled": {
 					"description": "if `false`, it disables the feature and the linter won't be executed. `true` by default",
@@ -3341,6 +3339,27 @@
 				{ "$ref": "#/definitions/RuleWithNoOptions" }
 			]
 		},
+		"RuleDomain": {
+			"description": "Rule domains",
+			"oneOf": [
+				{
+					"description": "React library rules",
+					"type": "string",
+					"enum": ["react"]
+				},
+				{ "description": "Testing rules", "type": "string", "enum": ["test"] },
+				{
+					"description": "Solid.js framework rules",
+					"type": "string",
+					"enum": ["solid"]
+				},
+				{
+					"description": "Next.js framework rules",
+					"type": "string",
+					"enum": ["next"]
+				}
+			]
+		},
 		"RuleDomainValue": {
 			"oneOf": [
 				{
@@ -3359,6 +3378,11 @@
 					"enum": ["recommended"]
 				}
 			]
+		},
+		"RuleDomains": {
+			"type": "object",
+			"additionalProperties": { "$ref": "#/definitions/RuleDomainValue" },
+			"propertyNames": { "$ref": "#/definitions/RuleDomain" }
 		},
 		"RuleFixConfiguration": {
 			"anyOf": [


### PR DESCRIPTION
## Summary

`RuleDomain` and `RuleDomainValue` were missing in the generated `biome_wasm.d.ts` declaration file. The declaration file is generated from the JSON schema (from `schemars`), and it didn't support `additionalProperties` and `propertyNames`. I added their support to the build script to generate the missing types.

Plus, supported rule domains are now validated in editors that supports JSON schema (Draft 6 or later):

<img width="659" alt="image" src="https://github.com/user-attachments/assets/14293c1b-3de7-4d21-b012-2abb5ec0703e" />

## Test Plan

Once this is merged, the changes will be synced to `biomejs/website` repository. `tsc` on the website repository will be green after that.
