### PR TITLE
chore: use test for type size verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,6 @@ dependencies = [
  "biome_js_syntax",
  "biome_js_type_info_macros",
  "biome_rowan",
- "static_assertions",
 ]
 
 [[package]]

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -18,4 +18,3 @@ workspace = true
 biome_js_syntax           = { workspace = true }
 biome_js_type_info_macros = { workspace = true }
 biome_rowan               = { workspace = true }
-static_assertions         = { workspace = true }

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -13,7 +13,6 @@ use std::{ops::Deref, str::FromStr, sync::Arc};
 
 use biome_js_type_info_macros::Resolvable;
 use biome_rowan::Text;
-use static_assertions::assert_eq_size;
 
 use crate::Resolvable;
 
@@ -29,9 +28,6 @@ use crate::Resolvable;
 //       so at the type level you would never know when your pointer is going to
 //       break.
 pub struct Type(Arc<TypeInner>);
-
-// `Type` should not be bigger than 8 bytes.
-assert_eq_size!(Type, usize);
 
 impl Deref for Type {
     type Target = TypeInner;
@@ -143,9 +139,6 @@ pub enum TypeInner {
     /// The `void` keyword.
     VoidKeyword,
 }
-
-// `TypeInner` should not be bigger than 16 bytes.
-assert_eq_size!(TypeInner, [usize; 2]);
 
 impl TypeInner {
     /// Returns whether the given type has been inferred.

--- a/crates/biome_js_type_info/src/type_info.tests.rs
+++ b/crates/biome_js_type_info/src/type_info.tests.rs
@@ -1,1 +1,16 @@
+use super::*;
 
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn verify_type_sizes() {
+    assert_eq!(
+        std::mem::size_of::<Type>(),
+        8,
+        "`Type` should not be bigger than 8 bytes"
+    );
+    assert_eq!(
+        std::mem::size_of::<TypeInner>(),
+        16,
+        "`TypeInner` should not be bigger than 16 bytes"
+    );
+}


### PR DESCRIPTION
## Summary

Reduces another crate dependency, and allows us to add a message directly to the failing assertions.

## Test Plan

Test added.
