### PR TITLE
perf(lint): remove allocation of strings

### DIFF
--- a/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
@@ -79,7 +79,7 @@ impl Rule for UseGenericFontNames {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.as_trimmed_text();
+        let property_name = node.name().ok()?.to_trimmed_text();
         let property_name = property_name.to_ascii_lowercase_cow();
 
         // Ignore `@font-face`. See more detail: https://drafts.csswg.org/css-fonts/#font-face-rule
@@ -117,7 +117,7 @@ impl Rule for UseGenericFontNames {
 
         // Ignore the last value if it's a CSS variable now.
         let last_value = font_families.last()?;
-        if is_css_variable(&last_value.as_trimmed_text()) {
+        if is_css_variable(&last_value.to_trimmed_text()) {
             return None;
         }
 
@@ -159,13 +159,13 @@ fn is_shorthand_font_property_with_keyword(properties: &CssGenericComponentValue
     properties.into_iter().len() == 1
         && properties
             .into_iter()
-            .any(|p| is_system_family_name_keyword(&p.as_trimmed_text()))
+            .any(|p| is_system_family_name_keyword(&p.to_trimmed_text()))
 }
 
 fn has_generic_font_family_property(nodes: &[AnyCssValue]) -> bool {
     nodes
         .iter()
-        .any(|n| is_font_family_keyword(&n.as_trimmed_text()))
+        .any(|n| is_font_family_keyword(&n.to_trimmed_text()))
 }
 
 fn collect_font_family_properties(properties: CssGenericComponentValueList) -> Vec<AnyCssValue> {

--- a/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/a11y/use_generic_font_names.rs
@@ -79,7 +79,7 @@ impl Rule for UseGenericFontNames {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.to_trimmed_string();
+        let property_name = node.name().ok()?.as_trimmed_text();
         let property_name = property_name.to_ascii_lowercase_cow();
 
         // Ignore `@font-face`. See more detail: https://drafts.csswg.org/css-fonts/#font-face-rule
@@ -117,7 +117,7 @@ impl Rule for UseGenericFontNames {
 
         // Ignore the last value if it's a CSS variable now.
         let last_value = font_families.last()?;
-        if is_css_variable(&last_value.to_trimmed_string()) {
+        if is_css_variable(&last_value.as_trimmed_text()) {
             return None;
         }
 
@@ -159,13 +159,13 @@ fn is_shorthand_font_property_with_keyword(properties: &CssGenericComponentValue
     properties.into_iter().len() == 1
         && properties
             .into_iter()
-            .any(|p| is_system_family_name_keyword(&p.to_trimmed_string()))
+            .any(|p| is_system_family_name_keyword(&p.as_trimmed_text()))
 }
 
 fn has_generic_font_family_property(nodes: &[AnyCssValue]) -> bool {
     nodes
         .iter()
-        .any(|n| is_font_family_keyword(&n.to_trimmed_string()))
+        .any(|n| is_font_family_keyword(&n.as_trimmed_text()))
 }
 
 fn collect_font_family_properties(properties: CssGenericComponentValueList) -> Vec<AnyCssValue> {

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
@@ -77,7 +77,7 @@ impl Rule for NoInvalidDirectionInLinearGradient {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let node_name = node.name().ok()?.to_trimmed_string();
+        let node_name = node.name().ok()?.as_trimmed_text();
         let linear_gradient_property = [
             "linear-gradient",
             "-webkit-linear-gradient",
@@ -91,7 +91,7 @@ impl Rule for NoInvalidDirectionInLinearGradient {
         let css_parameter = node.items();
 
         let first_css_parameter = css_parameter.first()?.ok()?;
-        let first_css_parameter_text = first_css_parameter.to_trimmed_string();
+        let first_css_parameter_text = first_css_parameter.as_trimmed_text();
         if IN_KEYWORD.is_match(&first_css_parameter_text) {
             return None;
         }

--- a/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_invalid_direction_in_linear_gradient.rs
@@ -77,7 +77,7 @@ impl Rule for NoInvalidDirectionInLinearGradient {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let node_name = node.name().ok()?.as_trimmed_text();
+        let node_name = node.name().ok()?.to_trimmed_text();
         let linear_gradient_property = [
             "linear-gradient",
             "-webkit-linear-gradient",
@@ -91,7 +91,7 @@ impl Rule for NoInvalidDirectionInLinearGradient {
         let css_parameter = node.items();
 
         let first_css_parameter = css_parameter.first()?.ok()?;
-        let first_css_parameter_text = first_css_parameter.as_trimmed_text();
+        let first_css_parameter_text = first_css_parameter.to_trimmed_text();
         if IN_KEYWORD.is_match(&first_css_parameter_text) {
             return None;
         }

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
@@ -75,7 +75,7 @@ impl Rule for NoUnknownProperty {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.as_trimmed_text();
+        let property_name = node.name().ok()?.to_trimmed_text();
         let property_name_lower = property_name.to_ascii_lowercase_cow();
         if !property_name_lower.starts_with("--")
             // Ignore `composes` property.

--- a/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unknown_property.rs
@@ -75,7 +75,7 @@ impl Rule for NoUnknownProperty {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.to_trimmed_string();
+        let property_name = node.name().ok()?.as_trimmed_text();
         let property_name_lower = property_name.to_ascii_lowercase_cow();
         if !property_name_lower.starts_with("--")
             // Ignore `composes` property.

--- a/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
@@ -105,12 +105,12 @@ fn is_unmatchable(nth: &AnyCssPseudoClassNth) -> bool {
             let constant = nth.offset().and_then(|offset| offset.value().ok());
 
             match (coefficient, constant) {
-                (Some(a), Some(b)) => a.to_trimmed_string() == "0" && b.to_trimmed_string() == "0",
-                (Some(a), None) => a.to_trimmed_string() == "0",
+                (Some(a), Some(b)) => a.as_trimmed_text() == "0" && b.as_trimmed_text() == "0",
+                (Some(a), None) => a.as_trimmed_text() == "0",
                 _ => false,
             }
         }
-        AnyCssPseudoClassNth::CssPseudoClassNthNumber(nth) => nth.to_trimmed_string() == "0",
+        AnyCssPseudoClassNth::CssPseudoClassNthNumber(nth) => nth.as_trimmed_text() == "0",
     }
 }
 

--- a/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
+++ b/crates/biome_css_analyze/src/lint/correctness/no_unmatchable_anb_selector.rs
@@ -105,12 +105,12 @@ fn is_unmatchable(nth: &AnyCssPseudoClassNth) -> bool {
             let constant = nth.offset().and_then(|offset| offset.value().ok());
 
             match (coefficient, constant) {
-                (Some(a), Some(b)) => a.as_trimmed_text() == "0" && b.as_trimmed_text() == "0",
-                (Some(a), None) => a.as_trimmed_text() == "0",
+                (Some(a), Some(b)) => a.to_trimmed_text() == "0" && b.to_trimmed_text() == "0",
+                (Some(a), None) => a.to_trimmed_text() == "0",
                 _ => false,
             }
         }
-        AnyCssPseudoClassNth::CssPseudoClassNthNumber(nth) => nth.as_trimmed_text() == "0",
+        AnyCssPseudoClassNth::CssPseudoClassNthNumber(nth) => nth.to_trimmed_text() == "0",
     }
 }
 

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
@@ -60,7 +60,7 @@ impl Rule for NoDuplicateProperties {
 
         for declaration in rule.declarations() {
             let prop = declaration.property();
-            let prop_name = prop.as_trimmed_text();
+            let prop_name = prop.to_trimmed_text();
             let prop_range = prop.range();
 
             let is_custom_property = prop_name.starts_with("--");

--- a/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_duplicate_properties.rs
@@ -60,7 +60,7 @@ impl Rule for NoDuplicateProperties {
 
         for declaration in rule.declarations() {
             let prop = declaration.property();
-            let prop_name = prop.to_trimmed_string();
+            let prop_name = prop.as_trimmed_text();
             let prop_range = prop.range();
 
             let is_custom_property = prop_name.starts_with("--");

--- a/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_missing_var_function.rs
@@ -157,7 +157,7 @@ impl Rule for NoMissingVarFunction {
         }
 
         let property_name = get_property_name(node)?;
-        let custom_variable_name = node.as_trimmed_text();
+        let custom_variable_name = node.to_trimmed_text();
 
         if IGNORED_PROPERTIES.contains(&property_name.text()) {
             return None;
@@ -201,7 +201,7 @@ impl Rule for NoMissingVarFunction {
 
     fn diagnostic(_: &RuleContext<Self>, node: &Self::State) -> Option<RuleDiagnostic> {
         let span = node.range();
-        let custom_variable_name = node.as_trimmed_text();
+        let custom_variable_name = node.to_trimmed_text();
         let custom_variable_name = custom_variable_name.text();
         Some(
             RuleDiagnostic::new(
@@ -244,10 +244,10 @@ fn get_property_name(node: &CssDashedIdentifier) -> Option<Text> {
             return match prop {
                 AnyCssProperty::CssBogusProperty(_) => None,
                 AnyCssProperty::CssComposesProperty(prop) => {
-                    Some(prop.name().ok()?.as_trimmed_text())
+                    Some(prop.name().ok()?.to_trimmed_text())
                 }
                 AnyCssProperty::CssGenericProperty(prop) => {
-                    Some(prop.name().ok()?.as_trimmed_text())
+                    Some(prop.name().ok()?.to_trimmed_text())
                 }
             };
         }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_class.rs
@@ -183,7 +183,7 @@ fn is_webkit_pseudo_class(node: &AnyPseudoLike) -> bool {
         let maybe_selector = CssPseudoElementSelector::cast_ref(prev);
         if let Some(selector) = maybe_selector.as_ref() {
             return WEBKIT_SCROLLBAR_PSEUDO_ELEMENTS
-                .contains(&selector.as_trimmed_text().trim_matches(':'));
+                .contains(&selector.to_trimmed_text().trim_matches(':'));
         };
         prev_element = prev.prev_sibling();
     }

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
@@ -72,16 +72,16 @@ impl Rule for NoUnknownPseudoElement {
 
         let should_not_trigger = match &pseudo_element {
             AnyCssPseudoElement::CssBogusPseudoElement(element) => {
-                should_not_trigger(element.as_trimmed_text().text())
+                should_not_trigger(element.to_trimmed_text().text())
             }
             AnyCssPseudoElement::CssPseudoElementFunctionIdentifier(ident) => {
                 should_not_trigger(ident.name().ok()?.text().into())
             }
             AnyCssPseudoElement::CssPseudoElementFunctionSelector(selector) => {
-                should_not_trigger(selector.as_trimmed_text().text().into())
+                should_not_trigger(selector.to_trimmed_text().text().into())
             }
             AnyCssPseudoElement::CssPseudoElementIdentifier(ident) => {
-                should_not_trigger(ident.name().ok()?.as_trimmed_text().text().into())
+                should_not_trigger(ident.name().ok()?.to_trimmed_text().text().into())
             }
         };
 
@@ -99,7 +99,7 @@ impl Rule for NoUnknownPseudoElement {
                 rule_category!(),
                 span,
                 markup! {
-                    "Unexpected unknown pseudo-elements: "<Emphasis>{ element.as_trimmed_text().text() }</Emphasis>
+                    "Unexpected unknown pseudo-elements: "<Emphasis>{ element.to_trimmed_text().text() }</Emphasis>
                 },
             )
             .note(markup! {

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_pseudo_element.rs
@@ -70,22 +70,22 @@ impl Rule for NoUnknownPseudoElement {
         let node: &CssPseudoElementSelector = ctx.query();
         let pseudo_element = node.element().ok()?;
 
-        let pseudo_element_name = match &pseudo_element {
-            AnyCssPseudoElement::CssBogusPseudoElement(element) => element.to_trimmed_string(),
+        let should_not_trigger = match &pseudo_element {
+            AnyCssPseudoElement::CssBogusPseudoElement(element) => {
+                should_not_trigger(element.as_trimmed_text().text())
+            }
             AnyCssPseudoElement::CssPseudoElementFunctionIdentifier(ident) => {
-                ident.name().ok()?.text().to_string()
+                should_not_trigger(ident.name().ok()?.text().into())
             }
             AnyCssPseudoElement::CssPseudoElementFunctionSelector(selector) => {
-                selector.to_trimmed_string()
+                should_not_trigger(selector.as_trimmed_text().text().into())
             }
             AnyCssPseudoElement::CssPseudoElementIdentifier(ident) => {
-                ident.name().ok()?.to_trimmed_string().to_string()
+                should_not_trigger(ident.name().ok()?.as_trimmed_text().text().into())
             }
         };
 
-        if !vender_prefix(pseudo_element_name.as_str()).is_empty()
-            || is_pseudo_elements(pseudo_element_name.to_ascii_lowercase_cow().as_ref())
-        {
+        if should_not_trigger {
             return None;
         }
 
@@ -99,7 +99,7 @@ impl Rule for NoUnknownPseudoElement {
                 rule_category!(),
                 span,
                 markup! {
-                    "Unexpected unknown pseudo-elements: "<Emphasis>{ element.to_trimmed_string() }</Emphasis>
+                    "Unexpected unknown pseudo-elements: "<Emphasis>{ element.as_trimmed_text().text() }</Emphasis>
                 },
             )
             .note(markup! {
@@ -113,4 +113,10 @@ impl Rule for NoUnknownPseudoElement {
             ),
         )
     }
+}
+
+/// It doesn't trigger the rule if the pseudo-element name isn't a vendor prefix or is a pseudo-element
+fn should_not_trigger(pseudo_element_name: &str) -> bool {
+    !vender_prefix(&pseudo_element_name).is_empty()
+        || is_pseudo_elements(&pseudo_element_name.to_ascii_lowercase_cow().as_ref())
 }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
@@ -73,7 +73,7 @@ impl Rule for NoDuplicateAtImportRules {
                         let import_url = import_rule
                             .url()
                             .ok()?
-                            .as_trimmed_text()
+                            .to_trimmed_text()
                             .to_lowercase_cow()
                             .replace("url(", "")
                             .replace(')', "")
@@ -81,7 +81,7 @@ impl Rule for NoDuplicateAtImportRules {
                         if let Some(media_query_set) = import_url_map.get_mut(&import_url) {
                             // if the current import_rule has no media queries or there are no queries saved in the
                             // media_query_set, this is always a duplicate
-                            if import_rule.media().as_trimmed_text().is_empty()
+                            if import_rule.media().to_trimmed_text().is_empty()
                                 || media_query_set.is_empty()
                             {
                                 return Some(import_rule);
@@ -91,7 +91,7 @@ impl Rule for NoDuplicateAtImportRules {
                                 match media {
                                     Ok(media) => {
                                         if !media_query_set.insert(
-                                            media.as_trimmed_text().to_lowercase_cow().into(),
+                                            media.to_trimmed_text().to_lowercase_cow().into(),
                                         ) {
                                             return Some(import_rule);
                                         }
@@ -105,7 +105,7 @@ impl Rule for NoDuplicateAtImportRules {
                                 match media {
                                     Ok(media) => {
                                         media_set.insert(
-                                            media.as_trimmed_text().to_lowercase_cow().into(),
+                                            media.to_trimmed_text().to_lowercase_cow().into(),
                                         );
                                     }
                                     _ => return None,

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_at_import_rules.rs
@@ -73,7 +73,7 @@ impl Rule for NoDuplicateAtImportRules {
                         let import_url = import_rule
                             .url()
                             .ok()?
-                            .to_trimmed_string()
+                            .as_trimmed_text()
                             .to_lowercase_cow()
                             .replace("url(", "")
                             .replace(')', "")
@@ -81,7 +81,7 @@ impl Rule for NoDuplicateAtImportRules {
                         if let Some(media_query_set) = import_url_map.get_mut(&import_url) {
                             // if the current import_rule has no media queries or there are no queries saved in the
                             // media_query_set, this is always a duplicate
-                            if import_rule.media().to_trimmed_string().is_empty()
+                            if import_rule.media().as_trimmed_text().is_empty()
                                 || media_query_set.is_empty()
                             {
                                 return Some(import_rule);
@@ -91,7 +91,7 @@ impl Rule for NoDuplicateAtImportRules {
                                 match media {
                                     Ok(media) => {
                                         if !media_query_set.insert(
-                                            media.to_trimmed_string().to_lowercase_cow().into(),
+                                            media.as_trimmed_text().to_lowercase_cow().into(),
                                         ) {
                                             return Some(import_rule);
                                         }
@@ -105,7 +105,7 @@ impl Rule for NoDuplicateAtImportRules {
                                 match media {
                                     Ok(media) => {
                                         media_set.insert(
-                                            media.to_trimmed_string().to_lowercase_cow().into(),
+                                            media.as_trimmed_text().to_lowercase_cow().into(),
                                         );
                                     }
                                     _ => return None,

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
@@ -66,7 +66,7 @@ impl Rule for NoDuplicateFontNames {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.as_trimmed_text();
+        let property_name = node.name().ok()?.to_trimmed_text();
         let property_name = property_name.to_ascii_lowercase_cow();
 
         let is_font_family = property_name == "font-family";
@@ -95,7 +95,7 @@ impl Rule for NoDuplicateFontNames {
             match css_value {
                 // A generic family name like `sans-serif` or unquoted font name.
                 AnyCssValue::CssIdentifier(val) => {
-                    let font_name = val.as_trimmed_text();
+                    let font_name = val.to_trimmed_text();
 
                     // check the case: "Arial", Arial
                     // we ignore the case of the font name is a keyword(context: https://github.com/stylelint/stylelint/issues/1284)
@@ -122,7 +122,7 @@ impl Rule for NoDuplicateFontNames {
                 AnyCssValue::CssString(val) => {
                     // FIXME: avoid String allocation
                     let normalized_font_name: String = val
-                        .as_trimmed_text()
+                        .to_trimmed_text()
                         .chars()
                         .filter(|&c| c != '\'' && c != '\"' && !c.is_whitespace())
                         .collect();

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_font_names.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use biome_analyze::{
     Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
@@ -8,6 +6,7 @@ use biome_css_syntax::{AnyCssGenericComponentValue, AnyCssValue, CssGenericPrope
 use biome_diagnostics::Severity;
 use biome_rowan::{AstNode, TextRange};
 use biome_string_case::StrLikeExtension;
+use std::collections::HashSet;
 
 use crate::utils::{find_font_family, is_font_family_keyword};
 
@@ -55,7 +54,7 @@ declare_lint_rule! {
 }
 
 pub struct RuleState {
-    value: String,
+    value: Box<str>,
     span: TextRange,
 }
 
@@ -67,7 +66,7 @@ impl Rule for NoDuplicateFontNames {
 
     fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
         let node = ctx.query();
-        let property_name = node.name().ok()?.to_trimmed_string();
+        let property_name = node.name().ok()?.as_trimmed_text();
         let property_name = property_name.to_ascii_lowercase_cow();
 
         let is_font_family = property_name == "font-family";
@@ -96,41 +95,45 @@ impl Rule for NoDuplicateFontNames {
             match css_value {
                 // A generic family name like `sans-serif` or unquoted font name.
                 AnyCssValue::CssIdentifier(val) => {
-                    let font_name = val.to_trimmed_string();
+                    let font_name = val.as_trimmed_text();
 
                     // check the case: "Arial", Arial
                     // we ignore the case of the font name is a keyword(context: https://github.com/stylelint/stylelint/issues/1284)
                     // e.g "sans-serif", sans-serif
-                    if family_names.contains(&font_name) && !is_font_family_keyword(&font_name) {
+                    if family_names.contains(font_name.text())
+                        && !is_font_family_keyword(&font_name)
+                    {
                         return Some(RuleState {
-                            value: font_name,
+                            value: font_name.into(),
                             span: val.range(),
                         });
                     }
 
                     // check the case: sans-self, sans-self
-                    if unquoted_family_names.contains(&font_name) {
+                    if unquoted_family_names.contains(font_name.text()) {
                         return Some(RuleState {
-                            value: font_name,
+                            value: font_name.into(),
                             span: val.range(),
                         });
                     }
-                    unquoted_family_names.insert(font_name);
+                    unquoted_family_names.insert(font_name.text().into());
                 }
                 // A font family name. e.g "Lucida Grande", "Arial".
                 AnyCssValue::CssString(val) => {
                     // FIXME: avoid String allocation
                     let normalized_font_name: String = val
-                        .to_trimmed_string()
+                        .as_trimmed_text()
                         .chars()
                         .filter(|&c| c != '\'' && c != '\"' && !c.is_whitespace())
                         .collect();
 
                     if family_names.contains(&normalized_font_name)
-                        || unquoted_family_names.contains(&normalized_font_name)
+                        || unquoted_family_names
+                            .iter()
+                            .any(|name| *name == normalized_font_name.as_str())
                     {
                         return Some(RuleState {
-                            value: normalized_font_name,
+                            value: normalized_font_name.into(),
                             span: val.range(),
                         });
                     }

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
@@ -63,7 +63,7 @@ impl Rule for NoDuplicateSelectorsKeyframeBlock {
                     let keyframe_selector = item.selectors().into_iter().next()?.ok()?;
                     if !selector_list.insert(
                         keyframe_selector
-                            .as_trimmed_text()
+                            .to_trimmed_text()
                             .to_ascii_lowercase_cow()
                             .to_string(),
                     ) {

--- a/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_duplicate_selectors_keyframe_block.rs
@@ -63,7 +63,7 @@ impl Rule for NoDuplicateSelectorsKeyframeBlock {
                     let keyframe_selector = item.selectors().into_iter().next()?.ok()?;
                     if !selector_list.insert(
                         keyframe_selector
-                            .to_trimmed_string()
+                            .as_trimmed_text()
                             .to_ascii_lowercase_cow()
                             .to_string(),
                     ) {

--- a/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
@@ -106,7 +106,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                     if let Some(prop_node) = CssGenericProperty::cast_ref(node)
                         .and_then(|property_node| property_node.name().ok())
                     {
-                        let prop = prop_node.as_trimmed_text();
+                        let prop = prop_node.to_trimmed_text();
                         #[expect(clippy::disallowed_methods)]
                         let prop_lowercase = prop.to_lowercase();
 
@@ -192,7 +192,7 @@ impl Rule for NoShorthandPropertyOverrides {
         let query = ctx.query();
 
         Some(NoDeclarationBlockShorthandPropertyOverridesState {
-            target_property: query.property_node.as_trimmed_text().into(),
+            target_property: query.property_node.to_trimmed_text().into(),
             override_property: query.override_property.clone().into(),
             span: query.text_range(),
         })

--- a/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_shorthand_property_overrides.rs
@@ -80,8 +80,8 @@ declare_lint_rule! {
 
 #[derive(Default)]
 struct PriorProperty {
-    original: String,
-    lowercase: String,
+    original: Box<str>,
+    lowercase: Box<str>,
 }
 
 #[derive(Default)]
@@ -106,7 +106,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                     if let Some(prop_node) = CssGenericProperty::cast_ref(node)
                         .and_then(|property_node| property_node.name().ok())
                     {
-                        let prop = prop_node.to_trimmed_string();
+                        let prop = prop_node.as_trimmed_text();
                         #[expect(clippy::disallowed_methods)]
                         let prop_lowercase = prop.to_lowercase();
 
@@ -132,8 +132,8 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
                         });
 
                         self.prior_props_in_block.push(PriorProperty {
-                            original: prop,
-                            lowercase: prop_lowercase,
+                            original: prop.into(),
+                            lowercase: prop_lowercase.into(),
                         });
                     }
                 }
@@ -146,7 +146,7 @@ impl Visitor for NoDeclarationBlockShorthandPropertyOverridesVisitor {
 #[derive(Clone)]
 pub struct NoDeclarationBlockShorthandPropertyOverridesQuery {
     property_node: AnyCssDeclarationName,
-    override_property: String,
+    override_property: Box<str>,
 }
 
 impl QueryMatch for NoDeclarationBlockShorthandPropertyOverridesQuery {
@@ -177,8 +177,8 @@ impl Queryable for NoDeclarationBlockShorthandPropertyOverridesQuery {
 }
 
 pub struct NoDeclarationBlockShorthandPropertyOverridesState {
-    target_property: String,
-    override_property: String,
+    target_property: Box<str>,
+    override_property: Box<str>,
     span: TextRange,
 }
 
@@ -192,8 +192,8 @@ impl Rule for NoShorthandPropertyOverrides {
         let query = ctx.query();
 
         Some(NoDeclarationBlockShorthandPropertyOverridesState {
-            target_property: query.property_node.to_trimmed_string(),
-            override_property: query.override_property.clone(),
+            target_property: query.property_node.as_trimmed_text().into(),
+            override_property: query.override_property.clone().into(),
             span: query.text_range(),
         })
     }

--- a/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noUnknownPseudoClass/invalid.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: invalid.css
+snapshot_kind: text
 ---
 # Input
 ```css
@@ -201,39 +202,6 @@ invalid.css:13:2 lint/nursery/noUnknownPseudoClass ━━━━━━━━━�
        │  ^^^^^^^^^^^
     14 │ @page :blank:unknown { }
     15 │ @page foo:unknown { }
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```
-invalid.css:14:14 lint/nursery/noUnknownPseudoClass ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown pseudo-class unknown 
-  
-    12 │ :slotted {}
-    13 │ :placeholder {}
-  > 14 │ @page :blank:unknown { }
-       │              ^^^^^^^
-    15 │ @page foo:unknown { }
-    16 │ :horizontal:decrement {}
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```
-invalid.css:15:11 lint/nursery/noUnknownPseudoClass ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown pseudo-class unknown 
-  
-    13 │ :placeholder {}
-    14 │ @page :blank:unknown { }
-  > 15 │ @page foo:unknown { }
-       │           ^^^^^^^
-    16 │ :horizontal:decrement {}
   
   i See MDN web docs for more details.
   

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -225,7 +225,7 @@ where
     let css_property = list
         .parent::<CssGenericProperty>()
         .and_then(|parent| parent.name().ok())
-        .and_then(|name| name.as_css_identifier().map(|name| name.as_trimmed_text()));
+        .and_then(|name| name.as_css_identifier().map(|name| name.to_trimmed_text()));
     let is_grid_property = css_property.as_ref().is_some_and(|name| {
         let name = name.to_ascii_lowercase_cow();
 

--- a/crates/biome_css_formatter/src/utils/component_value_list.rs
+++ b/crates/biome_css_formatter/src/utils/component_value_list.rs
@@ -1,14 +1,12 @@
-use std::cmp;
-
+use crate::CssFormatter;
 use crate::comments::CssComments;
+use crate::prelude::*;
 use biome_css_syntax::{CssGenericDelimiter, CssGenericProperty, CssLanguage, CssSyntaxKind};
 use biome_formatter::{CstFormatContext, write};
 use biome_formatter::{FormatOptions, FormatResult};
-use biome_string_case::StrLikeExtension;
-
-use crate::CssFormatter;
-use crate::prelude::*;
 use biome_rowan::{AstNode, AstNodeList, TextSize};
+use biome_string_case::StrLikeExtension;
+use std::cmp;
 
 pub(crate) fn write_component_value_list<N, I>(node: &N, f: &mut CssFormatter) -> FormatResult<()>
 where
@@ -227,10 +225,7 @@ where
     let css_property = list
         .parent::<CssGenericProperty>()
         .and_then(|parent| parent.name().ok())
-        .and_then(|name| {
-            name.as_css_identifier()
-                .map(|name| name.to_trimmed_string())
-        });
+        .and_then(|name| name.as_css_identifier().map(|name| name.as_trimmed_text()));
     let is_grid_property = css_property.as_ref().is_some_and(|name| {
         let name = name.to_ascii_lowercase_cow();
 
@@ -256,7 +251,7 @@ where
         ValueListLayout::PreserveInline
     } else if list.len() == 1 {
         ValueListLayout::SingleValue
-    } else if use_one_group_per_line(css_property, list) {
+    } else if use_one_group_per_line(css_property.as_deref(), list) {
         ValueListLayout::OneGroupPerLine
     } else if is_comma_separated
         && value_count > 12
@@ -268,7 +263,7 @@ where
     }
 }
 
-pub(crate) fn use_one_group_per_line<N, I>(css_property: Option<String>, list: &N) -> bool
+pub(crate) fn use_one_group_per_line<N, I>(css_property: Option<&str>, list: &N) -> bool
 where
     N: AstNodeList<Language = CssLanguage, Node = I> + AstNode<Language = CssLanguage>,
     I: AstNode<Language = CssLanguage> + IntoFormat<CssFormatContext>,

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -79,7 +79,7 @@ impl Rule for NoAriaHiddenOnFocusable {
 
                 match tabindex_val {
                     AnyJsxAttributeValue::AnyJsxTag(jsx_tag) => {
-                        let value = jsx_tag.to_trimmed_string().parse::<i32>();
+                        let value = jsx_tag.as_trimmed_text().text().parse::<i32>();
                         if let Ok(num) = value {
                             return (num >= 0).then_some(());
                         }

--- a/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_aria_hidden_on_focusable.rs
@@ -79,7 +79,7 @@ impl Rule for NoAriaHiddenOnFocusable {
 
                 match tabindex_val {
                     AnyJsxAttributeValue::AnyJsxTag(jsx_tag) => {
-                        let value = jsx_tag.as_trimmed_text().text().parse::<i32>();
+                        let value = jsx_tag.to_trimmed_text().text().parse::<i32>();
                         if let Ok(num) = value {
                             return (num >= 0).then_some(());
                         }

--- a/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
 
 impl Rule for UseFocusableInteractive {
     type Query = Aria<AnyJsxElement>;
-    type State = String;
+    type State = Box<str>;
     type Signals = Option<Self::State>;
     type Options = ();
 
@@ -68,7 +68,7 @@ impl Rule for UseFocusableInteractive {
                 if attribute_has_interactive_role(&role_attribute_value)?
                     && tabindex_attribute.is_none()
                 {
-                    return Some(role_attribute_value.to_trimmed_string());
+                    return Some(role_attribute_value.as_trimmed_text().text().into());
                 }
             }
         }

--- a/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_focusable_interactive.rs
@@ -68,7 +68,7 @@ impl Rule for UseFocusableInteractive {
                 if attribute_has_interactive_role(&role_attribute_value)?
                     && tabindex_attribute.is_none()
                 {
-                    return Some(role_attribute_value.as_trimmed_text().text().into());
+                    return Some(role_attribute_value.to_trimmed_text().text().into());
                 }
             }
         }

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
@@ -357,7 +357,7 @@ fn extract_string_value(expression: &Option<AnyJsExpression>) -> Option<String> 
                     String::new(),
                     |acc, element| {
                         if let Some(chunk) = element.as_js_template_chunk_element() {
-                            return acc + chunk.to_trimmed_string().as_str();
+                            return acc + chunk.as_trimmed_text().text();
                         }
                         acc
                     },

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_string_concat.rs
@@ -357,7 +357,7 @@ fn extract_string_value(expression: &Option<AnyJsExpression>) -> Option<String> 
                     String::new(),
                     |acc, element| {
                         if let Some(chunk) = element.as_js_template_chunk_element() {
-                            return acc + chunk.as_trimmed_text().text();
+                            return acc + chunk.to_trimmed_text().text();
                         }
                         acc
                     },

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -529,8 +529,8 @@ impl LogicalAndChain {
                 // they should be considered different even if `main_value_token`
                 // and `branch_value_token` are the same.
                 // Therefore, we need to check their arguments here.
-                if main_call_expression_args.args().as_trimmed_text()
-                    != branch_call_expression_args.args().as_trimmed_text()
+                if main_call_expression_args.args().to_trimmed_text()
+                    != branch_call_expression_args.args().to_trimmed_text()
                 {
                     return Ok(LogicalAndChainOrdering::Different);
                 }

--- a/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_optional_chain.rs
@@ -529,8 +529,8 @@ impl LogicalAndChain {
                 // they should be considered different even if `main_value_token`
                 // and `branch_value_token` are the same.
                 // Therefore, we need to check their arguments here.
-                if main_call_expression_args.args().to_trimmed_string()
-                    != branch_call_expression_args.args().to_trimmed_string()
+                if main_call_expression_args.args().as_trimmed_text()
+                    != branch_call_expression_args.args().as_trimmed_text()
                 {
                     return Ok(LogicalAndChainOrdering::Different);
                 }

--- a/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
@@ -74,7 +74,7 @@ impl Rule for NoFlatMapIdentity {
                 AnyJsExpression::JsArrowFunctionExpression(arg) => {
                     let parameter: String = match arg.parameters().ok()? {
                         biome_js_syntax::AnyJsArrowFunctionParameters::AnyJsBinding(p) => {
-                            p.to_trimmed_string().trim_matches(['(', ')']).to_owned()
+                            p.as_trimmed_text().trim_matches(['(', ')']).to_owned()
                         }
                         biome_js_syntax::AnyJsArrowFunctionParameters::JsParameters(p) => {
                             if p.items().len() == 1 {

--- a/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_flat_map_identity.rs
@@ -74,7 +74,7 @@ impl Rule for NoFlatMapIdentity {
                 AnyJsExpression::JsArrowFunctionExpression(arg) => {
                     let parameter: String = match arg.parameters().ok()? {
                         biome_js_syntax::AnyJsArrowFunctionParameters::AnyJsBinding(p) => {
-                            p.as_trimmed_text().trim_matches(['(', ')']).to_owned()
+                            p.to_trimmed_text().trim_matches(['(', ')']).to_owned()
                         }
                         biome_js_syntax::AnyJsArrowFunctionParameters::JsParameters(p) => {
                             if p.items().len() == 1 {

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -385,7 +385,7 @@ fn has_key_attribute(attributes: &JsxAttributeList) -> bool {
         // key must be statically provided, so no spread
         if let AnyJsxAttribute::JsxAttribute(attr) = attr {
             if let Ok(name) = attr.name() {
-                name.as_trimmed_text().text() == "key"
+                name.to_trimmed_text().text() == "key"
             } else {
                 false
             }

--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -385,7 +385,7 @@ fn has_key_attribute(attributes: &JsxAttributeList) -> bool {
         // key must be statically provided, so no spread
         if let AnyJsxAttribute::JsxAttribute(attr) = attr {
             if let Ok(name) = attr.name() {
-                name.to_trimmed_string() == "key"
+                name.as_trimmed_text().text() == "key"
             } else {
                 false
             }

--- a/crates/biome_js_analyze/src/lint/nursery/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_process_env.rs
@@ -55,7 +55,7 @@ impl Rule for NoProcessEnv {
         let model = ctx.model();
         let object = static_member_expr.object().ok()?;
         let member_expr = static_member_expr.member().ok()?;
-        if member_expr.as_js_name()?.to_trimmed_string() != "env" {
+        if member_expr.as_js_name()?.as_trimmed_text().text() != "env" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_process_env.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_process_env.rs
@@ -55,7 +55,7 @@ impl Rule for NoProcessEnv {
         let model = ctx.model();
         let object = static_member_expr.object().ok()?;
         let member_expr = static_member_expr.member().ok()?;
-        if member_expr.as_js_name()?.as_trimmed_text().text() != "env" {
+        if member_expr.as_js_name()?.to_trimmed_text().text() != "env" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
@@ -283,7 +283,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
             else {
                 return Some(false);
             };
-            if left_member.to_trimmed_string() != right_member.to_trimmed_string() {
+            if left_member.as_trimmed_text() != right_member.as_trimmed_text() {
                 return Some(false);
             }
             is_same_reference(left.object().ok()?, right.object().ok()?)
@@ -295,7 +295,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
         ) => {
             let left_member = left.member().ok()?;
             let right_member = right.member().ok()?;
-            if left_member.to_trimmed_string() != right_member.to_trimmed_string() {
+            if left_member.as_trimmed_text() != right_member.as_trimmed_text() {
                 Some(false)
             } else {
                 is_same_reference(left.object().ok()?, right.object().ok()?)
@@ -305,7 +305,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
         (
             AnyJsExpression::JsIdentifierExpression(left),
             AnyJsExpression::JsIdentifierExpression(right),
-        ) => Some(left.name().ok()?.to_trimmed_string() == right.name().ok()?.to_trimmed_string()),
+        ) => Some(left.name().ok()?.as_trimmed_text() == right.name().ok()?.as_trimmed_text()),
         // this
         (AnyJsExpression::JsThisExpression(_), AnyJsExpression::JsThisExpression(_)) => Some(true),
         _ => Some(false),

--- a/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_at_index.rs
@@ -283,7 +283,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
             else {
                 return Some(false);
             };
-            if left_member.as_trimmed_text() != right_member.as_trimmed_text() {
+            if left_member.to_trimmed_text() != right_member.to_trimmed_text() {
                 return Some(false);
             }
             is_same_reference(left.object().ok()?, right.object().ok()?)
@@ -295,7 +295,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
         ) => {
             let left_member = left.member().ok()?;
             let right_member = right.member().ok()?;
-            if left_member.as_trimmed_text() != right_member.as_trimmed_text() {
+            if left_member.to_trimmed_text() != right_member.to_trimmed_text() {
                 Some(false)
             } else {
                 is_same_reference(left.object().ok()?, right.object().ok()?)
@@ -305,7 +305,7 @@ fn is_same_reference(left: AnyJsExpression, right: AnyJsExpression) -> Option<bo
         (
             AnyJsExpression::JsIdentifierExpression(left),
             AnyJsExpression::JsIdentifierExpression(right),
-        ) => Some(left.name().ok()?.as_trimmed_text() == right.name().ok()?.as_trimmed_text()),
+        ) => Some(left.name().ok()?.to_trimmed_text() == right.name().ok()?.to_trimmed_text()),
         // this
         (AnyJsExpression::JsThisExpression(_), AnyJsExpression::JsThisExpression(_)) => Some(true),
         _ => Some(false),

--- a/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
@@ -364,7 +364,7 @@ fn extract_string_value(expression: AnyJsExpression) -> Option<String> {
     match expression {
         AnyJsExpression::JsUnaryExpression(unary) => match unary.operator() {
             Ok(JsUnaryOperator::Minus) => {
-                let argument = unary.argument().ok()?.as_trimmed_text();
+                let argument = unary.argument().ok()?.to_trimmed_text();
                 let is_numeric_literal = unary.is_signed_numeric_literal().ok()?;
                 is_numeric_literal.then_some(String::from("-") + argument.text())
             }

--- a/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_yoda_expression.rs
@@ -364,9 +364,9 @@ fn extract_string_value(expression: AnyJsExpression) -> Option<String> {
     match expression {
         AnyJsExpression::JsUnaryExpression(unary) => match unary.operator() {
             Ok(JsUnaryOperator::Minus) => {
-                let argument = unary.argument().ok()?.to_trimmed_string();
+                let argument = unary.argument().ok()?.as_trimmed_text();
                 let is_numeric_literal = unary.is_signed_numeric_literal().ok()?;
-                is_numeric_literal.then_some(String::from("-") + argument.as_str())
+                is_numeric_literal.then_some(String::from("-") + argument.text())
             }
             _ => None,
         },

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -131,11 +131,11 @@ impl Rule for UseNumberNamespace {
         let node = ctx.query();
         let (old_node, new_node) = match node {
             AnyJsExpression::JsIdentifierExpression(expression) => {
-                let name = expression.name().ok()?.to_trimmed_string();
-                if !GLOBAL_NUMBER_PROPERTIES.contains(&name.as_str()) {
+                let name = expression.name().ok()?.as_trimmed_text();
+                if !GLOBAL_NUMBER_PROPERTIES.contains(&name.text()) {
                     return None;
                 }
-                let (old_node, replacement) = match name.as_str() {
+                let (old_node, replacement) = match name.text() {
                     "Infinity" => {
                         if let Some(parent) = node.parent::<JsUnaryExpression>() {
                             match parent.operator().ok()? {
@@ -153,7 +153,7 @@ impl Rule for UseNumberNamespace {
                             (node.clone(), "POSITIVE_INFINITY")
                         }
                     }
-                    _ => (node.clone(), name.as_str()),
+                    _ => (node.clone(), name.text()),
                 };
                 (
                     old_node,

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -131,7 +131,7 @@ impl Rule for UseNumberNamespace {
         let node = ctx.query();
         let (old_node, new_node) = match node {
             AnyJsExpression::JsIdentifierExpression(expression) => {
-                let name = expression.name().ok()?.as_trimmed_text();
+                let name = expression.name().ok()?.to_trimmed_text();
                 if !GLOBAL_NUMBER_PROPERTIES.contains(&name.text()) {
                     return None;
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
@@ -43,19 +43,19 @@ declare_lint_rule! {
 
 impl Rule for NoDuplicateJsxProps {
     type Query = Ast<AnyJsxElement>;
-    type State = (String, Vec<JsxAttribute>);
-    type Signals = FxHashMap<String, Vec<JsxAttribute>>;
+    type State = (Box<str>, Vec<JsxAttribute>);
+    type Signals = FxHashMap<Box<str>, Vec<JsxAttribute>>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
 
-        let mut defined_attributes: FxHashMap<String, Vec<JsxAttribute>> = FxHashMap::default();
+        let mut defined_attributes: FxHashMap<Box<str>, Vec<JsxAttribute>> = FxHashMap::default();
         for attribute in node.attributes() {
             if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
                 if let Ok(name) = attr.name() {
                     defined_attributes
-                        .entry(name.to_trimmed_string())
+                        .entry(name.as_trimmed_text().text().into())
                         .or_default()
                         .push(attr);
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_jsx_props.rs
@@ -55,7 +55,7 @@ impl Rule for NoDuplicateJsxProps {
             if let AnyJsxAttribute::JsxAttribute(attr) = attribute {
                 if let Ok(name) = attr.name() {
                     defined_attributes
-                        .entry(name.as_trimmed_text().text().into())
+                        .entry(name.to_trimmed_text().text().into())
                         .or_default()
                         .push(attr);
                 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_redeclare.rs
@@ -145,7 +145,7 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
                 if let Some(decl) = id_binding.declaration() {
                     // Ignore the function itself.
                     if !matches!(decl, AnyJsBindingDeclaration::JsFunctionExpression(_)) {
-                        let name = id_binding.as_trimmed_text();
+                        let name = id_binding.to_trimmed_text();
                         declarations.insert(
                             name.text().into(),
                             (id_binding.syntax().text_trimmed_range(), decl),
@@ -161,7 +161,7 @@ fn check_redeclarations_in_single_scope(scope: &Scope, redeclarations: &mut Vec<
         // We consider only binding of a declaration
         // This allows to skip function parameters, methods, ...
         if let Some(decl) = id_binding.declaration() {
-            let name = id_binding.as_trimmed_text();
+            let name = id_binding.to_trimmed_text();
             if let Some((first_text_range, first_decl)) = declarations.get(name.text()) {
                 // Do not report:
                 // - mergeable declarations.

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -18,6 +18,7 @@ mod mutation;
 use crate::syntax::{SyntaxSlot, SyntaxSlots};
 use crate::{
     Language, RawSyntaxKind, SyntaxKind, SyntaxList, SyntaxNode, SyntaxToken, SyntaxTriviaPiece,
+    Text,
 };
 pub use batch::*;
 pub use mutation::{AstNodeExt, AstNodeListExt, AstSeparatedListExt};
@@ -215,6 +216,11 @@ pub trait AstNode: Clone {
     /// This function allocates a [String]
     fn to_trimmed_string(&self) -> std::string::String {
         self.syntax().text_trimmed().to_string()
+    }
+
+    /// Returns the string representation of this node without trivia, without allocating a string, if possible
+    fn as_trimmed_text(&self) -> Text {
+        self.syntax().text_trimmed().into_text()
     }
 
     fn range(&self) -> TextRange {

--- a/crates/biome_rowan/src/ast/mod.rs
+++ b/crates/biome_rowan/src/ast/mod.rs
@@ -219,7 +219,7 @@ pub trait AstNode: Clone {
     }
 
     /// Returns the string representation of this node without trivia, without allocating a string, if possible
-    fn as_trimmed_text(&self) -> Text {
+    fn to_trimmed_text(&self) -> Text {
         self.syntax().text_trimmed().into_text()
     }
 

--- a/crates/biome_rowan/src/text.rs
+++ b/crates/biome_rowan/src/text.rs
@@ -93,6 +93,12 @@ impl From<Text> for String {
     }
 }
 
+impl From<Text> for Box<str> {
+    fn from(value: Text) -> Self {
+        Box::from(value.text())
+    }
+}
+
 impl Text {
     pub fn text(&self) -> &str {
         match self {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Took a stab at removing the use to `to_trimmed_string` from some rules, because that method **allocates** a string.

I created a small utility to avoid using `syntax().text_trimmed().into_text()`.

I managed to remove it from the CSS rules, and few of the JS rules, but there are other rules where I didn't check, and some other places where it's needed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should stay green. One snapshot was updated because it was linting bogus nodes, but usually we don't force the handling of them, so it's fine not to handle that case.

<!-- What demonstrates that your implementation is correct? -->
