### PR TITLE
fix(xtask/codegen): handle languages with no keywords

### DIFF
--- a/xtask/codegen/src/generate_syntax_kinds.rs
+++ b/xtask/codegen/src/generate_syntax_kinds.rs
@@ -199,6 +199,24 @@ pub fn generate_syntax_kinds(grammar: KindsSrc, language_kind: LanguageKind) -> 
         }
     };
 
+    let keyword_impl = if all_keywords.is_empty() {
+        quote! {
+            pub fn from_keyword(_ident: &str) -> Option<#syntax_kind> {
+                None
+            }
+        }
+    } else {
+        quote! {
+            pub fn from_keyword(ident: &str) -> Option<#syntax_kind> {
+                let kw = match ident {
+                    #(#all_keyword_strings => #full_keywords,)*
+                    _ => return None,
+                };
+                Some(kw)
+            }
+        }
+    };
+
     let ast = quote! {
         #![allow(bad_style, missing_docs, unreachable_pub)]
         /// The kind of syntax node, e.g. `IDENT`, `FUNCTION_KW`, or `FOR_STMT`.
@@ -239,13 +257,7 @@ pub fn generate_syntax_kinds(grammar: KindsSrc, language_kind: LanguageKind) -> 
                 matches!(self, #(#lists)|*)
             }
 
-            pub fn from_keyword(ident: &str) -> Option<#syntax_kind> {
-                let kw = match ident {
-                    #(#all_keyword_strings => #full_keywords,)*
-                    _ => return None,
-                };
-                Some(kw)
-            }
+            #keyword_impl
 
             #syntax_kind_impl
 


### PR DESCRIPTION
## Summary

Some languages, such as YAML, do not, have any special keywords. The current implementation is unable to handle this, and instead will generate the `from_keyword` function:
```rust
let kw = match ident {
  _ => return None,
};
Some(kw)
```

Which led to following errors
```rust
error: unreachable expression
   --> crates/biome_yaml_syntax/src/generated/kind.rs:123:9
    |
120 |           let kw = match ident {
    |  __________________-
121 | |             _ => return None,
122 | |         };
    | |_________- any code following this `match` expression is unreachable, as all arms diverge
123 |           Some(kw)
    |           ^^^^^^^^ unreachable expression
    |
    = note: `-D unreachable-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unreachable_code)]`

error: unused variable: `kw`
   --> crates/biome_yaml_syntax/src/generated/kind.rs:120:13
    |
120 |         let kw = match ident {
    |             ^^ help: if this is intentional, prefix it with an underscore: `_kw`
    |
    = note: `-D unused-variables` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_variables)]`
```

This PR fixes this by generating different implementations depending on whether the language has any keywords or not

## Test Plan

`just gen-grammar` should not made any modifications.
