### PR TITLE
feat(assist/organizeImports): merge imports and exports

### DIFF
--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts
@@ -1,0 +1,8 @@
+// Comment 1
+export type { T4, T2 } from "mod";
+// Comment 2
+export type { T3, T1 } from "mod";
+// Comment 3
+export { A, D } from "mod";
+// Comment 4
+export { B, C } from "mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: mergeable_export.ts
+---
+# Input
+```ts
+// Comment 1
+export type { T4, T2 } from "mod";
+// Comment 2
+export type { T3, T1 } from "mod";
+// Comment 3
+export { A, D } from "mod";
+// Comment 4
+export { B, C } from "mod";
+
+```
+
+# Actions
+```diff
+@@ -1,8 +1,6 @@
+ // Comment 1
+-export type { T4, T2 } from "mod";
+ // Comment 2
+-export type { T3, T1 } from "mod";
++export type { T1, T2, T3, T4 } from "mod";
+ // Comment 3
+-export { A, D } from "mod";
+ // Comment 4
+-export { B, C } from "mod";
++export { A, B, C, D } from "mod";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts
@@ -1,0 +1,15 @@
+// Comment 1
+import type { T4, T2 } from "mod";
+// Comment 2
+import type { T3, T1 } from "mod";
+// Comment 3
+import { A, D } from "mod";
+// Comment 4
+import { B, C } from "mod";
+// Comment 5
+import { E, F } from "mod";
+// Comment 6
+import G, { H } from "mod";
+// Comment 7
+import I from "mod";
+import * as ns from "mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: mergeable_imports.ts
+---
+# Input
+```ts
+// Comment 1
+import type { T4, T2 } from "mod";
+// Comment 2
+import type { T3, T1 } from "mod";
+// Comment 3
+import { A, D } from "mod";
+// Comment 4
+import { B, C } from "mod";
+// Comment 5
+import { E, F } from "mod";
+// Comment 6
+import G, { H } from "mod";
+// Comment 7
+import I from "mod";
+import * as ns from "mod";
+
+```
+
+# Actions
+```diff
+@@ -1,15 +1,10 @@
+ // Comment 1
+-import type { T4, T2 } from "mod";
+ // Comment 2
+-import type { T3, T1 } from "mod";
++import type { T1, T2, T3, T4 } from "mod";
++// Comment 7
++import I, * as ns from "mod";
++// Comment 6
+ // Comment 3
+-import { A, D } from "mod";
+ // Comment 4
+-import { B, C } from "mod";
+ // Comment 5
+-import { E, F } from "mod";
+-// Comment 6
+-import G, { H } from "mod";
+-// Comment 7
+-import I from "mod";
+-import * as ns from "mod";
++import G, { A, B, C, D, E, F, H } from "mod";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts
@@ -1,0 +1,23 @@
+// File header comment
+import type { T1, T2 } from "mod";
+// Comment 2
+import type { U1 } from "package";
+// Comment 3
+import type { T3, T4 } from "mod";
+// Comment 4
+import { A, B } from "mod";
+// Comment 5
+import { X } from "package";
+// Comment 6
+import { C, D } from "mod";
+// Comment 7
+import { Y } from "package";
+// Comment 8
+import type { U2 } from "package";
+
+// Chunk 2
+
+// Comment 9
+import type { U3 } from "package";
+// Comment 10
+import { E } from "mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
@@ -1,0 +1,69 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: mergeable_unsorted_imports.ts
+---
+# Input
+```ts
+// File header comment
+import type { T1, T2 } from "mod";
+// Comment 2
+import type { U1 } from "package";
+// Comment 3
+import type { T3, T4 } from "mod";
+// Comment 4
+import { A, B } from "mod";
+// Comment 5
+import { X } from "package";
+// Comment 6
+import { C, D } from "mod";
+// Comment 7
+import { Y } from "package";
+// Comment 8
+import type { U2 } from "package";
+
+// Chunk 2
+
+// Comment 9
+import type { U3 } from "package";
+// Comment 10
+import { E } from "mod";
+
+```
+
+# Actions
+```diff
+@@ -1,23 +1,19 @@
+ // File header comment
+-import type { T1, T2 } from "mod";
+-// Comment 2
+-import type { U1 } from "package";
+ // Comment 3
+-import type { T3, T4 } from "mod";
++import type { T1, T2, T3, T4 } from "mod";
+ // Comment 4
+-import { A, B } from "mod";
++// Comment 6
++import { A, B, C, D } from "mod";
++// Comment 2
++// Comment 8
++import type { U1, U2 } from "package";
+ // Comment 5
+-import { X } from "package";
+-// Comment 6
+-import { C, D } from "mod";
+ // Comment 7
+-import { Y } from "package";
+-// Comment 8
+-import type { U2 } from "package";
++import { X, Y } from "package";
+ 
+ // Chunk 2
+ 
+-// Comment 9
+-import type { U3 } from "package";
+ // Comment 10
+ import { E } from "mod";
++// Comment 9
++import type { U3 } from "package";
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-same-source.ts.snap
@@ -18,19 +18,20 @@ import type * as types from "source";
 
 # Actions
 ```diff
