### PR TITLE
fix(lint): remove false-positives on hooks in a class method

### DIFF
--- a/.changeset/happy-crabs-sniff.md
+++ b/.changeset/happy-crabs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5629](https://github.com/biomejs/biome/issues/5629): useHookAtTopLevel no longer report false-positives where the hook is at the top-level in a class method.

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -13,11 +13,11 @@ use biome_deserialize::{
 };
 use biome_js_semantic::{CallsExtensions, SemanticModel};
 use biome_js_syntax::{
-    AnyFunctionLike, AnyJsBinding, AnyJsExpression, AnyJsFunction, AnyJsObjectMemberName,
-    JsArrayAssignmentPatternElement, JsArrayBindingPatternElement, JsCallExpression,
-    JsConditionalExpression, JsIfStatement, JsLanguage, JsLogicalExpression, JsMethodObjectMember,
-    JsObjectBindingPatternShorthandProperty, JsReturnStatement, JsSyntaxKind, JsSyntaxNode,
-    JsTryFinallyStatement, TextRange,
+    AnyFunctionLike, AnyJsBinding, AnyJsClassMemberName, AnyJsExpression, AnyJsFunction,
+    AnyJsObjectMemberName, JsArrayAssignmentPatternElement, JsArrayBindingPatternElement,
+    JsCallExpression, JsConditionalExpression, JsIfStatement, JsLanguage, JsLogicalExpression,
+    JsMethodClassMember, JsMethodObjectMember, JsObjectBindingPatternShorthandProperty,
+    JsReturnStatement, JsSyntaxKind, JsSyntaxNode, JsTryFinallyStatement, TextRange,
 };
 use biome_rowan::{AstNode, Language, SyntaxNode, WalkEvent, declare_node_union};
 use rustc_hash::FxHashMap;
@@ -77,7 +77,7 @@ declare_lint_rule! {
 }
 
 declare_node_union! {
-    pub AnyJsFunctionOrMethod = AnyJsFunction | JsMethodObjectMember
+    pub AnyJsFunctionOrMethod = AnyJsFunction | JsMethodClassMember | JsMethodObjectMember
 }
 
 impl AnyJsFunctionOrMethod {
@@ -97,6 +97,11 @@ impl AnyJsFunctionOrMethod {
                 .binding()
                 .as_ref()
                 .map(AnyJsBinding::to_trimmed_string),
+            AnyJsFunctionOrMethod::JsMethodClassMember(method) => method
+                .name()
+                .ok()
+                .as_ref()
+                .map(AnyJsClassMemberName::to_trimmed_string),
             AnyJsFunctionOrMethod::JsMethodObjectMember(method) => method
                 .name()
                 .ok()

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js
@@ -166,3 +166,19 @@ test('b', () => {
 
     render(<TestComponent />);
 });
+
+class DemoMethod {
+    useHook() {
+        if (condition) {
+            return useMemo(() => "string", []);
+        }
+    }
+}
+
+class DemoProperty {
+    useHook = () => {
+        if (condition) {
+            return useMemo(() => "string", []);
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/invalid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -173,6 +172,22 @@ test('b', () => {
 
     render(<TestComponent />);
 });
+
+class DemoMethod {
+    useHook() {
+        if (condition) {
+            return useMemo(() => "string", []);
+        }
+    }
+}
+
+class DemoProperty {
+    useHook = () => {
+        if (condition) {
+            return useMemo(() => "string", []);
+        }
+    }
+}
 
 ```
 
@@ -793,6 +808,44 @@ invalid.js:163:13 lint/correctness/useHookAtTopLevel ━━━━━━━━━
         │             ^^^^^^^
     164 │         };
     165 │     };
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:173:20 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    171 │     useHook() {
+    172 │         if (condition) {
+  > 173 │             return useMemo(() => "string", []);
+        │                    ^^^^^^^
+    174 │         }
+    175 │     }
+  
+  i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
+  
+  i See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+  
+
+```
+
+```
+invalid.js:181:20 lint/correctness/useHookAtTopLevel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook is being called conditionally, but all hooks must be called in the exact same order in every component render.
+  
+    179 │     useHook = () => {
+    180 │         if (condition) {
+  > 181 │             return useMemo(() => "string", []);
+        │                    ^^^^^^^
+    182 │         }
+    183 │     }
   
   i For React to preserve state between calls, hooks needs to be called unconditionally and always in the same order.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
@@ -130,3 +130,15 @@ describe("foo", () => {
   beforeEach(() => jest.useFakeTimers('legacy'));
   afterEach(() => jest.useRealTimers());
 })
+
+class DemoMethod {
+    useHook() {
+        return useMemo(() => "string", []);
+    }
+}
+
+class DemoProperty {
+    useHook = () => {
+        return useMemo(() => "string", []);
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -137,5 +136,17 @@ describe("foo", () => {
   beforeEach(() => jest.useFakeTimers('legacy'));
   afterEach(() => jest.useRealTimers());
 })
+
+class DemoMethod {
+    useHook() {
+        return useMemo(() => "string", []);
+    }
+}
+
+class DemoProperty {
+    useHook = () => {
+        return useMemo(() => "string", []);
+    }
+}
 
 ```


### PR DESCRIPTION
## Summary

Fixes #5629.

Added `JsMethodClassMember` to the union query.

## Test Plan

Added snapshot tests.
