### PR TITLE
fix(plugins): handle invalid spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ dependencies = [
  "camino",
  "crossbeam",
  "enumflags2",
- "getrandom 0.3.2",
+ "getrandom 0.2.15",
  "ignore",
  "insta",
  "notify",
@@ -2275,8 +2275,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2286,11 +2288,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -1435,7 +1435,8 @@ impl RuleDiagnostic {
         self.footer(LogCategory::Warn, msg)
     }
 
-    pub(crate) fn span(&self) -> Option<TextRange> {
+    #[inline]
+    pub fn span(&self) -> Option<TextRange> {
         self.span
     }
 

--- a/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_grit_plugin.rs
@@ -47,20 +47,39 @@ impl AnalyzerPlugin for AnalyzerGritPlugin {
 
         let file = GritTargetFile { parse: root, path };
         match self.grit_query.execute(file) {
-            Ok(result) => result
-                .logs
-                .iter()
-                .map(|log| {
-                    RuleDiagnostic::new(
+            Ok(result) => {
+                let mut diagnostics: Vec<_> = result
+                    .logs
+                    .iter()
+                    .map(|log| {
+                        RuleDiagnostic::new(
                         category!("plugin"),
                         log.range.map(from_grit_range),
                         markup!(<Emphasis>{name}</Emphasis>" logged: "<Info>{log.message}</Info>),
                     )
                     .verbose()
-                })
-                .chain(result.diagnostics)
-                .map(|diagnos| diagnos.subcategory(name.to_string()))
-                .collect(),
+                    })
+                    .chain(result.diagnostics)
+                    .map(|diagnostics| diagnostics.subcategory(name.to_string()))
+                    .collect();
+
+                if diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.span().is_none())
+                {
+                    diagnostics.push(RuleDiagnostic::new(
+                        category!("plugin"),
+                        None::<TextRange>,
+                        markup!(
+                            "Plugin "<Emphasis>{name}</Emphasis>" reported one or more diagnostics, "
+                            "but it didn't specify a valid "<Emphasis>"span"</Emphasis>". "
+                            "Diagnostics have been shown without context."
+                        ),
+                    ));
+                }
+
+                diagnostics
+            }
             Err(error) => vec![RuleDiagnostic::new(
                 category!("plugin"),
                 None::<TextRange>,

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -59,7 +59,7 @@ biome_text_edit         = { workspace = true }
 camino                  = { workspace = true }
 crossbeam               = { workspace = true }
 enumflags2              = { workspace = true, features = ["serde"] }
-getrandom               = { workspace = true, features = ["wasm_js"] }
+getrandom               = { workspace = true, features = ["js"] }
 ignore                  = { workspace = true }
 notify                  = { version = "8.0", features = ["crossbeam-channel"] }
 papaya                  = { workspace = true }

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_may_use_invalid_span.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_may_use_invalid_span.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_service/src/workspace.tests.rs
+expression: result.diagnostics
+---
+[
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Error,
+        description: "Prefer object spread instead of `Object.assign()`",
+        message: "Prefer object spread instead of `Object.assign()`",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/a.ts",
+                ),
+            ),
+            span: None,
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Information,
+        description: "Plugin plugin reported one or more diagnostics, but it didn't specify a valid span. Diagnostics have been shown without context.",
+        message: "Plugin "<Emphasis>"plugin"</Emphasis>" reported one or more diagnostics, but it didn't specify a valid "<Emphasis>"span"</Emphasis>". Diagnostics have been shown without context.",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/a.ts",
+                ),
+            ),
+            span: None,
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+]


### PR DESCRIPTION
## Summary

Plugins have to provide a `span` argument when reporting diagnostics. Naturally, they can mistakes when doing so.

Previously, incorrect spans would crash the process:

```
/home/arendjr/Projects/biome-plugin/src/routes/index.tsx internalError/panic  INTERNAL  ━━━━━━━━━━━━

  ✖ processing panicked: missing span
  
  ⚠ This diagnostic was derived from an internal Biome error. Potential bug, please report it if necessary.
```

With this PR, we gracefully handle such cases:

```
/src/routes/index.tsx plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Don't use visible task pls
  

/src/routes/index.tsx plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ Plugin qwik-plugin reported one or more diagnostics, but it didn't specify a valid span. Diagnostics have been shown without context.
```

Fixes #5471.

## Test Plan

Test case added.
