### PR TITLE
chore: add Platinum sponsor

### DIFF
--- a/packages/@biomejs/biome/README.md
+++ b/packages/@biomejs/biome/README.md
@@ -108,7 +108,7 @@ We use [Polar.sh](https://polar.sh/biomejs) to up-vote and promote specific feat
 
 ## Sponsors
 
-### Gold Sponsors
+### Platinum Sponsor
 
 <table>
   <tbody>
@@ -118,7 +118,7 @@ We use [Polar.sh](https://polar.sh/biomejs) to up-vote and promote specific feat
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/biomejs/resources/refs/heads/main/sponsors/vercel-dark.png" />
             <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/biomejs/resources/refs/heads/main/sponsors/vercel-light.png" />
-            <img src="https://raw.githubusercontent.com/biomejs/resources/refs/heads/main/sponsors/vercel-light.png" width="400" alt="Vercel" />
+            <img src="https://raw.githubusercontent.com/biomejs/resources/refs/heads/main/sponsors/vercel-light.png" width="500" alt="Vercel" />
           </picture>
         </a>
       </td>


### PR DESCRIPTION
## Summary

Update our sponsors section.

I updated the width to 500px, as that's the size of the asset. I notice that both Gold and Silver have "medium-sized" images according to our OpenCollective, while Platinum has a "large" one. I guess they already had a large one, since it was already bigger than the silvers sponsors :)

## Test Plan

N/A
