### PR TITLE
fix(cli): relative file path formatting (#5565)

### DIFF
--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -558,27 +558,25 @@ pub fn execute_mode(
     let processed = summary.changed + summary.unchanged;
     let should_exit_on_warnings = summary.warnings > 0 && cli_options.error_on_warnings;
 
+    let diagnostics_payload = DiagnosticsPayload {
+        verbose: cli_options.verbose,
+        diagnostic_level: cli_options.diagnostic_level,
+        diagnostics,
+    };
+
     match execution.report_mode {
         ReportMode::Terminal { with_summary } => {
             if with_summary {
                 let reporter = SummaryReporter {
                     summary,
-                    diagnostics_payload: DiagnosticsPayload {
-                        verbose: cli_options.verbose,
-                        diagnostic_level: cli_options.diagnostic_level,
-                        diagnostics,
-                    },
+                    diagnostics_payload,
                     execution: execution.clone(),
                 };
                 reporter.write(&mut SummaryReporterVisitor(console))?;
             } else {
                 let reporter = ConsoleReporter {
                     summary,
-                    diagnostics_payload: DiagnosticsPayload {
-                        verbose: cli_options.verbose,
-                        diagnostic_level: cli_options.diagnostic_level,
-                        diagnostics,
-                    },
+                    diagnostics_payload,
                     execution: execution.clone(),
                     evaluated_paths,
                 };
@@ -591,11 +589,7 @@ pub fn execute_mode(
                 });
             let reporter = JsonReporter {
                 summary,
-                diagnostics: DiagnosticsPayload {
-                    verbose: cli_options.verbose,
-                    diagnostic_level: cli_options.diagnostic_level,
-                    diagnostics,
-                },
+                diagnostics: diagnostics_payload,
                 execution: execution.clone(),
             };
             let mut buffer = JsonReporterVisitor::new(summary);
@@ -633,22 +627,14 @@ pub fn execute_mode(
         }
         ReportMode::GitHub => {
             let reporter = GithubReporter {
-                diagnostics_payload: DiagnosticsPayload {
-                    verbose: cli_options.verbose,
-                    diagnostic_level: cli_options.diagnostic_level,
-                    diagnostics,
-                },
+                diagnostics_payload,
                 execution: execution.clone(),
             };
             reporter.write(&mut GithubReporterVisitor(console))?;
         }
         ReportMode::GitLab => {
             let reporter = GitLabReporter {
-                diagnostics: DiagnosticsPayload {
-                    verbose: cli_options.verbose,
-                    diagnostic_level: cli_options.diagnostic_level,
-                    diagnostics,
-                },
+                diagnostics: diagnostics_payload,
                 execution: execution.clone(),
             };
             reporter.write(&mut GitLabReporterVisitor::new(
@@ -659,11 +645,7 @@ pub fn execute_mode(
         ReportMode::Junit => {
             let reporter = JunitReporter {
                 summary,
-                diagnostics_payload: DiagnosticsPayload {
-                    verbose: cli_options.verbose,
-                    diagnostic_level: cli_options.diagnostic_level,
-                    diagnostics,
-                },
+                diagnostics_payload,
                 execution: execution.clone(),
             };
             reporter.write(&mut JunitReporterVisitor::new(console))?;

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -395,6 +395,11 @@ impl<'ctx> DiagnosticsPrinter<'ctx> {
                             diagnostics_to_print.push(diag);
                         }
                     } else {
+                        let working_directory_prefix = self.working_directory.and_then(|wd| {
+                            let mut working_directory = wd.to_string();
+                            working_directory.push(std::path::MAIN_SEPARATOR);
+                            Some(working_directory)
+                        });
                         for diag in diagnostics {
                             let severity = diag.severity();
                             if self.should_skip_diagnostic(severity, diag.tags()) {
@@ -410,9 +415,9 @@ impl<'ctx> DiagnosticsPrinter<'ctx> {
                             let should_print = self.should_print();
 
                             if should_print {
-                                let file_path = self
-                                    .working_directory
-                                    .and_then(|wd| file_path.strip_prefix(wd.as_str()))
+                                let file_path = working_directory_prefix
+                                    .as_ref()
+                                    .and_then(|wd| file_path.strip_prefix(wd))
                                     .unwrap_or(file_path.as_str());
                                 let diag = diag
                                     .with_file_path(file_path)

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -395,11 +395,6 @@ impl<'ctx> DiagnosticsPrinter<'ctx> {
                             diagnostics_to_print.push(diag);
                         }
                     } else {
-                        let working_directory_prefix = self.working_directory.and_then(|wd| {
-                            let mut working_directory = wd.to_string();
-                            working_directory.push(std::path::MAIN_SEPARATOR);
-                            Some(working_directory)
-                        });
                         for diag in diagnostics {
                             let severity = diag.severity();
                             if self.should_skip_diagnostic(severity, diag.tags()) {
@@ -415,12 +410,8 @@ impl<'ctx> DiagnosticsPrinter<'ctx> {
                             let should_print = self.should_print();
 
                             if should_print {
-                                let file_path = working_directory_prefix
-                                    .as_ref()
-                                    .and_then(|wd| file_path.strip_prefix(wd))
-                                    .unwrap_or(file_path.as_str());
                                 let diag = diag
-                                    .with_file_path(file_path)
+                                    .with_file_path(file_path.as_str())
                                     .with_file_source_code(&content);
                                 diagnostics_to_print.push(diag)
                             }

--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -119,7 +119,7 @@ impl ReporterVisitor for ConsoleReporterVisitor<'_> {
             }
 
             if diagnostic.severity() >= diagnostics_payload.diagnostic_level {
-                if diagnostic.tags().is_verbose() && diagnostics_payload.verbose {
+                if diagnostics_payload.verbose {
                     self.0
                         .error(markup! {{PrintDiagnostic::verbose(diagnostic)}});
                 } else {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Here is a potential fix for the issue #5565

Closes #5565

## Test Plan

Here is new output format:

```
src/routes.tsx:128:35 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ This hook is being called from a nested function, but all hooks must be called unconditionally from the top-level component.
```