### PR TITLE
feat(core): allow plugins to control severity of diagnostics

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -192,8 +192,8 @@ where
         for plugin in plugins {
             let root: AnyParse = ctx.root.syntax().as_send().expect("not a root node").into();
             for diagnostic in plugin.evaluate(root, ctx.options.file_path.clone()) {
-                let name = diagnostic.subcategory.clone().expect("");
-                let text_range = diagnostic.span.expect("");
+                let name = diagnostic.subcategory.clone().expect("missing subcategory");
+                let text_range = diagnostic.span.expect("missing span");
 
                 // 1. check for top level suppression
                 if suppressions.top_level_suppression.suppressed_plugin(&name)

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1430,6 +1430,16 @@ impl RuleDiagnostic {
         self.subcategory = Some(subcategory);
         self
     }
+
+    /// Assigns an explicit severity.
+    ///
+    /// In most cases, severity should _not_ be explicitly assigned, since rule
+    /// categories and configuration define the severity. Currently this is only
+    /// used for plugins to allow plugin authors to assign an explicit severity.
+    pub fn with_severity(mut self, severity: Severity) -> Self {
+        self.severity = severity;
+        self
+    }
 }
 
 /// Code Action object returned by a single analysis rule

--- a/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit.snap
+++ b/crates/biome_css_analyze/tests/plugin/useLowercaseColors.grit.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: useLowercaseColors.grit
-snapshot_kind: text
 ---
 # Input
 ```css
@@ -17,7 +16,7 @@ div {
 ```
 useLowercaseColors.grit:3:12 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer lowercase colors
+  × Prefer lowercase colors
   
     1 │ div {
     2 │     color: red;

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpread.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpread.grit.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: preferObjectSpread.grit
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -17,7 +16,7 @@ Object.assign({ foo: 'bar'}, baz);
 ```
 preferObjectSpread.grit:1:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer object spread instead of `Object.assign()`
+  × Prefer object spread instead of `Object.assign()`
   
   > 1 │ Object.assign({}, foo);
       │               ^^^^^^^
@@ -30,7 +29,7 @@ preferObjectSpread.grit:1:15 plugin ━━━━━━━━━━━━━━�
 ```
 preferObjectSpread.grit:3:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer object spread instead of `Object.assign()`
+  × Prefer object spread instead of `Object.assign()`
   
     1 │ Object.assign({}, foo);
     2 │ 
@@ -45,7 +44,7 @@ preferObjectSpread.grit:3:15 plugin ━━━━━━━━━━━━━━�
 ```
 preferObjectSpread.grit:5:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer object spread instead of `Object.assign()`
+  × Prefer object spread instead of `Object.assign()`
   
     3 │ Object.assign({}, {foo: 'bar'});
     4 │ 

--- a/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
+++ b/crates/biome_js_analyze/tests/plugin/preferObjectSpreadSuppression.grit.snap
@@ -59,7 +59,7 @@ preferObjectSpreadSuppression.grit:6:1 suppressions/incorrect ━━━━━━
 ```
 preferObjectSpreadSuppression.grit:5:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer object spread instead of `Object.assign()`
+  × Prefer object spread instead of `Object.assign()`
   
     4 │ // biome-ignore-start lint/plugin/preferObjectSpreadSuppression: reason
   > 5 │ Object.assign({}, {foo: 'bar'});
@@ -73,7 +73,7 @@ preferObjectSpreadSuppression.grit:5:15 plugin ━━━━━━━━━━━
 ```
 preferObjectSpreadSuppression.grit:14:15 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer object spread instead of `Object.assign()`
+  × Prefer object spread instead of `Object.assign()`
   
     12 │ // only suppress specified plugin
     13 │ // biome-ignore lint/plugin/anotherPlugin: reason

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_are_loaded_and_used_during_analysis.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_are_loaded_and_used_during_analysis.snap
@@ -10,7 +10,7 @@ expression: result.diagnostics
                 link: None,
             },
         ),
-        severity: Information,
+        severity: Error,
         description: "Prefer object spread instead of `Object.assign()`",
         message: "Prefer object spread instead of `Object.assign()`",
         advices: Advices {

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_can_use_custom_severity.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_can_use_custom_severity.snap
@@ -1,0 +1,74 @@
+---
+source: crates/biome_service/src/workspace.tests.rs
+expression: result.diagnostics
+---
+[
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Warning,
+        description: "Don't set explicit colors. Use `.color-*` classes instead.",
+        message: "Don't set explicit colors. Use `.color-*` classes instead.",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/a.css",
+                ),
+            ),
+            span: Some(
+                4..14,
+            ),
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Warning,
+        description: "Don't set explicit colors. Use `.color-*` classes instead.",
+        message: "Don't set explicit colors. Use `.color-*` classes instead.",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/a.css",
+                ),
+            ),
+            span: Some(
+                4..14,
+            ),
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+]


### PR DESCRIPTION
## Summary

Adds the `severity` parameter to plugin function `register_diagnostic()`.

The default severity is now error.

## Test Plan

Added test + updated snapshots.
