### PR TITLE
fix(assist/organizeImports): allow suppression comments

### DIFF
--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -3,7 +3,7 @@ use biome_analyze::{
 };
 use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{AnyJsExportClause, AnyJsModuleItem, JsModule, JsSyntaxKind, JsSyntaxNode};
-use biome_rowan::{AstNode, TriviaPieceKind};
+use biome_rowan::{AstNode, TextRange, TriviaPieceKind};
 use biome_rowan::{BatchMutationExt, chain_trivia_pieces};
 use import_key::{ImportInfo, ImportKey};
 use rustc_hash::FxHashMap;
@@ -527,6 +527,19 @@ impl Rule for OrganizeImports {
     type State = Box<[Issue]>;
     type Signals = Option<Self::State>;
     type Options = Options;
+
+    fn text_range(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<TextRange> {
+        ctx.query()
+            .items()
+            .into_iter()
+            .find(|item| {
+                matches!(
+                    item,
+                    AnyJsModuleItem::JsImport(_) | AnyJsModuleItem::JsExport(_)
+                )
+            })
+            .map(|item| item.range())
+    }
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         struct ChunkBuilder {

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/suppressed-unsorted.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/suppressed-unsorted.js
@@ -1,0 +1,3 @@
+// biome-ignore assist/source/organizeImports: desc
+import B from "b";
+import A from "a";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/suppressed-unsorted.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/suppressed-unsorted.js.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: suppressed-unsorted.js
+---
+# Input
+```js
+// biome-ignore assist/source/organizeImports: desc
+import B from "b";
+import A from "a";
+
+```

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -2011,6 +2011,26 @@ if(a === -0) {}
         }],
     );
 
+    let mut inline_changes = HashMap::default();
+    inline_changes.insert(
+        url!("document.js"),
+        vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 0,
+                },
+                end: Position {
+                    line: 1,
+                    character: 0,
+                },
+            },
+            new_text: String::from(
+                "// biome-ignore assist/source/organizeImports: <explanation>\n",
+            ),
+        }],
+    );
+
     let expected_toplevel_suppression_action =
         lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
             title: String::from(
@@ -2031,9 +2051,30 @@ if(a === -0) {}
             data: None,
         });
 
+    let expected_line_suppression_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+        title: String::from("Suppress action assist/source/organizeImports for this line."),
+        kind: Some(lsp::CodeActionKind::new(
+            "quickfix.suppressRule.inline.biome",
+        )),
+        diagnostics: None,
+        edit: Some(lsp::WorkspaceEdit {
+            changes: Some(inline_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
+
     assert_eq!(
         res,
-        vec![expected_code_action, expected_toplevel_suppression_action]
+        vec![
+            expected_code_action,
+            expected_line_suppression_action,
+            expected_toplevel_suppression_action
+        ]
     );
 
     server.close_document().await?;


### PR DESCRIPTION
## Summary

This PR adds the ability of suppressing organizeImports.
The suppression comment has to be placed on the first import/export of the file.

## Test Plan

I added a test.
