### PR TITLE
ci(workflow): use depot for all jobs

### DIFF
--- a/.github/workflows/bench_cli.yml
+++ b/.github/workflows/bench_cli.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     name: Bench
     if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench_cli')
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
 
     steps:
       - name: Get PR SHA

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Bench
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
 
     steps:
 

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   version:
     name: Generate version
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     outputs:
       version: ${{ env.version }}
     steps:
@@ -127,7 +127,7 @@ jobs:
 
   build-wasm:
     name: Build WASM
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -154,7 +154,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs:
       - build
       - build-wasm

--- a/.github/workflows/beta_js_api.yml
+++ b/.github/workflows/beta_js_api.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   version:
     name: Generate version
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     outputs:
       version: ${{ env.version }}
     steps:
@@ -26,7 +26,7 @@ jobs:
   build:
     needs: version
     name: Package JavaScript APIs
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
 
     env:
       version: ${{ needs.version.outputs.version }}
@@ -80,7 +80,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: build
     environment: npm-publish
     permissions:

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   close-issues:
     if: github.repository == 'biomejs/biome'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-small
     steps:
       - name: Close issue without reproduction
         uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-small
     if: github.repository_owner == 'biomejs'
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   reply-labeled:
     if: github.repository == 'biomejs/biome'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-small
     steps:
       - name: Remove triaging label
         if: contains(github.event.issue.labels.*.name, 'S-Bug-confirmed') && contains(github.event.issue.labels.*.name, 'S-Needs triage')

--- a/.github/workflows/parser_conformance.yml
+++ b/.github/workflows/parser_conformance.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       pull-requests: write
     name: Parser conformance
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
 
     steps:
       - name: Checkout PR Branch

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   version:
     name: Generate version
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     outputs:
       version: ${{ env.version }}
     steps:
@@ -117,7 +117,7 @@ jobs:
 
   build-wasm:
     name: Build WASM
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: version
     steps:
       - name: Checkout repository
@@ -145,7 +145,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs:
       - build-binaries
       - build-wasm

--- a/.github/workflows/pull_request_js.yml
+++ b/.github/workflows/pull_request_js.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   format-js:
     name: Check JS Files
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pull_request_node.yml
+++ b/.github/workflows/pull_request_node.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   test-node-api:
     name: Test Node.js API
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   changesets:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,7 +45,7 @@ jobs:
 
   # Retrieve version of `@biomejs/biome` and `@biomejs/js-api`
   version:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: changesets
     if: needs.changesets.outputs.hasChangesets == 'false' && github.head_ref == 'changeset-release/main'
     outputs:
@@ -174,7 +174,7 @@ jobs:
 
   build-wasm:
     name: Build WASM
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: version
     if: needs.cli-version-changed.outputs.changed == 'true'
     steps:
@@ -203,7 +203,7 @@ jobs:
 
   build-js-api:
     name: Package JavaScript APIs
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: version
     if: needs.js-api-version-changed.outputs.changed == 'true'
     steps:
@@ -252,7 +252,7 @@ jobs:
 
   publish-cli:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs:
       - build-binaries
       - build-wasm
@@ -296,7 +296,7 @@ jobs:
 
   publish-js-api:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: build-js-api
     environment: npm-publish
     permissions:

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Check version
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     outputs:
       version: ${{ env.version }}
     steps:
@@ -142,7 +142,7 @@ jobs:
 
   build-wasm:
     name: Build WASM
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: check
     steps:
       - name: Checkout repository
@@ -170,7 +170,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs:
       - build
       - build-wasm

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check:
     name: Check version
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     outputs:
       version: ${{ env.version }}
       prerelease: ${{ env.prerelease }}
@@ -42,7 +42,7 @@ jobs:
 
   build:
     name: Package JavaScript APIs
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
 
     needs: check
     if: needs.check.outputs.version_changed == 'true' || needs.check.outputs.nightly == 'true'
@@ -105,7 +105,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     needs: build
     environment: npm-publish
     permissions:

--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build-wasm:
     name: Build @biomejs/wasm-web
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,7 +82,7 @@ jobs:
   repository-dispatch:
     name: Repository dispatch
     needs: build-wasm
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-arm-16
     steps:
       - name: Dispatch event on push
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR switches all our jobs to use the depot runners. 

For the small jobs, I thought we could use `depot-ubuntu-24.04-arm-small`, because they don't need a lot of computing power. The small jobs are: needs reproduction, close issue and labels.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass

<!-- What demonstrates that your implementation is correct? -->
