### PR TITLE
docs: copy docs of import sorting from website

### DIFF
--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -160,7 +160,7 @@ declare_source_rule! {
         language: "js",
         recommended: true,
         fix_kind: FixKind::Safe,
-     }
+    }
 }
 
 impl Rule for OrganizeImports {

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -13,28 +13,146 @@ pub mod legacy;
 pub mod util;
 
 declare_source_rule! {
-    /// Provides a whole-source code action to sort the imports in the file
-    /// using import groups and natural ordering.
+    /// Provides a whole-source code action to sort the imports in the file using import groups and natural ordering.
     ///
-    /// ## Examples
+    /// ## How imports are sorted
+    ///
+    /// Import statements are sorted by "distance". Modules that are "farther" from the user are put on the top, modules "closer" to the user are put on the bottom:
+    ///
+    /// 1. modules imported via `bun:` protocol. This is applicable when writing code run by Bun;
+    /// 1. built-in Node.js modules that are explicitly imported using the `node:` protocol and common Node built-ins such as `assert`;
+    /// 1. modules imported via `npm:` protocol. This is applicable when writing code run by Deno;
+    /// 1. modules that contain the protocol `:`. These are usually considered "virtual modules", modules that are injected by your working environment, e.g. `vite`;
+    /// 1. modules imported via URL;
+    /// 1. modules imported from libraries;
+    /// 1. modules imported via absolute imports;
+    /// 1. modules imported from a name prefixed by `#`. This is applicable when using [Node's subpath imports](https://nodejs.org/api/packages.html#subpath-imports);
+    /// 1. modules imported via relative imports;
+    /// 1. modules that couldn't be identified by the previous criteria;
+    ///
+    /// For example, given the following code:
+    ///
+    /// ```ts title="example.ts"
+    /// import uncle from "../uncle";
+    /// import sibling from "./sibling";
+    /// import express from "npm:express";
+    /// import imageUrl from "url:./image.png";
+    /// import { sortBy } from "virtual:utils";
+    /// import assert from "node:assert";
+    /// import aunt from "../aunt";
+    /// import { VERSION } from "https://deno.land/std/version.ts";
+    /// import { mock, test } from "node:test";
+    /// import { expect } from "bun:test";
+    /// import { internal } from "#internal";
+    /// import { secret } from "/absolute/path";
+    /// import React from "react";
+    /// ```
+    ///
+    /// They will be sorted like this:
+    ///
+    /// ```ts title="example.ts"
+    /// import { expect } from "bun:test";
+    /// import assert from "node:assert";
+    /// import { mock, test } from "node:test";
+    /// import express from "npm:express";
+    /// import { sortBy } from "virtual:utils";
+    /// import { VERSION } from "https://deno.land/std/version.ts";
+    /// import React from "react";
+    /// import { secret } from "/absolute/path";
+    /// import { internal } from "#internal";
+    /// import aunt from "../aunt";
+    /// import uncle from "../uncle";
+    /// import sibling from "./sibling";
+    /// import imageUrl from "url:./image.png";
+    /// ```
+    ///
+    /// You can apply the sorting in two ways: via [CLI](#import-sorting-via-cli) or [VSCode extension](#import-sorting-via-vscode-extension).
+    ///
+    /// ## Grouped imports
+    ///
+    /// It's widespread to have import statements in a certain order, primarily when you work on a frontend project, and you import CSS files:
     ///
     /// ```js
-    /// import React, {
-    ///     FC,
-    ///     useEffect,
-    ///     useRef,
-    ///     ChangeEvent,
-    ///     KeyboardEvent,
-    /// } from 'react';
-    /// import { logger } from '@core/logger';
-    /// import { reduce, debounce } from 'lodash';
-    /// import { Message } from '../Message';
-    /// import { createServer } from '@server/node';
-    /// import { Alert } from '@ui/Alert';
-    /// import { repeat, filter, add } from '../utils';
-    /// import { initializeApp } from '@core/app';
-    /// import { Popup } from '@ui/Popup';
-    /// import { createConnection } from '@server/database';
+    /// import "../styles/reset.css";
+    /// import "../styles/layout.css";
+    /// import { Grid } from "../components/Grid.jsx";
+    /// ```
+    ///
+    /// Another common case is import polyfills or shim files, that needs to stay at the top file:
+    ///
+    /// ```js
+    /// import "../polyfills/array/flatMap";
+    /// import { functionThatUsesFlatMap } from "./utils.js";
+    /// ```
+    ///
+    /// In these cases, Biome will sort all these three imports, and it might happen that the order will **break** your application.
+    ///
+    /// To avoid this, create a "group" of imports. You create a "group" by adding a **new line** to separate the groups.
+    ///
+    /// By doing so, Biome will limit the sorting only to the import statements that belong to the same group:
+    ///
+    /// ```js
+    /// // group 1, only these two files will be sorted
+    /// import "../styles/reset.css";
+    /// import "../styles/layout.css";
+    ///
+    /// // group 2, only this one is sorted
+    /// import { Grid } from "../components/Grid.jsx";
+    /// ```
+    ///
+    /// ```js
+    /// // group 1, the polyfill/shim
+    /// import "../polyfills/array/flatMap";
+    ///
+    /// // group 2, the files that require the polyfill/shim
+    /// import { functionThatUsesFlatMap } from "./utils.js";
+    /// ```
+    ///
+    /// ## Side effect imports
+    ///
+    /// [Side effect imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#forms_of_import_declarations) are import statements that usually don't import any name:
+    ///
+    /// ```js
+    /// import "./global.js"
+    /// ```
+    ///
+    /// Since it is difficult to determine which side effects a module triggers, the import sorter assumes that each side effect import forms its own import group.
+    ///
+    /// For example, the following imports form 4 import groups.
+    ///
+    /// ```js name="file.js"
+    /// import sibling from "./sibling";       // Import group 1
+    /// import { internal } from "#internal";  // Import group 1
+    /// import "z";  // Import group 2
+    /// import "a";  // Import group 3
+    /// import React from "react";         // Import group 4
+    /// import assert from "node:assert";  // Import group 4
+    /// ```
+    ///
+    /// Each group is independently sorted as follows:
+    ///
+    /// ```js name="file.js"
+    /// import { internal } from "#internal";  // Import group 1
+    /// import sibling from "./sibling";      // Import group 1
+    /// import "z";  // Import group 2
+    /// import "a";  // Import group 3
+    /// import assert from "node:assert";  // Import group 4
+    /// import React from "react";         // Import group 4
+    /// ```
+    ///
+    /// ## Import sorting via VSCode extension
+    ///
+    /// Any LSP-compatible editor supports imports sorting through the "Organize Imports" code action.
+    /// By default, this action can be run using the <kbd title="Shift">⇧</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd> keyboard shortcut, or is accessible through the _Command Palette_ (<kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd>+<kbd title="Shift">⇧</kbd>+<kbd>P</kbd>) by selecting _Organize Imports_.
+    ///
+    /// You can add the following to your VSCode extension configuration if you want the action to run automatically on save instead of calling it manually:
+    ///
+    /// ```json title="settings.json"
+    /// {
+    /// 	"editor.codeActionsOnSave":{
+    /// 		"source.organizeImports.biome": "explicit"
+    /// 	}
+    /// }
     /// ```
     pub OrganizeImports {
         version: "1.0.0",
@@ -42,7 +160,7 @@ declare_source_rule! {
         language: "js",
         recommended: true,
         fix_kind: FixKind::Safe,
-    }
+     }
 }
 
 impl Rule for OrganizeImports {

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -149,9 +149,9 @@ declare_source_rule! {
     ///
     /// ```json title="settings.json"
     /// {
-    /// 	"editor.codeActionsOnSave":{
-    /// 		"source.organizeImports.biome": "explicit"
-    /// 	}
+    ///   "editor.codeActionsOnSave":{
+    ///     "source.organizeImports.biome": "explicit"
+    ///   }
     /// }
     /// ```
     pub OrganizeImports {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Import sorting is now its own action, so we need to copy the documentation we have in the website inside another page.

I removed the part of the CLI, which can't be applied anymore.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Proof read

<!-- What demonstrates that your implementation is correct? -->
