### PR TITLE
ci: build WASM packages before publishing them to pkg.pr.new

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -114,11 +114,41 @@ jobs:
           name: cli-${{ matrix.target }}
           path: ./dist/biome-*
           if-no-files-found: error
+
+  build-wasm:
+    name: Build WASM
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM module for bundlers
+        run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-bundler --target bundler --release --scope biomejs crates/biome_wasm
+      - name: Build WASM module for node.js
+        run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-nodejs --target nodejs --release --scope biomejs crates/biome_wasm
+      - name: Build WASM module for the web
+        run: wasm-pack build --out-dir ../../packages/@biomejs/wasm-web --target web --release --scope biomejs crates/biome_wasm
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: wasm-${{ matrix.target }}
+          path: |
+            ./packages/@biomejs/wasm-bundler
+            ./packages/@biomejs/wasm-nodejs
+            ./packages/@biomejs/wasm-web
+          if-no-files-found: error
+
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs:
       - build-binaries
+      - build-wasm
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

It didn't build any wasm packages, but published to pkg.pr.new without any artifacts. I added a build-wasm job copied from the release.yml workflow.

## Test Plan

N/A
