### PR TITLE
fix(formatter): hug the object type in the only function parameter

### DIFF
--- a/.changeset/cyan-beans-yawn.md
+++ b/.changeset/cyan-beans-yawn.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#2406](https://github.com/biomejs/biome/issues/2406): Biome longer expands properties of object type annotations in function parameters to align with Prettier.
+Fixed [#2406](https://github.com/biomejs/biome/issues/2406): Biome longer expands properties of object type annotations in the only function parameter to align with Prettier.

--- a/crates/biome_js_formatter/tests/specs/ts/object/objects.ts
+++ b/crates/biome_js_formatter/tests/specs/ts/object/objects.ts
@@ -17,3 +17,35 @@ function fn2(foo: {
 }) {
 	console.log(foo);
 }
+
+// both the object pattern and the object type should be expanded
+function fn3({
+	foo,
+	bar,
+	baz,
+	qux,
+}: {
+	foo: string;
+	baz: string;
+	bar: string;
+	qux: string;
+}): void {
+}
+
+// the object type of `baz` should keep expanded
+function fn4(
+	bar: string,
+	baz: {
+		qux: string;
+	}
+): void {
+}
+
+// the object type of `baz` should be collapsed
+function fn5(
+	bar: string,
+	baz: { qux: string;
+	}
+): void {
+}
+

--- a/crates/biome_js_formatter/tests/specs/ts/object/objects.ts.snap
+++ b/crates/biome_js_formatter/tests/specs/ts/object/objects.ts.snap
@@ -25,6 +25,38 @@ function fn2(foo: {
 	console.log(foo);
 }
 
+// both the object pattern and the object type should be expanded
+function fn3({
+	foo,
+	bar,
+	baz,
+	qux,
+}: {
+	foo: string;
+	baz: string;
+	bar: string;
+	qux: string;
+}): void {
+}
+
+// the object type of `baz` should keep expanded
+function fn4(
+	bar: string,
+	baz: {
+		qux: string;
+	}
+): void {
+}
+
+// the object type of `baz` should be collapsed
+function fn5(
+	bar: string,
+	baz: { qux: string;
+	}
+): void {
+}
+
+
 ```
 
 
@@ -63,4 +95,28 @@ const fn = ({ foo, bar }: { foo: boolean; bar: string }) => {
 function fn2(foo: { bar: string }) {
 	console.log(foo);
 }
+
+// both the object pattern and the object type should be expanded
+function fn3({
+	foo,
+	bar,
+	baz,
+	qux,
+}: {
+	foo: string;
+	baz: string;
+	bar: string;
+	qux: string;
+}): void {}
+
+// the object type of `baz` should keep expanded
+function fn4(
+	bar: string,
+	baz: {
+		qux: string;
+	},
+): void {}
+
+// the object type of `baz` should be collapsed
+function fn5(bar: string, baz: { qux: string }): void {}
 ```


### PR DESCRIPTION
## Summary

Closes #5342 
Follow-up of #5174 

The type annotation in the only function parameter should be in the `Hug` layout, and the object type should not create another group.

This is the follow-up fix of #5174, so I modified the changeset previously added.

## Test Plan

Snapshot tests added.
