### PR TITLE
refactor(assist/useSortedAttributes): natural sorting and avoid cloning

### DIFF
--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx
@@ -1,2 +1,3 @@
 <Hello lastName="Smith" firstName="John" />;
 <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
+<Hello a10="" a9="" A="" />;

--- a/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedAttributes/unsorted.jsx.snap
@@ -6,30 +6,43 @@ expression: unsorted.jsx
 ```jsx
 <Hello lastName="Smith" firstName="John" />;
 <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
+<Hello a10="" a9="" A="" />;
 
 ```
 
 # Actions
 ```diff
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
 -<Hello lastName="Smith" firstName="John" />;
 +<Hello firstName="John" lastName="Smith" />;
  <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
+ <Hello a10="" a9="" A="" />;
 
 ```
 
 ```diff
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
  <Hello lastName="Smith" firstName="John" />;
 -<Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
 +<Hello address="NY" tel={5555555} {...this.props} lastName="Smith" firstName="John" />;
+ <Hello a10="" a9="" A="" />;
 
 ```
 
 ```diff
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
  <Hello lastName="Smith" firstName="John" />;
 -<Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
 +<Hello tel={5555555} address="NY" {...this.props} firstName="John" lastName="Smith" />;
+ <Hello a10="" a9="" A="" />;
+
+```
+
+```diff
+@@ -1,3 +1,3 @@
+ <Hello lastName="Smith" firstName="John" />;
+ <Hello tel={5555555} address="NY" {...this.props} lastName="Smith" firstName="John" />;
+-<Hello a10="" a9="" A="" />;
++<Hello A="" a9="" a10="" />;
 
 ```


### PR DESCRIPTION
## Summary

The main goal of this PR is to change the sorting algorithm: we now use a naturl sort.

`useSortedAttributes` heavily use cloning.
I reduced the number of cloning and allocations. There is room for improvements, however this will require changing the code structure.
We now also check if the props are sorted before emitting a signal.

Also we now use unstable sort.

## Test Plan

I added a test.
