### PR TITLE
fix(lint/noParameterAssign): handle unparenthesized arrow functions

### DIFF
--- a/.changeset/no-paraemter-assign-unparenthesized-arrow-function.md
+++ b/.changeset/no-paraemter-assign-unparenthesized-arrow-function.md
@@ -2,7 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-[noParameterAssign](https://biomejs.dev/linter/rules/no-parameter-assign) now reports reassigned parameter of unparenthesized arrow functions.
+Fixed [#5409](https://github.com/biomejs/biome/issues/5409): [noParameterAssign](https://biomejs.dev/linter/rules/no-parameter-assign) now reports reassigned parameter of unparenthesized arrow functions.
 
 The following code is now reported as invalid.
 
@@ -10,6 +10,3 @@ The following code is now reported as invalid.
 const f = param => {
   param = {}; // Reassigning a function parameter is confusing.
 };
-```
-
-Fixed [#5409](https://github.com/biomejs/biome/issues/5409).

--- a/.changeset/no-paraemter-assign-unparenthesized-arrow-function.md
+++ b/.changeset/no-paraemter-assign-unparenthesized-arrow-function.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+[noParameterAssign](https://biomejs.dev/linter/rules/no-parameter-assign) now reports reassigned parameter of unparenthesized arrow functions.
+
+The following code is now reported as invalid.
+
+```js
+const f = param => {
+  param = {}; // Reassigning a function parameter is confusing.
+};
+```
+
+Fixed [#5409](https://github.com/biomejs/biome/issues/5409).

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc
@@ -17,5 +17,6 @@
 	"function foo(a) { ({...a} = obj); }",
 	"function foo(a) { a &&= b; }",
 	"function foo(a) { a ||= b; }",
-	"function foo(a) { a ??= b; }"
+	"function foo(a) { a ??= b; }",
+	"const doSomething = req => { req = {}; };"
 ]

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc.snap
@@ -458,4 +458,26 @@ invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━�
 
 ```
 
+# Input
+```cjs
+const doSomething = req => { req = {}; };
+```
 
+# Diagnostics
+```
+invalid.jsonc:1:30 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Reassigning a function parameter is confusing.
+  
+  > 1 │ const doSomething = req => { req = {}; };
+      │                              ^^^
+  
+  i The parameter is declared here:
+  
+  > 1 │ const doSomething = req => { req = {}; };
+      │                     ^^^
+  
+  i Use a local variable instead.
+  
+
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5409

## Test Plan

I added a test.
