### PR TITLE
fix(codegen): use optional mapped type for rule domains

### DIFF
--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -733,7 +733,7 @@ export interface JsonParserConfiguration {
 	 */
 	allowTrailingCommas?: Bool;
 }
-export type RuleDomains = Record<RuleDomain, RuleDomainValue>;
+export type RuleDomains = { [K in RuleDomain]?: RuleDomainValue };
 export interface Rules {
 	a11y?: SeverityOrGroup_for_A11y;
 	complexity?: SeverityOrGroup_for_Complexity;


### PR DESCRIPTION
## Summary

Follow-up of #5306 

Previously, biome-wasm and biome-jsonrpc provided the following type for rule domains:

```ts
type RuleDomains = Record<RuleDomain, RuleDomainValue>;
```

We need to provide a value for **all** domains to satisfy the type:

```ts
let domains: RuleDomains = {
  react: "none",
  test: "none",
  solid: "none",
  next: "none",
};
```

This is not needed in this case. I changed the codegen to use an optional mapped type:

```ts
type RuleDomains = { [K in RuleDomain]?: RuleDomainValue };
```

## Test Plan

I'll use the generated type in biomejs/website to check the generated types are correct.
