### PR TITLE
feat(core): add light version of the semantic model to scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,10 +1155,8 @@ dependencies = [
 name = "biome_module_graph"
 version = "0.0.1"
 dependencies = [
- "biome_css_semantic",
  "biome_deserialize",
  "biome_fs",
- "biome_graphql_semantic",
  "biome_js_parser",
  "biome_js_syntax",
  "biome_js_type_info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,8 +1155,10 @@ dependencies = [
 name = "biome_module_graph"
 version = "0.0.1"
 dependencies = [
+ "biome_css_semantic",
  "biome_deserialize",
  "biome_fs",
+ "biome_graphql_semantic",
  "biome_js_parser",
  "biome_js_syntax",
  "biome_js_type_info",
@@ -1174,6 +1176,7 @@ dependencies = [
  "papaya",
  "rustc-hash 2.1.1",
  "serde_json",
+ "static_assertions",
 ]
 
 [[package]]

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -77,12 +77,6 @@ declare_lint_rule! {
     ///
     /// ## Known Limitations
     ///
-    /// * This rule currently only looks at the JSDoc comments that are attached
-    ///   to the _`export` statement_ nearest to the symbol's definition. If the
-    ///   symbol isn't exported in the same statement as in which it is defined,
-    ///   the visibility as specified in the `export` statement is used, not
-    ///   that of the symbol definition. Re-exports cannot (currently) override
-    ///   the visibility from the original `export`.
     /// * This rule only applies to imports from JavaScript and TypeScript
     ///   files. Imports for resources such as images or CSS files are exempted
     ///   regardless of the default visibility setting.
@@ -222,7 +216,7 @@ impl Rule for NoPrivateImports {
 
         let node = ctx.query();
         let Some(target_path) = module_info
-            .get_import_by_node(node)
+            .get_import_by_js_node(node)
             .and_then(|import| import.resolved_path.as_ref().ok())
         else {
             return Vec::new();

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -149,7 +149,7 @@ impl Rule for UseImportExtensions {
         let force_js_extensions = ctx.options().force_js_extensions;
 
         let node = ctx.query();
-        let import = module_info.get_import_by_node(node)?;
+        let import = module_info.get_import_by_js_node(node)?;
         let resolved_path = import.resolved_path.as_ref().ok()?;
 
         get_extensionless_import(node, resolved_path, force_js_extensions)

--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -98,7 +98,7 @@ impl Rule for NoImportCycles {
         let module_info = ctx.module_info_for_path(ctx.file_path())?;
 
         let node = ctx.query();
-        let import = module_info.get_import_by_node(node)?;
+        let import = module_info.get_import_by_js_node(node)?;
         let resolved_path = import.resolved_path.as_ref().ok()?;
 
         let imports = ctx.module_info_for_path(resolved_path)?;

--- a/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
@@ -99,7 +99,7 @@ impl Rule for NoUnresolvedImports {
         };
 
         let node = ctx.query();
-        let Some(import) = module_info.get_import_by_node(node) else {
+        let Some(import) = module_info.get_import_by_js_node(node) else {
             return Vec::new();
         };
 

--- a/crates/biome_js_analyze/src/services/module_graph.rs
+++ b/crates/biome_js_analyze/src/services/module_graph.rs
@@ -8,9 +8,9 @@ use camino::Utf8Path;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
-pub struct DependencyGraphService(Arc<ModuleGraph>);
+pub struct ModuleGraphService(Arc<ModuleGraph>);
 
-impl DependencyGraphService {
+impl ModuleGraphService {
     pub fn module_graph(&self) -> &ModuleGraph {
         self.0.as_ref()
     }
@@ -20,7 +20,7 @@ impl DependencyGraphService {
     }
 }
 
-impl FromServices for DependencyGraphService {
+impl FromServices for ModuleGraphService {
     fn from_services(
         rule_key: &RuleKey,
         services: &ServiceBag,
@@ -32,7 +32,7 @@ impl FromServices for DependencyGraphService {
     }
 }
 
-impl Phase for DependencyGraphService {
+impl Phase for ModuleGraphService {
     fn phase() -> Phases {
         Phases::Syntax
     }
@@ -62,7 +62,7 @@ where
     type Output = N;
 
     type Language = L;
-    type Services = DependencyGraphService;
+    type Services = ModuleGraphService;
 
     fn build_visitor(analyzer: &mut impl AddVisitor<L>, _: &L::Root) {
         analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default);

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -15,22 +15,20 @@ version              = "0.0.1"
 workspace = true
 
 [dependencies]
-biome_css_semantic     = { workspace = true }
-biome_fs               = { workspace = true }
-biome_graphql_semantic = { workspace = true }
-biome_js_syntax        = { workspace = true }
-biome_js_type_info     = { workspace = true }
-biome_package          = { workspace = true }
-biome_project_layout   = { workspace = true }
-biome_rowan            = { workspace = true }
-camino                 = { workspace = true }
-cfg-if                 = { workspace = true }
-once_cell              = "1.20.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
-oxc_resolver           = { workspace = true }
-papaya                 = { workspace = true }
-rustc-hash             = { workspace = true }
-serde_json             = { workspace = true }
-static_assertions      = { workspace = true }
+biome_fs             = { workspace = true }
+biome_js_syntax      = { workspace = true }
+biome_js_type_info   = { workspace = true }
+biome_package        = { workspace = true }
+biome_project_layout = { workspace = true }
+biome_rowan          = { workspace = true }
+camino               = { workspace = true }
+cfg-if               = { workspace = true }
+once_cell            = "1.20.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
+oxc_resolver         = { workspace = true }
+papaya               = { workspace = true }
+rustc-hash           = { workspace = true }
+serde_json           = { workspace = true }
+static_assertions    = { workspace = true }
 
 [dev-dependencies]
 biome_deserialize = { workspace = true }

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -15,19 +15,22 @@ version              = "0.0.1"
 workspace = true
 
 [dependencies]
-biome_fs             = { workspace = true }
-biome_js_syntax      = { workspace = true }
-biome_js_type_info   = { workspace = true }
-biome_package        = { workspace = true }
-biome_project_layout = { workspace = true }
-biome_rowan          = { workspace = true }
-camino               = { workspace = true }
-cfg-if               = { workspace = true }
-once_cell            = "1.20.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
-oxc_resolver         = { workspace = true }
-papaya               = { workspace = true }
-rustc-hash           = { workspace = true }
-serde_json           = { workspace = true }
+biome_css_semantic     = { workspace = true }
+biome_fs               = { workspace = true }
+biome_graphql_semantic = { workspace = true }
+biome_js_syntax        = { workspace = true }
+biome_js_type_info     = { workspace = true }
+biome_package          = { workspace = true }
+biome_project_layout   = { workspace = true }
+biome_rowan            = { workspace = true }
+camino                 = { workspace = true }
+cfg-if                 = { workspace = true }
+once_cell              = "1.20.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
+oxc_resolver           = { workspace = true }
+papaya                 = { workspace = true }
+rustc-hash             = { workspace = true }
+serde_json             = { workspace = true }
+static_assertions      = { workspace = true }
 
 [dev-dependencies]
 biome_deserialize = { workspace = true }

--- a/crates/biome_module_graph/src/js_semantic_model.rs
+++ b/crates/biome_module_graph/src/js_semantic_model.rs
@@ -88,6 +88,10 @@ pub enum JsDeclarationKind {
 
 impl JsDeclarationKind {
     /// Returns `true` for any declaration that _may_ be a type.
+    ///
+    /// The main reason why we can't be sure whether something is a value or a
+    /// type is the `Import` variant, for which we don't know the kind of what
+    /// we're importing.
     fn might_be_type(&self) -> bool {
         matches!(
             self,
@@ -101,6 +105,10 @@ impl JsDeclarationKind {
     }
 
     /// Returns `true` for any declaration that _may_ be a value.
+    ///
+    /// The main reason why we can't be sure whether something is a value or a
+    /// type is the `Import` variant, for which we don't know the kind of what
+    /// we're importing.
     fn might_be_value(&self) -> bool {
         matches!(
             self,
@@ -124,6 +132,7 @@ impl JsSemanticModelBuilder {
 
     pub fn push_node(&mut self, node: &JsSyntaxNode) {
         if let Some(import) = AnyJsImportClause::cast_ref(node) {
+            // TODO: Handle CommonJS imports too.
             self.push_import(import);
         } else if let Some(decl) = AnyJsDeclaration::cast_ref(node) {
             self.push_declaration(decl);

--- a/crates/biome_module_graph/src/js_semantic_model.rs
+++ b/crates/biome_module_graph/src/js_semantic_model.rs
@@ -1,0 +1,309 @@
+use biome_js_syntax::{
+    AnyJsDeclaration, AnyJsImportClause, JsFunctionDeclaration, JsSyntaxNode,
+    JsVariableDeclaration, JsVariableKind, TsTypeAliasDeclaration,
+};
+use biome_js_type_info::Type;
+use biome_rowan::{AstNode, Text};
+
+use crate::jsdoc_comment::JsdocComment;
+
+/// Simplified version of the JS Semantic Model, that provides just enough
+/// information to keep track of the types of all symbols in a module's global
+/// scope.
+///
+/// The model is discarded as soon as the module's inferrence has completed.
+#[derive(Clone, Debug)]
+pub(crate) struct JsSemanticModel {
+    pub declarations: Box<[JsDeclaration]>,
+}
+
+impl JsSemanticModel {
+    /// Finds the value declaration with the given `name`.
+    pub fn get_value(&self, name: &str) -> Option<&JsDeclaration> {
+        self.declarations
+            .iter()
+            .find(|decl| decl.name == name && decl.kind.might_be_value())
+    }
+
+    /// Finds the type declaration with the given `name`.
+    pub fn get_type(&self, name: &str) -> Option<&JsDeclaration> {
+        self.declarations
+            .iter()
+            .find(|decl| decl.name == name && decl.kind.might_be_type())
+    }
+}
+
+/// A single declaration of a variable or type.
+#[derive(Clone, Debug)]
+pub struct JsDeclaration {
+    /// The name of the thing being declared.
+    pub name: Text,
+
+    /// The kind of thing being declared.
+    pub kind: JsDeclarationKind,
+
+    /// Optional JSDoc comment associated with the declaration.
+    pub jsdoc_comment: Option<JsdocComment>,
+}
+
+#[derive(Clone, Debug)]
+pub enum JsDeclarationKind {
+    /// A `class` declaration.
+    ///
+    /// The type defined by the class.
+    #[expect(unused)] // TODO
+    Class(Type),
+
+    /// A `function` or `var` declaration.
+    ///
+    /// The type (either declared or inferred) of the value.
+    HoistedValue(Type),
+
+    /// An `import` declaration.
+    Import(Text),
+
+    /// An `import type` declaration.
+    ImportType(Text),
+
+    /// An interface declaration.
+    #[expect(unused)] // TODO
+    Interface,
+
+    /// A module declaration.
+    #[expect(unused)] // TODO
+    Module,
+
+    /// A namespace declaration.
+    #[expect(unused)] // TODO
+    Namespace,
+
+    /// A type declaration.
+    Type(Type),
+
+    /// A `let` or `const` declaration.
+    ///
+    /// The type (either declared or inferred) of the value.
+    Value(Type),
+}
+
+impl JsDeclarationKind {
+    /// Returns `true` for any declaration that _may_ be a type.
+    fn might_be_type(&self) -> bool {
+        matches!(
+            self,
+            Self::Class(_)
+                | Self::Import(_)
+                | Self::ImportType(_)
+                | Self::Namespace
+                | Self::Interface
+                | Self::Type(_)
+        )
+    }
+
+    /// Returns `true` for any declaration that _may_ be a value.
+    fn might_be_value(&self) -> bool {
+        matches!(
+            self,
+            Self::Class(_) | Self::HoistedValue(_) | Self::Import(_) | Self::Value(_)
+        )
+    }
+}
+
+/// Responsible for building the JsSemanticBuilder.
+#[derive(Debug, Default)]
+pub struct JsSemanticModelBuilder {
+    declarations: Vec<JsDeclaration>,
+}
+
+impl JsSemanticModelBuilder {
+    pub fn build(self) -> JsSemanticModel {
+        JsSemanticModel {
+            declarations: self.declarations.into(),
+        }
+    }
+
+    pub fn push_node(&mut self, node: &JsSyntaxNode) {
+        if let Some(import) = AnyJsImportClause::cast_ref(node) {
+            self.push_import(import);
+        } else if let Some(decl) = AnyJsDeclaration::cast_ref(node) {
+            self.push_declaration(decl);
+        }
+    }
+
+    fn push_declaration(&mut self, decl: AnyJsDeclaration) -> Option<()> {
+        match decl {
+            AnyJsDeclaration::JsClassDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::JsFunctionDeclaration(decl) => self.push_function_declaration(decl),
+            AnyJsDeclaration::JsVariableDeclaration(decl) => self.push_variable_declaration(decl),
+            AnyJsDeclaration::TsDeclareFunctionDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsEnumDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsExternalModuleDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsGlobalDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsImportEqualsDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsInterfaceDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsModuleDeclaration(_decl) => {
+                // TODO
+                None
+            }
+            AnyJsDeclaration::TsTypeAliasDeclaration(decl) => {
+                self.push_type_alias_declaration(decl)
+            }
+        }
+    }
+
+    fn push_function_declaration(&mut self, decl: JsFunctionDeclaration) -> Option<()> {
+        let binding = decl.id().ok()?;
+        let binding = binding.as_js_identifier_binding()?;
+        let name_token = binding.name_token().ok()?;
+
+        self.declarations.push(JsDeclaration {
+            name: name_token.token_text_trimmed().into(),
+            kind: JsDeclarationKind::HoistedValue(Type::from_js_function_declaration(&decl)),
+            jsdoc_comment: JsdocComment::try_from(decl.syntax()).ok(),
+        });
+
+        Some(())
+    }
+
+    fn push_import(&mut self, node: AnyJsImportClause) -> Option<()> {
+        match node {
+            AnyJsImportClause::JsImportBareClause(_node) => {}
+            AnyJsImportClause::JsImportCombinedClause(node) => {
+                let source = node.source().ok()?;
+                let source_token = source.as_js_module_source()?.value_token().ok()?;
+                let default_specifier = node.default_specifier().ok()?;
+                let local_name = default_specifier.local_name().ok()?;
+                let default_identifier = local_name.as_js_identifier_binding()?;
+                let default_name_token = default_identifier.name_token().ok()?;
+                self.declarations.push(JsDeclaration {
+                    name: default_name_token.token_text_trimmed().into(),
+                    kind: JsDeclarationKind::Import(source_token.token_text().into()),
+                    jsdoc_comment: None,
+                });
+                for specifier in node
+                    .specifier()
+                    .ok()?
+                    // TODO: Handle `.as_js_namespace_import_specifier()`
+                    .as_js_named_import_specifiers()?
+                    .specifiers()
+                {
+                    let specifier = specifier.ok()?;
+                    let local_name = specifier.local_name()?;
+                    let identifier = local_name.as_js_identifier_binding()?;
+                    let name_token = identifier.name_token().ok()?;
+                    self.declarations.push(JsDeclaration {
+                        name: name_token.token_text_trimmed().into(),
+                        kind: if specifier.type_token().is_some() {
+                            JsDeclarationKind::ImportType(source_token.token_text().into())
+                        } else {
+                            JsDeclarationKind::Import(source_token.token_text().into())
+                        },
+                        jsdoc_comment: None,
+                    });
+                }
+            }
+            AnyJsImportClause::JsImportDefaultClause(node) => {
+                let source = node.source().ok()?;
+                let source_token = source.as_js_module_source()?.value_token().ok()?;
+                let local_name = node.default_specifier().ok()?.local_name().ok()?;
+                let identifier = local_name.as_js_identifier_binding()?;
+                let name_token = identifier.name_token().ok()?;
+                self.declarations.push(JsDeclaration {
+                    name: name_token.token_text_trimmed().into(),
+                    kind: if node.type_token().is_some() {
+                        JsDeclarationKind::ImportType(source_token.token_text().into())
+                    } else {
+                        JsDeclarationKind::Import(source_token.token_text().into())
+                    },
+                    jsdoc_comment: None,
+                });
+            }
+            AnyJsImportClause::JsImportNamedClause(node) => {
+                let source = node.source().ok()?;
+                let source_token = source.as_js_module_source()?.value_token().ok()?;
+                for specifier in node.named_specifiers().ok()?.specifiers() {
+                    let specifier = specifier.ok()?;
+                    let local_name = specifier.local_name()?;
+                    let identifier = local_name.as_js_identifier_binding()?;
+                    let name_token = identifier.name_token().ok()?;
+                    self.declarations.push(JsDeclaration {
+                        name: name_token.token_text_trimmed().into(),
+                        kind: if node.type_token().is_some() || specifier.type_token().is_some() {
+                            JsDeclarationKind::ImportType(source_token.token_text().into())
+                        } else {
+                            JsDeclarationKind::Import(source_token.token_text().into())
+                        },
+                        jsdoc_comment: None,
+                    });
+                }
+            }
+            AnyJsImportClause::JsImportNamespaceClause(_node) => {
+                // TODO: Support namespace imports
+            }
+        }
+
+        Some(())
+    }
+
+    fn push_type_alias_declaration(&mut self, decl: TsTypeAliasDeclaration) -> Option<()> {
+        let binding = decl.binding_identifier().ok()?;
+        let name_token = binding.as_ts_identifier_binding()?.name_token().ok()?;
+        self.declarations.push(JsDeclaration {
+            name: name_token.token_text_trimmed().into(),
+            kind: JsDeclarationKind::Type(
+                Type::from_ts_type_alias_declaration(&decl).unwrap_or_default(),
+            ),
+            jsdoc_comment: JsdocComment::try_from(decl.syntax()).ok(),
+        });
+
+        Some(())
+    }
+
+    fn push_variable_declaration(&mut self, decl: JsVariableDeclaration) -> Option<()> {
+        let kind = decl.variable_kind().ok()?;
+        for declarator in decl.declarators() {
+            let declarator = declarator.ok()?;
+            let binding = declarator.id().ok()?;
+            // TODO: Handle object and array patterns
+            let binding = binding.as_any_js_binding()?.as_js_identifier_binding()?;
+            let name_token = binding.name_token().ok()?;
+
+            self.declarations.push(JsDeclaration {
+                name: name_token.token_text_trimmed().into(),
+                kind: match kind {
+                    JsVariableKind::Const | JsVariableKind::Let => JsDeclarationKind::Value(
+                        Type::from_js_variable_declarator(&declarator).unwrap_or_default(),
+                    ),
+                    JsVariableKind::Var => JsDeclarationKind::HoistedValue(
+                        Type::from_js_variable_declarator(&declarator).unwrap_or_default(),
+                    ),
+                    JsVariableKind::Using => return None,
+                },
+                jsdoc_comment: JsdocComment::try_from(decl.syntax()).ok(),
+            });
+        }
+
+        Some(())
+    }
+}

--- a/crates/biome_module_graph/src/jsdoc_comment.rs
+++ b/crates/biome_module_graph/src/jsdoc_comment.rs
@@ -1,0 +1,118 @@
+use std::ops::Deref;
+
+use biome_js_syntax::{JsSyntaxNode, JsSyntaxToken};
+use biome_rowan::TriviaPieceKind;
+
+/// Represents a normalised JSDoc comment.
+///
+/// Comments are trimmed and normalised to remove the trivia of the comment.
+///
+/// ## Example
+///
+/// Assuming the following JSDoc comment:
+///
+/// ```ts
+/// /**
+///  * Magic constant of fooness.
+///  *
+///  * For if you want more ways to write 1.
+///  */
+/// export const FOO = 1;
+/// ```
+///
+/// The normalised representation will become:
+/// `"Magic constant of fooness.\n\nFor if you want more ways to write 1."`.
+///    
+/// See https://jsdoc.app/ for the JSDoc reference.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JsdocComment(String);
+
+impl JsdocComment {
+    /// Creates a normalised JSDoc comment from the given comment `text`.
+    pub fn from_comment_text(text: &str) -> Self {
+        debug_assert!(text.starts_with("/**") && text.ends_with("*/"));
+
+        let mut result = text[3..text.len() - 2]
+            .lines()
+            .map(|line| {
+                let trimmed = line.trim();
+                trimmed.strip_prefix('*').map_or(trimmed, str::trim_start)
+            })
+            .fold(String::new(), |mut result, line| {
+                if !result.is_empty() {
+                    result.push('\n');
+                }
+                result.push_str(line);
+                result
+            });
+
+        // Trim trailing newlines.
+        while result.ends_with('\n') {
+            result.truncate(result.len() - 1);
+        }
+
+        Self(result)
+    }
+
+    /// Returns whether the given text is a valid JSDoc comment.
+    ///
+    /// JSDoc comments must start with exactly `/**` and with `*/`. Either more
+    /// or less asterisks in the opening are ignored.
+    pub fn text_is_jsdoc_comment(text: &str) -> bool {
+        text.starts_with("/**")
+            && text.as_bytes().get(3).is_some_and(|c| *c != b'*')
+            && text.ends_with("*/")
+    }
+
+    fn try_from_comment_text(text: &str) -> Option<Self> {
+        Self::text_is_jsdoc_comment(text).then(|| Self::from_comment_text(text))
+    }
+}
+
+impl AsRef<str> for JsdocComment {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Deref for JsdocComment {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl TryFrom<JsSyntaxNode> for JsdocComment {
+    type Error = ();
+
+    fn try_from(node: JsSyntaxNode) -> Result<Self, Self::Error> {
+        Self::try_from(&node)
+    }
+}
+
+impl TryFrom<&JsSyntaxNode> for JsdocComment {
+    type Error = ();
+
+    fn try_from(node: &JsSyntaxNode) -> Result<Self, Self::Error> {
+        node.first_token().ok_or(()).and_then(Self::try_from)
+    }
+}
+
+impl TryFrom<JsSyntaxToken> for JsdocComment {
+    type Error = ();
+
+    fn try_from(token: JsSyntaxToken) -> Result<Self, Self::Error> {
+        token
+            .leading_trivia()
+            .pieces()
+            .rev()
+            .find_map(|trivia| match trivia.kind() {
+                TriviaPieceKind::MultiLineComment | TriviaPieceKind::SingleLineComment => {
+                    JsdocComment::try_from_comment_text(trivia.text())
+                }
+                _ => None,
+            })
+            .ok_or(())
+    }
+}

--- a/crates/biome_module_graph/src/jsdoc_comment.rs
+++ b/crates/biome_module_graph/src/jsdoc_comment.rs
@@ -63,10 +63,6 @@ impl JsdocComment {
             && text.as_bytes().get(3).is_some_and(|c| *c != b'*')
             && text.ends_with("*/")
     }
-
-    fn try_from_comment_text(text: &str) -> Option<Self> {
-        Self::text_is_jsdoc_comment(text).then(|| Self::from_comment_text(text))
-    }
 }
 
 impl AsRef<str> for JsdocComment {
@@ -109,7 +105,9 @@ impl TryFrom<JsSyntaxToken> for JsdocComment {
             .rev()
             .find_map(|trivia| match trivia.kind() {
                 TriviaPieceKind::MultiLineComment | TriviaPieceKind::SingleLineComment => {
-                    JsdocComment::try_from_comment_text(trivia.text())
+                    let text = trivia.text();
+                    JsdocComment::text_is_jsdoc_comment(text)
+                        .then(|| JsdocComment::from_comment_text(text))
                 }
                 _ => None,
             })

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -1,5 +1,9 @@
+mod js_module_visitor;
+mod js_semantic_model;
+mod jsdoc_comment;
 mod module_graph;
-mod module_visitor;
+mod module_info;
 mod resolver_cache;
 
-pub use module_graph::{Export, Import, ModuleGraph, ModuleInfo, SUPPORTED_EXTENSIONS};
+pub use module_graph::{ModuleGraph, SUPPORTED_EXTENSIONS};
+pub use module_info::{Export, Import, ModuleInfo};

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -5,22 +5,23 @@
 //! detecting broken imports.
 //!
 //! The module graph is instantiated and updated inside the Workspace Server.
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 
 use biome_fs::{BiomePath, FileSystem, PathKind};
-use biome_js_syntax::{AnyJsImportLike, AnyJsRoot};
+use biome_js_syntax::AnyJsRoot;
 use biome_js_type_info::{Namespace, Type};
 use biome_project_layout::ProjectLayout;
-use biome_rowan::Text;
 use camino::{Utf8Path, Utf8PathBuf};
 use oxc_resolver::{EnforceExtension, ResolveOptions, ResolverGeneric};
 use papaya::{HashMap, HashMapRef, LocalGuard};
 use rustc_hash::FxBuildHasher;
 
-use crate::{module_visitor::ModuleVisitor, resolver_cache::ResolverCache};
+use crate::{
+    Export,
+    js_module_visitor::JsModuleVisitor,
+    module_info::{ModuleInfo, OwnExport},
+    resolver_cache::ResolverCache,
+};
 
 pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts", ".json", ".node",
@@ -109,9 +110,8 @@ impl ModuleGraph {
             .filter_map(|(path, root)| root.clone().map(|root| (path, root)))
         {
             let directory = path.parent().unwrap_or(path);
-            let visitor = ModuleVisitor::new(root, directory, &resolver);
-            let module_imports = visitor.collect_data();
-            imports.insert(path.to_path_buf(), module_imports);
+            let visitor = JsModuleVisitor::new(root, directory, &resolver);
+            imports.insert(path.to_path_buf(), visitor.collect_info());
         }
 
         // Update our `path_info` cache so that future usages of the
@@ -135,7 +135,11 @@ impl ModuleGraph {
     /// Finds an exported symbol by `symbol_name` as exported by `module`.
     ///
     /// Follows re-exports if necessary.
-    fn find_exported_symbol(&self, module: &ModuleInfo, symbol_name: &str) -> Option<OwnExport> {
+    pub(crate) fn find_exported_symbol(
+        &self,
+        module: &ModuleInfo,
+        symbol_name: &str,
+    ) -> Option<OwnExport> {
         let data = self.data.pin();
         let mut seen_paths = BTreeSet::new();
 
@@ -146,22 +150,24 @@ impl ModuleGraph {
             seen_paths: &mut BTreeSet<&'a Utf8Path>,
         ) -> Option<OwnExport> {
             match module.exports.get(symbol_name) {
-                Some(Export::Own(own_export)) => Some(own_export.clone()),
-                Some(Export::Reexport(import)) => match &import.resolved_path {
-                    Ok(path) if seen_paths.insert(path) => data.get(path).and_then(|module| {
-                        find_exported_symbol_with_seen_paths(data, module, symbol_name, seen_paths)
-                    }),
-                    _ => None,
-                },
-                // FIXME: We can create an `OwnExport` on the fly from a
-                //        `ReexportAll`, which sorta kinda makes sense,
-                //        because it does export the imported symbols under
-                //        its own name.
-                //        Still, it feels funny, and it means we always
-                //        ignore JSDoc comments added to such a re-export.
-                //        Should be fixed as part of #5312.
-                Some(Export::ReexportAll(_)) => Some(OwnExport {
-                    jsdoc_comment: None,
+                Some(Export::Own(own_export) | Export::OwnType(own_export)) => {
+                    Some(own_export.clone())
+                }
+                Some(Export::Reexport(import) | Export::ReexportType(import)) => {
+                    match &import.resolved_path {
+                        Ok(path) if seen_paths.insert(path) => data.get(path).and_then(|module| {
+                            find_exported_symbol_with_seen_paths(
+                                data,
+                                module,
+                                symbol_name,
+                                seen_paths,
+                            )
+                        }),
+                        _ => None,
+                    }
+                }
+                Some(Export::ReexportAll(reexport_all)) => Some(OwnExport {
+                    jsdoc_comment: reexport_all.jsdoc_comment.clone(),
                     ty: Type::Namespace(Box::new(Namespace(Box::new([])))),
                 }),
                 None => module.blanket_reexports.iter().find_map(|reexport| {
@@ -182,160 +188,6 @@ impl ModuleGraph {
 
         find_exported_symbol_with_seen_paths(&data, module, symbol_name, &mut seen_paths)
     }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct ModuleInfo {
-    /// Map of all static imports found in the module.
-    ///
-    /// Maps from the identifier found in the import statement to the absolute
-    /// path it resolves to. The resolved path may be looked up as key in the
-    /// [DependencyGraphModel::modules] map, although it is not required to
-    /// exist (for instance, if the path is outside the project's scope).
-    ///
-    /// Note that re-exports may introduce additional dependencies, because they
-    /// import another module and immediately re-export from that module.
-    /// Re-exports are tracked as part of [Self::exports] and
-    /// [Self::blanket_reexports].
-    pub static_imports: BTreeMap<String, Import>,
-
-    /// Map of all dynamic imports found in the module for which the import
-    /// identifier could be statically determined.
-    ///
-    /// Dynamic imports for which the identifier cannot be statically determined
-    /// (for instance, because a template string with variables is used) will be
-    /// omitted from this map.
-    ///
-    /// Maps from the identifier found in the import expression to the absolute
-    /// path it resolves to. The resolved path may be looked up as key in the
-    /// [DependencyGraphModel::modules] map, although it is not required to
-    /// exist (for instance, if the path is outside the project's scope).
-    ///
-    /// `require()` expressions in CommonJS sources are also included with the
-    /// dynamic imports.
-    pub dynamic_imports: BTreeMap<String, Import>,
-
-    /// Map of exports from the module.
-    ///
-    /// The keys are the names of the exports, where "default" is used for the
-    /// default export. See [Export] for information tracked per export.
-    ///
-    /// Re-exports are tracked in this map as well. They exception are "blanket"
-    /// re-exports, such as `export * from "other-module"`. Those are tracked in
-    /// [Self::forwarding_exports] instead.
-    pub exports: BTreeMap<Text, Export>,
-
-    /// Re-exports that apply to all symbols from another module, without
-    /// assigning a name to them.
-    pub blanket_reexports: Vec<ReexportAll>,
-}
-
-impl ModuleInfo {
-    /// Allows draining a single entry from the imports.
-    ///
-    /// Returns a `(specifier, import)` pair from either the static or dynamic
-    /// imports, whichever is non-empty. Returns `None` if both are empty.
-    ///
-    /// Using this method allows for consuming the struct while iterating over
-    /// it, without necessarily turning the entire struct into an iterator at
-    /// once.
-    pub fn drain_import(&mut self) -> Option<(String, Import)> {
-        if self.static_imports.is_empty() {
-            self.dynamic_imports.pop_first()
-        } else {
-            self.static_imports.pop_first()
-        }
-    }
-
-    /// Finds an exported symbol by `name`, using the `module_graph` to
-    /// lookup re-exports if necessary.
-    #[inline]
-    pub fn find_exported_symbol(
-        &self,
-        module_graph: &ModuleGraph,
-        name: &str,
-    ) -> Option<OwnExport> {
-        module_graph.find_exported_symbol(self, name)
-    }
-
-    /// Returns the information about a given import by its syntax node.
-    pub fn get_import_by_node(&self, node: &AnyJsImportLike) -> Option<&Import> {
-        let specifier_text = node.inner_string_text()?;
-        let specifier = specifier_text.text();
-        if node.is_static_import() {
-            self.static_imports.get(specifier)
-        } else {
-            self.dynamic_imports.get(specifier)
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct Import {
-    /// Absolute path of the resource being imported, if it can be resolved.
-    ///
-    /// If the import statement referred to a package dependency, the path will
-    /// point towards the resolved entry point of the package.
-    ///
-    /// If `None`, import resolution failed.
-    pub resolved_path: Result<Utf8PathBuf, String>,
-}
-
-/// Information tracked for every export.
-///
-/// Exports come in three varieties: "own" exports that are defined in the
-/// module itself, re-exports for named exports, and re-exports that apply to
-/// all symbols from another module.
-#[derive(Clone, Debug, PartialEq)]
-pub enum Export {
-    /// An export that is defined in this module.
-    Own(OwnExport),
-    /// An export that is re-exported by this module, but which is defined
-    /// within another module.
-    ///
-    /// E.g. `export { someSymbol } from "other-module"`.
-    Reexport(Import),
-    /// An export that creates an alias for all symbols from another module.
-    ///
-    /// E.g. `export { * as alias } from "other-module"`.
-    ReexportAll(ReexportAll),
-}
-
-/// Information tracked for every "own" export.
-#[derive(Clone, Debug, PartialEq)]
-pub struct OwnExport {
-    /// Optional JSDoc comment associated with the export.
-    ///
-    /// The comment is trimmed and normalized to remove the trivia of the
-    /// comment.
-    ///
-    /// ## Example
-    ///
-    /// Assuming the following export:
-    ///
-    /// ```ts
-    /// /**
-    ///  * Magic constant of fooness.
-    ///  *
-    ///  * For if you want more ways to write 1.
-    ///  */
-    /// export const FOO = 1;
-    /// ```
-    ///
-    /// The comment would be:
-    /// `"Magic constant of fooness.\n\nFor if you want more ways to write 1."`.
-    pub jsdoc_comment: Option<String>,
-
-    /// Type of the exported symbol.
-    pub ty: Type,
-}
-
-/// Information about an export statement that re-exports all symbols from
-/// another module.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ReexportAll {
-    /// Import from which the symbols are being re-exported.
-    pub import: Import,
 }
 
 #[cfg(test)]

--- a/crates/biome_module_graph/src/module_info.rs
+++ b/crates/biome_module_graph/src/module_info.rs
@@ -1,0 +1,160 @@
+use std::collections::BTreeMap;
+
+use biome_js_syntax::AnyJsImportLike;
+use biome_js_type_info::Type;
+use biome_rowan::Text;
+use camino::Utf8PathBuf;
+
+use crate::{ModuleGraph, jsdoc_comment::JsdocComment};
+
+/// Information restricted to a single module in the [ModuleGraph].
+#[derive(Clone, Debug, Default)]
+pub struct ModuleInfo {
+    /// Map of all static imports found in the module.
+    ///
+    /// Maps from the identifier found in the import statement to the absolute
+    /// path it resolves to. The resolved path may be looked up as key in the
+    /// [DependencyGraphModel::modules] map, although it is not required to
+    /// exist (for instance, if the path is outside the project's scope).
+    ///
+    /// Note that re-exports may introduce additional dependencies, because they
+    /// import another module and immediately re-export from that module.
+    /// Re-exports are tracked as part of [Self::exports] and
+    /// [Self::blanket_reexports].
+    pub static_imports: BTreeMap<String, Import>,
+
+    /// Map of all dynamic imports found in the module for which the import
+    /// identifier could be statically determined.
+    ///
+    /// Dynamic imports for which the identifier cannot be statically determined
+    /// (for instance, because a template string with variables is used) will be
+    /// omitted from this map.
+    ///
+    /// Maps from the identifier found in the import expression to the absolute
+    /// path it resolves to. The resolved path may be looked up as key in the
+    /// [DependencyGraphModel::modules] map, although it is not required to
+    /// exist (for instance, if the path is outside the project's scope).
+    ///
+    /// `require()` expressions in CommonJS sources are also included with the
+    /// dynamic imports.
+    pub dynamic_imports: BTreeMap<String, Import>,
+
+    /// Map of exports from the module.
+    ///
+    /// The keys are the names of the exports, where "default" is used for the
+    /// default export. See [Export] for information tracked per export.
+    ///
+    /// Re-exports are tracked in this map as well. The exception are "blanket"
+    /// re-exports, such as `export * from "other-module"`. Those are tracked in
+    /// [Self::forwarding_exports] instead.
+    pub exports: BTreeMap<Text, Export>,
+
+    /// Re-exports that apply to all symbols from another module, without
+    /// assigning a name to them.
+    pub blanket_reexports: Vec<ReexportAll>,
+}
+
+static_assertions::assert_impl_all!(ModuleInfo: Send, Sync);
+
+impl ModuleInfo {
+    /// Allows draining a single entry from the imports.
+    ///
+    /// Returns a `(specifier, import)` pair from either the static or dynamic
+    /// imports, whichever is non-empty. Returns `None` if both are empty.
+    ///
+    /// Using this method allows for consuming the struct while iterating over
+    /// it, without necessarily turning the entire struct into an iterator at
+    /// once.
+    pub fn drain_import(&mut self) -> Option<(String, Import)> {
+        if self.static_imports.is_empty() {
+            self.dynamic_imports.pop_first()
+        } else {
+            self.static_imports.pop_first()
+        }
+    }
+
+    /// Finds an exported symbol by `name`, using the `module_graph` to
+    /// lookup re-exports if necessary.
+    #[inline]
+    pub fn find_exported_symbol(
+        &self,
+        module_graph: &ModuleGraph,
+        name: &str,
+    ) -> Option<OwnExport> {
+        module_graph.find_exported_symbol(self, name)
+    }
+
+    /// Returns the information about a given import by its syntax node.
+    pub fn get_import_by_js_node(&self, node: &AnyJsImportLike) -> Option<&Import> {
+        let specifier_text = node.inner_string_text()?;
+        let specifier = specifier_text.text();
+        if node.is_static_import() {
+            self.static_imports.get(specifier)
+        } else {
+            self.dynamic_imports.get(specifier)
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Import {
+    /// Absolute path of the resource being imported, if it can be resolved.
+    ///
+    /// If the import statement referred to a package dependency, the path will
+    /// point towards the resolved entry point of the package.
+    ///
+    /// If `None`, import resolution failed.
+    pub resolved_path: Result<Utf8PathBuf, String>,
+}
+
+/// Information tracked for every export.
+///
+/// Exports come in three varieties: "own" exports that are defined in the
+/// module itself, re-exports for named exports, and re-exports that apply to
+/// all symbols from another module.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Export {
+    /// An export that is defined in this module.
+    Own(OwnExport),
+
+    /// An exported type that is defined in this module.
+    OwnType(OwnExport),
+
+    /// An export that is re-exported by this module, but which is defined
+    /// within another module.
+    ///
+    /// E.g. `export { someSymbol } from "other-module"`.
+    Reexport(Import),
+
+    /// A type that is re-exported by this module, but which is defined
+    /// within another module.
+    ///
+    /// E.g. `export type { someSymbol } from "other-module"`.
+    ReexportType(Import),
+
+    /// An export that creates an alias for all symbols from another module.
+    ///
+    /// E.g. `export { * as alias } from "other-module"`.
+    ReexportAll(ReexportAll),
+}
+
+/// Information tracked for every "own" export.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OwnExport {
+    /// Optional JSDoc comment associated with the symbol being exported.
+    pub jsdoc_comment: Option<JsdocComment>,
+
+    /// Type of the exported symbol.
+    pub ty: Type,
+}
+
+/// Information about an export statement that re-exports all symbols from
+/// another module.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReexportAll {
+    /// Optional JSDoc comment associated with the re-export statement.
+    pub jsdoc_comment: Option<JsdocComment>,
+
+    /// Import from which the symbols are being re-exported.
+    pub import: Import,
+}

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
@@ -8,7 +8,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "TODO: No types can be detected on these yet.",
+                JsdocComment(
+                    "TODO: No types can be detected on these yet.",
+                ),
             ),
             ty: Unknown,
         },
@@ -18,7 +20,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "TODO: No types can be detected on these yet.",
+                JsdocComment(
+                    "TODO: No types can be detected on these yet.",
+                ),
             ),
             ty: Unknown,
         },
@@ -28,7 +32,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "@package",
+                JsdocComment(
+                    "@package",
+                ),
             ),
             ty: Function(
                 Function {
@@ -76,7 +82,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "TODO: No types can be detected on these yet.",
+                JsdocComment(
+                    "TODO: No types can be detected on these yet.",
+                ),
             ),
             ty: Unknown,
         },
@@ -86,7 +94,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "@public\n@returns {JSX.Element}",
+                JsdocComment(
+                    "@public\n@returns {JSX.Element}",
+                ),
             ),
             ty: Function(
                 Function {
@@ -124,7 +134,9 @@ expression: data.exports
     ): Own(
         OwnExport {
             jsdoc_comment: Some(
-                "TODO: No types can be detected on these yet.",
+                JsdocComment(
+                    "TODO: No types can be detected on these yet.",
+                ),
             ),
             ty: Unknown,
         },
@@ -133,7 +145,51 @@ expression: data.exports
         "foo",
     ): Own(
         OwnExport {
+            jsdoc_comment: Some(
+                JsdocComment(
+                    "@returns {string}",
+                ),
+            ),
+            ty: Function(
+                Function {
+                    is_async: false,
+                    type_parameters: [],
+                    name: Some(
+                        Borrowed(
+                            "foo",
+                        ),
+                    ),
+                    parameters: [],
+                    return_type: Type(
+                        Unknown,
+                    ),
+                },
+            ),
+        },
+    ),
+    Borrowed(
+        "qux",
+    ): Own(
+        OwnExport {
             jsdoc_comment: None,
+            ty: Literal(
+                Number(
+                    Borrowed(
+                        "1",
+                    ),
+                ),
+            ),
+        },
+    ),
+    Borrowed(
+        "quz",
+    ): Own(
+        OwnExport {
+            jsdoc_comment: Some(
+                JsdocComment(
+                    "@private",
+                ),
+            ),
             ty: Unknown,
         },
     ),


### PR DESCRIPTION
## Summary

Fixes #5312.

This adds a light, and as of yet incomplete, version of the semantic model to the scanner. The goal isn't yet to do deep semantic analysis inside the scanned modules, but simply to resolve exported symbols when their declaration is in a different position than the export statement itself.

This makes sure that we can resolve both types and JSDoc comments more accurately through the module graph, and also resolves one of the limitations of `noPrivateImports` that we had in the beta.

JSDoc comments also have a dedicated type. The type definitions for type aliases has been refined as well.

## Test Plan

Tests added and snapshots updated.
