### PR TITLE
chore(html/formatter): better control over spacing

### DIFF
--- a/.changeset/silver-groups-shout.md
+++ b/.changeset/silver-groups-shout.md
@@ -22,7 +22,7 @@ An option `html.formatter.selfCloseVoidElements` allows to control whether the t
 
 ```diff
 - <input />
-+ <input >
++ <input>
 ```
 
 If you come from Prettier and you want to keep the same formatting behaviour, you should set the option to `"always"`:
@@ -38,7 +38,7 @@ If you come from Prettier and you want to keep the same formatting behaviour, yo
 ```
 
 ```diff
-- <input >
+- <input>
 + <input />
 ```
 

--- a/crates/biome_html_formatter/src/html/auxiliary/attribute.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/attribute.rs
@@ -12,7 +12,7 @@ pub(crate) struct FormatHtmlAttribute {
 }
 
 pub(crate) struct FormatHtmlAttributeOptions {
-    /// Whether or not this attribute belongs to a canonical tag.
+    /// Whether this attribute belongs to a canonical tag.
     pub is_canonical_html_element: bool,
 
     /// The name of the tag this attribute belongs to.

--- a/crates/biome_html_formatter/src/html/auxiliary/attribute_name.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/attribute_name.rs
@@ -7,7 +7,7 @@ use biome_html_syntax::{HtmlAttributeName, HtmlAttributeNameFields, HtmlTagName}
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FormatHtmlAttributeName {
-    /// Whether or not this attribute belongs to a canonical tag.
+    /// Whether this attribute belongs to a canonical tag.
     pub is_canonical_html_element: bool,
 
     /// The name of the tag this attribute belongs to.
@@ -15,7 +15,7 @@ pub(crate) struct FormatHtmlAttributeName {
 }
 
 pub(crate) struct FormatHtmlAttributeNameOptions {
-    /// Whether or not this attribute belongs to a canonical tag.
+    /// Whether this attribute belongs to a canonical tag.
     pub is_canonical_html_element: bool,
 
     /// The name of the tag this attribute belongs to.

--- a/crates/biome_html_formatter/src/html/auxiliary/self_closing_element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/self_closing_element.rs
@@ -20,7 +20,7 @@ impl FormatNodeRule<HtmlSelfClosingElement> for FormatHtmlSelfClosingElement {
         let name = name?;
         let is_canonical_html_tag = is_canonical_html_tag(&name);
 
-        write!(f, [l_angle_token.format(), name.format(), space()])?;
+        write!(f, [l_angle_token.format(), name.format()])?;
 
         let attr_group_id = f.group_id("element-attr-group-id");
         write!(
@@ -41,7 +41,7 @@ impl FormatNodeRule<HtmlSelfClosingElement> for FormatHtmlSelfClosingElement {
                 // When these tokens are borrowed, they are managed by the sibling `HtmlElementList` formatter.
                 if bracket_same_line {
                     write!(f, [hard_space()])?;
-                } else {
+                } else if self_close_void_elements.is_always() || attributes.len() >= 1 {
                     write!(f, [soft_line_break_or_space()])?;
                 }
 

--- a/crates/biome_html_formatter/src/html/lists/attribute_list.rs
+++ b/crates/biome_html_formatter/src/html/lists/attribute_list.rs
@@ -12,7 +12,7 @@ pub(crate) struct FormatHtmlAttributeList {
 }
 
 pub(crate) struct FormatHtmlAttributeListOptions {
-    /// Whether or not this attribute list belongs to a canonical tag.
+    /// Whether this attribute list belongs to a canonical tag.
     pub is_canonical_html_element: bool,
 
     /// The name of the tag this attribute list belongs to.

--- a/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html
+++ b/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html
@@ -1,14 +1,15 @@
-Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
-sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
-feugiat ac.<b
-  attribute="really long for this example"
-  actually="so long it should break and become multiline"
-  >Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
-  augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
-  vestibulum nulla.</b
+Lorem ipsum<b>dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
+	sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
+	feugiat ac.</b><b
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+>Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
+	augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
+	vestibulum nulla.</b
 >Donec maximus euismod egestas. Sed tempus semper efficitur. Suspendisse maximus
 ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
-  attribute="really long for this example"
-  actually="so long it should break and become multiline"
-/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
 viverra libero quis lacus euismod, ut consequat ante convallis.
+</span>

--- a/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/long-inline-elements.html.snap
@@ -6,20 +6,21 @@ snapshot_kind: text
 # Input
 
 ```html
-Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
-sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
-feugiat ac.<b
-  attribute="really long for this example"
-  actually="so long it should break and become multiline"
-  >Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
-  augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
-  vestibulum nulla.</b
+Lorem ipsum<b>dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
+	sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
+	feugiat ac.</b><b
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+>Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
+	augue mauris. Nullam sit amet blandit massa, at finibus felis. Nunc ut
+	vestibulum nulla.</b
 >Donec maximus euismod egestas. Sed tempus semper efficitur. Suspendisse maximus
 ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
