### PR TITLE
fix(lint): `noConsole` rule now correctly handles indirect `console.log` calls and references

### DIFF
--- a/.changeset/plenty-foxes-give.md
+++ b/.changeset/plenty-foxes-give.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fix #5620, `noConsole` rule now correctly handles indirect `console.log` calls and references.
+Fixed #5620, [noConsole](https://biomejs.dev/linter/rules/no-console/) rule now correctly handles indirect `console.log` calls and references.

--- a/.changeset/plenty-foxes-give.md
+++ b/.changeset/plenty-foxes-give.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix #5620, `noConsole` rule now correctly handles indirect `console.log` calls and references.

--- a/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_console.rs
@@ -6,8 +6,8 @@ use biome_console::markup;
 use biome_deserialize_macros::Deserializable;
 use biome_js_factory::make::{js_directive_list, js_function_body, js_statement_list, token};
 use biome_js_syntax::{
-    JsArrowFunctionExpression, JsCallExpression, JsExpressionStatement, JsStaticMemberExpression,
-    T, global_identifier,
+    AnyJsMemberExpression, JsArrowFunctionExpression, JsCallExpression, JsExpressionStatement, T,
+    global_identifier,
 };
 use biome_rowan::{AstNode, BatchMutationExt};
 
@@ -56,7 +56,7 @@ declare_lint_rule! {
 }
 
 impl Rule for NoConsole {
-    type Query = Semantic<JsStaticMemberExpression>;
+    type Query = Semantic<AnyJsMemberExpression>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = Box<NoConsoleOptions>;
@@ -69,9 +69,8 @@ impl Rule for NoConsole {
         if name.text() != "console" {
             return None;
         }
-        if let Ok(member_name) = member_expression.member() {
-            let member_name_token = member_name.value_token().ok()?;
-            let member_name = member_name_token.text_trimmed();
+        if let Some(member_name) = member_expression.member_name() {
+            let member_name = member_name.text();
             if ctx
                 .options()
                 .allow

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js
@@ -1,7 +1,9 @@
 console.log("invalid");
+console['log']("invalid");
 console.debug("invalid");
 
 console.info("ok");
+console['info']("ok");
 console.warn("ok");
 console.error("ok");
 console.assert(true, "ok");

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js.snap
@@ -6,9 +6,11 @@ expression: allowlist.js
 # Input
 ```js
 console.log("invalid");
+console['log']("invalid");
 console.debug("invalid");
 
 console.info("ok");
+console['info']("ok");
 console.warn("ok");
 console.error("ok");
 console.assert(true, "ok");
@@ -23,8 +25,8 @@ allowlist.js:1:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━
   
   > 1 │ console.log("invalid");
       │ ^^^^^^^^^^^
-    2 │ console.debug("invalid");
-    3 │ 
+    2 │ console['log']("invalid");
+    3 │ console.debug("invalid");
   
   i The use of console is often reserved for debugging.
   
@@ -41,19 +43,44 @@ allowlist.js:2:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━
   i Don't use console.
   
     1 │ console.log("invalid");
-  > 2 │ console.debug("invalid");
-      │ ^^^^^^^^^^^^^
-    3 │ 
-    4 │ console.info("ok");
+  > 2 │ console['log']("invalid");
+      │ ^^^^^^^^^^^^^^
+    3 │ console.debug("invalid");
+    4 │ 
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-    1 1 │   console.log("invalid");
-    2   │ - console.debug("invalid");
-    3 2 │   
-    4 3 │   console.info("ok");
+     1 1 │   console.log("invalid");
+     2   │ - console['log']("invalid");
+     3 2 │   console.debug("invalid");
+     4 3 │   
+  
+
+```
+
+```
+allowlist.js:3:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use console.
+  
+    1 │ console.log("invalid");
+    2 │ console['log']("invalid");
+  > 3 │ console.debug("invalid");
+      │ ^^^^^^^^^^^^^
+    4 │ 
+    5 │ console.info("ok");
+  
+  i The use of console is often reserved for debugging.
+  
+  i Unsafe fix: Remove console.
+  
+     1 1 │   console.log("invalid");
+     2 2 │   console['log']("invalid");
+     3   │ - console.debug("invalid");
+     4 3 │   
+     5 4 │   console.info("ok");
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/allowlist.js.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 103
 expression: allowlist.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -22,7 +22,7 @@ allowlist.js:1:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━
   i Don't use console.
   
   > 1 │ console.log("invalid");
-      │ ^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^
     2 │ console.debug("invalid");
     3 │ 
   
@@ -42,7 +42,7 @@ allowlist.js:2:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━
   
     1 │ console.log("invalid");
   > 2 │ console.debug("invalid");
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     3 │ 
     4 │ console.info("ok");
   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js
@@ -1,4 +1,5 @@
 console.log('hello world')
+console['log']('hello world')
 console.info('hello world')
 console.warn('hello world')
 console.table('hello world')

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js.snap
@@ -6,6 +6,7 @@ expression: invalid.js
 # Input
 ```js
 console.log('hello world')
+console['log']('hello world')
 console.info('hello world')
 console.warn('hello world')
 console.table('hello world')
@@ -25,8 +26,8 @@ invalid.js:1:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
   
   > 1 │ console.log('hello world')
       │ ^^^^^^^^^^^
-    2 │ console.info('hello world')
-    3 │ console.warn('hello world')
+    2 │ console['log']('hello world')
+    3 │ console.info('hello world')
   
   i The use of console is often reserved for debugging.
   
@@ -43,19 +44,19 @@ invalid.js:2:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
   i Don't use console.
   
     1 │ console.log('hello world')
-  > 2 │ console.info('hello world')
-      │ ^^^^^^^^^^^^
-    3 │ console.warn('hello world')
-    4 │ console.table('hello world')
+  > 2 │ console['log']('hello world')
+      │ ^^^^^^^^^^^^^^
+    3 │ console.info('hello world')
+    4 │ console.warn('hello world')
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     1 1 │   console.log('hello world')
-     2   │ - console.info('hello·world')
-     3 2 │   console.warn('hello world')
-     4 3 │   console.table('hello world')
+     1  1 │   console.log('hello world')
+     2    │ - console['log']('hello·world')
+     3  2 │   console.info('hello world')
+     4  3 │   console.warn('hello world')
   
 
 ```
@@ -66,21 +67,21 @@ invalid.js:3:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
   i Don't use console.
   
     1 │ console.log('hello world')
-    2 │ console.info('hello world')
-  > 3 │ console.warn('hello world')
+    2 │ console['log']('hello world')
+  > 3 │ console.info('hello world')
       │ ^^^^^^^^^^^^
-    4 │ console.table('hello world')
-    5 │ console.error('hello world')
+    4 │ console.warn('hello world')
+    5 │ console.table('hello world')
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     1 1 │   console.log('hello world')
-     2 2 │   console.info('hello world')
-     3   │ - console.warn('hello·world')
-     4 3 │   console.table('hello world')
-     5 4 │   console.error('hello world')
+     1  1 │   console.log('hello world')
+     2  2 │   console['log']('hello world')
+     3    │ - console.info('hello·world')
+     4  3 │   console.warn('hello world')
+     5  4 │   console.table('hello world')
   
 
 ```
@@ -90,22 +91,22 @@ invalid.js:4:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
 
   i Don't use console.
   
-    2 │ console.info('hello world')
-    3 │ console.warn('hello world')
-  > 4 │ console.table('hello world')
-      │ ^^^^^^^^^^^^^
-    5 │ console.error('hello world')
-    6 │ console.nonExistent('hello world')
+    2 │ console['log']('hello world')
+    3 │ console.info('hello world')
+  > 4 │ console.warn('hello world')
+      │ ^^^^^^^^^^^^
+    5 │ console.table('hello world')
+    6 │ console.error('hello world')
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     2 2 │   console.info('hello world')
-     3 3 │   console.warn('hello world')
-     4   │ - console.table('hello·world')
-     5 4 │   console.error('hello world')
-     6 5 │   console.nonExistent('hello world')
+     2  2 │   console['log']('hello world')
+     3  3 │   console.info('hello world')
+     4    │ - console.warn('hello·world')
+     5  4 │   console.table('hello world')
+     6  5 │   console.error('hello world')
   
 
 ```
@@ -115,22 +116,22 @@ invalid.js:5:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
 
   i Don't use console.
   
-    3 │ console.warn('hello world')
-    4 │ console.table('hello world')
-  > 5 │ console.error('hello world')
+    3 │ console.info('hello world')
+    4 │ console.warn('hello world')
+  > 5 │ console.table('hello world')
       │ ^^^^^^^^^^^^^
-    6 │ console.nonExistent('hello world')
-    7 │ console.log('with semicolon');
+    6 │ console.error('hello world')
+    7 │ console.nonExistent('hello world')
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     3 3 │   console.warn('hello world')
-     4 4 │   console.table('hello world')
-     5   │ - console.error('hello·world')
-     6 5 │   console.nonExistent('hello world')
-     7 6 │   console.log('with semicolon');
+     3  3 │   console.info('hello world')
+     4  4 │   console.warn('hello world')
+     5    │ - console.table('hello·world')
+     6  5 │   console.error('hello world')
+     7  6 │   console.nonExistent('hello world')
   
 
 ```
@@ -140,22 +141,22 @@ invalid.js:6:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
 
   i Don't use console.
   
-    4 │ console.table('hello world')
-    5 │ console.error('hello world')
-  > 6 │ console.nonExistent('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^
-    7 │ console.log('with semicolon');
-    8 │ 
+    4 │ console.warn('hello world')
+    5 │ console.table('hello world')
+  > 6 │ console.error('hello world')
+      │ ^^^^^^^^^^^^^
+    7 │ console.nonExistent('hello world')
+    8 │ console.log('with semicolon');
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     4 4 │   console.table('hello world')
-     5 5 │   console.error('hello world')
-     6   │ - console.nonExistent('hello·world')
-     7 6 │   console.log('with semicolon');
-     8 7 │   
+     4  4 │   console.warn('hello world')
+     5  5 │   console.table('hello world')
+     6    │ - console.error('hello·world')
+     7  6 │   console.nonExistent('hello world')
+     8  7 │   console.log('with semicolon');
   
 
 ```
@@ -165,46 +166,71 @@ invalid.js:7:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
 
   i Don't use console.
   
-    5 │ console.error('hello world')
-    6 │ console.nonExistent('hello world')
-  > 7 │ console.log('with semicolon');
-      │ ^^^^^^^^^^^
-    8 │ 
-    9 │ globalThis.console.warn();
+    5 │ console.table('hello world')
+    6 │ console.error('hello world')
+  > 7 │ console.nonExistent('hello world')
+      │ ^^^^^^^^^^^^^^^^^^^
+    8 │ console.log('with semicolon');
+    9 │ 
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     5 5 │   console.error('hello world')
-     6 6 │   console.nonExistent('hello world')
-     7   │ - console.log('with·semicolon');
-     8 7 │   
-     9 8 │   globalThis.console.warn();
+     5  5 │   console.table('hello world')
+     6  6 │   console.error('hello world')
+     7    │ - console.nonExistent('hello·world')
+     8  7 │   console.log('with semicolon');
+     9  8 │   
   
 
 ```
 
 ```
-invalid.js:9:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:8:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Don't use console.
   
-     7 │ console.log('with semicolon');
-     8 │ 
-   > 9 │ globalThis.console.warn();
-       │ ^^^^^^^^^^^^^^^^^^^^^^^
-    10 │ 
+     6 │ console.error('hello world')
+     7 │ console.nonExistent('hello world')
+   > 8 │ console.log('with semicolon');
+       │ ^^^^^^^^^^^
+     9 │ 
+    10 │ globalThis.console.warn();
   
   i The use of console is often reserved for debugging.
   
   i Unsafe fix: Remove console.
   
-     6 6 │   console.nonExistent('hello world')
-     7 7 │   console.log('with semicolon');
-     8   │ - 
-     9   │ - globalThis.console.warn();
-    10 8 │   
+     6  6 │   console.error('hello world')
+     7  7 │   console.nonExistent('hello world')
+     8    │ - console.log('with·semicolon');
+     9  8 │   
+    10  9 │   globalThis.console.warn();
+  
+
+```
+
+```
+invalid.js:10:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use console.
+  
+     8 │ console.log('with semicolon');
+     9 │ 
+  > 10 │ globalThis.console.warn();
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+  
+  i The use of console is often reserved for debugging.
+  
+  i Unsafe fix: Remove console.
+  
+     7 7 │   console.nonExistent('hello world')
+     8 8 │   console.log('with semicolon');
+     9   │ - 
+    10   │ - globalThis.console.warn();
+    11 9 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/invalid.js.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 103
 expression: invalid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -24,7 +24,7 @@ invalid.js:1:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
   i Don't use console.
   
   > 1 │ console.log('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^
     2 │ console.info('hello world')
     3 │ console.warn('hello world')
   
@@ -44,7 +44,7 @@ invalid.js:2:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
   
     1 │ console.log('hello world')
   > 2 │ console.info('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^
     3 │ console.warn('hello world')
     4 │ console.table('hello world')
   
@@ -68,7 +68,7 @@ invalid.js:3:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
     1 │ console.log('hello world')
     2 │ console.info('hello world')
   > 3 │ console.warn('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^
     4 │ console.table('hello world')
     5 │ console.error('hello world')
   
@@ -93,7 +93,7 @@ invalid.js:4:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
     2 │ console.info('hello world')
     3 │ console.warn('hello world')
   > 4 │ console.table('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     5 │ console.error('hello world')
     6 │ console.nonExistent('hello world')
   
@@ -118,7 +118,7 @@ invalid.js:5:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
     3 │ console.warn('hello world')
     4 │ console.table('hello world')
   > 5 │ console.error('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^
     6 │ console.nonExistent('hello world')
     7 │ console.log('with semicolon');
   
@@ -143,7 +143,7 @@ invalid.js:6:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
     4 │ console.table('hello world')
     5 │ console.error('hello world')
   > 6 │ console.nonExistent('hello world')
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^^^^^^^^^
     7 │ console.log('with semicolon');
     8 │ 
   
@@ -168,7 +168,7 @@ invalid.js:7:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
     5 │ console.error('hello world')
     6 │ console.nonExistent('hello world')
   > 7 │ console.log('with semicolon');
-      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │ ^^^^^^^^^^^
     8 │ 
     9 │ globalThis.console.warn();
   
@@ -193,7 +193,7 @@ invalid.js:9:1 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━━�
      7 │ console.log('with semicolon');
      8 │ 
    > 9 │ globalThis.console.warn();
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
     10 │ 
   
   i The use of console is often reserved for debugging.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5053.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5053.js.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 103
 expression: issue_5053.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -17,7 +17,7 @@ issue_5053.js:1:17 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━�
   i Don't use console.
   
   > 1 │ const x = () => console.log("test");
-      │                 ^^^^^^^^^^^^^^^^^^^
+      │                 ^^^^^^^^^^^
     2 │ [].forEach(() => console.log("test"));
     3 │ 
   
@@ -40,7 +40,7 @@ issue_5053.js:2:18 lint/suspicious/noConsole  FIXABLE  ━━━━━━━━�
   
     1 │ const x = () => console.log("test");
   > 2 │ [].forEach(() => console.log("test"));
-      │                  ^^^^^^^^^^^^^^^^^^^
+      │                  ^^^^^^^^^^^
     3 │ 
   
   i The use of console is often reserved for debugging.

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5620.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5620.js
@@ -1,0 +1,5 @@
+function callFn(fn) {
+    fn();
+}
+
+callFn(console.log);

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5620.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/issue_5620.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 103
+expression: issue_5620.js
+---
+# Input
+```js
+function callFn(fn) {
+    fn();
+}
+
+callFn(console.log);
+
+```
+
+# Diagnostics
+```
+issue_5620.js:5:8 lint/suspicious/noConsole ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Don't use console.
+  
+    3 │ }
+    4 │ 
+  > 5 │ callFn(console.log);
+      │        ^^^^^^^^^^^
+    6 │ 
+  
+  i The use of console is often reserved for debugging.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/valid.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/valid.js
@@ -3,4 +3,5 @@
 var a = 1;
 
 const console = { log: (args) => { /* do nothing */} };
-console.log('hello world')
+console.log('hello world');
+console['log']('hello world');

--- a/crates/biome_js_analyze/tests/specs/suspicious/noConsole/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noConsole/valid.js.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 103
 expression: valid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -10,6 +10,7 @@ snapshot_kind: text
 var a = 1;
 
 const console = { log: (args) => { /* do nothing */} };
-console.log('hello world')
+console.log('hello world');
+console['log']('hello world');
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #5620.

Handles all `console.xxx` member access cases, not only calls.

Changed text range in diagnostics (a) to bring in accordance with `eslint` (b) to reflect this change.

## Test Plan

Tests are updated.

<!-- What demonstrates that your implementation is correct? -->
