### PR TITLE
fix(lint): handle const + type bindings in useExportType

### DIFF
--- a/.changeset/thirty-deer-hope.md
+++ b/.changeset/thirty-deer-hope.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5382](https://github.com/biomejs/biome/issues/5382): `useExportType` no longer reports an identifier that bound by both a variable and a type.

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/issue5382.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/issue5382.ts
@@ -1,0 +1,8 @@
+const ErrorCode = {
+	invalidArgument: "invalid-argument",
+	internalError: "internal-error",
+};
+
+type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export {ErrorCode};

--- a/crates/biome_js_analyze/tests/specs/style/useExportType/issue5382.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useExportType/issue5382.ts.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue5382.ts
+---
+# Input
+```ts
+const ErrorCode = {
+	invalidArgument: "invalid-argument",
+	internalError: "internal-error",
+};
+
+type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+export {ErrorCode};
+
+```


### PR DESCRIPTION
## Summary

Closes #5382 

Previously, useExportType only checked the type binding when the identifier has multiple bindings, so it detected the identifier as a false postivie. Checking `Binding::is_type_only` for every binding will fix the issue.

## Test Plan

Snapshot tests added.
