### PR TITLE
refactor(migrate): escape squared braces

### DIFF
--- a/crates/biome_migrate/tests/specs/migrations/includes/invalid_globs.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/includes/invalid_globs.json.snap
@@ -34,21 +34,12 @@ invalid_globs.json:3:5 migrate  FIXABLE  ━━━━━━━━━━━━━
     4 │   }
     5 │ }
   
-  i This glob cannot be converted to the new glob format because it generates the follosing error: Character class `[]` are not supported. Use `\[` and `\]` to escape the characters.
-  
-    1 │ {
-    2 │   "files": {
-  > 3 │     "include": ["valid", "invalid?.js", "invalid[0-9].js"]
-      │                                                 ^
-    4 │   }
-    5 │ }
-  
   i Safe fix: Use includes instead.
   
     1 1 │   {
     2 2 │     "files": {
     3   │ - ····"include":·["valid",·"invalid?.js",·"invalid[0-9].js"]
-      3 │ + ····"includes":·["**/valid/**"]
+      3 │ + ····"includes":·["**/valid/**",·"**/invalid\\[0-9\\].js"]
     4 4 │     }
     5 5 │   }
   


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5442
We now escape squared braces whe nconverting `include`/`ignore` into `includes`.

## Test Plan

I updated the tests.