### PR TITLE
fix(core): handle `.mjs` extension in CommonJS packages

### DIFF
--- a/.changeset/fix-mjs-in-commonjs-package.md
+++ b/.changeset/fix-mjs-in-commonjs-package.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5606](https://github.com/biomejs/biome/issues/5606): We now correctly
+handle `.mjs` extensions in Node.js packages with `"type": "commonjs"`.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_lint_module_in_commonjs_package.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_lint_module_in_commonjs_package.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "files": { "includes": ["**/*"] } }
+```
+
+## `package.json`
+
+```json
+{ "type": "commonjs" }
+```
+
+## `src/file.mjs`
+
+```mjs
+import { foo } from "foo";
+var a = foo;
+
+```
+
+# Emitted Messages
+
+```block
+Checked 3 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -308,10 +308,12 @@ impl WorkspaceServer {
         let mut source = document_file_source.unwrap_or(DocumentFileSource::from_path(&path));
 
         if let DocumentFileSource::Js(js) = &mut source {
-            let manifest = self.project_layout.get_node_manifest_for_path(&path);
-            if let Some((_, manifest)) = manifest {
-                if manifest.r#type == Some(PackageType::CommonJs) && js.file_extension() == "js" {
-                    js.set_module_kind(ModuleKind::Script);
+            if path.extension().is_some_and(|extension| extension == "js") {
+                let manifest = self.project_layout.get_node_manifest_for_path(&path);
+                if let Some((_, manifest)) = manifest {
+                    if manifest.r#type == Some(PackageType::CommonJs) {
+                        js.set_module_kind(ModuleKind::Script);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #5605.

We made the mistake of looking at the extension of the `DocumentFileSource`, whose extension doesn't necessarily match the real extension of the path it is derived from.

## Test Plan

Added test case.
