### PR TITLE
fix(parse/html): emit proper diagnostics when closing tag has extra literals

### DIFF
--- a/crates/biome_html_parser/src/syntax/mod.rs
+++ b/crates/biome_html_parser/src/syntax/mod.rs
@@ -145,6 +145,12 @@ fn parse_closing_tag(p: &mut HtmlParser) -> ParsedSyntax {
         p.error(void_element_should_not_have_closing_tag(p, p.cur_range()).into_diagnostic(p));
     }
     let _name = parse_literal(p, HTML_TAG_NAME);
+
+    // There shouldn't be any attributes in a closing tag.
+    while p.at(HTML_LITERAL) {
+        p.error(closing_tag_should_not_have_attributes(p, p.cur_range()));
+        p.bump_remap(HTML_BOGUS);
+    }
     p.bump_with_context(T![>], HtmlLexContext::OutsideTag);
     Present(m.complete(p, HTML_CLOSING_ELEMENT))
 }

--- a/crates/biome_html_parser/src/syntax/parse_error.rs
+++ b/crates/biome_html_parser/src/syntax/parse_error.rs
@@ -56,3 +56,10 @@ pub(crate) fn void_element_should_not_have_closing_tag(
 ) -> ParseDiagnostic {
     ParseDiagnostic::new("Void elements should not have a closing tag.", range)
 }
+
+pub(crate) fn closing_tag_should_not_have_attributes(
+    _p: &HtmlParser,
+    range: TextRange,
+) -> ParseDiagnostic {
+    ParseDiagnostic::new("Closing tags should not have attributes.", range)
+}

--- a/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html
+++ b/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html
@@ -1,0 +1,1 @@
+<h{{ heading_level|default:2 }}>name</h{{ heading_level|default:2 }}>

--- a/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html.snap
+++ b/crates/biome_html_parser/tests/html_specs/error/template-langs/django/issue-5450.html.snap
@@ -1,0 +1,133 @@
+---
+source: crates/biome_html_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```html
+<h{{ heading_level|default:2 }}>name</h{{ heading_level|default:2 }}>
+
+```
+
+
+## AST
+
+```
+HtmlRoot {
+    bom_token: missing (optional),
+    directive: missing (optional),
+    html: HtmlElementList [
+        HtmlBogusElement {
+            items: [
+                HtmlOpeningElement {
+                    l_angle_token: L_ANGLE@0..1 "<" [] [],
+                    name: HtmlTagName {
+                        value_token: HTML_LITERAL@1..2 "h" [] [],
+                    },
+                    attributes: HtmlAttributeList [
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@2..5 "{{" [] [Whitespace(" ")],
+                            },
+                            initializer: missing (optional),
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@5..29 "heading_level|default:2" [] [Whitespace(" ")],
+                            },
+                            initializer: missing (optional),
+                        },
+                        HtmlAttribute {
+                            name: HtmlAttributeName {
+                                value_token: HTML_LITERAL@29..31 "}}" [] [],
+                            },
+                            initializer: missing (optional),
+                        },
+                    ],
+                    r_angle_token: R_ANGLE@31..32 ">" [] [],
+                },
+                HtmlElementList [
+                    HtmlContent {
+                        value_token: HTML_LITERAL@32..36 "name" [] [],
+                    },
+                ],
+                HtmlBogusElement {
+                    items: [
+                        L_ANGLE@36..37 "<" [] [],
+                        SLASH@37..38 "/" [] [],
+                        HtmlTagName {
+                            value_token: HTML_LITERAL@38..42 "h{{" [] [Whitespace(" ")],
+                        },
+                        HTML_BOGUS@42..66 "heading_level|default:2" [] [Whitespace(" ")],
+                        HTML_BOGUS@66..68 "}}" [] [],
+                        R_ANGLE@68..69 ">" [] [],
+                    ],
+                },
+            ],
+        },
+    ],
+    eof_token: EOF@69..70 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: HTML_ROOT@0..70
+  0: (empty)
+  1: (empty)
+  2: HTML_ELEMENT_LIST@0..69
+    0: HTML_BOGUS_ELEMENT@0..69
+      0: HTML_OPENING_ELEMENT@0..32
+        0: L_ANGLE@0..1 "<" [] []
+        1: HTML_TAG_NAME@1..2
+          0: HTML_LITERAL@1..2 "h" [] []
+        2: HTML_ATTRIBUTE_LIST@2..31
+          0: HTML_ATTRIBUTE@2..5
+            0: HTML_ATTRIBUTE_NAME@2..5
+              0: HTML_LITERAL@2..5 "{{" [] [Whitespace(" ")]
+            1: (empty)
+          1: HTML_ATTRIBUTE@5..29
+            0: HTML_ATTRIBUTE_NAME@5..29
+              0: HTML_LITERAL@5..29 "heading_level|default:2" [] [Whitespace(" ")]
+            1: (empty)
+          2: HTML_ATTRIBUTE@29..31
+            0: HTML_ATTRIBUTE_NAME@29..31
+              0: HTML_LITERAL@29..31 "}}" [] []
+            1: (empty)
+        3: R_ANGLE@31..32 ">" [] []
+      1: HTML_ELEMENT_LIST@32..36
+        0: HTML_CONTENT@32..36
+          0: HTML_LITERAL@32..36 "name" [] []
+      2: HTML_BOGUS_ELEMENT@36..69
+        0: L_ANGLE@36..37 "<" [] []
+        1: SLASH@37..38 "/" [] []
+        2: HTML_TAG_NAME@38..42
+          0: HTML_LITERAL@38..42 "h{{" [] [Whitespace(" ")]
+        3: HTML_BOGUS@42..66 "heading_level|default:2" [] [Whitespace(" ")]
+        4: HTML_BOGUS@66..68 "}}" [] []
+        5: R_ANGLE@68..69 ">" [] []
+  3: EOF@69..70 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+issue-5450.html:1:43 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Closing tags should not have attributes.
+  
+  > 1 │ <h{{ heading_level|default:2 }}>name</h{{ heading_level|default:2 }}>
+      │                                           ^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ 
+  
+issue-5450.html:1:67 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Closing tags should not have attributes.
+  
+  > 1 │ <h{{ heading_level|default:2 }}>name</h{{ heading_level|default:2 }}>
+      │                                                                   ^^
+    2 │ 
+  
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Closes #5450

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added a parser test.
