### PR TITLE
fix(editorconfig): parse char classes in globs

### DIFF
--- a/.changeset/editorconfig-charclass-parsing.md
+++ b/.changeset/editorconfig-charclass-parsing.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5410](https://github.com/biomejs/biome/issues/5410). Biome now correctly parse an `.editorconfig` that includes character classes in glob patterns.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,12 +4492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "vte"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,6 @@ dependencies = [
  "rustc-hash 2.1.1",
  "schemars",
  "serde",
- "serde_ini",
  "tests_macros",
 ]
 
@@ -417,7 +416,6 @@ dependencies = [
  "oxc_resolver",
  "schemars",
  "serde",
- "serde_ini",
  "serde_json",
  "termcolor",
  "terminal_size",
@@ -3449,12 +3447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "result"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
-
-[[package]]
 name = "rgb"
 version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,17 +3707,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
-]
-
-[[package]]
-name = "serde_ini"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb236687e2bb073a7521c021949be944641e671b8505a94069ca37b656c81139"
-dependencies = [
- "result",
- "serde",
- "void",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,6 @@ rust-lapper          = "1.1.0"
 rustc-hash           = "2.1.1"
 schemars             = { version = "0.8.22", features = ["indexmap2", "smallvec"] }
 serde                = { version = "1.0.219", features = ["derive"] }
-serde_ini            = "0.2.0"
 serde_json           = "1.0.140"
 similar              = "2.7.0"
 smallvec             = { version = "1.15.0", features = ["union", "const_new", "serde"] }

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -512,3 +512,53 @@ indent_size = 8
         result,
     ));
 }
+
+#[test]
+fn non_closed_section() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Utf8Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*
+indent_style = space
+indent_size = 8
+"#,
+    );
+
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["format"].as_slice()));
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "non_closed_section",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn root_parse_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Utf8Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+root = on
+"#,
+    );
+
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["format"].as_slice()));
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "root_parse_error",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/cases/editorconfig.rs
+++ b/crates/biome_cli/tests/cases/editorconfig.rs
@@ -562,3 +562,53 @@ root = on
         result,
     ));
 }
+
+#[test]
+fn end_of_line_parse_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Utf8Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+[*]
+end_of_line = lfcr
+"#,
+    );
+
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["format"].as_slice()));
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "end_of_line_parse_error",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn indent_size_parse_error() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let editorconfig = Utf8Path::new(".editorconfig");
+    fs.insert(
+        editorconfig.into(),
+        r#"
+  [*]
+  indent_size = 1000
+"#,
+    );
+
+    let (fs, result) = run_cli(fs, &mut console, Args::from(["format"].as_slice()));
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "indent_size_parse_error",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/end_of_line_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/end_of_line_parse_error.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*]
+end_of_line = lfcr
+
+```
+
+# Termination Message
+
+```block
+.editorconfig:3:15 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Invalid `end_of_line` value: `lf`, `cr`, or `crlf` is expected.
+  
+    2 │ [*]
+  > 3 │ end_of_line = lfcr
+      │               ^^^^
+    4 │ 
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/indent_size_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/indent_size_parse_error.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `.editorconfig`
+
+```editorconfig
+
+  [*]
+  indent_size = 1000
+
+```
+
+# Termination Message
+
+```block
+.editorconfig:3:17 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × number too large to fit in target type
+  
+    2 │   [*]
+  > 3 │   indent_size = 1000
+      │                 ^^^^
+    4 │ 
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/non_closed_section.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/non_closed_section.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `.editorconfig`
+
+```editorconfig
+
+[*
+indent_style = space
+indent_size = 8
+
+```
+
+# Termination Message
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Failed to parse the .editorconfig file.
+    
+    Caused by:
+      a section must be closed with `]`
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/non_closed_section.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/non_closed_section.snap
@@ -15,12 +15,14 @@ indent_size = 8
 # Termination Message
 
 ```block
-configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.editorconfig:2:1 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Failed to parse the .editorconfig file.
-    
-    Caused by:
-      a section must be closed with `]`
+  × A section must be closed with `]`.
+  
+  > 2 │ [*
+      │ ^^
+    3 │ indent_style = space
+    4 │ indent_size = 8
   
 
 

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/root_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/root_parse_error.snap
@@ -1,0 +1,25 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `.editorconfig`
+
+```editorconfig
+
+root = on
+
+```
+
+# Termination Message
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Failed to parse the .editorconfig file.
+    
+    Caused by:
+      provided string was not `true` or `false`
+  
+
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/root_parse_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/root_parse_error.snap
@@ -13,12 +13,13 @@ root = on
 # Termination Message
 
 ```block
-configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+.editorconfig:2:8 configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Failed to parse the .editorconfig file.
-    
-    Caused by:
-      provided string was not `true` or `false`
+  × Invalid boolean value: `true` or `false` is expected.
+  
+  > 2 │ root = on
+      │        ^^
+    3 │ 
   
 
 

--- a/crates/biome_configuration/Cargo.toml
+++ b/crates/biome_configuration/Cargo.toml
@@ -19,7 +19,7 @@ biome_css_analyze        = { workspace = true }
 biome_css_syntax         = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }
-biome_diagnostics        = { workspace = true, features = ["serde_ini", "oxc_resolver"] }
+biome_diagnostics        = { workspace = true, features = ["oxc_resolver"] }
 biome_flags              = { workspace = true }
 biome_formatter          = { workspace = true, features = ["serde"] }
 biome_glob               = { workspace = true }
@@ -41,7 +41,6 @@ regex                    = { workspace = true }
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }
-serde_ini                = { workspace = true }
 
 [features]
 default = ["schema"]

--- a/crates/biome_diagnostics/Cargo.toml
+++ b/crates/biome_diagnostics/Cargo.toml
@@ -40,7 +40,6 @@ enumflags2                   = { workspace = true, features = ["serde"] }
 oxc_resolver                 = { workspace = true, optional = true }
 schemars                     = { workspace = true, optional = true }
 serde                        = { workspace = true, features = ["derive"] }
-serde_ini                    = { workspace = true, optional = true }
 serde_json                   = { workspace = true }
 termcolor                    = { workspace = true }
 terminal_size                = { workspace = true }
@@ -51,7 +50,6 @@ bpaf         = ["dep:bpaf"]
 camino       = ["dep:camino"]
 oxc_resolver = ["dep:oxc_resolver"]
 schema       = ["dep:schemars", "biome_text_edit/schema", "biome_diagnostics_categories/schema", "biome_console/schema"]
-serde_ini    = ["dep:serde_ini"]
 std          = []
 
 [dev-dependencies]

--- a/crates/biome_diagnostics/src/adapters.rs
+++ b/crates/biome_diagnostics/src/adapters.rs
@@ -173,45 +173,6 @@ impl Diagnostic for SerdeJsonError {
     }
 }
 
-#[cfg(feature = "serde_ini")]
-#[derive(Debug, Clone)]
-pub struct IniError {
-    error: serde_ini::de::Error,
-}
-
-#[cfg(feature = "serde_ini")]
-impl Diagnostic for IniError {
-    fn category(&self) -> Option<&'static Category> {
-        Some(category!("configuration"))
-    }
-
-    fn severity(&self) -> crate::Severity {
-        crate::Severity::Error
-    }
-
-    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(fmt, "{}", self.error)
-    }
-
-    fn message(&self, fmt: &mut fmt::Formatter<'_>) -> std::io::Result<()> {
-        fmt.write_markup(markup!({ AsConsoleDisplay(&self.error) }))
-    }
-}
-
-#[cfg(feature = "serde_ini")]
-impl biome_console::fmt::Display for IniError {
-    fn fmt(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
-        write!(fmt, "{:?}", self.error)
-    }
-}
-
-#[cfg(feature = "serde_ini")]
-impl From<serde_ini::de::Error> for IniError {
-    fn from(error: serde_ini::de::Error) -> Self {
-        Self { error }
-    }
-}
-
 #[cfg(feature = "camino")]
 #[derive(Debug, Clone)]
 pub struct CaminoError {

--- a/crates/biome_diagnostics/src/lib.rs
+++ b/crates/biome_diagnostics/src/lib.rs
@@ -16,9 +16,6 @@ pub mod serde;
 #[cfg(feature = "camino")]
 pub use adapters::CaminoError;
 
-#[cfg(feature = "serde_ini")]
-pub use adapters::IniError;
-
 #[cfg(feature = "oxc_resolver")]
 pub use adapters::ResolveError;
 


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5410

I finally decided to implement our own parser because the format used by EditorConfig is really simple.

## Test Plan

I added a test.
