### PR TITLE
fix(analyzer): use binary search to find diagnostics

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -519,15 +519,19 @@ where
                     let index =
                         self.suppressions
                             .line_suppressions
-                            .partition_point(|suppression| {
-                                suppression.text_range.end() < entry.text_range.start()
+                            .binary_search_by(|suppression| {
+                                if suppression.text_range.end() < entry.text_range.start() {
+                                    Ordering::Less
+                                } else if entry.text_range.end() < suppression.text_range.start() {
+                                    Ordering::Greater
+                                } else {
+                                    Ordering::Equal
+                                }
                             });
 
-                    if index >= self.suppressions.line_suppressions.len() {
-                        None
-                    } else {
-                        Some(&mut self.suppressions.line_suppressions[index])
-                    }
+                    index
+                        .ok()
+                        .map(|index| &mut self.suppressions.line_suppressions[index])
                 }
             };
 

--- a/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_arrow_function.rs
@@ -126,6 +126,15 @@ impl Rule for UseArrowFunction {
         Some(())
     }
 
+    fn text_range(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<TextRange> {
+        let node = ctx.query();
+        let AnyThisScopeMetadata { scope, .. } = node;
+        let AnyThisScope::JsFunctionExpression(function_expression) = scope else {
+            return None;
+        };
+        Some(function_expression.function_token().ok()?.text_range())
+    }
+
     fn diagnostic(ctx: &RuleContext<Self>, _: &Self::State) -> Option<RuleDiagnostic> {
         Some(
             RuleDiagnostic::new(


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/5562


The regression was introduced by https://github.com/biomejs/biome/pull/4714

The real issue wasn't how we suppressions were discovered, but by the fact that the diagnostic was emitting a text range that was spanning over multiple lines, and this was tripping the suppression engine.

Usually, text ranges emitted by our rules should be in one line, and that's what `text_range` is for. I implemented the function for the rule that was at fault, and now everything works again :) 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new tests. No changesets needed, since it's a fix of a fix, so the original changeset is still valid. 

<!-- What demonstrates that your implementation is correct? -->
