### PR TITLE
refactor(lint): a11y utils to reduce duplicate function definitions

### DIFF
--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -270,4 +270,17 @@ impl AriaRoles {
             },
         }
     }
+
+    /// Check if the element's implicit ARIA semantics have been removed.
+    /// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role
+    ///
+    /// Ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isPresentationRole.js
+    pub fn is_presentation_role(&self, element: &impl Element) -> bool {
+        if let Some(attribute) = element.find_attribute_by_name(|n| n == "role") {
+            if let Some(value) = attribute.value() {
+                return matches!(value.as_ref(), "presentation" | "none");
+            }
+        }
+        false
+    }
 }

--- a/crates/biome_aria/src/roles.rs
+++ b/crates/biome_aria/src/roles.rs
@@ -272,9 +272,10 @@ impl AriaRoles {
     }
 
     /// Check if the element's implicit ARIA semantics have been removed.
-    /// See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role
     ///
-    /// Ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isPresentationRole.js
+    /// Ref:
+    /// - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role
+    /// - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isPresentationRole.js
     pub fn is_presentation_role(&self, element: &impl Element) -> bool {
         if let Some(attribute) = element.find_attribute_by_name(|n| n == "role") {
             if let Some(value) = attribute.value() {

--- a/crates/biome_js_analyze/src/a11y.rs
+++ b/crates/biome_js_analyze/src/a11y.rs
@@ -8,18 +8,21 @@ use biome_js_syntax::jsx_ext::AnyJsxElement;
 /// - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isHiddenFromScreenReader.js
 pub(crate) fn is_hidden_from_screen_reader(element: &AnyJsxElement) -> bool {
     let is_aria_hidden = element.has_truthy_attribute("aria-hidden");
-    let name = element.name_value_token().ok();
-    if let Some(name) = name {
-        if name.text_trimmed() == "input" {
+    if is_aria_hidden {
+        return true;
+    }
+
+    match element.name_value_token().ok() {
+        Some(name) if name.text_trimmed() == "input" => {
             let is_input_hidden = element
                 .find_attribute_by_name("type")
                 .and_then(|attribute| attribute.as_static_value())
                 .and_then(|value| value.as_string_constant().map(|value| value == "hidden"))
                 .unwrap_or_default();
-            return is_aria_hidden || is_input_hidden;
+            is_input_hidden
         }
+        _ => false,
     }
-    false
 }
 
 /// Check if the element is `contentEditable`

--- a/crates/biome_js_analyze/src/a11y.rs
+++ b/crates/biome_js_analyze/src/a11y.rs
@@ -1,0 +1,36 @@
+use biome_js_syntax::jsx_ext::AnyJsxElement;
+
+/// Check the element is hidden from screen reader.
+///
+/// Ref:
+/// - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
+/// - https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/hidden
+/// - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isHiddenFromScreenReader.js
+pub(crate) fn is_hidden_from_screen_reader(element: &AnyJsxElement) -> bool {
+    let is_aria_hidden = element.has_truthy_attribute("aria-hidden");
+    let name = element.name_value_token().ok();
+    if let Some(name) = name {
+        if name.text_trimmed() == "input" {
+            let is_input_hidden = element
+                .find_attribute_by_name("type")
+                .and_then(|attribute| attribute.as_static_value())
+                .and_then(|value| value.as_string_constant().map(|value| value == "hidden"))
+                .unwrap_or_default();
+            return is_aria_hidden || is_input_hidden;
+        }
+    }
+    false
+}
+
+/// Check if the element is `contentEditable`
+///
+/// Ref:
+/// - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable
+/// - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/v6.10.0/src/util/isContentEditable.js
+pub(crate) fn is_content_editable(element: &AnyJsxElement) -> bool {
+    element
+        .find_attribute_by_name("contentEditable")
+        .and_then(|attribute| attribute.as_static_value())
+        .and_then(|value| value.as_string_constant().map(|value| value == "true"))
+        .unwrap_or_default()
+}

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -16,6 +16,7 @@ use biome_suppression::{SuppressionDiagnostic, parse_suppression_comment};
 use std::ops::Deref;
 use std::sync::{Arc, LazyLock};
 
+mod a11y;
 pub mod assist;
 mod ast_utils;
 pub mod globals;

--- a/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
@@ -43,6 +43,11 @@ declare_lint_rule! {
     /// </>
     /// ```
     ///
+    /// Custom components are not checked.
+    /// ```jsx
+    /// <TestComponent onClick={doFoo} />
+    /// ```
+    ///
     pub NoStaticElementInteractions {
         version: "1.9.0",
         name: "noStaticElementInteractions",

--- a/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_static_element_interactions.rs
@@ -93,6 +93,11 @@ impl Rule for NoStaticElementInteractions {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
+        // Custom components are not checked because we do not know what DOM will be used.
+        if node.is_custom_component() {
+            return None;
+        }
+
         if is_hidden_from_screen_reader(node) {
             return None;
         }


### PR DESCRIPTION
## Summary


Several a11y lint rules currently define similar functions independently. 
This PR changes them to use a single consolidated implementation.
And  explicitly skip linting to custom components in `noStaticElementInteractions`.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing tests should pass.

<!-- What demonstrates that your implementation is correct? -->
