### PR TITLE
feat(organizeImports): add import matchers

### DIFF
--- a/crates/biome_deserialize_macros/src/deserializable_derive.rs
+++ b/crates/biome_deserialize_macros/src/deserializable_derive.rs
@@ -59,7 +59,7 @@ impl DeriveInput {
                         let ident = variant.ident;
                         let key = attrs
                             .rename
-                            .unwrap_or_else(|| Case::Camel.convert(&ident.to_string()));
+                            .unwrap_or_else(|| Case::Camel.convert(ident.to_string().trim_start_matches("r#")));
 
                         DeserializableVariantData { ident, key }
                     })
@@ -85,9 +85,9 @@ impl DeriveInput {
                                     return None;
                                 }
 
-                                let key = attrs
-                                    .rename
-                                    .unwrap_or_else(|| Case::Camel.convert(&ident.to_string()));
+                                let key = attrs.rename.unwrap_or_else(|| {
+                                    Case::Camel.convert(ident.to_string().trim_start_matches("r#"))
+                                });
 
                                 if rest_field.is_some() && attrs.rest {
                                     abort!(

--- a/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
@@ -5,7 +5,10 @@ use biome_js_syntax::{
 use biome_rowan::AstNode;
 
 use super::{
-    TypePlacement, comparable_token::ComparableToken, import_groups, import_source,
+    TypePlacement,
+    comparable_token::ComparableToken,
+    import_groups::{self, ImportCandidate, ImportSourceCandidate},
+    import_source,
     specifiers_attributes::JsNamedSpecifiers,
 };
 
@@ -33,7 +36,7 @@ impl ImportKey {
         };
         Self {
             section,
-            group: groups.index(&info),
+            group: groups.index(&((&info).into())),
             source: info.source,
             has_no_attributes: info.has_no_attributes,
             kind: info.kind,
@@ -234,5 +237,13 @@ impl ImportInfo {
             named_specifiers.map(JsNamedSpecifiers::JsExportNamedFromSpecifierList),
             attributes,
         ))
+    }
+}
+impl<'a> From<&'a ImportInfo> for ImportCandidate<'a> {
+    fn from(value: &'a ImportInfo) -> Self {
+        Self {
+            has_type_token: value.kind.has_type_token(),
+            source: ImportSourceCandidate::new(&value.source),
+        }
     }
 }

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.options.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": {
+					"level": "on",
+					"options": {
+                        "groups": [
+							[{ "type": true, "source": [":NODE:", ":URL:"] }, "exception"],
+							{ "type": true, "source": ":BUN:" },
+							{ "type": true },
+                            [":NODE:", ":URL:"],
+                            ":BUN:"
+                        ]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts
@@ -1,0 +1,10 @@
+import V1 from "bun:package";
+import V2 from "node:package";
+import V3 from "package";
+import V4 from "https://example.com";
+import V5 from "exception";
+import type T1 from "bun:package";
+import type T2 from "node:package";
+import type T3 from "package";
+import type T4 from "https://example.com";
+

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-first-groups.ts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: type-first-groups.ts
+---
+# Input
+```ts
+import V1 from "bun:package";
+import V2 from "node:package";
+import V3 from "package";
+import V4 from "https://example.com";
+import V5 from "exception";
+import type T1 from "bun:package";
+import type T2 from "node:package";
+import type T3 from "package";
+import type T4 from "https://example.com";
+
+
+```
+
+# Diagnostics
+```
+type-first-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 1 │ import V1 from "bun:package";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ import V2 from "node:package";
+    3 │ import V3 from "package";
+  
+  i Safe fix: Organize Imports (Biome)
+  
+     1    │ - import·V1·from·"bun:package";
+     2    │ - import·V2·from·"node:package";
+     3    │ - import·V3·from·"package";
+     4    │ - import·V4·from·"https://example.com";
+     5    │ - import·V5·from·"exception";
+     6    │ - import·type·T1·from·"bun:package";
+     7    │ - import·type·T2·from·"node:package";
+     8    │ - import·type·T3·from·"package";
+     9    │ - import·type·T4·from·"https://example.com";
+        1 │ + import·type·T4·from·"https://example.com";
+        2 │ + import·type·T2·from·"node:package";
+        3 │ + import·V5·from·"exception";
+        4 │ + import·type·T1·from·"bun:package";
+        5 │ + import·type·T3·from·"package";
+        6 │ + import·V4·from·"https://example.com";
+        7 │ + import·V2·from·"node:package";
+        8 │ + import·V1·from·"bun:package";
+        9 │ + import·V3·from·"package";
+    10 10 │   
+    11 11 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.options.json
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.options.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": {
+					"level": "on",
+					"options": {
+                        "groups": [
+							{ "type": false, "source": ":NODE:" },
+							{ "type": false, "source": ":BUN:" },
+							{ "type": false },
+                            ":NODE:",
+                            ":BUN:"
+                        ]
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts
@@ -1,0 +1,6 @@
+import type T1 from "bun:package";
+import type T2 from "node:package";
+import type T3 from "package";
+import V1 from "bun:package";
+import V2 from "node:package";
+import V3 from "package";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/type-last-groups.ts.snap
@@ -1,0 +1,44 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: type-last-groups.ts
+---
+# Input
+```ts
+import type T1 from "bun:package";
+import type T2 from "node:package";
+import type T3 from "package";
+import V1 from "bun:package";
+import V2 from "node:package";
+import V3 from "package";
+
+```
+
+# Diagnostics
+```
+type-last-groups.ts:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 1 │ import type T1 from "bun:package";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ import type T2 from "node:package";
+    3 │ import type T3 from "package";
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1   │ - import·type·T1·from·"bun:package";
+    2   │ - import·type·T2·from·"node:package";
+    3   │ - import·type·T3·from·"package";
+    4   │ - import·V1·from·"bun:package";
+    5   │ - import·V2·from·"node:package";
+    6   │ - import·V3·from·"package";
+      1 │ + import·V2·from·"node:package";
+      2 │ + import·V1·from·"bun:package";
+      3 │ + import·V3·from·"package";
+      4 │ + import·type·T2·from·"node:package";
+      5 │ + import·type·T1·from·"bun:package";
+      6 │ + import·type·T3·from·"package";
+    7 7 │   
+  
+
+```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3093,7 +3093,7 @@ export interface Convention {
 	 */
 	selector: Selector;
 }
-export type GroupMatcher = PredefinedGroupMatcher | ImportSourceGlob;
+export type GroupMatcher = ImportMatcher | SourceMatcher;
 export type StableHookResult = boolean | number[];
 export interface CustomRestrictedImportOptions {
 	/**
@@ -3137,11 +3137,11 @@ export interface Selector {
 	 */
 	scope: Scope;
 }
-export type PredefinedGroupMatcher = string;
-/**
- * Glob to match against import sources.
- */
-export type ImportSourceGlob = Glob;
+export interface ImportMatcher {
+	source?: SourcesMatcher;
+	type?: boolean;
+}
+export type SourceMatcher = PredefinedGroupMatcher | ImportSourceGlob;
 /**
  * Supported cases.
  */
@@ -3191,6 +3191,12 @@ export type Kind =
 	| "typeMethod";
 export type Modifiers = RestrictedModifier[];
 export type Scope = "any" | "global";
+export type SourcesMatcher = SourceMatcher | SourceMatcher[];
+export type PredefinedGroupMatcher = string;
+/**
+ * Glob to match against import sources.
+ */
+export type ImportSourceGlob = Glob;
 export type RestrictedModifier =
 	| "abstract"
 	| "private"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1660,8 +1660,8 @@
 		},
 		"GroupMatcher": {
 			"anyOf": [
-				{ "$ref": "#/definitions/PredefinedGroupMatcher" },
-				{ "$ref": "#/definitions/ImportSourceGlob" }
+				{ "$ref": "#/definitions/ImportMatcher" },
+				{ "$ref": "#/definitions/SourceMatcher" }
 			]
 		},
 		"GroupPlainConfiguration": {
@@ -1823,6 +1823,18 @@
 		"ImportGroups": {
 			"type": "array",
 			"items": { "$ref": "#/definitions/ImportGroup" }
+		},
+		"ImportMatcher": {
+			"type": "object",
+			"properties": {
+				"source": {
+					"anyOf": [
+						{ "$ref": "#/definitions/SourcesMatcher" },
+						{ "type": "null" }
+					]
+				},
+				"type": { "type": ["boolean", "null"] }
+			}
 		},
 		"ImportSourceGlob": {
 			"description": "Glob to match against import sources.",
@@ -4262,6 +4274,18 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"SourceMatcher": {
+			"anyOf": [
+				{ "$ref": "#/definitions/PredefinedGroupMatcher" },
+				{ "$ref": "#/definitions/ImportSourceGlob" }
+			]
+		},
+		"SourcesMatcher": {
+			"anyOf": [
+				{ "$ref": "#/definitions/SourceMatcher" },
+				{ "type": "array", "items": { "$ref": "#/definitions/SourceMatcher" } }
+			]
 		},
 		"StableHookResult": {
 			"oneOf": [


### PR DESCRIPTION
## Summary

Following user and maintainer feedbacks, this PR provides an alternative to the `typePlacement` option I introduced in https://github.com/biomejs/biome/pull/5582
Note that the PR doesn't remove `typePlacement`.
I left the removal to another PR.

Instead of introducing a new option to separate types, this PR introduces general import matchers.
This provides more flexibility to the users and improves extensibility to add more matching behaviors on imports/exports in the future if required.

For example the following config allows placing types first:

```json
{
  "options": {
    "groups": [
      { "type": true },
    ]
  }
}
```

This one places types last:

```json
{
  "options": {
    "groups": [
      { "type": false },
    ]
  }
}
```

Here is a more complex example:

```json
{
  "options": {
    "groups": [
      { "type": true, "source": [":NODE:", ":URL:"] },
      { "type": true, "source": ":BUN:" },
      { "type": true },
      [":NODE:", ":URL:"],
      ":BUN:"
    ]
  }
}
```

This can also be written as:

```json
{
  "options": {
    "groups": [
      [{ "type": true, "source": ":NODE:" }, { "type": true, "source": ":URL:" }],
      { "type": true, "source": ":BUN:" },
      { "type": true },
      [":NODE:", ":URL:"],
      ":BUN:"
    ]
  }
}
```

Note that this approach is more verbose than https://github.com/biomejs/biome/pull/5582 because you have to repeat groups.

## Test Plan

I added two tests.
