### PR TITLE
refactor: use type info in `noFloatingPromises`

### DIFF
--- a/crates/biome_rowan/src/text.rs
+++ b/crates/biome_rowan/src/text.rs
@@ -71,6 +71,12 @@ impl PartialEq for Text {
     }
 }
 
+impl PartialEq<&'_ str> for Text {
+    fn eq(&self, other: &&str) -> bool {
+        self.text() == *other
+    }
+}
+
 impl PartialOrd for Text {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))


### PR DESCRIPTION
## Summary

This extends our type inference foundation with the ability to infer types from JavaScript object shapes as well as function expressions.

Furthermore, I've updated a small piece of `noFloatingPromises` so that it actually uses our new type info data structures. They're still created ad-hoc, but it works without any of the `noFloatingPromises` tests (which are quite extensive, thanks to @kaykdm) failing.

Another small step, but it validates that we can move forward this way.

Also create a few small utilities to avoid some duplication.

## Test Plan

`noFloatingPromises` tests are still green.
