### PR TITLE
ci: fix beta release for JS API

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,6 +1,14 @@
 name: Beta release CLI
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The version to release
+        default: 'v0.8.0-beta'
+
+env:
+  INPUT_VERSION: ${{ inputs.version }}
 
 jobs:
   version:

--- a/.github/workflows/beta_js_api.yml
+++ b/.github/workflows/beta_js_api.yml
@@ -1,6 +1,14 @@
 name: Beta release JavaScript API
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The version to release
+        default: 'v0.8.0-beta'
+
+env:
+  INPUT_VERSION: ${{ inputs.version }}
 
 jobs:
   version:
@@ -98,7 +106,6 @@ jobs:
 
       - name: Publish npm package as beta
         run: npm publish packages/@biomejs/js-api --tag beta --access public --provenance
-        if: needs.build.outputs.prerelease == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/@biomejs/biome/scripts/update-beta-version.mjs
+++ b/packages/@biomejs/biome/scripts/update-beta-version.mjs
@@ -14,7 +14,11 @@ if (
 	throw new Error("GITHUB_SHA environment variable is undefined");
 }
 
-const version = "2.0.0-beta.1";
+const version = process.env.INPUT_VERSION;
+if (typeof version !== "string" || version === "") {
+	throw new Error("INPUT_VERSION environment variable is undefined");
+}
+
 rootManifest.version = version;
 
 const content = JSON.stringify(rootManifest);

--- a/packages/@biomejs/js-api/scripts/update-beta-version.mjs
+++ b/packages/@biomejs/js-api/scripts/update-beta-version.mjs
@@ -14,7 +14,11 @@ if (
 	throw new Error("GITHUB_SHA environment variable is undefined");
 }
 
-const version = "0.8.0-beta";
+const version = process.env.INPUT_VERSION;
+if (typeof version !== "string" || version === "") {
+	throw new Error("INPUT_VERSION environment variable is undefined");
+}
+
 rootManifest.version = version;
 
 const content = JSON.stringify(rootManifest);


### PR DESCRIPTION
## Summary

Follow-up of #5448 

There was an unnecessary `if` condition on the step and `@biomejs/js-api` was not published correctly. Removed the condition.

Plus, I added a workflow_dispatch input to specify what version to publish.

## Test Plan

N/A
