### PR TITLE
feat(noExplicitType): cover `const` exported variables

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_inferrable_types.rs
@@ -3,13 +3,12 @@ use biome_analyze::RuleSource;
 use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
+use biome_js_syntax::AnyJsLiteralExpression;
 use biome_js_syntax::{
     AnyJsExpression, AnyTsPropertyAnnotation, AnyTsVariableAnnotation, JsFormalParameter,
-    JsInitializerClause, JsPropertyClassMember, JsSyntaxKind, JsVariableDeclaration,
-    JsVariableDeclarator, JsVariableDeclaratorList, TsPropertyParameter, TsReadonlyModifier,
-    TsTypeAnnotation,
+    JsInitializerClause, JsPropertyClassMember, JsVariableDeclaration, JsVariableDeclarator,
+    JsVariableDeclaratorList, TsPropertyParameter, TsReadonlyModifier, TsTypeAnnotation,
 };
-use biome_js_syntax::{AnyJsLiteralExpression, AnyTsType};
 use biome_rowan::AstNode;
 use biome_rowan::BatchMutationExt;
 
@@ -113,7 +112,7 @@ impl Rule for NoInferrableTypes {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let init = ctx.query();
         let init_expr = init.expression().ok()?.omit_parentheses();
-        if has_trivially_inferrable_type(&init_expr).is_some() {
+        if init_expr.has_trivially_inferrable_type() {
             // `is_const` signals a const context (const declarations, readonly properties)
             // non const contexts are other situations (let/var declarations, mutable properties, formal parameters)
             let mut is_const = false;
@@ -158,7 +157,7 @@ impl Rule for NoInferrableTypes {
                 //
                 // However, we ignore the case where <literal> is `null`,
                 // because in unsafe null mode, it is possible to assign `null` and `undefined` to any type.
-                if (is_const && is_non_null_literal_type(&ty))
+                if (is_const && ty.is_non_null_literal_type())
                     || (!is_const
                         && ty.is_primitive_type()
                         && !matches!(
@@ -204,31 +203,4 @@ impl Rule for NoInferrableTypes {
             mutation,
         ))
     }
-}
-
-fn has_trivially_inferrable_type(expr: &AnyJsExpression) -> Option<()> {
-    match expr {
-        AnyJsExpression::AnyJsLiteralExpression(_) => Some(()),
-        AnyJsExpression::JsTemplateExpression(tpl_expr) => tpl_expr.tag().is_none().then_some(()),
-        AnyJsExpression::JsUnaryExpression(unary_exp) => {
-            match unary_exp.operator_token().ok()?.kind() {
-                JsSyntaxKind::BANG
-                | JsSyntaxKind::MINUS
-                | JsSyntaxKind::PLUS
-                | JsSyntaxKind::VOID_KW => Some(()),
-                _ => None,
-            }
-        }
-        _ => None,
-    }
-}
-
-fn is_non_null_literal_type(ty: &AnyTsType) -> bool {
-    matches!(
-        ty,
-        AnyTsType::TsBooleanLiteralType(_)
-            | AnyTsType::TsBigintLiteralType(_)
-            | AnyTsType::TsNumberLiteralType(_)
-            | AnyTsType::TsStringLiteralType(_)
-    )
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
@@ -91,8 +91,8 @@ function fn() {
 	};
 }
 
-const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
-const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
+const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
+const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
 
 
 // Returning object from function

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
@@ -98,8 +98,8 @@ function fn() {
 	};
 }
 
-const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
-const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
+const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
+const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
 
 
 // Returning object from function
@@ -160,7 +160,7 @@ invalid.ts:1:1 lint/nursery/useExplicitType ━━━━━━━━━━━━
     2 │ 	return;
     3 │ }
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -179,7 +179,7 @@ invalid.ts:5:1 lint/nursery/useExplicitType ━━━━━━━━━━━━
     6 │ 	return;
     7 │ }
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -201,7 +201,7 @@ invalid.ts:9:10 lint/nursery/useExplicitType ━━━━━━━━━━━�
     12 │ 
     13 │ var arrowFn = () => "test";
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -220,7 +220,7 @@ invalid.ts:13:15 lint/nursery/useExplicitType ━━━━━━━━━━━�
     14 │ 
     15 │ class Test {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -242,7 +242,7 @@ invalid.ts:17:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     20 │ 	set prop() {}
     21 │ 	method() {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -264,7 +264,7 @@ invalid.ts:21:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     24 │ 	arrow = () => "arrow";
     25 │ 	private method() {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -283,7 +283,7 @@ invalid.ts:24:10 lint/nursery/useExplicitType ━━━━━━━━━━━�
     25 │ 	private method() {
     26 │ 		return;
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -305,7 +305,7 @@ invalid.ts:25:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     28 │ }
     29 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -326,7 +326,7 @@ invalid.ts:31:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     34 │ };
     35 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -347,7 +347,7 @@ invalid.ts:37:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     40 │ };
     41 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -366,7 +366,7 @@ invalid.ts:42:14 lint/nursery/useExplicitType ━━━━━━━━━━━�
     43 │ const func = (value: number) => ({ type: "X", value }) as Action;
     44 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -384,7 +384,7 @@ invalid.ts:43:14 lint/nursery/useExplicitType ━━━━━━━━━━━�
     44 │ 
     45 │ export default () => {};
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -403,7 +403,7 @@ invalid.ts:45:16 lint/nursery/useExplicitType ━━━━━━━━━━━�
     46 │ export default function () {}
     47 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -421,7 +421,7 @@ invalid.ts:46:16 lint/nursery/useExplicitType ━━━━━━━━━━━�
     47 │ 
     48 │ // check higher order functions
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -439,7 +439,7 @@ invalid.ts:49:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
     50 │ const arrowFn = () => function () {};
     51 │ const arrowFn = () => {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -458,7 +458,7 @@ invalid.ts:50:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
     51 │ const arrowFn = () => {
     52 │ 	return () => {};
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -477,7 +477,7 @@ invalid.ts:52:9 lint/nursery/useExplicitType ━━━━━━━━━━━�
     53 │ };
     54 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -501,7 +501,7 @@ invalid.ts:57:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
     66 │ const arrowFn = (a: number) => {
     67 │ 	switch (a) {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -525,7 +525,7 @@ invalid.ts:66:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
     79 │ 
     80 │ function f() {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -544,7 +544,7 @@ invalid.ts:80:1 lint/nursery/useExplicitType ━━━━━━━━━━━�
     81 │ 	if (x) {
     82 │ 		return 0;
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -563,7 +563,7 @@ invalid.ts:87:1 lint/nursery/useExplicitType ━━━━━━━━━━━�
     88 │ 	let str = "hey";
     89 │ 	return function (): string {
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -577,12 +577,12 @@ invalid.ts:94:29 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
     92 │ }
     93 │ 
-  > 94 │ const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
+  > 94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
        │                             ^^^^^^^^^^^^^^
-    95 │ const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
+    95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
     96 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -590,18 +590,18 @@ invalid.ts:94:29 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:94:81 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:94:69 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
   
     92 │ }
     93 │ 
-  > 94 │ const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
-       │                                                                                 ^^^^^^^^
-    95 │ const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
+  > 94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
+       │                                                                     ^^^^^^^^^^^^^^
+    95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
     96 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -613,12 +613,12 @@ invalid.ts:95:36 lint/nursery/useExplicitType ━━━━━━━━━━━�
 
   × Missing return type on function.
   
-    94 │ const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
-  > 95 │ const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
+    94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
+  > 95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
        │                                    ^^^^^^^^^^^^^^
     96 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -626,16 +626,16 @@ invalid.ts:95:36 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:95:79 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:95:76 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
   
-    94 │ const x = { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} };
-  > 95 │ const x = { bar: { namedFunctions: function alpha () => {}, unNamedFunctions: function () => {} } }
-       │                                                                               ^^^^^^^^^^^
+    94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
+  > 95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
+       │                                                                            ^^^^^^^^^^^^^^
     96 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -654,7 +654,7 @@ invalid.ts:107:16 lint/nursery/useExplicitType ━━━━━━━━━━━
     108 │     arrowFunc: () => {},
     109 │   }
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -673,7 +673,7 @@ invalid.ts:115:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     116 │ }
     117 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -691,7 +691,7 @@ invalid.ts:119:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     120 │ 	propertyName: string;
     121 │ };
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -709,7 +709,7 @@ invalid.ts:124:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     125 │ }
     126 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -728,7 +728,7 @@ invalid.ts:129:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     130 │ }
     131 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -746,7 +746,7 @@ invalid.ts:133:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
     134 │ }
     135 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -764,7 +764,7 @@ invalid.ts:137:17 lint/nursery/useExplicitType ━━━━━━━━━━━
     138 │ }
     139 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -783,7 +783,7 @@ invalid.ts:140:19 lint/nursery/useExplicitType ━━━━━━━━━━━
     141 │ const x = { bar: { prop: () => {} } }
     142 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   
