### PR TITLE
feat(core): skip non-root configuration files

### DIFF
--- a/crates/biome_configuration/src/diagnostics.rs
+++ b/crates/biome_configuration/src/diagnostics.rs
@@ -37,6 +37,8 @@ pub enum BiomeDiagnostic {
 
     NoConfigurationFileFound(NoConfigurationFileFound),
 
+    NonRootConfiguration(NonRootConfiguration),
+
     /// Thrown when trying to **create** a new configuration file, but it exists already
     ConfigAlreadyExists(ConfigAlreadyExists),
 
@@ -129,6 +131,12 @@ impl BiomeDiagnostic {
         })
     }
 
+    pub fn non_root_configuration(path: &Utf8Path) -> Self {
+        Self::NonRootConfiguration(NonRootConfiguration {
+            path: path.to_string(),
+        })
+    }
+
     pub fn cant_resolve(path: impl Display, source: oxc_resolver::ResolveError) -> Self {
         Self::CantResolve(CantResolve {
             message: MessageAndDescription::from(
@@ -195,6 +203,21 @@ pub struct ConfigAlreadyExists {}
     )
 )]
 pub struct NoConfigurationFileFound {
+    #[location(resource)]
+    path: String,
+}
+
+#[derive(Debug, Diagnostic, Serialize, Deserialize)]
+#[diagnostic(
+    category = "configuration",
+    severity = Error,
+    message(
+        message("The given configuration file ("<Emphasis>{self.path}</Emphasis>") is not a root configuration."),
+        description = "The given configuration file {path} is not a root configuration."
+    ),
+    advice = "When an explicit configuration path is given, you must supply the project's root configuration"
+)]
+pub struct NonRootConfiguration {
     #[location(resource)]
     path: String,
 }

--- a/crates/biome_deserialize/src/lib.rs
+++ b/crates/biome_deserialize/src/lib.rs
@@ -443,7 +443,7 @@ pub struct Deserialized<T> {
     /// Diagnostics emitted during the parsing and deserialization phase
     diagnostics: Vec<Error>,
     /// The deserialized result, or `None` if the deserialization failed
-    deserialized: Option<T>,
+    pub deserialized: Option<T>,
 }
 
 impl<T> Deserialized<T> {

--- a/crates/biome_diagnostics/src/advice.rs
+++ b/crates/biome_diagnostics/src/advice.rs
@@ -82,6 +82,12 @@ pub trait Visit {
     }
 }
 
+impl Advices for str {
+    fn record(&self, visitor: &mut dyn Visit) -> io::Result<()> {
+        visitor.record_log(LogCategory::Info, &self)
+    }
+}
+
 /// The category for a log advice, defines how the message should be presented
 /// to the user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/biome_diagnostics_macros/src/generate.rs
+++ b/crates/biome_diagnostics_macros/src/generate.rs
@@ -187,11 +187,14 @@ fn generate_advices(input: &DeriveStructInput) -> TokenStream {
         return quote!();
     }
 