-@@ -1,9 +1,9 @@
+@@ -1,9 +1,8 @@
 -import { A, B } from "source";
- import Json from "source" with { "type": "json "};
 +import * as macros from "source" with { "type": "macro "};
-+import { m1, m2 } from "source" with { "type": "macro "};
- import G, * as H from "source";
- import D, { E, F } from "source";
-+import type * as types from "source";
- import * as N from "source";
--import { m1, m2 } from "source" with { "type": "macro "};
+ import Json from "source" with { "type": "json "};
+-import G, * as H from "source";
+-import D, { E, F } from "source";
+-import * as N from "source";
+ import { m1, m2 } from "source" with { "type": "macro "};
 -import * as macros from "source" with { "type": "macro "};
++import type * as types from "source";
  import type { T1, T2 } from "source";
 -import type * as types from "source";
-+import { A, B } from "source";
++import * as N from "source";
++import G, * as H from "source";
++import D, { A, B, E, F } from "source";
 
 ```


### PR DESCRIPTION
## Summary

This PR introduces the merge of imports and exports.
Here is an example:

```diff
- import type { T4, T2 } from "mod";
- import type { T3, T1 } from "mod";
+ import type { T1, T2, T3, T4 } from "mod";
- import { A, D } from "mod";
- import { B, C } from "mod";
+ import { A, B, C, D } from "mod";
```

We merge the following statements in order:

1. A default import and a namespace import are merged into a combined import
   ```diff
   - import * as ns from "mod";
   - import D from "mod";
   + import D, * as ns from "mod";
     import { A, B } from "mod";
   ```
3. A default import and a named import are merged into a combined import
   ```diff
   - import D from "mod";
   - import { A, B } from "mod";
   + import D, { A, B } from "mod";
   ```
4. Two named imports/exports are merged into a single named import/export
   ```diff
   - import { A, B } from "mod";
   - import { C, D } from "mod";
   + import { A, B, C, D } from "mod";
   ```

To make the merging simpler I had to change how we order import and export kinds for a same source.
**The order now matches the order from the TypeScript LSP import sorter**.

In contrast to the TypeScript LSP we don't merge the following statements:

- A default import and a combined default-named import
  ```diff
  - import A from  "mod";
  - import B, { C } from  "mod";
  + import { default as A, default as B, C } from  "mod";
  ```
- Two combined default-named imports
  ```diff
  - import A, { C } from  "mod";
  - import B, { D } from  "mod";
  + import { default as A, default as B, C, D } from  "mod";
  ```

I think these merging choice are questionable.
Thus, I didn't implement them

Also, the TypeScript LSP prefers merging a default import with a named import instead of merging a default import with a namespace import. I made the opposite choice because it is simpler to implement with the current order.

## Test Plan

I added some test.
