### PR TITLE
chore: add ignore entries to scanner

### DIFF
--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -27,7 +27,15 @@ pub use workspace_watcher::{WatcherInstruction, WorkspaceWatcher};
 /// Path entries that should be ignored in the workspace, even by the scanner.
 ///
 /// These cannot (yet) be configured.
-const IGNORE_ENTRIES: &[&[u8]] = &[b".git", b".timestamp", b".DS_Store"];
+const IGNORE_ENTRIES: &[&[u8]] = &[
+    b".cache",
+    b".git",
+    b".output",
+    b".timestamp",
+    b".turbo",
+    b".vercel",
+    b".DS_Store",
+];
 
 /// This is the main entrypoint of the application.
 pub struct App<'app> {


### PR DESCRIPTION
## Summary

Add some entries to the scanner's ignore entries, based on reports in Discord.

## Test Plan

We'll have to hear from users on this one, I'm afraid.
