### PR TITLE
fix(cli): emit error when no extension exist

### DIFF
--- a/.changeset/lucky-boats-rush.md
+++ b/.changeset/lucky-boats-rush.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where Biome didn't report any error when `--stdin-file-path` didn't have any extension.
+Now Biome returns an error if `--stdin-file-path` doesn't have an extension.

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -15,6 +15,7 @@ use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DropPatternParams, FeaturesBuilder, FileContent,
     FixFileParams, FormatFileParams, OpenFileParams, SupportsFeatureParams,
 };
+use camino::Utf8PathBuf;
 use std::borrow::Cow;
 
 pub(crate) fn run<'a>(
@@ -31,7 +32,9 @@ pub(crate) fn run<'a>(
 
     let std_in_file = biome_path
         .extension()
-        .map(|ext| BiomePath::new(format!("{}.{}", TEMPORARY_INTERNAL_FILE_NAME, ext)))
+        .map(|ext| {
+            BiomePath::new(Utf8PathBuf::from(TEMPORARY_INTERNAL_FILE_NAME).with_extension(ext))
+        })
         .ok_or_else(|| CliDiagnostic::from(StdinDiagnostic::new_no_extension()))?;
 
     if mode.is_format() {

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -1,7 +1,8 @@
 //! In here, there are the operations that run via standard input
 //!
+use crate::diagnostics::StdinDiagnostic;
 use crate::execute::Execution;
-use crate::{CliDiagnostic, CliSession, TraversalMode};
+use crate::{CliDiagnostic, CliSession, TEMPORARY_INTERNAL_FILE_NAME, TraversalMode};
 use biome_analyze::RuleCategoriesBuilder;
 use biome_console::{ConsoleExt, markup};
 use biome_diagnostics::Diagnostic;
@@ -11,8 +12,8 @@ use biome_service::WorkspaceError;
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::projects::ProjectKey;
 use biome_service::workspace::{
-    ChangeFileParams, DropPatternParams, FeaturesBuilder, FileContent, FixFileParams,
-    FormatFileParams, OpenFileParams, SupportsFeatureParams,
+    ChangeFileParams, CloseFileParams, DropPatternParams, FeaturesBuilder, FileContent,
+    FixFileParams, FormatFileParams, OpenFileParams, SupportsFeatureParams,
 };
 use std::borrow::Cow;
 
@@ -27,6 +28,11 @@ pub(crate) fn run<'a>(
     let workspace = &*session.app.workspace;
     let console = &mut *session.app.console;
     let mut version = 0;
+
+    let std_in_file = biome_path
+        .extension()
+        .map(|ext| BiomePath::new(format!("{}.{}", TEMPORARY_INTERNAL_FILE_NAME, ext)))
+        .ok_or_else(|| CliDiagnostic::from(StdinDiagnostic::new_no_extension()))?;
 
     if mode.is_format() {
         let file_features = workspace.file_features(SupportsFeatureParams {
@@ -49,14 +55,14 @@ pub(crate) fn run<'a>(
         if file_features.supports_format() {
             workspace.open_file(OpenFileParams {
                 project_key,
-                path: biome_path.clone(),
+                path: std_in_file.clone(),
                 content: FileContent::from_client(content),
                 document_file_source: None,
                 persist_node_cache: false,
             })?;
             let printed = workspace.format_file(FormatFileParams {
                 project_key,
-                path: biome_path.clone(),
+                path: std_in_file.clone(),
             })?;
 
             let code = printed.into_code();
@@ -69,6 +75,10 @@ pub(crate) fn run<'a>(
             console.append(markup! {
                 {output}
             });
+            workspace.close_file(CloseFileParams {
+                project_key,
+                path: std_in_file.clone(),
+            })?;
         } else {
             console.append(markup! {
                 {content}
@@ -76,14 +86,14 @@ pub(crate) fn run<'a>(
             console.error(markup! {
                 <Warn>"The content was not formatted because the formatter is currently disabled."</Warn>
             });
-            return Err(CliDiagnostic::stdin());
+            return Err(StdinDiagnostic::new_not_formatted().into());
         }
     } else if mode.is_check() || mode.is_lint() {
         let mut new_content = Cow::Borrowed(content);
 
         workspace.open_file(OpenFileParams {
             project_key,
-            path: biome_path.clone(),
+            path: std_in_file.clone(),
             content: FileContent::from_client(content),
             document_file_source: None,
             persist_node_cache: false,
@@ -109,6 +119,7 @@ pub(crate) fn run<'a>(
                 console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
             }
             console.append(markup! {{content}});
+
             return Ok(());
         };
 
@@ -133,7 +144,7 @@ pub(crate) fn run<'a>(
                 let fix_file_result = workspace.fix_file(FixFileParams {
                     project_key,
                     fix_file_mode: *fix_file_mode,
-                    path: biome_path.clone(),
+                    path: std_in_file.clone(),
                     should_format: mode.is_check() && file_features.supports_format(),
                     only: only.clone(),
                     skip: skip.clone(),
@@ -153,7 +164,7 @@ pub(crate) fn run<'a>(
                     workspace.change_file(ChangeFileParams {
                         project_key,
                         content: output.clone(),
-                        path: biome_path.clone(),
+                        path: std_in_file.clone(),
                         version,
                     })?;
                     new_content = Cow::Owned(output);
@@ -164,7 +175,7 @@ pub(crate) fn run<'a>(
         if file_features.supports_format() && mode.is_check() {
             let printed = workspace.format_file(FormatFileParams {
                 project_key,
-                path: biome_path.clone(),
+                path: std_in_file.clone(),
             })?;
             let code = printed.into_code();
             let output = match biome_path.extension() {
@@ -187,7 +198,7 @@ pub(crate) fn run<'a>(
                 });
 
                 if !mode.is_write() {
-                    return Err(CliDiagnostic::stdin());
+                    return Err(StdinDiagnostic::new_not_formatted().into());
                 }
             }
             Cow::Owned(ref new_content) => {
@@ -196,6 +207,10 @@ pub(crate) fn run<'a>(
                 });
             }
         }
+        workspace.close_file(CloseFileParams {
+            project_key,
+            path: std_in_file.clone(),
+        })?;
     } else if let TraversalMode::Search { pattern, .. } = mode.traversal_mode() {
         // Make sure patterns are always cleaned up at the end of execution.
         let _ = session.app.workspace.drop_pattern(DropPatternParams {
@@ -206,5 +221,6 @@ pub(crate) fn run<'a>(
     } else {
         console.append(markup! {{content}});
     }
+
     Ok(())
 }

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -41,6 +41,14 @@ pub(crate) const VERSION: &str = match option_env!("BIOME_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 
+/// File name  that is temporarily used when running the workspace internally.
+/// When using this file, make sure to close it via [Workspace::close_file].
+pub const TEMPORARY_INTERNAL_FILE_NAME: &str = "__BIOME_INTERNAL_FILE__";
+
+/// JSON file that is temporarily to handle internal files via [Workspace].
+/// When using this file, make sure to close it via [Workspace::close_file].
+pub const TEMPORARY_INTERNAL_REPORTER_FILE: &str = "__BIOME_INTERNAL_FILE__.json";
+
 /// Global context for an execution of the CLI
 pub struct CliSession<'app> {
     /// Instance of [App] used by this run of the CLI

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1236,6 +1236,32 @@ fn format_stdin_with_errors() {
 }
 
 #[test]
+fn format_stdin_errors_with_no_file_extension() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    console
+        .in_buffer
+        .push("function f() {return{}}".to_string());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--stdin-file-path", "mock"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "format_stdin_errors_with_no_file_extension",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn does_not_format_if_disabled() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_stdin_errors_with_no_file_extension.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_stdin_errors_with_no_file_extension.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+# Input messages
+
+```block
+function f() {return{}}
+```
+
+# Termination Message
+
+```block
+stdin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The file passed via --stdin-file-path doesn't have an extension. Biome needs a file extension to know how handle the file.
+  
+
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes two bugs:
1. The stdin mode didn't check if `--stdin-file-path` contains an extension. The extension is required because it infers the document type; without it, Biome can't handle the file.
2. This is more of an internal bug, but I believe a user hit a particular use case. In stdin mode, the user needs to pass an arbitrary file so we can infer the extension. The thing is, if the user is running the Daemon, chances are that the Workspace already has a file with the same name. To avoid clashes, we use an internal, arbitrary file name. When using this arbitrary file name, we close it too at the end of the operation. This was affecting the JSON reporter too.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test for `1.`. CI should stay green

<!-- What demonstrates that your implementation is correct? -->
