### PR TITLE
chore: set 2024 as default Rustfmt style edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 newline_style = "Unix"
+style_edition = "2024"


### PR DESCRIPTION
Biome switched to 2024 style edition in 9b2d5db56ebe3abc1306707 but did not set the style_edition in rustfmt.toml so if your editor runs rustfmt it now formats it with 2015 (the default) instead of 2024.


## Summary

My editor runs `rustfmt` which defaults to 2015

## Test Plan

This configures rustfmt.toml to be in line with the formatting xtask

```
rustfmt --config newline_style=Unix --config style_edition=2024
```