### PR TITLE
feat(assist/organizeImports): allow predefined groups in lists

### DIFF
--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -173,7 +173,7 @@ impl Glob {
     }
 
     /// Tests whether the given path matches this pattern, ignoring the negation.
-    fn is_raw_match(&self, path: impl AsRef<std::path::Path>) -> bool {
+    pub fn is_raw_match(&self, path: impl AsRef<std::path::Path>) -> bool {
         self.glob.is_match(path)
     }
 
@@ -302,6 +302,11 @@ impl<'a> CandidatePath<'a> {
     /// Tests whether the current path matches `glob`.
     pub fn matches(&self, glob: &Glob) -> bool {
         glob.is_match_candidate(self)
+    }
+
+    /// Tests whether the current path matches `glob` ignoring the negation of `glob`.
+    pub fn matches_raw(&self, glob: &Glob) -> bool {
+        glob.is_raw_match_candidate(self)
     }
 
     /// Match against a list of globs where negated globs are handled as exceptions.

--- a/crates/biome_js_analyze/src/assist/source/organize_imports/import_groups.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports/import_groups.rs
@@ -36,12 +36,9 @@ impl ImportGroups {
         self.0
             .get((first_group as usize)..(second_group as usize))
             .is_some_and(|groups| {
-                groups.iter().any(|group| {
-                    matches!(
-                        group,
-                        ImportGroup::Predefined(PredefinedImportGroup::BlankLine)
-                    )
-                })
+                groups
+                    .iter()
+                    .any(|group| matches!(group, ImportGroup::BlankLine,))
             })
     }
 }
@@ -50,18 +47,19 @@ impl ImportGroups {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum ImportGroup {
-    Predefined(PredefinedImportGroup),
-    Glob(Box<ImportSourceGlob>),
-    GlobList(Box<[ImportSourceGlob]>),
+    #[serde(rename = ":BLANK_LINE:")]
+    BlankLine,
+    Matcher(GroupMatcher),
+    MatcherList(Box<[GroupMatcher]>),
 }
 impl ImportGroup {
     pub fn contains(&self, candidate: &ImportSourceCandidate) -> bool {
         match self {
-            ImportGroup::Predefined(predefined) => predefined.contains(candidate),
-            ImportGroup::Glob(glob) => glob.is_match(candidate),
-            ImportGroup::GlobList(globs) => candidate
-                .path_candidate
-                .matches_with_exceptions(globs.iter().map(|glob| &glob.0)),
+            ImportGroup::BlankLine => false,
+            ImportGroup::Matcher(glob) => glob.is_match(candidate),
+            ImportGroup::MatcherList(matchers) => {
+                candidate.matches_with_exceptions(matchers.iter())
+            }
         }
     }
 }
@@ -73,22 +71,135 @@ impl Deserializable for ImportGroup {
     ) -> Option<Self> {
         if value.visitable_type() == Some(biome_deserialize::DeserializableType::Str) {
             let value_text = Text::deserialize(ctx, value, name)?;
-            if value_text.starts_with(':') && value_text.ends_with(':') {
-                Deserializable::deserialize(ctx, value, name).map(ImportGroup::Predefined)
+            if value_text.text() == ":BLANK_LINE:" {
+                Some(ImportGroup::BlankLine)
             } else {
-                Deserializable::deserialize(ctx, value, name).map(ImportGroup::Glob)
+                Deserializable::deserialize(ctx, value, name).map(ImportGroup::Matcher)
             }
         } else {
-            Deserializable::deserialize(ctx, value, name).map(ImportGroup::GlobList)
+            Deserializable::deserialize(ctx, value, name).map(ImportGroup::MatcherList)
         }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum GroupMatcher {
+    Predefined(NegatablePredefinedGroupMatcher),
+    Glob(Box<ImportSourceGlob>),
+}
+impl GroupMatcher {
+    pub fn is_negated(&self) -> bool {
+        match self {
+            Self::Predefined(matcher) => matcher.is_negated(),
+            Self::Glob(glob) => glob.is_negated(),
+        }
+    }
+
+    /// Tests whether the given `candidate` matches this matcher.
+    pub fn is_match(&self, candidate: &ImportSourceCandidate) -> bool {
+        match self {
+            Self::Predefined(matcher) => matcher.is_match(candidate),
+            Self::Glob(glob) => glob.is_match(candidate),
+        }
+    }
+
+    /// Tests whether the given `candidate` matches this matcher, ignoring the negation.
+    pub fn is_raw_match(&self, candidate: &ImportSourceCandidate) -> bool {
+        match self {
+            Self::Predefined(matcher) => matcher.is_raw_match(candidate),
+            Self::Glob(glob) => glob.is_raw_match(candidate),
+        }
+    }
+}
+impl biome_deserialize::Deserializable for GroupMatcher {
+    fn deserialize(
+        ctx: &mut impl DeserializationContext,
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+    ) -> Option<Self> {
+        let text = biome_deserialize::Text::deserialize(ctx, value, name)?;
+        if text.ends_with(':') && (text.starts_with(':') || text.starts_with("!:")) {
+            text.parse().ok().map(GroupMatcher::Predefined)
+        } else {
+            Deserializable::deserialize(ctx, value, name).map(GroupMatcher::Glob)
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct NegatablePredefinedGroupMatcher {
+    is_negated: bool,
+    matcher: PredefinedGroupMatcher,
+}
+impl NegatablePredefinedGroupMatcher {
+    pub fn is_negated(&self) -> bool {
+        self.is_negated
+    }
+
+    /// Tests whether the given `candidate` matches this matcher.
+    pub fn is_match(&self, candidate: &ImportSourceCandidate) -> bool {
+        self.is_raw_match(candidate) != self.is_negated
+    }
+
+    /// Tests whether the given `candidate` matches this matcher, ignoring the negation.
+    pub fn is_raw_match(&self, candidate: &ImportSourceCandidate) -> bool {
+        self.matcher.is_match(candidate)
+    }
+}
+impl std::fmt::Display for NegatablePredefinedGroupMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let negation = if self.is_negated { "!" } else { "" };
+        let matcher_repr = &self.matcher;
+        write!(f, "{negation}{matcher_repr}")
+    }
+}
+impl std::fmt::Debug for NegatablePredefinedGroupMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+impl From<NegatablePredefinedGroupMatcher> for String {
+    fn from(value: NegatablePredefinedGroupMatcher) -> Self {
+        value.to_string()
+    }
+}
+impl std::str::FromStr for NegatablePredefinedGroupMatcher {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (is_negated, value) = if let Some(stripped) = value.strip_prefix('!') {
+            (true, stripped)
+        } else {
+            (false, value)
+        };
+        let matcher = PredefinedGroupMatcher::from_str(value)?;
+        Ok(Self {
+            is_negated,
+            matcher,
+        })
+    }
+}
+impl TryFrom<String> for NegatablePredefinedGroupMatcher {
+    type Error = &'static str;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for NegatablePredefinedGroupMatcher {
+    fn schema_name() -> String {
+        "PredefinedGroupMatcher".to_string()
+    }
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
     }
 }
 
 #[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-pub enum PredefinedImportGroup {
-    #[serde(rename = ":BLANK_LINE:")]
-    BlankLine,
+pub enum PredefinedGroupMatcher {
     #[serde(rename = ":ALIAS:")]
     Alias,
     #[serde(rename = ":BUN:")]
@@ -104,12 +215,11 @@ pub enum PredefinedImportGroup {
     #[serde(rename = ":URL:")]
     Url,
 }
-impl PredefinedImportGroup {
-    fn contains(&self, candidate: &ImportSourceCandidate) -> bool {
+impl PredefinedGroupMatcher {
+    fn is_match(&self, candidate: &ImportSourceCandidate) -> bool {
         let source_kind = candidate.source_kund();
         let source = candidate.as_str();
         match self {
-            Self::BlankLine => false,
             Self::Alias => source_kind == ImportSourceKind::Alias,
             Self::Bun => {
                 (source_kind == ImportSourceKind::Package && source == "bun")
@@ -127,15 +237,54 @@ impl PredefinedImportGroup {
         }
     }
 }
+impl std::fmt::Display for PredefinedGroupMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let repr = match self {
+            // Don't forget to update `impl std::str::FromStr for PredefinedImportGroup`
+            PredefinedGroupMatcher::Alias => "ALIAS",
+            PredefinedGroupMatcher::Bun => "BUN",
+            PredefinedGroupMatcher::Node => "NODE",
+            PredefinedGroupMatcher::Package => "PACKAGE",
+            PredefinedGroupMatcher::ProtocolPackage => "PACKAGE_WITH_PROTOCOL",
+            PredefinedGroupMatcher::Path => "PATH",
+            PredefinedGroupMatcher::Url => "URL",
+        };
+        f.write_str(repr)
+    }
+}
+impl std::str::FromStr for PredefinedGroupMatcher {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            ":ALIAS:" => Ok(Self::Alias),
+            ":BUN:" => Ok(Self::Bun),
+            ":NODE:" => Ok(Self::Node),
+            ":PACKAGE:" => Ok(Self::Package),
+            ":PACKAGE_WITH_PROTOCOL:" => Ok(Self::ProtocolPackage),
+            ":PATH:" => Ok(Self::Path),
+            ":URL:" => Ok(Self::Url),
+            _ => Err("invalid predefined group"),
+        }
+    }
+}
 
 /// Glob to match against import sources.
 #[derive(Clone, Debug, Deserializable, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ImportSourceGlob(Glob);
 impl ImportSourceGlob {
+    pub fn is_negated(&self) -> bool {
+        self.0.is_negated()
+    }
+
     /// Tests whether the given import source matches this pattern or not.
     pub fn is_match(&self, import_source: &ImportSourceCandidate) -> bool {
         import_source.path_candidate.matches(&self.0)
+    }
+
+    /// Tests whether the given import source matches this pattern or not.
+    pub fn is_raw_match(&self, import_source: &ImportSourceCandidate) -> bool {
+        import_source.path_candidate.matches_raw(&self.0)
     }
 }
 
@@ -143,6 +292,7 @@ impl ImportSourceGlob {
 ///
 /// Constructing candidates has a very small cost associated with it.
 /// The cost is amortized by matching against several import source globs.
+#[derive(Debug)]
 pub struct ImportSourceCandidate<'a> {
     source: &'a ImportSource<ComparableToken>,
     path_candidate: CandidatePath<'a>,
@@ -163,5 +313,26 @@ impl<'a> ImportSourceCandidate<'a> {
     /// Returns the original string of this import source.
     pub fn as_str(&self) -> &'a str {
         self.source.inner().0.text()
+    }
+
+    /// Tests whether the current path matches `matcher`.
+    pub fn matches(&self, matcher: &GroupMatcher) -> bool {
+        matcher.is_match(self)
+    }
+
+    /// Match against a list of matchers where negated matchers are handled as exceptions.
+    /// Returns `default` if there is no matchers that match.
+    pub fn matches_with_exceptions<'b, I>(&self, matchers: I) -> bool
+    where
+        I: IntoIterator<Item = &'b GroupMatcher>,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        // Iterate in reverse order to avoid unnecessary glob matching.
+        for matcher in matchers.into_iter().rev() {
+            if matcher.is_raw_match(self) {
+                return !matcher.is_negated();
+            }
+        }
+        false
     }
 }

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js
@@ -1,0 +1,5 @@
+import { A } from "@my/lib";
+import { B } from "@my/lib/subpath";
+import alias from "@/alias";
+import alias from "@scoped/package";
+import path from "./path";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: custom-order-mixed-glob-groups.js
+---
+# Input
+```js
+import { A } from "@my/lib";
+import { B } from "@my/lib/subpath";
+import alias from "@/alias";
+import alias from "@scoped/package";
+import path from "./path";
+
+```
+
+# Actions
+```diff
+@@ -1,5 +1,7 @@
++import alias from "@scoped/package";
++
+ import { A } from "@my/lib";
+ import { B } from "@my/lib/subpath";
++import path from "./path";
++
+ import alias from "@/alias";
+-import alias from "@scoped/package";
+-import path from "./path";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/custom-order-mixed-glob-groups.options.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": {
+					"level": "on",
+					"options": {
+                        "groups": [
+                            [":PACKAGE:", "!@my/lib", "!@my/lib/**"],
+							":BLANK_LINE:",
+							["@my/lib", "@my/lib/**"],
+                            "!:ALIAS:",
+							":BLANK_LINE:"
+                        ]
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2997,10 +2997,7 @@ If `false`, no such exception will be made.
 	 */
 	ignoreNull: boolean;
 }
-export type ImportGroup =
-	| PredefinedImportGroup
-	| ImportSourceGlob
-	| ImportSourceGlob[];
+export type ImportGroup = null | GroupMatcher | GroupMatcher[];
 export type Visibility = "public" | "package" | "private";
 export type DependencyAvailability = boolean | string[];
 export interface Hook {
@@ -3050,19 +3047,7 @@ export interface Convention {
 	 */
 	selector: Selector;
 }
-export type PredefinedImportGroup =
-	| ":BLANK_LINE:"
-	| ":ALIAS:"
-	| ":BUN:"
-	| ":NODE:"
-	| ":PACKAGE:"
-	| ":PACKAGE_WITH_PROTOCOL:"
-	| ":PATH:"
-	| ":URL:";
-/**
- * Glob to match against import sources.
- */
-export type ImportSourceGlob = Glob;
+export type GroupMatcher = PredefinedGroupMatcher | ImportSourceGlob;
 export type StableHookResult = boolean | number[];
 export interface CustomRestrictedImportOptions {
 	/**
@@ -3106,6 +3091,11 @@ export interface Selector {
 	 */
 	scope: Scope;
 }
+export type PredefinedGroupMatcher = string;
+/**
+ * Glob to match against import sources.
+ */
+export type ImportSourceGlob = Glob;
 /**
  * Supported cases.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1677,6 +1677,12 @@
 			},
 			"additionalProperties": false
 		},
+		"GroupMatcher": {
+			"anyOf": [
+				{ "$ref": "#/definitions/PredefinedGroupMatcher" },
+				{ "$ref": "#/definitions/ImportSourceGlob" }
+			]
+		},
 		"GroupPlainConfiguration": {
 			"oneOf": [
 				{
@@ -1821,12 +1827,9 @@
 		},
 		"ImportGroup": {
 			"anyOf": [
-				{ "$ref": "#/definitions/PredefinedImportGroup" },
-				{ "$ref": "#/definitions/ImportSourceGlob" },
-				{
-					"type": "array",
-					"items": { "$ref": "#/definitions/ImportSourceGlob" }
-				}
+				{ "type": "null" },
+				{ "$ref": "#/definitions/GroupMatcher" },
+				{ "type": "array", "items": { "$ref": "#/definitions/GroupMatcher" } }
 			]
 		},
 		"ImportGroups": {
@@ -3289,19 +3292,7 @@
 			"type": "array",
 			"items": { "$ref": "#/definitions/PluginConfiguration" }
 		},
-		"PredefinedImportGroup": {
-			"type": "string",
-			"enum": [
-				":BLANK_LINE:",
-				":ALIAS:",
-				":BUN:",
-				":NODE:",
-				":PACKAGE:",
-				":PACKAGE_WITH_PROTOCOL:",
-				":PATH:",
-				":URL:"
-			]
-		},
+		"PredefinedGroupMatcher": { "type": "string" },
 		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
 		"QuoteStyle": { "type": "string", "enum": ["double", "single"] },
 		"Regex": { "type": "string" },


### PR DESCRIPTION
## Summary

This Pr adds the support for negated predefined groups and placing predefined groups in list.
This will simplify some configs such as https://github.com/biomejs/biome/issues/5435

I didn't change the documentation to avoid any confusion since the docs is diretcly published on `next.biomejs.dev`

## Test Plan

I added a test.