-    let advices = input.advices.iter();
+    let advices = input.advices.iter().map(|advice| match advice {
+        StaticOrDynamic::Static(literal) => quote! { #literal },
+        StaticOrDynamic::Dynamic(token_stream) => quote! { &self.#token_stream },
+    });
 
     quote! {
         fn advices(&self, visitor: &mut dyn biome_diagnostics::Visit) -> ::std::io::Result<()> {
-            #( biome_diagnostics::Advices::record(&self.#advices, visitor)?; )*
+            #( biome_diagnostics::Advices::record(#advices, visitor)?; )*
             Ok(())
         }
     }

--- a/crates/biome_diagnostics_macros/src/parse.rs
+++ b/crates/biome_diagnostics_macros/src/parse.rs
@@ -22,7 +22,7 @@ pub(crate) struct DeriveStructInput {
     pub(crate) category: Option<StaticOrDynamic<syn::LitStr>>,
     pub(crate) description: Option<StaticOrDynamic<StringOrMarkup>>,
     pub(crate) message: Option<StaticOrDynamic<StringOrMarkup>>,
-    pub(crate) advices: Vec<TokenStream>,
+    pub(crate) advices: Vec<StaticOrDynamic<syn::LitStr>>,
     pub(crate) verbose_advices: Vec<TokenStream>,
     pub(crate) location: Vec<(TokenStream, LocationField)>,
     pub(crate) tags: Option<StaticOrDynamic<Punctuated<Ident, Token![|]>>>,
@@ -125,6 +125,9 @@ impl DeriveStructInput {
                                 }
                             }
                         }
+                        DiagnosticAttr::Advice(attr) => {
+                            result.advices.push(StaticOrDynamic::Static(attr.value));
+                        }
                         DiagnosticAttr::Tags(attr) => {
                             result.tags = Some(StaticOrDynamic::Static(attr.tags));
                         }
@@ -163,7 +166,7 @@ impl DeriveStructInput {
                 }
 
                 if attr.path.is_ident("advice") {
-                    result.advices.push(ident.clone());
+                    result.advices.push(StaticOrDynamic::Dynamic(ident.clone()));
                     continue;
                 }
 
@@ -270,6 +273,7 @@ enum DiagnosticAttr {
     Severity(SeverityAttr),
     Category(CategoryAttr),
     Message(MessageAttr),
+    Advice(AdviceAttr),
     Tags(TagsAttr),
 }
 
@@ -287,6 +291,10 @@ impl Parse for DiagnosticAttr {
 
         if name == "message" {
             return Ok(Self::Message(input.parse()?));
+        }
+
+        if name == "advice" {
+            return Ok(Self::Advice(input.parse()?));
         }
 
         if name == "tags" {
@@ -408,6 +416,20 @@ impl Parse for SplitMessageAttr {
         }
 
         Err(Error::new_spanned(name, "unknown attribute"))
+    }
+}
+
+struct AdviceAttr {
+    _eq_token: Token![=],
+    value: syn::LitStr,
+}
+
+impl Parse for AdviceAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            _eq_token: input.parse()?,
+            value: input.parse()?,
+        })
     }
 }
 

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -127,6 +127,18 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
         search_dir: &Utf8Path,
         search_files: &[&str],
     ) -> Option<AutoSearchResult> {
+        self.auto_search_files_with_predicate(search_dir, search_files, &mut |_, _| true)
+    }
+
+    /// Same as `auto_search_files()`, but runs a predicate on the path and
+    /// content of any file that matches `search_files` before deciding if it
+    /// really is a match.
+    fn auto_search_files_with_predicate(
+        &self,
+        search_dir: &Utf8Path,
+        search_files: &[&str],
+        predicate: &mut dyn FnMut(&Utf8Path, &str) -> bool,
+    ) -> Option<AutoSearchResult> {
         let mut current_search_dir = search_dir.to_path_buf();
         let mut is_searching_in_parent_dir = false;
 
@@ -136,6 +148,9 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
                 let file_path = current_search_dir.join(file_name);
                 match self.read_file_from_path(&file_path) {
                     Ok(content) => {
+                        if !predicate(&file_path, &content) {
+                            break;
+                        }
                         if is_searching_in_parent_dir {
                             info!(
                                 "Biome auto discovered the file at the following path that isn't in the working directory:\n{:?}",

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -196,30 +196,42 @@ fn load_config(fs: &dyn FileSystem, base_path: ConfigurationPathHint) -> LoadCon
             return load_user_config(fs, config_file_path, external_resolution_base_path);
         }
     };
-    let Some(auto_search_result) = fs.auto_search_files(
+
+    // We search for the first non-root `biome.json` or `biome.jsonc` files:
+    let mut deserialized = None;
+    let mut predicate = |file_path: &Utf8Path, content: &str| -> bool {
+        let parser_options = match file_path.extension() {
+            Some("json") => JsonParserOptions::default(),
+            _ => JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
+        };
+
+        let deserialized_content =
+            deserialize_from_json_str::<Configuration>(content, parser_options, "");
+        let is_root = deserialized_content
+            .deserialized
+            .as_ref()
+            .is_some_and(|config| config.root.is_none_or(|root| root.value()));
+        if is_root {
+            deserialized = Some(deserialized_content);
+        }
+        is_root
+    };
+
+    let Some(auto_search_result) = fs.auto_search_files_with_predicate(
         &configuration_directory,
         &[ConfigName::biome_json(), ConfigName::biome_jsonc()],
+        &mut predicate,
     ) else {
         return Ok(None);
     };
 
-    // We first search for `biome.json` or `biome.jsonc` files
-    let AutoSearchResult {
-        content, file_path, ..
-    } = auto_search_result;
-
-    let parser_options = match file_path.extension() {
-        Some("json") => JsonParserOptions::default(),
-        _ => JsonParserOptions::default()
-            .with_allow_comments()
-            .with_allow_trailing_commas(),
-    };
-
-    let deserialized = deserialize_from_json_str::<Configuration>(&content, parser_options, "");
-
     Ok(Some(ConfigurationPayload {
-        deserialized,
-        configuration_file_path: file_path,
+        // Unwrapping is safe because the predicate in the search above would
+        // only return `true` if it assigned `Some` value:
+        deserialized: deserialized.unwrap(),
+        configuration_file_path: auto_search_result.file_path,
         external_resolution_base_path,
     }))
 }
@@ -269,6 +281,14 @@ fn load_user_config(
 
         let content = fs.read_file_from_path(config_path.as_path())?;
         let deserialized = deserialize_from_json_str::<Configuration>(&content, parser_options, "");
+        if deserialized
+            .deserialized
+            .as_ref()
+            .is_some_and(|config| config.root.is_some_and(|root| !root.value()))
+        {
+            return Err(BiomeDiagnostic::non_root_configuration(config_file_path).into());
+        }
+
         Ok(Some(ConfigurationPayload {
             deserialized,
             configuration_file_path: config_path.to_path_buf(),
@@ -557,8 +577,10 @@ impl ConfigurationExt for Configuration {
 
 #[cfg(test)]
 mod test {
-    use crate::configuration::load_configuration;
-    use biome_configuration::ConfigurationPathHint;
+    use crate::{WorkspaceError, configuration::load_configuration};
+    use biome_configuration::{
+        BiomeDiagnostic, ConfigurationPathHint, diagnostics::ConfigurationDiagnostic,
+    };
     use biome_fs::MemoryFileSystem;
     use camino::Utf8PathBuf;
 
@@ -571,5 +593,59 @@ mod test {
         let result = load_configuration(&fs, path_hint);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_skip_non_root_configuration() {
+        let mut fs = MemoryFileSystem::default();
+        fs.insert(
+            Utf8PathBuf::from("/biome.json"),
+            r#"{ "linter": { "enabled": false } }"#.to_string(),
+        );
+        fs.insert(
+            Utf8PathBuf::from("/nested/biome.json"),
+            r#"{ "root": false, "linter": { "enabled": true } }"#.to_string(),
+        );
+        let path_hint = ConfigurationPathHint::FromWorkspace(Utf8PathBuf::from("/nested"));
+
+        match load_configuration(&fs, path_hint) {
+            Ok(loaded) => {
+                assert!(
+                    loaded
+                        .configuration
+                        .linter
+                        .is_some_and(|linter| !linter.is_enabled())
+                );
+            }
+            Err(err) => {
+                panic!("Config loading failed: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn should_refuse_user_provided_non_root_configuration() {
+        let mut fs = MemoryFileSystem::default();
+        fs.insert(
+            Utf8PathBuf::from("/biome.json"),
+            r#"{ "linter": { "enabled": false } }"#.to_string(),
+        );
+        fs.insert(
+            Utf8PathBuf::from("/nested/biome.json"),
+            r#"{ "root": false, "linter": { "enabled": true } }"#.to_string(),
+        );
+        let path_hint = ConfigurationPathHint::FromUser(Utf8PathBuf::from("/nested"));
+
+        match load_configuration(&fs, path_hint) {
+            Ok(_) => panic!("Config loading should have failed"),
+            Err(err) => {
+                assert!(matches!(
+                    err,
+                    WorkspaceError::Configuration(ConfigurationDiagnostic::Biome(
+                        BiomeDiagnostic::NonRootConfiguration(_)
+                    ))
+                ));
+            }
+        }
     }
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -45,7 +45,9 @@ use std::borrow::Cow;
 use std::ops::Deref;
 use tracing::instrument;
 
-/// Global settings for the entire project.
+/// Settings active in a project.
+///
+/// These can be either root settings, or settings for a section of the project.
 #[derive(Clone, Debug, Default)]
 pub struct Settings {
     /// Formatter settings applied to all files in the project.


### PR DESCRIPTION
## Summary

Implements a small but important part for the upcoming monorepo support: non-root configuration files (those with a `root: false` field) are automatically skipped in the auto-search for finding a Biome configuration file.

If users explicitly provide a path to a non-root configuration file, we'll error with a diagnostic. In theory we could do an auto-search from the non-root file, but I'm not sure if it's desired, and if it is we can implement it later (it looks a bit tricky).

## Test Plan

Tests added.
