### PR TITLE
fix(diagnostics): correctly print emulator files

### DIFF
--- a/crates/biome_diagnostics/src/display.rs
+++ b/crates/biome_diagnostics/src/display.rs
@@ -117,13 +117,13 @@ impl<D: Diagnostic + ?Sized> fmt::Display for PrintHeader<'_, D> {
                 fmt.write_str(name)?;
             } else {
                 let path_name = Path::new(name);
-                if path_name.is_absolute() {
+                if is_jetbrains {
+                    fmt.write_str(&format!(" at {name}"))?;
+                } else if path_name.is_absolute() {
                     let link = format!("file://{name}");
                     fmt.write_markup(markup! {
                         <Hyperlink href={link}>{name}</Hyperlink>
                     })?;
-                } else if is_jetbrains {
-                    fmt.write_str(&format!(" at {name}"))?;
                 } else if cfg!(debug_assertions) && cfg!(windows) {
                     fmt.write_str(name.replace('\\', "/").as_str())?;
                 } else {
@@ -675,7 +675,7 @@ impl<W: fmt::Write + ?Sized> fmt::Write for IndentWriter<'_, W> {
 
 /// Tests whether the name of the terminal emulator matches the given `name`.
 fn is_terminal_program(name: &str) -> bool {
-    if cfg!(debug_assertions) {
+    if cfg!(test) {
         false
     } else {
         // https://github.com/JetBrains/jediterm/issues/253#issuecomment-1280492436


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes two issues:
- it moves the `is_jetbrains` check further up, so the `at ...` is correctly printed regardless if the path is absolute or relative. This was a small regression of when we decided to pass relative paths, where stripped paths have a leading `/`, which creates a false positive in `Path::is_absolute`
- changes the `cfg` query to use `test` instead of `debug_assertions`, so we can see the result in the terminal when we run `cargo biome-cli-dev`


> [!IMPORTANT]
> The `at file.json` trick doesn't work for the new JetBrains emulator (beta)



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested manually in VSCode and RustRover

<!-- What demonstrates that your implementation is correct? -->
