### PR TITLE
docs: include how to use configuration in the js-api README

### DIFF
--- a/packages/@biomejs/js-api/README.md
+++ b/packages/@biomejs/js-api/README.md
@@ -26,6 +26,9 @@ const biome = await Biome.create({
 	distribution: Distribution.NODE, // Or BUNDLER / WEB depending on the distribution package you've installed
 });
 
+// Optionally apply a Biome configuration (instead of biome.json)
+biome.applyConfiguration({...});
+
 const formatted = biome.formatContent("function f   (a, b) { return a == b; }", {
 	filePath: "example.js",
 });

--- a/packages/@biomejs/js-api/README.md
+++ b/packages/@biomejs/js-api/README.md
@@ -26,8 +26,10 @@ const biome = await Biome.create({
 	distribution: Distribution.NODE, // Or BUNDLER / WEB depending on the distribution package you've installed
 });
 
+const projectKey = biome.openProject('path/to/project/dir');
+
 // Optionally apply a Biome configuration (instead of biome.json)
-biome.applyConfiguration({...});
+biome.applyConfiguration(projectKey, {...});
 
 const formatted = biome.formatContent("function f   (a, b) { return a == b; }", {
 	filePath: "example.js",


### PR DESCRIPTION
Included how to use Biome configurations in the js-api package.

## Summary

The README made absolutely no mention of how to use Biome configurations with the js-api package, which I guess normally wouldn't be a problem *if* it supported reading the biome.json file by default. Was wondering why it wasn't applying, and had to look through the source & abuse Intellisense to figure out that this was even possible in js-api.

https://discord.com/channels/1132231889290285117/1132231889911029825/1355987574786752683 -> me coping in the Discord server before I figured it out

## Test Plan
N/A (documentation update)