@@ -800,7 +800,7 @@ invalid.ts:141:26 lint/nursery/useExplicitType ━━━━━━━━━━━
         │                          ^^^^^^^^
     142 │ 
   
-  i Declaring the return type makes the code self-documenting and can speed up TypeScript type checking.
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type annotation.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts
@@ -1,0 +1,8 @@
+export const foo = {};
+
+
+const bar = {};
+
+export {
+	bar
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
@@ -1,0 +1,51 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidDeclarationStatements.ts
+snapshot_kind: text
+---
+# Input
+```ts
+export const foo = {};
+
+
+const bar = {};
+
+export {
+	bar
+}
+
+```
+
+# Diagnostics
+```
+invalidDeclarationStatements.ts:1:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+  > 1 │ export const foo = {};
+      │              ^^^
+    2 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```
+
+```
+invalidDeclarationStatements.ts:4:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+  > 4 │ const bar = {};
+      │       ^^^
+    5 │ 
+    6 │ export {
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a return type annotation.
+  
+
+```

--- a/crates/biome_js_syntax/src/expr_ext.rs
+++ b/crates/biome_js_syntax/src/expr_ext.rs
@@ -1381,6 +1381,24 @@ impl AnyJsExpression {
             _ => false,
         }
     }
+
+    pub fn has_trivially_inferrable_type(&self) -> bool {
+        match self {
+            AnyJsExpression::AnyJsLiteralExpression(_) => true,
+            AnyJsExpression::JsTemplateExpression(tpl_expr) => tpl_expr.tag().is_none(),
+            AnyJsExpression::JsUnaryExpression(unary_exp) => {
+                let kind = unary_exp.operator_token().map(|t| t.kind());
+                match kind {
+                    Ok(JsSyntaxKind::BANG)
+                    | Ok(JsSyntaxKind::MINUS)
+                    | Ok(JsSyntaxKind::PLUS)
+                    | Ok(JsSyntaxKind::VOID_KW) => true,
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
 }
 
 /// Iterator that returns the callee names in "top down order".

--- a/crates/biome_js_syntax/src/type_ext.rs
+++ b/crates/biome_js_syntax/src/type_ext.rs
@@ -69,13 +69,41 @@ impl AnyTsType {
     /// assert!(AnyTsType::TsNumberType(number).is_primitive_type());
     /// assert!(AnyTsType::TsStringType(string).is_primitive_type());
     /// ```
-    pub fn is_primitive_type(&self) -> bool {
+    pub const fn is_primitive_type(&self) -> bool {
         matches!(
             self,
             AnyTsType::TsBooleanType(_)
                 | AnyTsType::TsBigintType(_)
                 | AnyTsType::TsNumberType(_)
                 | AnyTsType::TsStringType(_)
+        )
+    }
+
+    /// Returns `true` if `self` is a non-null literal type.
+    ///
+    /// ### Examples
+    ///
+    /// ```
+    /// use biome_js_factory::make;
+    /// use biome_js_syntax::T;
+    /// use biome_js_syntax::AnyTsType;
+    ///
+    /// let boolean = make::ts_boolean_literal_type(make::token(T![boolean]));
+    /// let bigint = make::ts_bigint_literal_type(make::token(T![bigint])).build();
+    /// let number = make::ts_number_literal_type(make::token(T![number])).build();
+    /// let string = make::ts_string_literal_type(make::token(T![string]));
+    ///
+    /// assert!(AnyTsType::TsBooleanLiteralType(boolean).is_non_null_literal_type());
+    /// assert!(AnyTsType::TsBigintLiteralType(bigint).is_non_null_literal_type());
+    /// assert!(AnyTsType::TsNumberLiteralType(number).is_non_null_literal_type());
+    /// assert!(AnyTsType::TsStringLiteralType(string).is_non_null_literal_type());
+    pub const fn is_non_null_literal_type(&self) -> bool {
+        matches!(
+            self,
+            AnyTsType::TsBooleanLiteralType(_)
+                | AnyTsType::TsBigintLiteralType(_)
+                | AnyTsType::TsNumberLiteralType(_)
+                | AnyTsType::TsStringLiteralType(_)
         )
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Related https://github.com/biomejs/biome/issues/2017

This PR adds code to cover exported `const` variables. I refactored the code a bit, and made some logic inside `noInferrableTypes` generic so it could be used in this rule too.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added new test cases. I fixed some snapshots because they had invalid code.

<!-- What demonstrates that your implementation is correct? -->
