### PR TITLE
fix(lint/noNoninteractiveElementToInteractiveRole): fix mistakenly flagging `<li role="treeitem">`

### DIFF
--- a/.changeset/gorgeous-cooks-pump.md
+++ b/.changeset/gorgeous-cooks-pump.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `noNoninteractiveElementToInteractiveRole` mistakenly flagging `<li role="treeitem">`

--- a/.changeset/gorgeous-cooks-pump.md
+++ b/.changeset/gorgeous-cooks-pump.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed `noNoninteractiveElementToInteractiveRole` mistakenly flagging `<li role="treeitem">`
+Fixed [`noNoninteractiveElementToInteractiveRole`](https://biomejs.dev/linter/rules/no-noninteractive-element-to-interactive-role/) mistakenly flagging `<li role="treeitem">`,

--- a/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_noninteractive_element_to_interactive_role.rs
@@ -82,6 +82,14 @@ impl Rule for NoNoninteractiveElementToInteractiveRole {
                 .ok()?
                 .token_text_trimmed();
 
+            // Exception: role `treeitem` is allowed on `<li>`
+            // Reason: `treeitem` has the superclass role `listitem`, which means it is made to be used on `<li>`
+            // Ref: https://w3c.github.io/aria/#treeitem
+            // Ref: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-1a/
+            if element_name.text() == "li" && role_attribute_value == "treeitem" {
+                return None;
+            }
+
             if ctx.aria_roles().is_not_interactive_element(node)
                 && AriaRole::from_roles(role_attribute_value)
                     .is_some_and(|role| role.is_interactive())

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementToInteractiveRole/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementToInteractiveRole/valid.jsx
@@ -107,3 +107,4 @@ let a = <tr role="tabpanel" />;
 let a = <tr role="tree" />;
 let a = <tr role="treegrid" />;
 let a = <tr role="treeitem" />;
+let a = <li role="treeitem" />;

--- a/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/noNoninteractiveElementToInteractiveRole/valid.jsx.snap
@@ -113,7 +113,6 @@ let a = <tr role="tabpanel" />;
 let a = <tr role="tree" />;
 let a = <tr role="treegrid" />;
 let a = <tr role="treeitem" />;
+let a = <li role="treeitem" />;
 
 ```
-
-


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
I elected for this simple fix because it's unclear what the more generalized heuristic would be here. In lieu of that, I've documented the precise reason for the exception.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #5446

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Added to the snapshot test.
