### PR TITLE
chore: remove detection of multiple config files

### DIFF
--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -790,11 +790,6 @@ pub(crate) trait CommandRunner: Sized {
                 cli_options.verbose,
             )?;
         }
-        if loaded_configuration.double_configuration_found {
-            console.log(markup! {
-                <Warn>"Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file."</Warn>
-            })
-        }
         info!(
             "Configuration file loaded: {:?}, diagnostics detected {}",
             loaded_configuration.file_path,

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -215,7 +215,6 @@ impl Display for RageConfiguration<'_> {
                         diagnostics,
                         directory_path,
                         file_path,
-                        ..
                     } = loaded_configuration;
                     let vcs_enabled = configuration.is_vcs_enabled();
                     let mut settings = Settings::default();

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -501,8 +501,6 @@ pub struct ConfigurationPayload {
     pub configuration_file_path: Utf8PathBuf,
     /// The base path where the external configuration in a package should be resolved from
     pub external_resolution_base_path: Utf8PathBuf,
-    /// Whether `biome.json` and `biome.jsonc` were found in the same folder
-    pub double_configuration_found: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -644,13 +644,6 @@ impl Session {
             return ConfigurationStatus::Error;
         }
 
-        if loaded_configuration.double_configuration_found {
-            warn!(
-                "Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file."
-            );
-            self.client.log_message(MessageType::WARNING, "Both biome.json and biome.jsonc files were found in the same folder. Biome will use the biome.json file.").await;
-        }
-
         info!("Configuration loaded successfully from disk.");
         info!("Update workspace settings.");
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR removes the detection of multiple configuration files.

While it is nice to have, it forces us to do multiple FS operations just to show a warning. Also, the current implementation was buggy while I tested it in a real-world project.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