-  attribute="really long for this example"
-  actually="so long it should break and become multiline"
-/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+	attribute="really long for this example"
+	actually="so long it should break and become multiline"
+>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
 viverra libero quis lacus euismod, ut consequat ante convallis.
+</span>
 
 ```
 
@@ -43,9 +44,12 @@ Self close void elements: never
 -----
 
 ```html
-Lorem ipsum<span />dolor sit amet, consectetur adipiscing elit. Sed eu diam vel
-sem congue pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros
-feugiat ac.<b
+Lorem ipsum<b
+	>dolor sit amet, consectetur adipiscing elit. Sed eu diam vel sem congue
+	pulvinar at vitae purus. Morbi volutpat arcu massa, eu laoreet eros feugiat
+	ac.</b
+>
+<b
 	attribute="really long for this example"
 	actually="so long it should break and become multiline"
 	>Etiam sit amet turpis blandit, volutpat magna nec, luctus justo. Nam nec
@@ -55,6 +59,7 @@ feugiat ac.<b
 ut risus vel sollicitudin. Maecenas eu bibendum lorem.<span
 	attribute="really long for this example"
 	actually="so long it should break and become multiline"
-/>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
-viverra libero quis lacus euismod, ut consequat ante convallis.
+	>Sed porttitor commodo commodo. Morbi luctus consequat maximus. Vestibulum
+	viverra libero quis lacus euismod, ut consequat ante convallis.
+</span>
 ```

--- a/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/self-closing.html.snap
@@ -47,20 +47,20 @@ Self close void elements: never
 
 ```html
 <div>
-	<br >
-	<img >
-	<area >
-	<base >
-	<br >
-	<col >
-	<embed >
-	<hr >
-	<img >
-	<input >
-	<link >
-	<meta >
-	<source >
-	<track >
-	<wbr >
+	<br>
+	<img>
+	<area>
+	<base>
+	<br>
+	<col>
+	<embed>
+	<hr>
+	<img>
+	<input>
+	<link>
+	<meta>
+	<source>
+	<track>
+	<wbr>
 </div>
 ```

--- a/crates/biome_html_formatter/tests/specs/html/self-closing/always.html
+++ b/crates/biome_html_formatter/tests/specs/html/self-closing/always.html
@@ -1,17 +1,14 @@
-<div>
-	<br>
-	<img>
-	<area>
-	<base>
-	<br>
-	<col>
-	<embed>
-	<hr>
-	<img>
-	<input>
-	<link>
-	<meta>
-	<source>
-	<track>
-	<wbr>
-</div>
+<br>
+<img>
+<area>
+<base>
+<col>
+<embed>
+<hr>
+<img>
+<input>
+<link>
+<meta>
+<source>
+<track>
+<wbr>

--- a/crates/biome_html_formatter/tests/specs/html/self-closing/always.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/self-closing/always.html.snap
@@ -6,23 +6,20 @@ snapshot_kind: text
 # Input
 
 ```html
-<div>
-	<br>
-	<img>
-	<area>
-	<base>
-	<br>
-	<col>
-	<embed>
-	<hr>
-	<img>
-	<input>
-	<link>
-	<meta>
-	<source>
-	<track>
-	<wbr>
-</div>
+<br>
+<img>
+<area>
+<base>
+<col>
+<embed>
+<hr>
+<img>
+<input>
+<link>
+<meta>
+<source>
+<track>
+<wbr>
 
 ```
 
@@ -46,23 +43,20 @@ Self close void elements: never
 -----
 
 ```html
-<div>
-	<br >
-	<img >
-	<area >
-	<base >
-	<br >
-	<col >
-	<embed >
-	<hr >
-	<img >
-	<input >
-	<link >
-	<meta >
-	<source >
-	<track >
-	<wbr >
-</div>
+<br>
+<img>
+<area>
+<base>
+<col>
+<embed>
+<hr>
+<img>
+<input>
+<link>
+<meta>
+<source>
+<track>
+<wbr>
 ```
 
 ## Output 1
@@ -80,21 +74,18 @@ Self close void elements: always
 -----
 
 ```html
-<div>
-	<br />
-	<img />
-	<area />
-	<base />
-	<br />
-	<col />
-	<embed />
-	<hr />
-	<img />
-	<input />
-	<link />
-	<meta />
-	<source />
-	<track />
-	<wbr />
-</div>
+<br />
+<img />
+<area />
+<base />
+<col />
+<embed />
+<hr />
+<img />
+<input />
+<link />
+<meta />
+<source />
+<track />
+<wbr />
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This is a follow-up of https://github.com/biomejs/biome/pull/5600#discussion_r2031483188

We don't print a space after the tag name if it's a void element and there aren't attributes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the tests

<!-- What demonstrates that your implementation is correct? -->
