### PR TITLE
feat(service): sort diagnostics by severity in descending order

### DIFF
--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -191,6 +191,9 @@ impl DiagnosticsCollector {
             }
         }
 
+        // Sort diagnostics by severity to put the most severe diagnostics first.
+        diagnostics.sort_by(|a, b| b.severity().cmp(&a.severity()));
+
         diagnostics
     }
 }

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -284,3 +284,7 @@ fn open_file(ctx: &ScanContext, path: &BiomePath) {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "scanner.tests.rs"]
+mod tests;

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -13,6 +13,7 @@ use biome_diagnostics::{Diagnostic as _, Error, Severity};
 use biome_fs::{BiomePath, PathInterner, TraversalContext, TraversalScope};
 use camino::Utf8Path;
 use crossbeam::channel::{Receiver, Sender, unbounded};
+use std::cmp::Reverse;
 use std::collections::BTreeSet;
 use std::panic::catch_unwind;
 use std::sync::RwLock;
@@ -192,7 +193,7 @@ impl DiagnosticsCollector {
         }
 
         // Sort diagnostics by severity to put the most severe diagnostics first.
-        diagnostics.sort_by(|a, b| b.severity().cmp(&a.severity()));
+        diagnostics.sort_by_key(|d| Reverse(d.severity()));
 
         diagnostics
     }

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -1,6 +1,6 @@
-use biome_diagnostics::serde::Diagnostic as SerdeDiagnostic;
 use biome_diagnostics::Diagnostic;
 use biome_diagnostics::diagnostic::Severity;
+use biome_diagnostics::serde::Diagnostic as SerdeDiagnostic;
 use crossbeam::channel::unbounded;
 
 use super::*;
@@ -34,13 +34,11 @@ struct InformationDiagnostic {}
 
 #[test]
 fn test_diagnostics_collector_sorting() {
-    let collector = DiagnosticsCollector{
+    let collector = DiagnosticsCollector {
         diagnostic_level: Severity::Hint,
-        verbose: false
+        verbose: false,
     };
     let (sender, receiver) = unbounded();
-
-
 
     // Send diagnostics with different severities in random order
     let warning = SerdeDiagnostic::new(WarningDiagnostic {});

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -9,28 +9,12 @@ use super::*;
 #[diagnostic(
     category = "lint/style/noShoutyConstants",
     tags(FIXABLE),
-    message = "Test diagnostic message",
-    severity = Warning
+    message = "Test diagnostic message"
 )]
-struct WarningDiagnostic {}
-
-#[derive(Debug, Diagnostic)]
-#[diagnostic(
-    category = "lint/style/noShoutyConstants",
-    tags(FIXABLE),
-    message = "Test diagnostic message",
-    severity = Error
-)]
-struct ErrorDiagnostic {}
-
-#[derive(Debug, Diagnostic)]
-#[diagnostic(
-    category = "lint/style/noShoutyConstants",
-    tags(FIXABLE),
-    message = "Test diagnostic message",
-    severity = Information
-)]
-struct InformationDiagnostic {}
+struct TestDiagnostic {
+    #[severity]
+    severity: Severity,
+}
 
 #[test]
 fn test_diagnostics_collector_sorting() {
@@ -40,10 +24,10 @@ fn test_diagnostics_collector_sorting() {
     };
     let (sender, receiver) = unbounded();
 
-    // Send diagnostics with different severities in random order
-    let warning = SerdeDiagnostic::new(WarningDiagnostic {});
-    let error = SerdeDiagnostic::new(ErrorDiagnostic {});
-    let info = SerdeDiagnostic::new(InformationDiagnostic {});
+    // Send diagnostics with different severities
+    let warning = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Warning });
+    let error = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Error });
+    let info = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Information });
 
     // Send in an order different from severity
     sender.send(info).unwrap();

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -1,0 +1,62 @@
+use biome_diagnostics::serde::Diagnostic as SerdeDiagnostic;
+use biome_diagnostics::Diagnostic;
+use biome_diagnostics::diagnostic::Severity;
+use crossbeam::channel::unbounded;
+
+use super::*;
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    category = "lint/style/noShoutyConstants",
+    tags(FIXABLE),
+    message = "Test diagnostic message",
+    severity = Warning
+)]
+struct WarningDiagnostic {}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    category = "lint/style/noShoutyConstants",
+    tags(FIXABLE),
+    message = "Test diagnostic message",
+    severity = Error
+)]
+struct ErrorDiagnostic {}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    category = "lint/style/noShoutyConstants",
+    tags(FIXABLE),
+    message = "Test diagnostic message",
+    severity = Information
+)]
+struct InformationDiagnostic {}
+
+#[test]
+fn test_diagnostics_collector_sorting() {
+    let collector = DiagnosticsCollector{
+        diagnostic_level: Severity::Hint,
+        verbose: false
+    };
+    let (sender, receiver) = unbounded();
+
+
+
+    // Send diagnostics with different severities in random order
+    let warning = SerdeDiagnostic::new(WarningDiagnostic {});
+    let error = SerdeDiagnostic::new(ErrorDiagnostic {});
+    let info = SerdeDiagnostic::new(InformationDiagnostic {});
+
+    // Send in an order different from severity
+    sender.send(info).unwrap();
+    sender.send(warning).unwrap();
+    sender.send(error).unwrap();
+    drop(sender);
+
+    let result = collector.run(receiver);
+
+    // Verify diagnostics are sorted by severity (error > warning > info)
+    assert_eq!(result[0].severity(), Severity::Error);
+    assert_eq!(result[1].severity(), Severity::Warning);
+    assert_eq!(result[2].severity(), Severity::Information);
+}

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -22,9 +22,15 @@ fn test_diagnostics_collector_sorting() {
     let (sender, receiver) = unbounded();
 
     // Send diagnostics with different severities
-    let warning = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Warning });
-    let error = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Error });
-    let info = SerdeDiagnostic::new(TestDiagnostic { severity: Severity::Information });
+    let warning = SerdeDiagnostic::new(TestDiagnostic {
+        severity: Severity::Warning,
+    });
+    let error = SerdeDiagnostic::new(TestDiagnostic {
+        severity: Severity::Error,
+    });
+    let info = SerdeDiagnostic::new(TestDiagnostic {
+        severity: Severity::Information,
+    });
 
     // Send in an order different from severity
     sender.send(info).unwrap();

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -18,10 +18,7 @@ struct TestDiagnostic {
 
 #[test]
 fn test_diagnostics_collector_sorting() {
-    let collector = DiagnosticsCollector {
-        diagnostic_level: Severity::Hint,
-        verbose: false,
-    };
+    let collector = DiagnosticsCollector::new();
     let (sender, receiver) = unbounded();
 
     // Send diagnostics with different severities


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

If Biome is to enforce a limit on the number of diagnostics shown to the user, then it ought to sort them so as to show the most severe diagnostics first.

See [Discussion#5180](https://github.com/biomejs/biome/discussions/5180)

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

I implemented a simple test of the sorting logic in `scanner.tests.ts`