### PR TITLE
refactor(assist/useSortedKeys): use our own natural order impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,6 @@ dependencies = [
  "enumflags2",
  "globset",
  "insta",
- "natord",
  "regex",
  "roaring",
  "rustc-hash 2.1.1",
@@ -970,11 +969,11 @@ dependencies = [
  "biome_json_parser",
  "biome_json_syntax",
  "biome_rowan",
+ "biome_string_case",
  "biome_suppression",
  "biome_test_utils",
  "camino",
  "insta",
- "natord",
  "rustc-hash 2.1.1",
  "tests_macros",
 ]
@@ -2921,12 +2920,6 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "natord"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "new_debug_unreachable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,6 @@ grit-util            = "0.5.1"
 ignore               = "0.4.23"
 indexmap             = { version = "2.8.0" }
 insta                = "1.42.2"
-natord               = "1.0.9"
 oxc_resolver         = "4.2"
 papaya               = "0.2"
 path-absolutize      = { version = "3.1.1", optional = false, features = ["use_unix_paths_on_wasm"] }

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -34,7 +34,6 @@ bitvec                   = "1.0.1"
 camino                   = { workspace = true }
 enumflags2               = { workspace = true }
 globset                  = { workspace = true }
-natord                   = { workspace = true }
 regex                    = { workspace = true }
 roaring                  = "0.10.10"
 rustc-hash               = { workspace = true }

--- a/crates/biome_js_analyze/tests/specs/source/useSortedKeys/unsorted.js
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedKeys/unsorted.js
@@ -11,6 +11,8 @@ const obj = {
 	aba: 2,
 	abc: 3,
 	abb: 3,
+	a10: 0,
+	19: 0,
 	get aaa() {
 		return "";
 	},

--- a/crates/biome_js_analyze/tests/specs/source/useSortedKeys/unsorted.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/useSortedKeys/unsorted.js.snap
@@ -17,6 +17,8 @@ const obj = {
 	aba: 2,
 	abc: 3,
 	abb: 3,
+	a10: 0,
+	19: 0,
 	get aaa() {
 		return "";
 	},
@@ -26,11 +28,21 @@ const obj = {
 
 # Actions
 ```diff
-@@ -1,17 +1,17 @@
+@@ -1,6 +1,6 @@
  const obj = {
 +	a: 1,
  	b: 1,
 -	a: 1,
+ 	...g,
+ 	ba: 2,
+ 	ab: 1,
+
+```
+
+```diff
+@@ -2,18 +2,18 @@
+ 	b: 1,
+ 	a: 1,
  	...g,
 -	ba: 2,
 -	ab: 1,
@@ -43,6 +55,9 @@ const obj = {
 -	aba: 2,
 -	abc: 3,
 -	abb: 3,
++	19: 0,
+ 	a10: 0,
+-	19: 0,
  	get aaa() {
  		return "";
  	},

--- a/crates/biome_json_analyze/Cargo.toml
+++ b/crates/biome_json_analyze/Cargo.toml
@@ -19,8 +19,8 @@ biome_diagnostics  = { workspace = true }
 biome_json_factory = { workspace = true }
 biome_json_syntax  = { workspace = true }
 biome_rowan        = { workspace = true }
+biome_string_case  = { workspace = true }
 biome_suppression  = { workspace = true }
-natord             = { workspace = true }
 rustc-hash         = { workspace = true }
 
 [dev-dependencies]

--- a/crates/biome_json_analyze/src/assist/source/use_sorted_keys.rs
+++ b/crates/biome_json_analyze/src/assist/source/use_sorted_keys.rs
@@ -5,6 +5,7 @@ use biome_diagnostics::Applicability;
 use biome_json_factory::make::{json_member_list, token};
 use biome_json_syntax::{JsonMember, JsonMemberList, T};
 use biome_rowan::{AstNode, AstNodeExt, AstSeparatedList, BatchMutationExt};
+use biome_string_case::StrLikeExtension;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -37,11 +38,14 @@ pub struct MemberKey {
 
 impl Ord for MemberKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Sort keys using natural ordering
-        natord::compare(
-            &self.node.name().unwrap().to_trimmed_string(),
-            &other.node.name().unwrap().to_trimmed_string(),
-        )
+        // Keep the order for elements that cannot be compared
+        let Ok(self_name) = self.node.name().and_then(|name| name.inner_string_text()) else {
+            return Ordering::Equal;
+        };
+        let Ok(other_name) = other.node.name().and_then(|name| name.inner_string_text()) else {
+            return Ordering::Equal;
+        };
+        self_name.text().ascii_nat_cmp(other_name.text())
     }
 }
 


### PR DESCRIPTION
## Summary

Replace natord with our own implementation (the one used by the import sorter and other rules).
This allows removing our dependency over `natord`.

## Test Plan

I added a test.
