### PR TITLE
fix(migrate): improve error messages when parsing Prettier configuration

### DIFF
--- a/.changeset/fancy-animals-kiss.md
+++ b/.changeset/fancy-animals-kiss.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved context in error messages when migrating Prettier configurations

--- a/crates/biome_cli/src/execute/migrate.rs
+++ b/crates/biome_cli/src/execute/migrate.rs
@@ -9,7 +9,6 @@ use biome_deserialize::Merge;
 use biome_deserialize::json::deserialize_from_json_ast;
 use biome_diagnostics::Diagnostic;
 use biome_diagnostics::{PrintDiagnostic, category};
-use biome_formatter::ParseFormatNumberError;
 use biome_fs::{BiomePath, OpenOptions};
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_formatter::format_node;
@@ -96,14 +95,11 @@ pub(crate) fn run(migrate_payload: MigratePayload) -> Result<(), CliDiagnostic> 
                 return Ok(());
             };
             let old_biome_config = biome_config.clone();
-            let prettier_biome_config =
-                prettier_config
-                    .try_into()
-                    .map_err(|err: ParseFormatNumberError| {
-                        CliDiagnostic::MigrateError(MigrationDiagnostic {
-                            reason: err.to_string(),
-                        })
-                    })?;
+            let prettier_biome_config = prettier_config.try_into().map_err(|err| {
+                CliDiagnostic::MigrateError(MigrationDiagnostic {
+                    reason: format!("{:#}", err),
+                })
+            })?;
             biome_config.merge_with(prettier_biome_config);
             if let Ok(ignore_patterns) = ignorefile::read_ignore_file(fs, prettier::IGNORE_FILE) {
                 if !ignore_patterns.patterns.is_empty() {

--- a/crates/biome_cli/tests/commands/migrate_prettier.rs
+++ b/crates/biome_cli/tests/commands/migrate_prettier.rs
@@ -440,3 +440,70 @@ fn prettier_migrate_overrides() {
         result,
     ));
 }
+
+#[test]
+fn prettier_migrate_override_with_bad_print_width() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "formatter": { "enabled": true } }"#;
+    let prettier = r#"{
+        "overrides": [{
+            "files": ["**/*.test.js"],
+            "options": { "printWidth": 666 }
+        }]
+    }"#;
+
+    let configuration_path = Utf8Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Utf8Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["migrate", "prettier"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_override_with_bad_print_width",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn prettier_migrate_with_bad_top_level_print_width() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let configuration = r#"{ "formatter": { "enabled": true } }"#;
+    let prettier = r#"{ "printWidth": 666 }"#;
+
+    let configuration_path = Utf8Path::new("biome.json");
+    fs.insert(configuration_path.into(), configuration.as_bytes());
+
+    let prettier_path = Utf8Path::new(".prettierrc");
+    fs.insert(prettier_path.into(), prettier.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["migrate", "prettier"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "prettier_migrate_with_bad_top_level_print_width",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_format/line_width_parse_errors_overflow.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/line_width_parse_errors_overflow.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Termination Message
 
@@ -10,10 +10,8 @@ flags/invalid ━━━━━━━━━━━━━━━━━━━━━━
   × Failed to parse CLI arguments.
     
     Caused by:
-      couldn't parse `321`: The line width should be between 1 and 320 
+      couldn't parse `321`: The line width should be between 1 and 320, got 321 
   
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_override_with_bad_print_width.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_override_with_bad_print_width.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "formatter": { "enabled": true } }
+```
+
+## `.prettierrc`
+
+```prettierrc
+{
+        "overrides": [{
+            "files": ["**/*.test.js"],
+            "options": { "printWidth": 666 }
+        }]
+    }
+```
+
+# Termination Message
+
+```block
+migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Migration has encountered an error: override element matching ["**/*.test.js"]: The line width should be between 1 and 320, got 666
+  
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_bad_top_level_print_width.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_with_bad_top_level_print_width.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "formatter": { "enabled": true } }
+```
+
+## `.prettierrc`
+
+```prettierrc
+{ "printWidth": 666 }
+```
+
+# Termination Message
+
+```block
+migrate ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Migration has encountered an error: top-level Prettier configuration: The line width should be between 1 and 320, got 666
+  
+  
+
+
+```

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -413,6 +413,8 @@ impl Debug for ParseFormatNumberError {
     }
 }
 
+impl std::error::Error for ParseFormatNumberError {}
+
 impl std::fmt::Display for ParseFormatNumberError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -453,12 +455,15 @@ impl std::fmt::Display for IndentWidthFromIntError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "The indent width should be between {} and {}",
+            "The indent width should be between {} and {}, got {}",
             LineWidth::MIN,
             LineWidth::MAX,
+            self.0,
         )
     }
 }
+
+impl std::error::Error for IndentWidthFromIntError {}
 
 /// Error type returned when converting a u16 to a [LineWidth] fails
 #[derive(Clone, Copy, Debug)]
@@ -468,12 +473,15 @@ impl std::fmt::Display for LineWidthFromIntError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "The line width should be between {} and {}",
+            "The line width should be between {} and {}, got {}",
             LineWidth::MIN,
             LineWidth::MAX,
+            self.0,
         )
     }
 }
+
+impl std::error::Error for LineWidthFromIntError {}
 
 impl From<LineWidth> for u16 {
     fn from(value: LineWidth) -> Self {


### PR DESCRIPTION
## Summary

Before:

```
$ yarn biome migrate prettier --verbose
migrate ━━━

  ✖ Migration has encountered an error: The line width should be between 1 and 320
```

After:

```
$ ../biome/target/debug/biome migrate prettier
migrate ━━━

  ✖ Migration has encountered an error: override element matching ["red/ac/ted.ts"]: The line width should be between 1 and 320, got 666
```

## Test Plan

Snapshot tests showing the new errors added.