### PR TITLE
fix(syntax/noTypeOnlyImportAttributes): ignore all commonjs files

### DIFF
--- a/.changeset/no-type-only-import-attributes-ignore-commonjs-package.md
+++ b/.changeset/no-type-only-import-attributes-ignore-commonjs-package.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": major
+---
+
+Fixed [#5564](https://github.com/biomejs/biome/issues/5564). `noTypeOnlyImportAttributes` now ignores files ending with the extension `.ts` when the type field of `package.json` is set to `commonjs`.

--- a/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.ts
@@ -1,0 +1,3 @@
+import type { TypeFromRequire } from "pkg" with {
+    "resolution-mode": "require"
+};

--- a/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noTypeOnlyImportAttributes/valid_cjs.ts.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_cjs.ts
+---
+# Input
+```ts
+import type { TypeFromRequire } from "pkg" with {
+    "resolution-mode": "require"
+};
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5564

We now check the `type` field in `package.json`.
Also, I added a test to only check TypeScript files. 

## Test Plan

I added a test
