### PR TITLE
fix(workspace): don't parse files if no tools are enabled for them

### DIFF
--- a/.changeset/selfish-gorillas-attend.md
+++ b/.changeset/selfish-gorillas-attend.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed unnecessarily parsing files that would have no work done on them anyway

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -3420,3 +3420,43 @@ fn html_enabled_by_arg_format() {
         result,
     ));
 }
+
+#[test]
+fn html_not_processed_when_disabled() {
+    // HTML files should not be parsed when no tools are enabled.
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("file.html");
+    fs.insert(file_path.into(), "<!DOCTYPE");
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--html-formatter-enabled=false",
+                "--write",
+                file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert!(matches!(
+        result,
+        Err(biome_cli::CliDiagnostic::NoFilesWereProcessed(_))
+    ));
+
+    assert_file_contents(&fs, file_path, "<!DOCTYPE");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "html_not_processed_when_disabled",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_format/html_not_processed_when_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/html_not_processed_when_disabled.snap
@@ -1,0 +1,34 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `file.html`
+
+```html
+<!DOCTYPE
+```
+
+# Termination Message
+
+```block
+internalError/io ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.html format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Can't format code because it contains syntax errors
+  
+
+```
+
+```block
+Formatted 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -8,7 +8,7 @@ pub use crate::file_handlers::astro::{ASTRO_FENCE, AstroFileHandler};
 use crate::file_handlers::graphql::GraphqlFileHandler;
 pub use crate::file_handlers::svelte::{SVELTE_FENCE, SvelteFileHandler};
 pub use crate::file_handlers::vue::{VUE_FENCE, VueFileHandler};
-use crate::settings::{Settings, WorkspaceSettingsHandle};
+use crate::settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle};
 use crate::workspace::{
     FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult, RenameResult,
 };
@@ -30,8 +30,9 @@ use biome_fs::BiomePath;
 use biome_graphql_analyze::METADATA as graphql_metadata;
 use biome_graphql_syntax::{GraphqlFileSource, GraphqlLanguage};
 use biome_grit_patterns::{GritQuery, GritQueryEffect, GritTargetFile};
+use biome_grit_syntax::GritLanguage;
 use biome_grit_syntax::file_source::GritFileSource;
-use biome_html_syntax::HtmlFileSource;
+use biome_html_syntax::{HtmlFileSource, HtmlLanguage};
 use biome_js_analyze::METADATA as js_metadata;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::{
@@ -363,6 +364,71 @@ impl DocumentFileSource {
             | DocumentFileSource::Grit(_) => true,
             DocumentFileSource::Ignore => true,
             DocumentFileSource::Unknown => false,
+        }
+    }
+
+    pub fn formatter_enabled(path: &Utf8Path, settings: Option<&Settings>) -> bool {
+        let file_source = DocumentFileSource::from(path);
+        match file_source {
+            DocumentFileSource::Js(_) => {
+                JsLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Css(_) => {
+                CssLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Graphql(_) => {
+                GraphqlLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Json(_) => {
+                JsonLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Html(_) => {
+                HtmlLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Grit(_) => {
+                GritLanguage::formatter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Ignore | DocumentFileSource::Unknown => false,
+        }
+    }
+
+    pub fn linter_enabled(path: &Utf8Path, settings: Option<&Settings>) -> bool {
+        match DocumentFileSource::from_path(path) {
+            DocumentFileSource::Js(_) => JsLanguage::linter_enabled_for_file_path(settings, path),
+            DocumentFileSource::Css(_) => CssLanguage::linter_enabled_for_file_path(settings, path),
+            DocumentFileSource::Graphql(_) => {
+                GraphqlLanguage::linter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Json(_) => {
+                JsonLanguage::linter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Html(_) => {
+                HtmlLanguage::linter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Grit(_) => {
+                GritLanguage::linter_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Ignore | DocumentFileSource::Unknown => false,
+        }
+    }
+
+    pub fn assist_enabled(path: &Utf8Path, settings: Option<&Settings>) -> bool {
+        match DocumentFileSource::from_path(path) {
+            DocumentFileSource::Js(_) => JsLanguage::assist_enabled_for_file_path(settings, path),
+            DocumentFileSource::Css(_) => CssLanguage::assist_enabled_for_file_path(settings, path),
+            DocumentFileSource::Graphql(_) => {
+                GraphqlLanguage::assist_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Json(_) => {
+                JsonLanguage::assist_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Html(_) => {
+                HtmlLanguage::assist_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Grit(_) => {
+                GritLanguage::assist_enabled_for_file_path(settings, path)
+            }
+            DocumentFileSource::Ignore | DocumentFileSource::Unknown => false,
         }
     }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The HTML parser and formatter is incomplete. If the user doesn't have any tools enabled for HTML, we shouldn't even be trying to parse the file. ~~The same can be said for all the languages we support.~~

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Fixes #5450

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a test, CI should pass.
