### PR TITLE
feat(core): implement "thin" type resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,8 +946,20 @@ name = "biome_js_type_info"
 version = "0.0.1"
 dependencies = [
  "biome_js_syntax",
+ "biome_js_type_info_macros",
  "biome_rowan",
  "static_assertions",
+]
+
+[[package]]
+name = "biome_js_type_info_macros"
+version = "0.0.1"
+dependencies = [
+ "biome_string_case",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,6 @@ dependencies = [
 name = "biome_js_type_info_macros"
 version = "0.0.1"
 dependencies = [
- "biome_string_case",
  "proc-macro-error2",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ biome_js_parser              = { version = "0.5.7", path = "./crates/biome_js_pa
 biome_js_semantic            = { version = "0.5.7", path = "./crates/biome_js_semantic" }
 biome_js_syntax              = { version = "0.5.7", path = "./crates/biome_js_syntax" }
 biome_js_type_info           = { version = "0.0.1", path = "./crates/biome_js_type_info" }
+biome_js_type_info_macros    = { version = "0.0.1", path = "./crates/biome_js_type_info_macros" }
 biome_json_analyze           = { version = "0.5.7", path = "./crates/biome_json_analyze" }
 biome_json_factory           = { version = "0.5.7", path = "./crates/biome_json_factory" }
 biome_json_formatter         = { version = "0.5.7", path = "./crates/biome_json_formatter" }

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
@@ -12,7 +14,7 @@ use biome_js_syntax::{
     JsStaticMemberExpression, JsSyntaxKind, JsThisExpression, JsVariableDeclarator,
     TsReturnTypeAnnotation, binding_ext::AnyJsBindingDeclaration, global_identifier,
 };
-use biome_js_type_info::{Type, TypeMember};
+use biome_js_type_info::{Type, TypeInner, TypeMember};
 use biome_rowan::{
     AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, SyntaxNode, SyntaxNodeCast,
     TriviaPieceKind,
@@ -999,8 +1001,8 @@ fn is_ts_type_a_promise(
 
 fn find_promise_in_object(object: &JsObjectExpression, member_name: &str) -> Option<bool> {
     let ty = Type::from_js_object_expression(object);
-    match ty {
-        Type::Object(object) => object.members().iter().find_map(|member| match member {
+    match ty.deref() {
+        TypeInner::Object(object) => object.members().iter().find_map(|member| match member {
             TypeMember::CallSignature(_) | TypeMember::Constructor(_) => None,
             TypeMember::Method(member) => match member.name == member_name {
                 true => Some(

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -15,6 +15,7 @@ version              = "0.0.1"
 workspace = true
 
 [dependencies]
-biome_js_syntax   = { workspace = true }
-biome_rowan       = { workspace = true }
-static_assertions = { workspace = true }
+biome_js_syntax           = { workspace = true }
+biome_js_type_info_macros = { workspace = true }
+biome_rowan               = { workspace = true }
+static_assertions         = { workspace = true }

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -1,4 +1,6 @@
-mod inference;
+mod local_inference;
+mod resolver;
 mod type_info;
 
+pub use resolver::*;
 pub use type_info::*;

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -1,0 +1,83 @@
+use biome_rowan::Text;
+
+use crate::{Type, TypeInner, TypeReferenceQualifier};
+
+const MAX_RESOLUTION_DEPTH: usize = 16;
+
+/// Trait for implementing type resolution.
+///
+/// In Biome, we define three levels of type inference:
+/// - **Local inference.** Constrained to the expression or statement from which
+///   the type is inferred. Doesn't perform any type resolution.
+/// - **Thin**, or module-level, type inference. Can perform type resolution as
+///   long as the referenced types are defined in the same module.
+/// - **Full inference**. Can perform type resolution across modules.
+///
+/// Since both thin inference and full inference rely on type resolution, we
+/// also have two layers of type *resolution*, both of which implement this
+/// trait.
+pub trait TypeResolver {
+    /// Resolves a type by its `qualifier`.
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type>;
+
+    /// Resolves the type of a value by its `identifier`.
+    fn resolve_type_of(&self, identifier: &Text) -> Option<Type>;
+}
+
+impl Type {
+    /// Attempts to resolve all unresolved types using the given resolver.
+    pub fn resolve(&mut self, resolver: &dyn TypeResolver) {
+        let stack = &[&**self];
+        if self.needs_resolving(resolver, stack) {
+            *self = self.resolved(resolver, stack);
+        }
+    }
+}
+
+/// Trait to be implemented by `Type` and its subtypes to aid the resolver.
+pub(crate) trait Resolvable {
+    /// Returns whether (part of) the type can and should be resolved.
+    fn needs_resolving(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> bool;
+
+    /// Returns the resolved version of this type.
+    ///
+    /// You should first call `Self::needs_resolving()` to avoid making
+    /// needless clones.
+    fn resolved(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> Self;
+}
+
+impl Resolvable for Type {
+    fn needs_resolving(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> bool {
+        // We only call this function through `Type::resolve()` which passes the
+        // first element, so the following range should always be valid:
+        let inner = &**self;
+        if stack.len() >= MAX_RESOLUTION_DEPTH || stack[0..stack.len() - 1].contains(&inner) {
+            return false;
+        }
+
+        let mut stack = stack.to_vec();
+        stack.push(inner);
+        inner.needs_resolving(resolver, &stack)
+    }
+
+    /// Returns the resolved version of this type.
+    ///
+    /// You should first call `Self::call_be_resolved()` to avoid making
+    /// needless clones.
+    fn resolved(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> Self {
+        let inner = &**self;
+        let mut stack = stack.to_vec();
+        stack.push(inner);
+        inner.resolved(resolver, &stack).into()
+    }
+}
+
+impl Resolvable for bool {
+    fn needs_resolving(&self, _resolver: &dyn TypeResolver, _stack: &[&TypeInner]) -> bool {
+        false
+    }
+
+    fn resolved(&self, _resolver: &dyn TypeResolver, _stack: &[&TypeInner]) -> Self {
+        *self
+    }
+}

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -48,8 +48,8 @@ pub(crate) trait Resolvable {
 
 impl Resolvable for Type {
     fn needs_resolving(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> bool {
-        // We only call this function through `Type::resolve()` which passes the
-        // first element, so the following range should always be valid:
+        debug_assert!(!stack.is_empty(), "stack must be initialised");
+
         let inner = &**self;
         if stack.len() >= MAX_RESOLUTION_DEPTH || stack[0..stack.len() - 1].contains(&inner) {
             return false;

--- a/crates/biome_js_type_info_macros/Cargo.toml
+++ b/crates/biome_js_type_info_macros/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 authors.workspace    = true
 categories.workspace = true
-description          = "Macros to help implement deserializable types in Biome"
+description          = "Macros to help implement type resolution"
 edition.workspace    = true
 homepage.workspace   = true
 keywords.workspace   = true
 license.workspace    = true
-name                 = "biome_deserialize_macros"
+name                 = "biome_js_type_info_macros"
 repository.workspace = true
-version              = "0.6.0"
+version              = "0.0.1"
 
 [lib]
 proc-macro = true

--- a/crates/biome_js_type_info_macros/Cargo.toml
+++ b/crates/biome_js_type_info_macros/Cargo.toml
@@ -14,7 +14,6 @@ version              = "0.0.1"
 proc-macro = true
 
 [dependencies]
-biome_string_case = { workspace = true }
 proc-macro-error2 = { workspace = true }
 proc-macro2       = { workspace = true }
 quote             = { workspace = true }

--- a/crates/biome_js_type_info_macros/src/lib.rs
+++ b/crates/biome_js_type_info_macros/src/lib.rs
@@ -1,0 +1,36 @@
+mod resolvable_derive;
+
+use proc_macro::TokenStream;
+use proc_macro_error2::*;
+use syn::{DeriveInput, parse_macro_input};
+
+/// Implements the `Resolvable` trait for a given type.
+///
+/// Types with a derived `Resolvable` implementation are expected to be one of
+/// the following:
+/// - A struct with either named fields, or a single unnamed field, whose types
+///   are either:
+///   - A primitive type.
+///   - Our `Text` type.
+///   - A type that is itself `Resolvable`.
+///   - An `Option<T>` or a `Box<[T]>`, where `T` is one of the above.
+/// - An enum whose variants are either:
+///   - A unit variant.
+///   - A variant with a single unnamed field whose type is either `Text`,
+///     another `Resolvable` type, or a `Box<T>` where `T` implements
+///     `Resolvable`.
+#[proc_macro_derive(Resolvable)]
+#[proc_macro_error]
+pub fn derive_resolvable(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let input = resolvable_derive::DeriveInput::parse(input);
+
+    let tokens = resolvable_derive::generate_resolvable(input);
+
+    if false {
+        panic!("{tokens}");
+    }
+
+    TokenStream::from(tokens)
+}

--- a/crates/biome_js_type_info_macros/src/resolvable_derive.rs
+++ b/crates/biome_js_type_info_macros/src/resolvable_derive.rs
@@ -1,0 +1,424 @@
+use proc_macro_error2::*;
+use proc_macro2::{Ident, TokenStream};
+use quote::{ToTokens, quote};
+use syn::{Data, Fields, GenericArgument, PathArguments, Type};
+
+pub(crate) enum DeriveInput {
+    Enum {
+        ident: Ident,
+        variants: Vec<VariantData>,
+    },
+    Struct {
+        ident: Ident,
+        fields: Vec<FieldData>,
+    },
+    Unit {
+        ident: Ident,
+        ty: Type,
+    },
+}
+
+pub(crate) struct FieldData {
+    ident: Ident,
+    ty: Type,
+}
+
+pub(crate) struct VariantData {
+    ident: Ident,
+    ty: Option<Type>,
+}
+
+impl DeriveInput {
+    pub fn parse(input: syn::DeriveInput) -> Self {
+        let ident = input.ident.clone();
+
+        match input.data {
+            Data::Struct(data)
+                if data.fields.len() == 1
+                    && data
+                        .fields
+                        .iter()
+                        .next()
+                        .is_some_and(|field| field.ident.is_none()) =>
+            {
+                Self::Unit {
+                    ident,
+                    ty: data.fields.into_iter().next().unwrap().ty,
+                }
+            }
+            Data::Struct(data) => {
+                let fields = data
+                    .fields
+                    .into_iter()
+                    .map(|field| {
+                        let Some(ident) = field.ident else {
+                            abort!(
+                                ident,
+                                "Resolvable derive requires either named struct fields or a struct with a single unnamed field"
+                            );
+                        };
+                        let ty = field.ty;
+
+                        FieldData { ident, ty }
+                    })
+                    .collect();
+
+                Self::Struct { ident, fields }
+            }
+            Data::Enum(data) => {
+                let variants = data
+                    .variants
+                    .into_iter()
+                    .map(|variant| {
+                        let ident = variant.ident;
+                        let ty = match variant.fields {
+                            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Some(fields.unnamed.into_iter().next().unwrap().ty),
+                            Fields::Unit => None,
+                            fields => abort!(
+                                fields,
+                                "Resolvable derive requires enum variants with either a single unnamed field or no field at all"
+                            )
+                        };
+
+                        VariantData { ident, ty }
+                    })
+                    .collect();
+
+                Self::Enum { ident, variants }
+            }
+            _ => abort!(
+                input,
+                "Resolvable can only be derived for structs and enums"
+            ),
+        }
+    }
+}
+
+pub(crate) fn generate_resolvable(input: DeriveInput) -> TokenStream {
+    match input {
+        DeriveInput::Enum { ident, variants } => generate_resolvable_enum(ident, variants),
+        DeriveInput::Struct { ident, fields } => generate_resolvable_struct(ident, fields),
+        DeriveInput::Unit { ident, ty } => generate_resolvable_unit_type(ident, ty),
+    }
+}
+
+pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>) -> TokenStream {
+    let variants_need_resolving = variants.iter().map(|VariantData { ident, ty }| match ty {
+        Some(ty) => {
+            let needs_resolving = unit_type_needs_resolving(ty);
+            quote! { Self::#ident(ty) => #needs_resolving }
+        }
+        None => quote! { Self::#ident => false },
+    });
+
+    let resolved_variants = variants.iter().map(|VariantData { ident, ty }| match ty {
+        Some(ty) => {
+            let resolved_ty = resolved_unit_type(ty);
+            quote! { Self::#ident(ty) => Self::#ident(#resolved_ty) }
+        }
+        None => quote! { Self::#ident => Self::#ident },
+    });
+
+    quote! {
+        impl crate::Resolvable for #ident {
+            fn needs_resolving(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> bool {
+                match self {
+                    #( #variants_need_resolving ),*
+                }
+            }
+
+            fn resolved(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> Self {
+                match self {
+                    #( #resolved_variants ),*
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -> TokenStream {
+    let needs_resolving = fields
+        .iter()
+        .filter_map(|FieldData { ident, ty }| type_needs_resolving(IdentOrZero::Ident(ident), ty));
+
+    let resolved_fields = fields.iter().map(|FieldData { ident, ty }| {
+        let resolved_ty = resolved_type(IdentOrZero::Ident(ident), ty);
+        quote! { #ident: #resolved_ty }
+    });
+
+    quote! {
+        impl crate::Resolvable for #ident {
+            fn needs_resolving(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> bool {
+                #( #needs_resolving )||*
+            }
+
+            fn resolved(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> Self {
+                Self {
+                    #( #resolved_fields ),*
+                }
+            }
+        }
+    }
+}
+
+fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
+    let needs_resolving =
+        type_needs_resolving(IdentOrZero::Zero, &ty).unwrap_or_else(|| quote! { false });
+    let resolved_field = resolved_type(IdentOrZero::Zero, &ty);
+
+    quote! {
+        impl crate::Resolvable for #ident {
+            fn needs_resolving(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> bool {
+                #needs_resolving
+            }
+
+            fn resolved(&self, resolver: &dyn crate::TypeResolver, stack: &[&crate::TypeInner]) -> Self {
+                Self(#resolved_field)
+            }
+        }
+    }
+}
+
+fn resolved_type(ident: IdentOrZero, ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { self.#ident.clone() }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => {
+                            quote! {
+                                self.#ident.clone()
+                            }
+                        }
+                        Type::Path(_) => quote! {
+                            self.#ident.iter().map(|elem| elem.resolved(resolver, stack)).collect()
+                        },
+                        _ => abort!(slice, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! {
+                                self.#ident.clone()
+                            }
+                        } else {
+                            quote! {
+                                Box::new(self.#ident.resolved(resolver, stack))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident.clone() }
+                        } else {
+                            quote! { self.#ident.as_ref().map(|f| f.resolved(resolver, stack)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { self.#ident.resolved(resolver, stack) }
+        }
+    }
+}
+
+enum IdentOrZero<'a> {
+    Ident(&'a Ident),
+    Zero,
+}
+
+impl ToTokens for IdentOrZero<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Ident(ident) => ident.to_tokens(tokens),
+            Self::Zero => quote! { 0 }.to_tokens(tokens),
+        }
+    }
+}
+
+fn type_needs_resolving(ident: IdentOrZero, ty: &Type) -> Option<TokenStream> {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => None,
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => None,
+                        Type::Path(_) => Some(quote! {
+                            self.#ident.iter().any(|elem| elem.needs_resolving(resolver, stack))
+                        }),
+                        _ => None,
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            None
+                        } else {
+                            Some(quote! {
+                                self.#ident.needs_resolving(resolver, stack)
+                            })
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            None
+                        } else {
+                            Some(quote! {
+                                self.#ident
+                                    .as_ref()
+                                    .map_or(false, |f| f.needs_resolving(resolver, stack))
+                            })
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        _ => Some(quote! { self.#ident.needs_resolving(resolver, stack) }),
+    }
+}
+
+fn resolved_unit_type(ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { ty.clone() }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
+                        Type::Path(_) => quote! {
+                            ty.iter().any(|elem| elem.needs_resolving(resolver, stack))
+                        },
+                        _ => abort!(args, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty.clone() }
+                        } else {
+                            quote! { Box::new(ty.resolved(resolver, stack)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty.clone() }
+                        } else {
+                            quote! { ty.as_ref().map(|f| f.resolved(resolver, stack)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { ty.resolved(resolver, stack) }
+        }
+    }
+}
+
+fn unit_type_needs_resolving(ty: &Type) -> Option<TokenStream> {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => Some(quote! { false }),
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => Some(quote! { false }),
+                        Type::Path(_) => Some(quote! {
+                            ty.iter().any(|elem| elem.needs_resolving(resolver, stack))
+                        }),
+                        _ => None,
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            Some(quote! { false })
+                        } else {
+                            Some(quote! { ty.needs_resolving(resolver, stack) })
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            Some(quote! { false })
+                        } else {
+                            Some(quote! {
+                                ty
+                                    .as_ref()
+                                    .map_or(false, |f| f.needs_resolving(resolver, stack))
+                            })
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        },
+        _ => Some(quote! { ty.needs_resolving(resolver, stack) }),
+    }
+}

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -1,6 +1,7 @@
 mod binding;
 mod collector;
 mod scope;
+mod type_resolver;
 mod visitor;
 
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
@@ -166,6 +167,22 @@ pub enum JsExport {
     ///
     /// E.g. `export type { someSymbol } from "other-module"`.
     ReexportType(JsReexport),
+}
+
+impl JsExport {
+    pub fn as_own_export(&self) -> Option<&JsOwnExport> {
+        match self {
+            JsExport::Own(own_export) | JsExport::OwnType(own_export) => Some(own_export),
+            JsExport::Reexport(_) | JsExport::ReexportType(_) => None,
+        }
+    }
+
+    pub fn as_own_export_mut(&mut self) -> Option<&mut JsOwnExport> {
+        match self {
+            JsExport::Own(own_export) | JsExport::OwnType(own_export) => Some(own_export),
+            JsExport::Reexport(_) | JsExport::ReexportType(_) => None,
+        }
+    }
 }
 
 /// Represents an import to one or more symbols from an external path.

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -76,6 +76,11 @@ impl JsBinding {
             id: binding.scope_id,
         }
     }
+
+    /// Returns a reference to the binding's type.
+    pub fn ty(&self) -> &Type {
+        &self.data.binding(self.id).ty
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/biome_module_graph/src/js_module_info/type_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/type_resolver.rs
@@ -1,0 +1,47 @@
+use biome_js_type_info::{Type, TypeReferenceQualifier, TypeResolver};
+use biome_rowan::Text;
+
+use super::collector::JsModuleInfoCollector;
+
+/// Type resolver that is able to resolve types within a given scope of a
+/// module.
+///
+/// Responsible for what we call "thin type resolution". See [TypeResolver] for
+/// more information.
+pub(super) struct JsModuleTypeResolver<'a> {
+    collector: &'a JsModuleInfoCollector,
+}
+
+impl<'a> JsModuleTypeResolver<'a> {
+    pub(super) fn from_collector(collector: &'a JsModuleInfoCollector) -> Self {
+        Self { collector }
+    }
+}
+
+impl TypeResolver for JsModuleTypeResolver<'_> {
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type> {
+        if qualifier.parts().len() == 1 {
+            self.resolve_type_of(&qualifier.parts()[0])
+        } else {
+            // TODO: Resolve nested qualifiers
+            None
+        }
+    }
+
+    fn resolve_type_of(&self, identifier: &Text) -> Option<Type> {
+        // TODO: We probably need to traverse parent scopes at some point.
+        //       But since we mainly care about exported symbols, which only
+        //       exist at the module's global scope, we can get away with this
+        //       for now.
+        self.collector.scopes[0]
+            .bindings_by_name
+            .get(identifier.text())
+            .and_then(|binding_id| {
+                let ty = &self.collector.bindings[binding_id.index()].ty;
+                match ty.is_inferred() {
+                    true => Some(ty.clone()),
+                    false => None,
+                }
+            })
+    }
+}

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use biome_fs::{BiomePath, FileSystem, PathKind};
 use biome_js_syntax::AnyJsRoot;
-use biome_js_type_info::{Namespace, Type};
+use biome_js_type_info::{Namespace, TypeInner};
 use biome_project_layout::ProjectLayout;
 use camino::{Utf8Path, Utf8PathBuf};
 use oxc_resolver::{EnforceExtension, ResolveOptions, ResolverGeneric};
@@ -159,7 +159,11 @@ impl ModuleGraph {
                         Some(JsOwnExport {
                             jsdoc_comment: reexport.jsdoc_comment.clone(),
                             local_name: None,
-                            ty: Type::Namespace(Box::new(Namespace(Box::new([])))),
+                            // TODO: Infer members.
+                            ty: TypeInner::Namespace(Box::new(Namespace::from_type_members(
+                                Box::new([]),
+                            )))
+                            .into(),
                         })
                     } else {
                         match reexport.import.resolved_path.as_deref() {

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__export_default_function_declaration.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__export_default_function_declaration.snap
@@ -15,34 +15,41 @@ expression: data.exports
             local_name: Some(
                 "Component",
             ),
-            ty: Function(
-                Function {
-                    is_async: false,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "Component",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: false,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "Component",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Reference(
-                            TypeReference {
-                                qualifier: TypeReferenceQualifier(
-                                    [
-                                        Borrowed(
-                                            "JSX",
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Reference(
+                                    TypeReference {
+                                        qualifier: TypeReferenceQualifier(
+                                            [
+                                                Borrowed(
+                                                    "JSX",
+                                                ),
+                                                Borrowed(
+                                                    "Element",
+                                                ),
+                                            ],
                                         ),
-                                        Borrowed(
-                                            "Element",
+                                        ty: Type(
+                                            Unknown,
                                         ),
-                                    ],
+                                        type_parameters: [],
+                                    },
                                 ),
-                                type_parameters: [],
-                            },
+                            ),
                         ),
-                    ),
-                },
+                    },
+                ),
             ),
         },
     ),

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__export_referenced_function.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__export_referenced_function.snap
@@ -15,20 +15,24 @@ expression: data.exports
             local_name: Some(
                 "foo",
             ),
-            ty: Function(
-                Function {
-                    is_async: false,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "foo",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: false,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "foo",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Unknown,
-                    ),
-                },
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Unknown,
+                            ),
+                        ),
+                    },
+                ),
             ),
         },
     ),

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
@@ -11,17 +11,93 @@ expression: data.exports
             local_name: Some(
                 "superComputer",
             ),
-            ty: Reference(
-                TypeReference {
-                    qualifier: TypeReferenceQualifier(
-                        [
-                            Borrowed(
-                                "DeepThought",
+            ty: Type(
+                Reference(
+                    TypeReference {
+                        qualifier: TypeReferenceQualifier(
+                            [
+                                Borrowed(
+                                    "DeepThought",
+                                ),
+                            ],
+                        ),
+                        ty: Type(
+                            Class(
+                                Class {
+                                    name: Some(
+                                        Borrowed(
+                                            "DeepThought",
+                                        ),
+                                    ),
+                                    members: [
+                                        Method(
+                                            MethodTypeMember {
+                                                is_async: false,
+                                                type_parameters: [],
+                                                name: Borrowed(
+                                                    "answerMe",
+                                                ),
+                                                parameters: [],
+                                                return_type: Type(
+                                                    Type(
+                                                        Number,
+                                                    ),
+                                                ),
+                                                is_optional: false,
+                                            },
+                                        ),
+                                        Method(
+                                            MethodTypeMember {
+                                                is_async: false,
+                                                type_parameters: [],
+                                                name: Borrowed(
+                                                    "giveMeABiggerAnswer",
+                                                ),
+                                                parameters: [
+                                                    FunctionParameter {
+                                                        name: Some(
+                                                            Borrowed(
+                                                                "delta",
+                                                            ),
+                                                        ),
+                                                        ty: Type(
+                                                            Number,
+                                                        ),
+                                                        is_optional: false,
+                                                        is_rest: false,
+                                                    },
+                                                ],
+                                                return_type: Type(
+                                                    Type(
+                                                        Unknown,
+                                                    ),
+                                                ),
+                                                is_optional: false,
+                                            },
+                                        ),
+                                        Method(
+                                            MethodTypeMember {
+                                                is_async: false,
+                                                type_parameters: [],
+                                                name: Borrowed(
+                                                    "whatWasTheUltimateQuestion",
+                                                ),
+                                                parameters: [],
+                                                return_type: Type(
+                                                    Type(
+                                                        UnknownKeyword,
+                                                    ),
+                                                ),
+                                                is_optional: false,
+                                            },
+                                        ),
+                                    ],
+                                },
                             ),
-                        ],
-                    ),
-                    type_parameters: [],
-                },
+                        ),
+                        type_parameters: [],
+                    },
+                ),
             ),
         },
     ),
@@ -33,10 +109,12 @@ expression: data.exports
             local_name: Some(
                 "theAnswer",
             ),
-            ty: Literal(
-                Number(
-                    Borrowed(
-                        "42",
+            ty: Type(
+                Literal(
+                    Number(
+                        Borrowed(
+                            "42",
+                        ),
                     ),
                 ),
             ),

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
@@ -15,7 +15,9 @@ expression: exports
             local_name: Some(
                 "a",
             ),
-            ty: Unknown,
+            ty: Type(
+                Unknown,
+            ),
         },
     ),
     Borrowed(
@@ -30,7 +32,9 @@ expression: exports
             local_name: Some(
                 "b",
             ),
-            ty: Unknown,
+            ty: Type(
+                Unknown,
+            ),
         },
     ),
     Borrowed(
@@ -45,20 +49,24 @@ expression: exports
             local_name: Some(
                 "bar",
             ),
-            ty: Function(
-                Function {
-                    is_async: false,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "bar",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: false,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "bar",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Unknown,
-                    ),
-                },
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Unknown,
+                            ),
+                        ),
+                    },
+                ),
             ),
         },
     ),
@@ -70,22 +78,28 @@ expression: exports
             local_name: Some(
                 "baz",
             ),
-            ty: Function(
-                Function {
-                    is_async: true,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "baz",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: true,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "baz",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Promise(
-                            Unknown,
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Promise(
+                                    Type(
+                                        Unknown,
+                                    ),
+                                ),
+                            ),
                         ),
-                    ),
-                },
+                    },
+                ),
             ),
         },
     ),
@@ -101,7 +115,9 @@ expression: exports
             local_name: Some(
                 "d",
             ),
-            ty: Unknown,
+            ty: Type(
+                Unknown,
+            ),
         },
     ),
     Static(
@@ -116,34 +132,41 @@ expression: exports
             local_name: Some(
                 "Component",
             ),
-            ty: Function(
-                Function {
-                    is_async: false,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "Component",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: false,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "Component",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Reference(
-                            TypeReference {
-                                qualifier: TypeReferenceQualifier(
-                                    [
-                                        Borrowed(
-                                            "JSX",
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Reference(
+                                    TypeReference {
+                                        qualifier: TypeReferenceQualifier(
+                                            [
+                                                Borrowed(
+                                                    "JSX",
+                                                ),
+                                                Borrowed(
+                                                    "Element",
+                                                ),
+                                            ],
                                         ),
-                                        Borrowed(
-                                            "Element",
+                                        ty: Type(
+                                            Unknown,
                                         ),
-                                    ],
+                                        type_parameters: [],
+                                    },
                                 ),
-                                type_parameters: [],
-                            },
+                            ),
                         ),
-                    ),
-                },
+                    },
+                ),
             ),
         },
     ),
@@ -159,7 +182,9 @@ expression: exports
             local_name: Some(
                 "e",
             ),
-            ty: Unknown,
+            ty: Type(
+                Unknown,
+            ),
         },
     ),
     Borrowed(
@@ -174,20 +199,24 @@ expression: exports
             local_name: Some(
                 "foo",
             ),
-            ty: Function(
-                Function {
-                    is_async: false,
-                    type_parameters: [],
-                    name: Some(
-                        Borrowed(
-                            "foo",
+            ty: Type(
+                Function(
+                    Function {
+                        is_async: false,
+                        type_parameters: [],
+                        name: Some(
+                            Borrowed(
+                                "foo",
+                            ),
                         ),
-                    ),
-                    parameters: [],
-                    return_type: Type(
-                        Unknown,
-                    ),
-                },
+                        parameters: [],
+                        return_type: Type(
+                            Type(
+                                Unknown,
+                            ),
+                        ),
+                    },
+                ),
             ),
         },
     ),
@@ -199,10 +228,12 @@ expression: exports
             local_name: Some(
                 "qux",
             ),
-            ty: Literal(
-                Number(
-                    Borrowed(
-                        "1",
+            ty: Type(
+                Literal(
+                    Number(
+                        Borrowed(
+                            "1",
+                        ),
                     ),
                 ),
             ),
@@ -220,7 +251,9 @@ expression: exports
             local_name: Some(
                 "quz",
             ),
-            ty: Unknown,
+            ty: Type(
+                Unknown,
+            ),
         },
     ),
 }


### PR DESCRIPTION
## Summary

Another milestone towards implementation type inference: Indexed modules now have their types resolved before being added to the module graph.

Take the following code snippet:

```ts
class DeepThought {
    /* class members */
}

export const superComputer = new DeepThought();
```

With this change, we can now successfully determine the type of `superComputer`, even though the `DeepThought` class is never being exported.

In order to accomplish this, I've introduced a `TypeResolver` trait and a `Resolvable` trait, with the latter also having a matching derive macro. The `TypeResolver` trait only has a single implementation for now, but I anticipate to be able to reuse the same trait when I implement full inference across modules.

## Test Plan

Snapshots updated. I had already prepared a test for this functionality in a previous PR. Look for the snapshot that references the symbol `DeepThought`. This reference now resolves to the class definition with its members.
