### PR TITLE
feat(linter): make useImportExtensions check imports with sub extensions

### DIFF
--- a/.changeset/olive-trains-buy.md
+++ b/.changeset/olive-trains-buy.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": minor
+---
+
+[useImportExtensions](https://biomejs.dev/linter/rules/use-import-extensions/) now checks imports with sub extensions.
+```js
+- import 'styles.css'
++ import 'styles.css.ts'
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalid.ts
@@ -20,3 +20,7 @@ import './sub?query=string&query2#hash'
 import('./sub/foo')
 import( /** A **/'./sub/foo'/** B **/ )
 require("./sub/foo")
+
+import "./sub/styles.css"
+import "./sub/component.svg.svelte";
+import "./sub/component.svg.svelte?query=string&query2#hash";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalid.ts.snap
@@ -27,6 +27,9 @@ import('./sub/foo')
 import( /** A **/'./sub/foo'/** B **/ )
 require("./sub/foo")
 
+import "./sub/styles.css"
+import "./sub/component.svg.svelte";
+import "./sub/component.svg.svelte?query=string&query2#hash";
 ```
 
 # Diagnostics
@@ -364,6 +367,7 @@ invalid.ts:22:9 lint/correctness/useImportExtensions  FIXABLE  ━━━━━�
   > 22 │ require("./sub/foo")
        │         ^^^^^^^^^^^
     23 │ 
+    24 │ import "./sub/styles.css"
   
   i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
   
@@ -374,6 +378,71 @@ invalid.ts:22:9 lint/correctness/useImportExtensions  FIXABLE  ━━━━━�
     22    │ - require("./sub/foo")
        22 │ + require("./sub/foo.ts")
     23 23 │   
+    24 24 │   import "./sub/styles.css"
+  
+
+```
+
+```
+invalid.ts:24:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    22 │ require("./sub/foo")
+    23 │ 
+  > 24 │ import "./sub/styles.css"
+       │        ^^^^^^^^^^^^^^^^^^
+    25 │ import "./sub/component.svg.svelte";
+    26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .ts.
+  
+    22 22 │   require("./sub/foo")
+    23 23 │   
+    24    │ - import·"./sub/styles.css"
+       24 │ + import·"./sub/styles.css.ts"
+    25 25 │   import "./sub/component.svg.svelte";
+    26 26 │   import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+
+```
+
+```
+invalid.ts:25:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    24 │ import "./sub/styles.css"
+  > 25 │ import "./sub/component.svg.svelte";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .ts.
+  
+    23 23 │   
+    24 24 │   import "./sub/styles.css"
+    25    │ - import·"./sub/component.svg.svelte";
+       25 │ + import·"./sub/component.svg.svelte.ts";
+    26 26 │   import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+
+```
+
+```
+invalid.ts:26:8 lint/correctness/useImportExtensions ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    24 │ import "./sub/styles.css"
+    25 │ import "./sub/component.svg.svelte";
+  > 26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithForcedJsExtensions.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithForcedJsExtensions.ts
@@ -20,3 +20,7 @@ import './sub?query=string&query2#hash'
 import('./sub/foo')
 import( /** A **/'./sub/foo'/** B **/ )
 require("./sub/foo")
+
+import "./sub/styles.css"
+import "./sub/component.svg.svelte";
+import "./sub/component.svg.svelte?query=string&query2#hash";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithForcedJsExtensions.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithForcedJsExtensions.ts.snap
@@ -27,6 +27,9 @@ import('./sub/foo')
 import( /** A **/'./sub/foo'/** B **/ )
 require("./sub/foo")
 
+import "./sub/styles.css"
+import "./sub/component.svg.svelte";
+import "./sub/component.svg.svelte?query=string&query2#hash";
 ```
 
 # Diagnostics
@@ -364,6 +367,7 @@ invalidWithForcedJsExtensions.ts:22:9 lint/correctness/useImportExtensions  FIXA
   > 22 │ require("./sub/foo")
        │         ^^^^^^^^^^^
     23 │ 
+    24 │ import "./sub/styles.css"
   
   i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
   
@@ -374,6 +378,71 @@ invalidWithForcedJsExtensions.ts:22:9 lint/correctness/useImportExtensions  FIXA
     22    │ - require("./sub/foo")
        22 │ + require("./sub/foo.js")
     23 23 │   
+    24 24 │   import "./sub/styles.css"
+  
+
+```
+
+```
+invalidWithForcedJsExtensions.ts:24:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    22 │ require("./sub/foo")
+    23 │ 
+  > 24 │ import "./sub/styles.css"
+       │        ^^^^^^^^^^^^^^^^^^
+    25 │ import "./sub/component.svg.svelte";
+    26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .js.
+  
+    22 22 │   require("./sub/foo")
+    23 23 │   
+    24    │ - import·"./sub/styles.css"
+       24 │ + import·"./sub/styles.css.js"
+    25 25 │   import "./sub/component.svg.svelte";
+    26 26 │   import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+
+```
+
+```
+invalidWithForcedJsExtensions.ts:25:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    24 │ import "./sub/styles.css"
+  > 25 │ import "./sub/component.svg.svelte";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .js.
+  
+    23 23 │   
+    24 24 │   import "./sub/styles.css"
+    25    │ - import·"./sub/component.svg.svelte";
+       25 │ + import·"./sub/component.svg.svelte.js";
+    26 26 │   import "./sub/component.svg.svelte?query=string&query2#hash";
+  
+
+```
+
+```
+invalidWithForcedJsExtensions.ts:26:8 lint/correctness/useImportExtensions ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Add a file extension for relative imports.
+  
+    24 │ import "./sub/styles.css"
+    25 │ import "./sub/component.svg.svelte";
+  > 26 │ import "./sub/component.svg.svelte?query=string&query2#hash";
+       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/component.svg.svelte.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/component.svg.svelte.ts
@@ -1,0 +1,1 @@
+/* should not generate diagnostics */

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/component.svg.svelte.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/component.svg.svelte.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: component.svg.svelte.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/styles.css.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/styles.css.ts
@@ -1,0 +1,1 @@
+/* should not generate diagnostics */

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/styles.css.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/styles.css.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: styles.css.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
@@ -18,3 +18,4 @@ require('./sub/foo.ts');
 // If the import doesn't resolve at all, we don't report a diagnostic:
 // It means the import is broken beyond missing an extension.
 import './sub/baz';
+import './sub/baz.css';

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
@@ -24,5 +24,6 @@ require('./sub/foo.ts');
 // If the import doesn't resolve at all, we don't report a diagnostic:
 // It means the import is broken beyond missing an extension.
 import './sub/baz';
+import './sub/baz.css';
 
 ```


### PR DESCRIPTION
## Summary

In JS ecosystem it is popular to have files with sub extensions/file steam.
[CSS modules](https://github.com/css-modules/css-modules) `styles.css.ts`
[Svelte](https://svelte.dev/docs/svelte/svelte-js-files) `rune.svelte.ts`
And more. Currently editors auto import without .ts extension so it is easy to miss that you are not using actual file extension.
This MR fixes it. 

I originally planned to only check specific extensions, however I decided against it:
- Rule would miss valid cases and for not much perf gain.
- Even `filename.ts.ts` is not [that rare](https://github.com/search?q=path%3A**%2F*.ts.ts&type=code).
- Some people might use naming convention which uses dots instead of dashes and so on.

## Test Plan

Added snapshots