### PR TITLE
fix: accept hard brace characters in glob validation

### DIFF
--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -479,7 +479,7 @@ fn validate_glob(pattern: &str) -> Result<(), GlobError> {
             b'\\' => {
                 // Accept a restrictive set of escape sequence
                 if let Some((_, c)) = it.next() {
-                    if !matches!(c, b'!' | b'*' | b'?' | b'{' | b'}' | b'[' | b']' | b'\\') {
+                    if !matches!(c, b'!' | b'*' | b'?' | b'{' | b'}' | b'\\') {
                         return Err(GlobError::Regular {
                             kind: GlobErrorKind::InvalidEscape,
                             index: i as u32,
@@ -495,12 +495,6 @@ fn validate_glob(pattern: &str) -> Result<(), GlobError> {
             b'?' => {
                 return Err(GlobError::Regular {
                     kind: GlobErrorKind::UnsupportedAnyCharacter,
-                    index: i as u32,
-                });
-            }
-            b'[' | b']' => {
-                return Err(GlobError::Regular {
-                    kind: GlobErrorKind::UnsupportedCharacterClass,
                     index: i as u32,
                 });
             }

--- a/crates/biome_json_parser/src/lexer/mod.rs
+++ b/crates/biome_json_parser/src/lexer/mod.rs
@@ -521,9 +521,9 @@ impl<'src> Lexer<'src> {
                     self.advance(1);
 
                     match self.current_byte() {
-                        Some(b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't') => {
-                            self.advance(1)
-                        }
+                        Some(
+                            b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' | b'[' | b']',
+                        ) => self.advance(1),
 
                         Some(b'u') => match (self.lex_unicode_escape(), state) {
                             (Ok(_), _) => {}
@@ -545,11 +545,10 @@ impl<'src> Lexer<'src> {
                                 let c = self.current_char_unchecked();
                                 self.diagnostics.push(
                                     ParseDiagnostic::new(
-
                                         "Invalid escape sequence",
                                         escape_start..self.text_position() + c.text_len(),
                                     )
-                                        .with_hint(r#"Valid escape sequences are: `\\`, `\/`, `/"`, `\b\`, `\f`, `\n`, `\r`, `\t` or any unicode escape sequence `\uXXXX` where X is hexedecimal number. "#),
+                                        .with_hint(r#"Valid escape sequences are: `\\`, `\/`, `/"`, `\b\`, `\f`, `\n`, `\r`, `\t`, `\[`, `\]` or any unicode escape sequence `\uXXXX` where X is hexedecimal number. "#),
                                 );
                                 state = LexStringState::InvalidEscapeSequence;
                             }


### PR DESCRIPTION
## Summary

While trying 2.0.0-beta.1, I noticed I couldn't pass in globs with hard braces (`[` or `]`) for file globs in `includes` for the new configuration. From what I'm aware of, these characters are valid for file system paths on Linux, macOS, and Windows, at least.

Looking at history, I couldn't find any specific reason for disallowing these characters related to compatbility or for Biome-specific reasons. I may be missing the reasoning/context, though.

## Test Plan

I compiled and tried a release binary in our monorepo and can now use these globs in `includes` in the new Biome 2 configuration. I'm not sure if there's a wider blast radius I should check for when it comes to the proposed changes.
