### PR TITLE
fix: add scanning time to traverse time

### DIFF
--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -549,7 +549,7 @@ pub fn execute_mode(
     } = traverse(&execution, &mut session, project_key, cli_options, paths)?;
     // We join the duration of the scanning with the duration of the traverse.
     if let Some(duration) = duration {
-        summary.duration = summary.duration.add(duration);
+        summary.duration += duration;
     }
     let console = session.app.console;
     let errors = summary.errors;

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -30,7 +30,6 @@ use biome_service::workspace::{
 use camino::{Utf8Path, Utf8PathBuf};
 use std::ffi::OsString;
 use std::fmt::{Display, Formatter};
-use std::ops::Add;
 use std::time::Duration;
 use tracing::{info, instrument};
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Adds the summary duration to the total amount of time. I'm not sure if this implementation is correct because, technically, there's some other code executed between scanning and traverse. Maybe we should start `Insta::now` way early and finish at the end of the traversal? 

Let me know what you think.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
