### PR TITLE
fix(lint/useRegexLiterals): correctly handle escaped anti-slashes

### DIFF
--- a/.changeset/use-regex-literals-escaping-bug.md
+++ b/.changeset/use-regex-literals-escaping-bug.md
@@ -1,0 +1,21 @@
+---
+"@biomejs/biome": patch
+---
+
+[useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals) now suggests a correct fix when the pattern contains an escaped anti-slash `\/`.
+
+Previously the rule suggested the following fix that led to a syntax error:
+
+```diff
+- new RegExp("\/");
++ /\\//
+```
+
+The rule now suggests a correct fix:
+
+```diff
+- new RegExp("\/");
++ /\//
+```
+
+Fixed [#5487](https://github.com/biomejs/biome/issues/5487).

--- a/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_regex_literals.rs
@@ -10,7 +10,7 @@ use biome_js_syntax::{
     JsComputedMemberExpression, JsNewOrCallExpression, JsSyntaxKind, JsSyntaxToken,
     global_identifier, static_value::StaticValue,
 };
-use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, SyntaxError, TokenText};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, SyntaxError, TextRange, TokenText};
 
 use crate::{JsRuleAction, services::semantic::Semantic};
 
@@ -55,8 +55,8 @@ declare_lint_rule! {
 }
 
 pub struct UseRegexLiteralsState {
-    pattern: String,
-    flags: Option<String>,
+    pattern: StaticValue,
+    flags: Option<StaticValue>,
 }
 
 impl Rule for UseRegexLiterals {
@@ -81,11 +81,11 @@ impl Rule for UseRegexLiterals {
         let mut args = args.iter();
 
         let pattern = args.next()?;
-        let pattern = create_pattern(pattern, model)?;
+        let pattern = extract_valid_pattern(pattern, model)?;
 
         let flags = match args.next() {
             Some(flags) => {
-                let flags = create_flags(flags)?;
+                let flags = extract_valid_flags(flags)?;
                 Some(flags)
             }
             None => None,
@@ -111,16 +111,14 @@ impl Rule for UseRegexLiterals {
             JsNewOrCallExpression::JsCallExpression(node) => AnyJsExpression::from(node.clone()),
         };
 
-        let token = JsSyntaxToken::new_detached(
-            JsSyntaxKind::JS_REGEX_LITERAL,
-            &format!(
-                "/{}/{}",
-                state.pattern,
-                state.flags.as_deref().unwrap_or_default()
-            ),
-            [],
-            [],
+        let regex = create_regex(
+            state.pattern.text(),
+            state
+                .flags
+                .as_ref()
+                .unwrap_or(&StaticValue::EmptyString(TextRange::empty(0.into()))),
         );
+        let token = JsSyntaxToken::new_detached(JsSyntaxKind::JS_REGEX_LITERAL, &regex, [], []);
         let next = AnyJsExpression::AnyJsLiteralExpression(AnyJsLiteralExpression::from(
             js_regex_literal_expression(token),
         ));
@@ -139,14 +137,15 @@ impl Rule for UseRegexLiterals {
     }
 }
 
-fn create_pattern(
+fn extract_valid_pattern(
     pattern: Result<AnyJsCallArgument, SyntaxError>,
     model: &SemanticModel,
-) -> Option<String> {
-    let pattern = pattern.ok()?;
-    let expr = pattern.as_any_js_expression()?;
-    if let Some(expr) = expr.as_js_template_expression() {
-        if let Some(tag) = expr.tag() {
+) -> Option<StaticValue> {
+    let Ok(AnyJsCallArgument::AnyJsExpression(expr)) = pattern else {
+        return None;
+    };
+    if let Some(template_expr) = expr.as_js_template_expression() {
+        if let Some(tag) = template_expr.tag() {
             let (object, member) = match tag.omit_parentheses() {
                 AnyJsExpression::JsStaticMemberExpression(expr) => {
                     let object = expr.object().ok()?;
@@ -166,22 +165,52 @@ fn create_pattern(
             }
         };
     };
-    let pattern = extract_literal_string(pattern)?;
-    let pattern = pattern.replace("\\\\", "\\");
 
-    // Convert slash to "\/" to avoid parsing error in autofix.
-    let pattern = pattern.replace('/', "\\/");
-
-    // If pattern is empty, (?:) is used instead.
-    if pattern.is_empty() {
-        return Some("(?:)".to_string());
-    }
-
-    // A repetition without quantifiers is invalid.
-    if pattern == "*" || pattern == "+" || pattern == "?" {
+    let pattern = expr.omit_parentheses().as_static_value()?;
+    // A regex cannot contain a repetition without a quantifier.
+    if matches!(pattern.as_string_constant()?, "*" | "+" | "?") {
         return None;
     }
     Some(pattern)
+}
+
+fn create_regex(pattern: &str, flags: &StaticValue) -> String {
+    let flags = flags.text();
+    let mut pattern_bytes = pattern.bytes().enumerate();
+    let mut last_copied_inmdex = 0;
+    // Reserve space for the pattern, its delimiters and its flags
+    let mut new_pattern = String::with_capacity(pattern.len() + 2 + flags.len());
+    new_pattern.push('/');
+    while let Some((index, byte)) = pattern_bytes.next() {
+        match byte {
+            b'\n' => {
+                new_pattern.push_str(&pattern[last_copied_inmdex..index]);
+                new_pattern.push_str(r"\n");
+                last_copied_inmdex = index + 1;
+            }
+            b'\\' => {
+                if matches!(pattern_bytes.next(), Some((_, b'\\'))) {
+                    new_pattern.push_str(&pattern[last_copied_inmdex..index]);
+                    last_copied_inmdex = index + 1;
+                }
+            }
+            // Convert slash to "\/" to avoid parsing error in autofix.
+            b'/' => {
+                new_pattern.push_str(&pattern[last_copied_inmdex..index]);
+                new_pattern.push_str(r"\/");
+                last_copied_inmdex = index + 1;
+            }
+            _ => {}
+        }
+    }
+    if pattern.is_empty() {
+        new_pattern.push_str("(?:)");
+    } else {
+        new_pattern.push_str(&pattern[last_copied_inmdex..]);
+    }
+    new_pattern.push('/');
+    new_pattern.push_str(flags);
+    new_pattern
 }
 
 fn is_regexp_object(expr: AnyJsExpression, model: &SemanticModel) -> bool {
@@ -209,27 +238,16 @@ fn parse_node(node: &JsNewOrCallExpression) -> Option<(AnyJsExpression, JsCallAr
     }
 }
 
-fn create_flags(flags: Result<AnyJsCallArgument, SyntaxError>) -> Option<String> {
-    let flags = flags.ok()?;
-    let flags = extract_literal_string(flags)?;
+fn extract_valid_flags(flags: Result<AnyJsCallArgument, SyntaxError>) -> Option<StaticValue> {
+    let Ok(AnyJsCallArgument::AnyJsExpression(flags)) = flags else {
+        return None;
+    };
+    let flags = flags.omit_parentheses().as_static_value()?;
     // u flag (Unicode mode) and v flag (unicodeSets mode) cannot be combined.
-    if flags == "uv" || flags == "vu" {
+    if matches!(flags.as_string_constant()?, "uv" | "vu") {
         return None;
     }
     Some(flags)
-}
-
-fn extract_literal_string(from: AnyJsCallArgument) -> Option<String> {
-    let AnyJsCallArgument::AnyJsExpression(expr) = from else {
-        return None;
-    };
-    expr.omit_parentheses()
-        .as_static_value()
-        .and_then(|value| match value {
-            StaticValue::String(_) => Some(value.text().to_string().replace('\n', "\\n")),
-            StaticValue::EmptyString(_) => Some(String::new()),
-            _ => None,
-        })
 }
 
 fn extract_inner_text(expr: &JsComputedMemberExpression) -> Option<TokenText> {

--- a/crates/biome_js_analyze/tests/specs/complexity/useRegexLiterals/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/useRegexLiterals/invalid.js
@@ -1,0 +1,4 @@
+// https://github.com/biomejs/biome/issues/5487
+new RegExp("\/pattern$");
+
+new RegExp("\🙂pattern");

--- a/crates/biome_js_analyze/tests/specs/complexity/useRegexLiterals/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useRegexLiterals/invalid.js.snap
@@ -1,0 +1,61 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.js
+---
+# Input
+```js
+// https://github.com/biomejs/biome/issues/5487
+new RegExp("\/pattern$");
+
+new RegExp("\🙂pattern");
+
+```
+
+# Diagnostics
+```
+invalid.js:2:1 lint/complexity/useRegexLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use a regular expression literal instead of the RegExp constructor.
+  
+    1 │ // https://github.com/biomejs/biome/issues/5487
+  > 2 │ new RegExp("\/pattern$");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ new RegExp("\🙂pattern");
+  
+  i Regular expression literals avoid some escaping required in a string literal, and are easier to analyze statically.
+  
+  i Safe fix: Use a literal notation instead.
+  
+    1 1 │   // https://github.com/biomejs/biome/issues/5487
+    2   │ - new·RegExp("\/pattern$");
+      2 │ + /\/pattern$/;
+    3 3 │   
+    4 4 │   new RegExp("\🙂pattern");
+  
+
+```
+
+```
+invalid.js:4:1 lint/complexity/useRegexLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Use a regular expression literal instead of the RegExp constructor.
+  
+    2 │ new RegExp("\/pattern$");
+    3 │ 
+  > 4 │ new RegExp("\🙂pattern");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+  
+  i Regular expression literals avoid some escaping required in a string literal, and are easier to analyze statically.
+  
+  i Safe fix: Use a literal notation instead.
+  
+    2 2 │   new RegExp("\/pattern$");
+    3 3 │   
+    4   │ - new·RegExp("\🙂pattern");
+      4 │ + /\🙂pattern/;
+    5 5 │   
+  
+
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5487

I also took the opportunity of improving the implementation.

## Test Plan

I added a test.
