### PR TITLE
fix: use alphabetical order in Ord and PartialOrd impls on RuleDomain

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -479,7 +479,7 @@ impl RuleSourceKind {
 }
 
 /// Rule domains
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(
@@ -510,6 +510,19 @@ impl Display for RuleDomain {
             RuleDomain::Solid => fmt.write_str("solid"),
             RuleDomain::Next => fmt.write_str("next"),
         }
+    }
+}
+
+impl Ord for RuleDomain {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Rule domains should be in alphabetical order
+        format!("{self:?}").cmp(&format!("{other:?}"))
+    }
+}
+
+impl PartialOrd for RuleDomain {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
## Summary

From https://github.com/biomejs/website/pull/1815#discussion_r1986060422

Removed deriving `Ord` and `PartialOrd`, added their impls to use alphabetical order.

## Test Plan

I'll pull the synced changes to check the ordering is correct in biomejs/website#1815
