### PR TITLE
feat(core): add `Typed` service and update `noFloatingPromises`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,9 +943,11 @@ dependencies = [
 name = "biome_js_type_info"
 version = "0.0.1"
 dependencies = [
+ "biome_js_parser",
  "biome_js_syntax",
  "biome_js_type_info_macros",
  "biome_rowan",
+ "insta",
 ]
 
 [[package]]
@@ -1185,6 +1187,7 @@ dependencies = [
  "once_cell",
  "oxc_resolver",
  "papaya",
+ "rust-lapper",
  "rustc-hash 2.1.1",
  "serde_json",
  "static_assertions",

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -1,26 +1,15 @@
-use std::ops::Deref;
-
 use biome_analyze::{
     FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_js_factory::make;
-use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsClassMember, AnyJsExpression, AnyTsType, JsArrowFunctionExpression, JsCallExpression,
-    JsClassDeclaration, JsClassExpression, JsClassMemberList, JsExpressionStatement,
-    JsExtendsClause, JsFormalParameter, JsFunctionDeclaration, JsIdentifierExpression,
-    JsInitializerClause, JsLanguage, JsMethodClassMember, JsMethodObjectMember, JsObjectExpression,
-    JsStaticMemberExpression, JsSyntaxKind, JsThisExpression, JsVariableDeclarator,
-    TsReturnTypeAnnotation, binding_ext::AnyJsBindingDeclaration, global_identifier,
+    AnyJsExpression, JsArrowFunctionExpression, JsExpressionStatement, JsFunctionDeclaration,
+    JsMethodClassMember, JsMethodObjectMember, JsSyntaxKind,
 };
-use biome_js_type_info::{Type, TypeInner, TypeMember};
-use biome_rowan::{
-    AstNode, AstNodeList, AstSeparatedList, BatchMutationExt, SyntaxNode, SyntaxNodeCast,
-    TriviaPieceKind,
-};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, SyntaxNodeCast, TriviaPieceKind};
 
-use crate::{JsRuleAction, services::semantic::Semantic};
+use crate::{JsRuleAction, services::typed::Typed};
 
 declare_lint_rule! {
     /// Require Promise-like statements to be handled appropriately.
@@ -178,44 +167,24 @@ declare_lint_rule! {
 }
 
 impl Rule for NoFloatingPromises {
-    type Query = Semantic<JsExpressionStatement>;
+    type Query = Typed<JsExpressionStatement>;
     type State = ();
     type Signals = Option<Self::State>;
     type Options = ();
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
-        let model = ctx.model();
         let expression = node.expression().ok()?;
-        match expression.omit_parentheses() {
-            AnyJsExpression::JsCallExpression(js_call_expression) => {
-                let any_js_expression = js_call_expression.callee().ok()?;
-
-                if !is_callee_a_promise(&any_js_expression, model)? {
-                    return None;
-                }
-
-                if is_handled_promise(&js_call_expression).unwrap_or_default() {
-                    return None;
-                }
-
-                Some(())
-            }
-            AnyJsExpression::JsIdentifierExpression(js_identifier_expression) => {
-                if !is_binding_a_promise(&js_identifier_expression, model, None)? {
-                    return None;
-                }
-
-                Some(())
-            }
-            AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
-                if !is_member_expression_callee_a_promise(&static_member_expr, model)? {
-                    return None;
-                }
-                Some(())
-            }
-            _ => None,
+        let ty = ctx.type_for_expression(&expression);
+        if !ty.is_promise_instance() {
+            return None;
         }
+
+        if is_handled_promise(expression).unwrap_or_default() {
+            return None;
+        }
+
+        Some(())
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
@@ -259,200 +228,11 @@ impl Rule for NoFloatingPromises {
     }
 }
 
-/// Checks if the callee of a JavaScript expression is a promise.
+/// Checks if a JS `expression` is a handled Promise-like expression.
 ///
-/// This function inspects the callee of a given JavaScript expression to determine
-/// if it is a promise. It returns `true` if the callee is a promise, otherwise `false`.
-///
-/// The function works by finding the binding of the callee and checking if it is a promise.
-///
-/// # Arguments
-///
-/// * `callee` - A reference to an `AnyJsExpression` representing the callee to check.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-///
-/// # Returns
-///
-/// * `true` if the callee is a promise.
-/// * `false` otherwise.
-///
-/// # Examples
-///
-/// Example JavaScript code that would return `true`:
-/// ```typescript
-/// async function returnsPromise(): Promise<string> {
-///     return "value";
-/// }
-///
-/// returnsPromise().then(() => {});
-/// ```
-///
-/// ```typescript
-/// const obj = {
-///   async returnsPromise(): Promise<string> {
-///     return 'value';
-///   },
-/// };
-///
-/// obj['returnsPromise']();
-/// ```
-///
-/// Example JavaScript code that would return `false`:
-/// ```typescript
-/// function doesNotReturnPromise() {
-///     return 42;
-/// }
-///
-/// doesNotReturnPromise().then(() => {});
-/// ```
-fn is_callee_a_promise(callee: &AnyJsExpression, model: &SemanticModel) -> Option<bool> {
-    match callee {
-        AnyJsExpression::JsIdentifierExpression(js_ident_expr) => {
-            is_binding_a_promise(js_ident_expr, model, None)
-        }
-        AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
-            is_member_expression_callee_a_promise(static_member_expr, model)
-        }
-        AnyJsExpression::JsComputedMemberExpression(computed_member_expr) => {
-            let object = computed_member_expr.object().ok()?;
-            let member = computed_member_expr.member().ok()?;
-            let literal_expr = member.as_any_js_literal_expression()?;
-            let string_literal = literal_expr.as_js_string_literal_expression()?;
-            let value_token_text = string_literal.inner_string_text().ok()?;
-            let value_text = value_token_text.text();
-
-            match object {
-                AnyJsExpression::JsIdentifierExpression(js_ident_expr) => {
-                    is_binding_a_promise(&js_ident_expr, model, Some(value_text))
-                }
-                AnyJsExpression::JsThisExpression(js_this_expr) => {
-                    check_this_expression(&js_this_expr, value_text, model)
-                }
-                _ => None,
-            }
-        }
-        _ => Some(false),
-    }
-}
-
-/// Checks if a binding is a promise.
-///
-/// This function inspects the binding of a given `JsIdentifierExpression` to determine
-/// if it is a promise. It returns `Some(true)` if the binding is a promise, `Some(false)` if it is not,
-/// and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `js_ident_expr` - A reference to a `JsIdentifierExpression` representing the identifier to check.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-/// * `target_method_name` - An optional name of the method to check if it is a promise.
-///
-/// # Returns
-///
-/// * `Some(true)` if the binding is a promise.
-/// * `Some(false)` if the binding is not a promise.
-/// * `None` if there is an error in the process.
-///
-fn is_binding_a_promise(
-    js_ident_expr: &JsIdentifierExpression,
-    model: &SemanticModel,
-    target_method_name: Option<&str>,
-) -> Option<bool> {
-    let reference = js_ident_expr.name().ok()?;
-    let binding = model.binding(&reference)?;
-    let any_js_binding_decl = binding.tree().declaration()?;
-
-    match any_js_binding_decl {
-        AnyJsBindingDeclaration::JsFunctionDeclaration(func_decl) => {
-            Some(is_function_a_promise(&func_decl))
-        }
-        AnyJsBindingDeclaration::JsVariableDeclarator(js_var_decl) => Some(
-            is_initializer_a_promise(&js_var_decl.initializer()?, model, target_method_name)
-                .unwrap_or_default()
-                || is_variable_annotation_a_promise(&js_var_decl, model).unwrap_or_default(),
-        ),
-        AnyJsBindingDeclaration::JsFormalParameter(js_formal_param) => {
-            // function foo(props: Type)
-            let value_token = reference.value_token().ok()?;
-            let ts_type_annotation = js_formal_param.type_annotation()?;
-            let any_ts_type = ts_type_annotation.ty().ok()?;
-            is_ts_type_a_promise(
-                &any_ts_type,
-                model,
-                target_method_name.or_else(|| Some(value_token.text_trimmed())),
-            )
-        }
-        AnyJsBindingDeclaration::JsObjectBindingPatternShorthandProperty(js_obj_binding) => {
-            // function foo({ bar }: Type)
-            let value_token = reference.value_token().ok()?;
-            let js_formal_param = find_js_formal_parameter(js_obj_binding.syntax())?;
-            let type_annotation = js_formal_param.type_annotation()?;
-            let any_ts_type = type_annotation.ty().ok()?;
-            is_ts_type_a_promise(&any_ts_type, model, Some(value_token.text_trimmed()))
-        }
-        AnyJsBindingDeclaration::JsObjectBindingPatternRest(js_obj_binding) => {
-            // function foo({ bar, ...rest }: Type)
-            let js_formal_param = find_js_formal_parameter(js_obj_binding.syntax())?;
-            let type_annotation = js_formal_param.type_annotation()?;
-            let any_ts_type = type_annotation.ty().ok()?;
-            is_ts_type_a_promise(&any_ts_type, model, target_method_name)
-        }
-        _ => Some(false),
-    }
-}
-
-fn is_function_a_promise(func_decl: &JsFunctionDeclaration) -> bool {
-    func_decl.async_token().is_some()
-        || is_return_type_a_promise(func_decl.return_type_annotation()).unwrap_or_default()
-}
-
-/// Checks if a TypeScript return type annotation is a `Promise`.
-///
-/// This function inspects the return type annotation of a TypeScript function to determine
-/// if it is a `Promise`. It returns `Some(true)` if the return type annotation is `Promise`,
-/// `Some(false)` if it is not, and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `return_type` - An optional `TsReturnTypeAnnotation` to check.
-///
-/// # Returns
-///
-/// * `Some(true)` if the return type annotation is `Promise`.
-/// * `Some(false)` if the return type annotation is not `Promise`.
-/// * `None` if there is an error in the process.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `Some(true)`:
-/// ```typescript
-/// async function returnsPromise(): Promise<void> {}
-/// ```
-///
-/// Example TypeScript code that would return `false`:
-/// ```typescript
-/// function doesNotReturnPromise(): void {}
-/// ```
-fn is_return_type_a_promise(return_type: Option<TsReturnTypeAnnotation>) -> Option<bool> {
-    let ts_return_type_anno = return_type?.ty().ok()?;
-    let any_ts_type = ts_return_type_anno.as_any_ts_type()?;
-    let reference_type = any_ts_type.as_ts_reference_type()?;
-    let any_ts_name = reference_type.name().ok()?;
-    let name = any_ts_name.as_js_reference_identifier()?;
-
-    Some(name.has_name("Promise"))
-}
-
-/// Checks if a `JsCallExpression` is a handled Promise-like expression.
-/// - Calling its .then() with two arguments
-/// - Calling its .catch() with one argument
-///
-/// This function inspects a `JsCallExpression` to determine if it is a handled Promise-like expression.
-/// It returns `Some(true)` if the expression is handled, `Some(false)` if it is not, and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `js_call_expression` - A reference to a `JsCallExpression` to check.
+/// A `Promise` is considered handled if:
+/// - It calls its `.then()` method with two arguments, _or_
+/// - It calls its `.catch()` method with one argument.
 ///
 /// # Returns
 ///
@@ -470,7 +250,12 @@ fn is_return_type_a_promise(return_type: Option<TsReturnTypeAnnotation>) -> Opti
 /// const promise: Promise<unknown> = new Promise((resolve, reject) => resolve('value'));
 /// promise.then(() => "aaa").catch(() => null).finally(() => null)
 /// ```
-fn is_handled_promise(js_call_expression: &JsCallExpression) -> Option<bool> {
+fn is_handled_promise(expression: AnyJsExpression) -> Option<bool> {
+    let js_call_expression = match expression.omit_parentheses() {
+        AnyJsExpression::JsCallExpression(js_call_expression) => js_call_expression,
+        _ => return None,
+    };
+
     let expr = js_call_expression.callee().ok()?;
     let static_member_expr = expr.as_js_static_member_expression()?;
     let member = static_member_expr.member().ok()?;
@@ -480,8 +265,7 @@ fn is_handled_promise(js_call_expression: &JsCallExpression) -> Option<bool> {
 
     if name == "finally" {
         let expr = static_member_expr.object().ok()?;
-        let callee = expr.as_js_call_expression()?;
-        return is_handled_promise(callee);
+        return is_handled_promise(expr);
     }
     if name == "catch" {
         let call_args = js_call_expression.arguments().ok()?;
@@ -495,78 +279,6 @@ fn is_handled_promise(js_call_expression: &JsCallExpression) -> Option<bool> {
     }
 
     Some(false)
-}
-
-/// Checks if the callee of a `JsStaticMemberExpression` is a promise expression.
-///
-/// This function inspects the callee of a `JsStaticMemberExpression` to determine
-/// if it is a promise expression. It returns `Some(true)` if the callee is a promise expression,
-/// `Some(false)` if it is not, and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `static_member_expr` - A reference to a `JsStaticMemberExpression` to check.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-///
-/// # Returns
-///
-/// * `Some(true)` if the callee is a promise expression.
-/// * `Some(false)` if the callee is not a promise expression.
-/// * `None` if there is an error in the process.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `true`:
-/// ```typescript
-/// async function returnsPromise(): Promise<void> {}
-///
-/// returnsPromise().then(() => null).catch(() => {});
-///
-/// globalThis.Promise.reject('value').finally();
-/// ```
-///
-/// Example TypeScript code that would return `false`:
-/// ```typescript
-/// function doesNotReturnPromise(): void {}
-///
-/// doesNotReturnPromise().then(() => null).catch(() => {});
-/// ```
-fn is_member_expression_callee_a_promise(
-    static_member_expr: &JsStaticMemberExpression,
-    model: &SemanticModel,
-) -> Option<bool> {
-    let expr = static_member_expr.object().ok()?;
-
-    if is_expression_a_promise(&expr, model) {
-        return Some(true);
-    }
-
-    match expr {
-        AnyJsExpression::JsCallExpression(js_call_expr) => {
-            let callee = js_call_expr.callee().ok()?;
-            is_callee_a_promise(&callee, model)
-        }
-        AnyJsExpression::JsIdentifierExpression(js_ident_expr) => {
-            let value_token = static_member_expr
-                .member()
-                .ok()
-                .and_then(|js_name| js_name.value_token().ok());
-
-            if let Some(token) = value_token {
-                return is_binding_a_promise(&js_ident_expr, model, Some(token.text_trimmed()));
-            }
-            is_binding_a_promise(&js_ident_expr, model, None)
-        }
-        AnyJsExpression::JsThisExpression(js_this_expr) => {
-            let js_name = static_member_expr.member().ok()?;
-            let value_token = js_name.value_token().ok()?;
-            check_this_expression(&js_this_expr, value_token.text_trimmed(), model)
-        }
-        AnyJsExpression::JsStaticMemberExpression(static_member_expr) => {
-            is_member_expression_callee_a_promise(&static_member_expr, model)
-        }
-        _ => Some(false),
-    }
 }
 
 /// Checks if the given `JsExpressionStatement` is within an async function.
@@ -603,432 +315,4 @@ fn is_in_async_function(node: &JsExpressionStatement) -> bool {
             _ => None,
         })
         .is_some()
-}
-
-/// Checks if the initializer is an async function or returns a promise.
-///
-/// This function inspects the initializer of a given `JsVariableDeclarator` to determine
-/// if it is an async function or returns a promise. It returns `Some(true)` if the initializer
-/// is an async function or returns a promise, `Some(false)` if it is not, and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `js_variable_declarator` - A reference to a `JsVariableDeclarator` to check.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-/// * `target_method_name` - An optional name of the method to check if it is a promise.
-///
-/// # Returns
-///
-/// * `Some(true)` if the initializer is an async function or returns a promise.
-/// * `Some(false)` if the initializer is not an async function and does not return a promise.
-/// * `None` if there is an error in the process.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `Some(true)`:
-///
-/// ```typescript
-/// const returnsPromise = async (): Promise<string> => {
-///   return 'value';
-/// }
-///
-/// const returnsPromise = async function (): Promise<string> {
-///   return 'value'
-/// }
-///
-/// const promise = new Promise((resolve) => resolve('value'));
-///
-/// const promiseWithGlobalIdentifier = new window.Promise((resolve, reject) => resolve('value'));
-/// ```
-fn is_initializer_a_promise(
-    initializer_clause: &JsInitializerClause,
-    model: &SemanticModel,
-    target_method_name: Option<&str>,
-) -> Option<bool> {
-    let expr = initializer_clause.expression().ok()?;
-    match expr.omit_parentheses() {
-        AnyJsExpression::JsArrowFunctionExpression(arrow_func) => Some(
-            arrow_func.async_token().is_some()
-                || is_return_type_a_promise(arrow_func.return_type_annotation())
-                    .unwrap_or_default(),
-        ),
-        AnyJsExpression::JsFunctionExpression(func_expr) => Some(
-            func_expr.async_token().is_some()
-                || is_return_type_a_promise(func_expr.return_type_annotation()).unwrap_or_default(),
-        ),
-        AnyJsExpression::JsNewExpression(js_new_epr) => {
-            let any_js_expr = js_new_epr.callee().ok()?;
-            if is_expression_a_promise(&any_js_expr, model) {
-                return Some(true);
-            }
-            let ident_expr = any_js_expr.as_js_identifier_expression()?;
-            let reference = ident_expr.name().ok()?;
-            let binding = model.binding(&reference)?;
-            let any_js_binding_decl = binding.tree().declaration()?;
-            match any_js_binding_decl {
-                AnyJsBindingDeclaration::JsClassDeclaration(class_decl) => {
-                    find_and_check_class_member(&class_decl.members(), target_method_name?, model)
-                }
-                AnyJsBindingDeclaration::JsVariableDeclarator(js_var_decl) => {
-                    let initializer = js_var_decl.initializer()?;
-                    is_initializer_a_promise(&initializer, model, target_method_name)
-                }
-                _ => None,
-            }
-        }
-        AnyJsExpression::JsClassExpression(class_expr) => {
-            find_and_check_class_member(&class_expr.members(), target_method_name?, model)
-        }
-        AnyJsExpression::JsObjectExpression(object_expr) => {
-            find_promise_in_object(&object_expr, target_method_name?)
-        }
-        _ => Some(false),
-    }
-}
-
-/// Checks if a `JsVariableDeclarator` has a TypeScript type annotation of `Promise`.
-///
-/// This function inspects the type annotation of a given `JsVariableDeclarator` to determine
-/// if it is a `Promise`. It returns `Some(true)` if the type annotation is `Promise`,
-/// `Some(false)` if it is not, and `None` if there is an error in the process.
-///
-/// # Arguments
-///
-/// * `js_variable_declarator` - A reference to a `JsVariableDeclarator` to check.
-///
-/// # Returns
-///
-/// * `Some(true)` if the type annotation is `Promise`.
-/// * `Some(false)` if the type annotation is not `Promise`.
-/// * `None` if there is an error in the process.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `Some(true)`:
-/// ```typescript
-/// const returnsPromise: () => Promise<string> = () => {
-///   return Promise.resolve("value")
-/// }
-///
-/// const promise: Promise<string> = new Promise((resolve) => resolve('value'));
-/// ```
-fn is_variable_annotation_a_promise(
-    js_variable_declarator: &JsVariableDeclarator,
-    model: &SemanticModel,
-) -> Option<bool> {
-    let any_ts_var_anno = js_variable_declarator.variable_annotation()?;
-    let ts_type_anno = any_ts_var_anno.as_ts_type_annotation()?;
-    let any_ts_type = ts_type_anno.ty().ok()?;
-    is_ts_type_a_promise(&any_ts_type, model, None)
-}
-
-/// Checks if an expression is a `Promise`.
-///
-/// This function inspects a given `AnyJsExpression` to determine if it represents a `Promise`,
-/// either as a global identifier (e.g., `window.Promise`) or directly (e.g., `Promise.resolve`).
-/// It also checks that the found `Promise` is not a binding.
-/// It returns `true` if the expression is a `Promise` and is not a binding, otherwise `false`.
-///
-/// # Arguments
-///
-/// * `expr` - A reference to an `AnyJsExpression` to check.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-///
-/// # Returns
-///
-/// * `true` if the expression is a `Promise` and is not a binding.
-/// * `false` otherwise.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `true`:
-/// ```typescript
-/// window.Promise.resolve();
-/// globalThis.Promise.resolve();
-/// Promise.resolve('value').then(() => { });
-/// Promise.all([p1, p2, p3]);
-/// ```
-///
-/// Example TypeScript code that would return `false`:
-/// ```typescript
-/// const Promise = { resolve(): {} };
-/// Promise.resolve()
-/// ```
-fn is_expression_a_promise(expr: &AnyJsExpression, model: &SemanticModel) -> bool {
-    let (reference, value) = match global_identifier(expr) {
-        Some(result) => result,
-        None => return false,
-    };
-
-    if value.text() != "Promise" {
-        return false;
-    }
-
-    if model.binding(&reference).is_some() {
-        return false;
-    }
-
-    true
-}
-
-/// Traverses up the syntax tree to find the class declaration and checks if a method is a promise.
-///
-/// This function traverses up the syntax tree from the given `JsThisExpression` to find the nearest
-/// class declaration. It then searches for a method or property in the class that matches the provided
-/// `target_name`. If a matching member is found, it checks if the member is a promise.
-///
-/// # Arguments
-///
-/// * `js_this_expression` - A `JsThisExpression` representing the `this` keyword in the syntax tree.
-/// * `target_name` - The name of the method or property to search for.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-///
-/// # Returns
-///
-/// * `Some(true)` if the class member is a promise.
-/// * `Some(false)` if the class member is not a promise.
-/// * `None` if there is an error in the process or if the class member is not found.
-///
-/// # Examples
-///
-/// Example TypeScript code that would return `Some(true)`:
-/// ```typescript
-/// class Api {
-///   async returnsPromise(): Promise<string> {
-///     return 'value';
-///   }
-///   async someMethod() {
-///     this.returnsPromise();
-///   }
-/// }
-/// ```
-///
-/// Example TypeScript code that would return `Some(false)`:
-/// ```typescript
-/// class Api {
-///   returnsString(){
-///     return 'value';
-///   }
-///   async someMethod() {
-///     this.returnsString();
-///   }
-/// }
-/// ```
-fn check_this_expression(
-    js_this_expression: &JsThisExpression,
-    target_name: &str,
-    model: &SemanticModel,
-) -> Option<bool> {
-    js_this_expression
-        .syntax()
-        .ancestors()
-        .skip(1)
-        .find_map(|ancestor| match ancestor.kind() {
-            JsSyntaxKind::JS_CLASS_MEMBER_LIST => {
-                let class_member_list = JsClassMemberList::cast(ancestor)?;
-                find_and_check_class_member(&class_member_list, target_name, model)
-            }
-            JsSyntaxKind::JS_OBJECT_MEMBER_LIST => {
-                let object = ancestor.parent().and_then(JsObjectExpression::cast)?;
-                find_promise_in_object(&object, target_name)
-            }
-            _ => None,
-        })
-}
-
-/// Finds a class method or property by matching the given name and checks if it is a promise.
-///
-/// This function searches for a class method or property in the given `JsClassMemberList`
-/// by matching the provided `target_name`. If a matching member is found, it checks if the member
-/// is a promise. If no matching member is found, it checks the parent class (if any) and recursively
-/// checks the method or property in the parent class.
-///
-/// # Arguments
-///
-/// * `class_member_list` - A reference to a `JsClassMemberList` representing the class members to search in.
-/// * `target_name` - The name of the method or property to search for.
-/// * `model` - A reference to the `SemanticModel` used for resolving bindings.
-///
-/// # Returns
-///
-/// * `Some(true)` if the class member is a promise.
-/// * `Some(false)` if the class member is not a promise.
-/// * `None` if there is an error in the process or if the class member is not found.
-///
-fn find_and_check_class_member(
-    class_member_list: &JsClassMemberList,
-    target_name: &str,
-    model: &SemanticModel,
-) -> Option<bool> {
-    // Check current class first
-    if let Some(member) = find_class_method_or_property(class_member_list, target_name) {
-        return is_class_member_a_promise(&member, model);
-    }
-
-    // Check parent class if exists
-    check_parent_class(class_member_list, target_name, model)
-}
-
-fn check_parent_class(
-    class_member_list: &JsClassMemberList,
-    target_name: &str,
-    model: &SemanticModel,
-) -> Option<bool> {
-    let parent_class_decl =
-        if let Some(class_decl) = class_member_list.parent::<JsClassDeclaration>() {
-            get_parent_class_declaration(&class_decl.extends_clause()?, model)?
-        } else if let Some(class_expr) = class_member_list.parent::<JsClassExpression>() {
-            get_parent_class_declaration(&class_expr.extends_clause()?, model)?
-        } else {
-            return None;
-        };
-
-    find_and_check_class_member(&parent_class_decl.members(), target_name, model)
-}
-
-/// Extracts the parent class declaration from an extends clause
-fn get_parent_class_declaration(
-    extends_clause: &JsExtendsClause,
-    model: &SemanticModel,
-) -> Option<JsClassDeclaration> {
-    let super_class = extends_clause.super_class().ok()?;
-    let identifier_expression = super_class.as_js_identifier_expression()?;
-    let reference = identifier_expression.name().ok()?;
-    let binding = model.binding(&reference)?;
-    let any_js_binding_decl = binding.tree().declaration()?;
-
-    match any_js_binding_decl {
-        AnyJsBindingDeclaration::JsClassDeclaration(parent_class_decl) => Some(parent_class_decl),
-        _ => None,
-    }
-}
-
-fn find_class_method_or_property(
-    class_member_list: &JsClassMemberList,
-    target_name: &str,
-) -> Option<AnyJsClassMember> {
-    class_member_list.iter().find(|member| match member {
-        AnyJsClassMember::JsMethodClassMember(method) => method
-            .name()
-            .ok()
-            .and_then(|name| name.name())
-            .is_some_and(|class_member_name| class_member_name.text() == target_name),
-        AnyJsClassMember::JsPropertyClassMember(property) => property
-            .name()
-            .ok()
-            .and_then(|name| name.name())
-            .is_some_and(|class_member_name| class_member_name.text() == target_name),
-        _ => false,
-    })
-}
-
-fn is_class_member_a_promise(
-    class_member: &AnyJsClassMember,
-    model: &SemanticModel,
-) -> Option<bool> {
-    match class_member {
-        AnyJsClassMember::JsMethodClassMember(method) => Some(
-            method.async_token().is_some()
-                || is_return_type_a_promise(method.return_type_annotation()).unwrap_or_default(),
-        ),
-        AnyJsClassMember::JsPropertyClassMember(property) => {
-            if let Some(property_annotation) = property.property_annotation() {
-                let ts_type_annotation = property_annotation.as_ts_type_annotation()?;
-                let any_ts_type = ts_type_annotation.ty().ok()?;
-
-                return is_ts_type_a_promise(&any_ts_type, model, None);
-            }
-
-            if let Some(initializer_clause) = property.value() {
-                return is_initializer_a_promise(&initializer_clause, model, None);
-            }
-
-            None
-        }
-        _ => None,
-    }
-}
-
-fn is_ts_type_a_promise(
-    any_ts_type: &AnyTsType,
-    model: &SemanticModel,
-    target_member_name: Option<&str>,
-) -> Option<bool> {
-    match any_ts_type {
-        AnyTsType::TsFunctionType(func_type) => {
-            let return_type = func_type.return_type().ok()?;
-            let ref_type = return_type.as_any_ts_type()?.as_ts_reference_type()?;
-            let name = ref_type.name().ok()?;
-            let identifier = name.as_js_reference_identifier()?;
-
-            Some(identifier.has_name("Promise"))
-        }
-        AnyTsType::TsReferenceType(ts_ref_type) => {
-            let name = ts_ref_type.name().ok()?;
-            let identifier = name.as_js_reference_identifier()?;
-            if identifier.has_name("Promise") {
-                return Some(true);
-            }
-
-            let binding = model.binding(identifier)?;
-            let any_js_binding_decl = binding.tree().declaration()?;
-            match any_js_binding_decl {
-                AnyJsBindingDeclaration::TsTypeAliasDeclaration(ts_type_alias) => {
-                    let any_ts_type = ts_type_alias.ty().ok()?;
-                    is_ts_type_a_promise(&any_ts_type, model, target_member_name)
-                }
-                _ => None,
-            }
-        }
-        AnyTsType::TsObjectType(ts_object_type) => {
-            let target_name = target_member_name?;
-            for member in ts_object_type.members() {
-                let property = member.as_ts_property_signature_type_member()?;
-                let name = property.name().ok()?;
-                let js_literal_member_name = name.as_js_literal_member_name()?;
-                let value = js_literal_member_name.value().ok()?;
-                if value.text_trimmed() == target_name {
-                    let ts_type_annotation = property.type_annotation()?;
-                    let any_ts_type = ts_type_annotation.ty().ok()?;
-                    return is_ts_type_a_promise(&any_ts_type, model, None);
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn find_promise_in_object(object: &JsObjectExpression, member_name: &str) -> Option<bool> {
-    let ty = Type::from_js_object_expression(object);
-    match ty.deref() {
-        TypeInner::Object(object) => object.members().iter().find_map(|member| match member {
-            TypeMember::CallSignature(_) | TypeMember::Constructor(_) => None,
-            TypeMember::Method(member) => match member.name == member_name {
-                true => Some(
-                    member
-                        .return_type
-                        .as_type()
-                        .is_some_and(|ty| ty.is_promise()),
-                ),
-                false => None,
-            },
-            TypeMember::Property(member) => match member.name == member_name {
-                true => {
-                    Some(member.ty.is_promise() || member.ty.is_function_that_returns_promise())
-                }
-                false => None,
-            },
-        }),
-        _ => Some(false),
-    }
-}
-
-/// Traverses up the syntax tree from the given node to find `JsFormalParameter`.
-///
-/// This function traverses up the syntax tree from the given `SyntaxNode` to find the nearest
-/// `JsFormalParameter`. It returns `Some(JsFormalParameter)` if a `JsFormalParameter` is found,
-/// otherwise it returns `None`.
-fn find_js_formal_parameter(node: &SyntaxNode<JsLanguage>) -> Option<JsFormalParameter> {
-    node.ancestors().skip(1).find_map(JsFormalParameter::cast)
 }

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -35,14 +35,14 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// async function returnsPromise(): Promise<string> {
     ///   return 'value';
     /// }
     /// returnsPromise().then(() => {});
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// const returnsPromise = async (): Promise<string> => {
     ///   return 'value';
     /// }
@@ -51,16 +51,16 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// const promise = new Promise((resolve) => resolve('value'));
     /// promise.then(() => { }).finally(() => { });
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// Promise.all([p1, p2, p3])
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// class Api {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -71,7 +71,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// class Parent {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -85,7 +85,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// class Api {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -95,7 +95,7 @@ declare_lint_rule! {
     /// api.returnsPromise().then(() => {}).finally(() => {});
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// const obj = {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -105,7 +105,7 @@ declare_lint_rule! {
     /// obj.returnsPromise();
     /// ```
     ///
-    /// ```ts,expect_diagnostic
+    /// ```ts
     /// type Props = {
     ///   returnsPromise: () => Promise<void>;
     /// };

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -176,6 +176,9 @@ impl Rule for NoFloatingPromises {
         let node = ctx.query();
         let expression = node.expression().ok()?;
         let ty = ctx.type_for_expression(&expression);
+
+        // Uncomment the following line for debugging convenience:
+        //let printed = format!("type of {expression:?} = {ty:?}");
         if !ty.is_promise_instance() {
             return None;
         }

--- a/crates/biome_js_analyze/src/services/mod.rs
+++ b/crates/biome_js_analyze/src/services/mod.rs
@@ -3,3 +3,4 @@ pub mod control_flow;
 pub mod manifest;
 pub mod module_graph;
 pub mod semantic;
+pub mod typed;

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -1,0 +1,92 @@
+use biome_analyze::{
+    AddVisitor, FromServices, MissingServicesDiagnostic, Phase, Phases, QueryKey, QueryMatch,
+    Queryable, RuleKey, ServiceBag, SyntaxVisitor,
+};
+use biome_js_syntax::{AnyJsExpression, AnyJsRoot, JsLanguage, JsSyntaxNode};
+use biome_js_type_info::Type;
+use biome_module_graph::{JsModuleInfo, ModuleGraph};
+use biome_rowan::{AstNode, TextRange};
+use camino::Utf8PathBuf;
+use std::sync::Arc;
+
+/// Service for use with type inference rules.
+#[derive(Debug, Clone)]
+pub struct TypedService {
+    module_info: Option<JsModuleInfo>,
+    modules: Arc<ModuleGraph>,
+}
+
+impl TypedService {
+    pub fn module_graph(&self) -> &ModuleGraph {
+        self.modules.as_ref()
+    }
+
+    pub fn type_for_expression(&self, expr: &AnyJsExpression) -> Type {
+        self.module_info
+            .as_ref()
+            .map(|module_info| module_info.resolved_type_for_expression(expr, self.module_graph()))
+            .unwrap_or_default()
+    }
+}
+
+impl FromServices for TypedService {
+    fn from_services(
+        rule_key: &RuleKey,
+        services: &ServiceBag,
+    ) -> Result<Self, MissingServicesDiagnostic> {
+        let file_path: &Arc<Utf8PathBuf> = services
+            .get_service()
+            .ok_or_else(|| MissingServicesDiagnostic::new(rule_key.rule_name(), &["FilePath"]))?;
+        let module_graph: &Arc<ModuleGraph> = services.get_service().ok_or_else(|| {
+            MissingServicesDiagnostic::new(rule_key.rule_name(), &["ModuleGraph"])
+        })?;
+        let module_info = module_graph.module_info_for_path(file_path.as_ref());
+        Ok(Self {
+            module_info,
+            modules: module_graph.clone(),
+        })
+    }
+}
+
+impl Phase for TypedService {
+    fn phase() -> Phases {
+        Phases::Syntax
+    }
+}
+
+/// Query type usable by lint rules that wish to perform type inference on
+/// nodes.
+#[derive(Clone)]
+pub struct Typed<N>(N);
+
+impl<N> QueryMatch for Typed<N>
+where
+    N: AstNode<Language = JsLanguage> + 'static,
+{
+    fn text_range(&self) -> TextRange {
+        self.0.range()
+    }
+}
+
+impl<N> Queryable for Typed<N>
+where
+    N: AstNode<Language = JsLanguage> + 'static,
+{
+    type Input = JsSyntaxNode;
+    type Output = N;
+
+    type Language = JsLanguage;
+    type Services = TypedService;
+
+    fn build_visitor(analyzer: &mut impl AddVisitor<JsLanguage>, _root: &AnyJsRoot) {
+        analyzer.add_visitor(Phases::Syntax, SyntaxVisitor::default);
+    }
+
+    fn key() -> QueryKey<Self::Language> {
+        QueryKey::Syntax(N::KIND_SET)
+    }
+
+    fn unwrap_match(_: &ServiceBag, node: &Self::Input) -> Self::Output {
+        N::unwrap_cast(node.clone())
+    }
+}

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -26,11 +26,10 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"async function returnsPromise() {
-  return 'value';
-}
-returnsPromise().then(() => { }).finally(() => { });
-"#;
+    const SOURCE: &str = r#"const promiseWithGlobalIdentifier = new window.Promise((resolve, reject) =>
+	resolve("value")
+);
+promiseWithGlobalIdentifier.then(() => {});"#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -1,11 +1,14 @@
 use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never, RuleFilter};
 use biome_deserialize::TextRange;
 use biome_diagnostics::{Diagnostic, DiagnosticExt, Severity, print_diagnostic_to_string};
+use biome_fs::TemporaryFs;
 use biome_js_analyze::{JsAnalyzerServices, analyze};
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::JsFileSource;
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
+use biome_test_utils::module_graph_for_test_file;
+use camino::Utf8PathBuf;
 use std::slice;
 use std::sync::Arc;
 
@@ -22,20 +25,30 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[ignore]
 #[test]
 fn quick_test() {
-    const SOURCE: &str = r#"f({ prop: () => {} })"#;
+    const FILENAME: &str = "dummyFile.ts";
+    const SOURCE: &str = r#"async function returnsPromise() {
+  return 'value';
+}
+returnsPromise().then(() => { }).finally(() => { });
+"#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
+    let mut fs = TemporaryFs::new("quick_test");
+    fs.create_file(FILENAME, SOURCE);
+    let file_path = Utf8PathBuf::from(format!("{}/{FILENAME}", fs.cli_path()));
+
     let mut error_ranges: Vec<TextRange> = Vec::new();
-    let options = AnalyzerOptions::default();
-    let rule_filter = RuleFilter::Rule("nursery", "useExplicitType");
+    let options = AnalyzerOptions::default().with_file_path(file_path.clone());
+    let rule_filter = RuleFilter::Rule("nursery", "noFloatingPromises");
 
     let mut dependencies = Dependencies::default();
     dependencies.add("buffer", "latest");
 
+    let project_layout = project_layout_with_top_level_dependencies(dependencies);
     let services = crate::JsAnalyzerServices::from((
-        Default::default(),
-        project_layout_with_top_level_dependencies(dependencies),
+        module_graph_for_test_file(file_path.as_path(), project_layout.as_ref()),
+        project_layout,
         JsFileSource::tsx(),
     ));
 
@@ -53,7 +66,7 @@ fn quick_test() {
                 error_ranges.push(diag.location().span.unwrap());
                 let error = diag
                     .with_severity(Severity::Warning)
-                    .with_file_path("dummyFile")
+                    .with_file_path(FILENAME)
                     .with_file_source_code(SOURCE);
                 let text = print_diagnostic_to_string(&error);
                 eprintln!("{text}");

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::{fs::read_to_string, slice};
 
 const TESTS_WITH_MODULE_GRAPH: &[&str] = &[
+    "noFloatingPromises",
     "noImportCycles",
     "noPrivateImports",
     "noUnresolvedImports",

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -308,7 +308,7 @@ async function testCallingReturnsPromise(props: Props) {
 const testDestructuringAndCallingReturnsPromise = async ({
 	returnsPromise,
 }: Props) => {
-	returnsPromise();
+	returnsPromise(); // FIXME: REGRESSION
 };
 async function testPassingReturnsPromiseDirectly(
 	returnsPromise: () => Promise<void>

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -314,7 +314,7 @@ async function testCallingReturnsPromise(props: Props) {
 const testDestructuringAndCallingReturnsPromise = async ({
 	returnsPromise,
 }: Props) => {
-	returnsPromise();
+	returnsPromise(); // FIXME: REGRESSION
 };
 async function testPassingReturnsPromiseDirectly(
 	returnsPromise: () => Promise<void>
@@ -1480,27 +1480,6 @@ invalid.ts:306:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━
   
     306 │ → await·props.returnsPromise().then(()·=>·{});
         │   ++++++                                      
-
-```
-
-```
-invalid.ts:311:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    309 │ 	returnsPromise,
-    310 │ }: Props) => {
-  > 311 │ 	returnsPromise();
-        │ 	^^^^^^^^^^^^^^^^^
-    312 │ };
-    313 │ async function testPassingReturnsPromiseDirectly(
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-  i Unsafe fix: Add await operator.
-  
-    311 │ → await·returnsPromise();
-        │   ++++++                 
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js
@@ -4,7 +4,10 @@ async function returnsPromise() {
 
 await returnsPromise();
 void returnsPromise();
-return returnsPromise();
+
+function otherFunction() {
+  return returnsPromise();
+}
 
 returnsPromise().then(
   () => { },

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.js.snap
@@ -10,7 +10,10 @@ async function returnsPromise() {
 
 await returnsPromise();
 void returnsPromise();
-return returnsPromise();
+
+function otherFunction() {
+  return returnsPromise();
+}
 
 returnsPromise().then(
   () => { },
@@ -18,4 +21,5 @@ returnsPromise().then(
 );
 
 returnsPromise().catch(() => { });
+
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
@@ -5,7 +5,10 @@ async function returnsPromise(): Promise<string> {
 
 await returnsPromise();
 void returnsPromise();
-return returnsPromise();
+
+function otherFunction() {
+  return returnsPromise();
+}
 
 returnsPromise().then(
   () => { },
@@ -21,7 +24,7 @@ promise.then(() => { }, () => { })
 Promise.resolve('value').then(() => { }, () => { })
 Promise.all([p1, p2, p3]).catch(() => { })
 
-const Promise = { resolve(): {} };
+const Promise = { resolve() { return null; } };
 Promise.resolve()
 async function bindingPromiseInsideFunction() {
   Promise.resolve()

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
@@ -11,7 +11,10 @@ async function returnsPromise(): Promise<string> {
 
 await returnsPromise();
 void returnsPromise();
-return returnsPromise();
+
+function otherFunction() {
+  return returnsPromise();
+}
 
 returnsPromise().then(
   () => { },
@@ -27,7 +30,7 @@ promise.then(() => { }, () => { })
 Promise.resolve('value').then(() => { }, () => { })
 Promise.all([p1, p2, p3]).catch(() => { })
 
-const Promise = { resolve(): {} };
+const Promise = { resolve() { return null; } };
 Promise.resolve()
 async function bindingPromiseInsideFunction() {
   Promise.resolve()

--- a/crates/biome_js_syntax/src/union_ext.rs
+++ b/crates/biome_js_syntax/src/union_ext.rs
@@ -1,9 +1,9 @@
 use crate::{
     AnyJsArrowFunctionParameters, AnyJsBinding, AnyJsClass, AnyJsClassMember, AnyJsClassMemberName,
-    AnyJsFunction, AnyJsFunctionBody, AnyTsPropertyAnnotation, AnyTsVariableAnnotation,
-    JsClassMemberList, JsDecoratorList, JsExtendsClause, JsInitializerClause, JsSyntaxToken,
-    JsVariableDeclarator, TsImplementsClause, TsReturnTypeAnnotation, TsTypeAnnotation,
-    TsTypeParameters,
+    AnyJsFunction, AnyJsFunctionBody, AnyTsPropertyAnnotation, AnyTsPropertySignatureAnnotation,
+    AnyTsVariableAnnotation, JsClassMemberList, JsDecoratorList, JsExtendsClause,
+    JsInitializerClause, JsSyntaxToken, JsVariableDeclarator, TsImplementsClause,
+    TsReturnTypeAnnotation, TsTypeAnnotation, TsTypeParameters,
 };
 use biome_rowan::{AstNode, AstSeparatedList, SyntaxResult};
 
@@ -280,15 +280,18 @@ impl AnyTsVariableAnnotation {
 impl AnyTsPropertyAnnotation {
     pub fn type_annotation(&self) -> SyntaxResult<Option<TsTypeAnnotation>> {
         match self {
-            AnyTsPropertyAnnotation::TsDefinitePropertyAnnotation(definite) => {
-                definite.type_annotation().map(Some)
-            }
-            AnyTsPropertyAnnotation::TsOptionalPropertyAnnotation(optional) => {
-                Ok(optional.type_annotation())
-            }
-            AnyTsPropertyAnnotation::TsTypeAnnotation(type_annotation) => {
-                Ok(Some(type_annotation.clone()))
-            }
+            Self::TsDefinitePropertyAnnotation(definite) => definite.type_annotation().map(Some),
+            Self::TsOptionalPropertyAnnotation(optional) => Ok(optional.type_annotation()),
+            Self::TsTypeAnnotation(type_annotation) => Ok(Some(type_annotation.clone())),
+        }
+    }
+}
+
+impl AnyTsPropertySignatureAnnotation {
+    pub fn type_annotation(&self) -> SyntaxResult<Option<TsTypeAnnotation>> {
+        match self {
+            Self::TsOptionalPropertyAnnotation(optional) => Ok(optional.type_annotation()),
+            Self::TsTypeAnnotation(annotation) => Ok(Some(annotation.clone())),
         }
     }
 }

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -18,3 +18,7 @@ workspace = true
 biome_js_syntax           = { workspace = true }
 biome_js_type_info_macros = { workspace = true }
 biome_rowan               = { workspace = true }
+
+[dev-dependencies]
+biome_js_parser = { workspace = true }
+insta           = { workspace = true }

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -132,6 +132,22 @@ impl Type {
                     }
                     _ => self.clone(),
                 },
+                TypeofExpression::Super(expr) => {
+                    let class = expr.parent.resolved(resolver, stack);
+                    match class.deref() {
+                        TypeInner::Class(class) => match class.extends.as_ref() {
+                            Some(super_class) => {
+                                Self::instance_of(super_class.resolved(resolver, stack))
+                            }
+                            None => Self::unknown(),
+                        },
+                        _ => Self::unknown(),
+                    }
+                }
+                TypeofExpression::This(expr) => {
+                    let class = expr.parent.resolved(resolver, stack);
+                    Self::instance_of(class)
+                }
             },
             TypeInner::TypeofValue(value) if value.ty.is_inferred() => {
                 value.ty.resolved(resolver, stack)

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -1,0 +1,146 @@
+use std::ops::Deref;
+
+use crate::{Resolvable, Type, TypeInner, TypeMember, TypeResolver, TypeofExpression};
+
+impl Type {
+    /// Flattens the given type.
+    ///
+    /// Flattening is both an optimisation as well as an aid to make our
+    /// reasoning about types easier. It removes unnecessary indirections from
+    /// our type structures, and should be performed every time after we perform
+    /// type resolution.
+    ///
+    /// ## Example
+    ///
+    /// Consider the following example:
+    ///
+    /// ```ts
+    /// const c = 1;
+    ///
+    /// type A = typeof c;
+    /// ```
+    ///
+    /// After local inference, the inferred type of `A` is:
+    ///
+    /// ```no_test
+    /// Type(TypeInner::TypeofValue {
+    ///     identifier: "c",
+    ///     ty: Type::unknown()
+    /// })
+    /// ```
+    ///
+    /// Once we've performed thin type resolution, this becomes:
+    ///
+    /// ```no_test
+    /// Type(TypeInner::TypeofValue {
+    ///     identifier: "c",
+    ///     ty: Type(TypeInner::Literal(Literal::Number(1)))
+    /// })
+    /// ```
+    ///
+    /// With flattening, we can reduce this to:
+    ///
+    /// ```no_test
+    /// Type(TypeInner::Literal(Literal::Number(1)))
+    /// ```
+    pub fn flattened(&self, resolver: &dyn TypeResolver, stack: &[&TypeInner]) -> Self {
+        match &**self {
+            TypeInner::Reference(reference) | TypeInner::TypeofType(reference)
+                if reference.ty.is_inferred() =>
+            {
+                reference
+                    .ty
+                    .with_type_parameters(&reference.type_parameters)
+                    .resolved(resolver, stack)
+            }
+            TypeInner::TypeofExpression(expr) => match expr.as_ref() {
+                TypeofExpression::Addition(_expr) => {
+                    // TODO
+                    self.clone()
+                }
+                TypeofExpression::Await(expr) => match expr.argument.deref() {
+                    TypeInner::Literal(literal) => TypeInner::Literal(literal.clone()).into(),
+                    TypeInner::Object(object) => match object.find_promise_type() {
+                        Some(ty) => ty.resolved(resolver, stack),
+                        None => self.clone(),
+                    },
+                    _ => self.clone(),
+                },
+                TypeofExpression::Call(expr) => match expr.callee.deref() {
+                    TypeInner::Function(function) => match function.return_type.as_type() {
+                        Some(ty) => Self::instance_of(ty.clone()).resolved(resolver, stack),
+                        None => self.clone(),
+                    },
+                    TypeInner::Object(object) => {
+                        match object
+                            .members
+                            .iter()
+                            .find(|member| member.has_name("constructor"))
+                        {
+                            Some(member) => Self::instance_of(member.to_type(&expr.callee))
+                                .resolved(resolver, stack),
+                            None => Self::unknown(),
+                        }
+                    }
+                    _ => self.clone(),
+                },
+                TypeofExpression::New(expr) => {
+                    let callee = expr.callee.resolved(resolver, stack);
+                    match callee.deref() {
+                        TypeInner::Class(class) => {
+                            let num_args = expr.arguments.len();
+                            let ty = class
+                                .members
+                                .iter()
+                                .find_map(|member| match member {
+                                    TypeMember::Constructor(constructor) => {
+                                        // TODO: We might need to make an attempt to match
+                                        //       type signatures too.
+                                        (constructor.parameters.len() == num_args)
+                                            .then(|| constructor.return_type.clone())
+                                            .flatten()
+                                    }
+                                    _ => None,
+                                })
+                                .map_or_else(|| callee.clone(), |ty| ty.resolved(resolver, stack));
+                            Self::instance_of(ty)
+                        }
+                        // TODO: Handle objects with call signatures.
+                        _ => self.clone(),
+                    }
+                }
+                TypeofExpression::StaticMember(expr) => match expr.object.deref() {
+                    TypeInner::Class(class) => {
+                        let member = class
+                            .all_members()
+                            .find(|member| member.is_static() && member.has_name(&expr.member));
+                        match member {
+                            Some(member) => Self::instance_of(member.to_type(&expr.object))
+                                .resolved(resolver, stack),
+                            None => Self::unknown(),
+                        }
+                    }
+                    TypeInner::Object(object) => {
+                        let member = object
+                            .all_members()
+                            .find(|member| !member.is_static() && member.has_name(&expr.member));
+                        match member {
+                            Some(member) => Self::instance_of(member.to_type(&expr.object))
+                                .resolved(resolver, stack),
+                            None => Self::unknown(),
+                        }
+                    }
+                    _ => self.clone(),
+                },
+            },
+            TypeInner::TypeofValue(value) if value.ty.is_inferred() => {
+                value.ty.resolved(resolver, stack)
+            }
+            _ => self.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "flattening.tests.rs"]
+mod tests;

--- a/crates/biome_js_type_info/src/flattening.tests.rs
+++ b/crates/biome_js_type_info/src/flattening.tests.rs
@@ -1,0 +1,120 @@
+use insta::assert_debug_snapshot;
+
+use crate::test_util::{
+    HardcodedSymbolResolver, PromiseResolver, get_expression_statement, get_function_declaration,
+    parse_ts,
+};
+
+use super::*;
+
+#[test]
+fn infer_flattened_type_of_promise_returning_function() {
+    const CODE: &str = r#"function returnsPromise(): Promise<number> {
+    return Promise.resolved(true);
+}"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let mut ty = Type::from_js_function_declaration(&decl);
+    ty.resolve(&PromiseResolver);
+
+    assert_debug_snapshot!(ty);
+}
+
+#[test]
+fn infer_flattened_type_of_async_function() {
+    const CODE: &str = r#"async function returnsPromise(): Promise<string> {
+	return "value";
+}"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let mut ty = Type::from_js_function_declaration(&decl);
+    ty.resolve(&PromiseResolver);
+
+    assert_debug_snapshot!(ty);
+}
+
+#[test]
+fn infer_flattened_type_from_invocation_of_promise_returning_function() {
+    const CODE: &str = r#"function returnsPromise(): Promise<number> {
+    return Promise.resolved(true);
+}
+
+returnsPromise()"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let mut function_ty = Type::from_js_function_declaration(&decl);
+    function_ty.resolve(&PromiseResolver);
+
+    let expr = get_expression_statement(&root);
+    let mut expr_ty = Type::from_any_js_expression(&expr.expression().unwrap());
+    expr_ty.resolve(&HardcodedSymbolResolver("returnsPromise", function_ty));
+
+    assert_debug_snapshot!(expr_ty);
+}
+
+#[test]
+fn infer_flattened_type_from_chained_invocation_of_promise_returning_function() {
+    const CODE: &str = r#"function returnsPromise(): Promise<number> {
+    return Promise.resolved(true);
+}
+
+returnsPromise().then(() => {})"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let mut function_ty = Type::from_js_function_declaration(&decl);
+    function_ty.resolve(&PromiseResolver);
+
+    let expr = get_expression_statement(&root);
+    let mut expr_ty = Type::from_any_js_expression(&expr.expression().unwrap());
+    expr_ty.resolve(&HardcodedSymbolResolver("returnsPromise", function_ty));
+
+    assert_debug_snapshot!(expr_ty);
+}
+
+#[test]
+fn infer_flattened_type_from_double_chained_invocation_of_promise_returning_function() {
+    const CODE: &str = r#"function returnsPromise(): Promise<number> {
+    return Promise.resolved(true);
+}
+
+returnsPromise().then(() => {}).finally(() => {})"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let mut function_ty = Type::from_js_function_declaration(&decl);
+    function_ty.resolve(&PromiseResolver);
+
+    let expr = get_expression_statement(&root);
+    let mut expr_ty = Type::from_any_js_expression(&expr.expression().unwrap());
+    expr_ty.resolve(&HardcodedSymbolResolver("returnsPromise", function_ty));
+
+    assert_debug_snapshot!(expr_ty);
+}
+
+#[test]
+fn infer_flattened_type_from_direct_promise_instance() {
+    const CODE: &str = r#"new Promise((resolve) => resolve("value"))"#;
+
+    let root = parse_ts(CODE);
+    let expr = get_expression_statement(&root);
+    let mut expr_ty = Type::from_any_js_expression(&expr.expression().unwrap());
+    expr_ty.resolve(&PromiseResolver);
+
+    assert_debug_snapshot!(expr_ty);
+}
+
+#[test]
+fn infer_flattened_type_from_static_promise_function() {
+    const CODE: &str = r#"Promise.resolve("value")"#;
+
+    let root = parse_ts(CODE);
+    let expr = get_expression_statement(&root);
+    let mut expr_ty = Type::from_any_js_expression(&expr.expression().unwrap());
+    expr_ty.resolve(&PromiseResolver);
+
+    assert_debug_snapshot!(expr_ty);
+}

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -127,11 +127,14 @@ pub(crate) static WINDOW: LazyLock<Object> = LazyLock::new(|| Object {
     prototype: None,
     members: Arc::new([TypeMember::Property(PropertyTypeMember {
         name: Text::Static("Promise"),
-        ty: TypeInner::Reference(Box::new(TypeReference {
-            qualifier: TypeReferenceQualifier::from_name(Text::Static("Promise")),
-            ty: Type::unknown(),
-            type_parameters: Arc::new([]),
-        }))
+        ty: TypeInner::TypeofType(Box::new(
+            TypeInner::Reference(Box::new(TypeReference {
+                qualifier: TypeReferenceQualifier::from_name(Text::Static("Promise")),
+                ty: Type::unknown(),
+                type_parameters: Arc::new([]),
+            }))
+            .into(),
+        ))
         .into(),
         is_optional: false,
         is_static: false,

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -1,0 +1,121 @@
+//! Hardcoded global definitions.
+
+// FIXME: Implement inference from type definitions.
+
+use std::sync::{Arc, LazyLock};
+
+use biome_rowan::Text;
+
+use crate::{
+    Class, GenericTypeParameter, MethodTypeMember, PropertyTypeMember, Type, TypeId, TypeInner,
+    TypeMember, TypeReference, TypeReferenceQualifier,
+};
+
+pub(crate) static ARRAY_TYPE: LazyLock<Type> =
+    LazyLock::new(|| TypeInner::Class(Box::new(ARRAY.clone())).into());
+
+pub(crate) static ARRAY: LazyLock<Class> = LazyLock::new(|| {
+    // TODO: Use generics to propagate return value of function argument as
+    //       return value of the then/catch handlers.
+    Class {
+        id: TypeId::new(),
+        name: Some(Text::Static("Array")),
+        type_parameters: Arc::new([GenericTypeParameter {
+            name: Text::Static("T"),
+            ty: Type::unknown(),
+        }]),
+        extends: None,
+        members: Arc::new([TypeMember::Property(
+            PropertyTypeMember::default()
+                .with_name(Text::Static("length"))
+                .with_type(Type::number()),
+        )]),
+    }
+});
+
+pub(crate) static PROMISE_TYPE: LazyLock<Type> =
+    LazyLock::new(|| TypeInner::Class(Box::new(PROMISE.clone())).into());
+
+pub(crate) static PROMISE: LazyLock<Class> = LazyLock::new(|| {
+    // Don't use `Type::promise_of()` or we'll create a deadlock trying to
+    // acquire `PROMISE` itself.
+    fn promise_of(ty: Type) -> Type {
+        TypeInner::Reference(Box::new(TypeReference {
+            qualifier: TypeReferenceQualifier::from_name(Text::Static("Promise")),
+            ty: Type::unknown(),
+            type_parameters: Arc::new([ty]),
+        }))
+        .into()
+    }
+
+    // TODO: Use generics to propagate return value of function argument as
+    //       return value of the then/catch handlers.
+    Class {
+        id: TypeId::new(),
+        name: Some(Text::Static("Promise")),
+        type_parameters: Arc::new([GenericTypeParameter {
+            name: Text::Static("T"),
+            ty: Type::unknown(),
+        }]),
+        extends: None,
+        members: Arc::new([
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("all"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("allSettled"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("any"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("race"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("reject"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("resolve"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("try"))
+                    .with_static()
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("catch"))
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("finally"))
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+            TypeMember::Method(
+                MethodTypeMember::default()
+                    .with_name(Text::Static("then"))
+                    .with_return_type(promise_of(Type::unknown())),
+            ),
+        ]),
+    }
+});

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, LazyLock};
 use biome_rowan::Text;
 
 use crate::{
-    Class, GenericTypeParameter, MethodTypeMember, PropertyTypeMember, Type, TypeId, TypeInner,
-    TypeMember, TypeReference, TypeReferenceQualifier,
+    Class, GenericTypeParameter, MethodTypeMember, Object, PropertyTypeMember, Type, TypeId,
+    TypeInner, TypeMember, TypeReference, TypeReferenceQualifier,
 };
 
 pub(crate) static ARRAY_TYPE: LazyLock<Type> =
@@ -118,4 +118,22 @@ pub(crate) static PROMISE: LazyLock<Class> = LazyLock::new(|| {
             ),
         ]),
     }
+});
+
+pub(crate) static WINDOW_TYPE: LazyLock<Type> =
+    LazyLock::new(|| TypeInner::Object(Box::new(WINDOW.clone())).into());
+
+pub(crate) static WINDOW: LazyLock<Object> = LazyLock::new(|| Object {
+    prototype: None,
+    members: Arc::new([TypeMember::Property(PropertyTypeMember {
+        name: Text::Static("Promise"),
+        ty: TypeInner::Reference(Box::new(TypeReference {
+            qualifier: TypeReferenceQualifier::from_name(Text::Static("Promise")),
+            ty: Type::unknown(),
+            type_parameters: Arc::new([]),
+        }))
+        .into(),
+        is_optional: false,
+        is_static: false,
+    })]),
 });

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -1,6 +1,11 @@
+mod flattening;
+mod globals;
 mod local_inference;
 mod resolver;
 mod type_info;
+
+#[cfg(test)]
+mod test_util;
 
 pub use resolver::*;
 pub use type_info::*;

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -852,8 +852,16 @@ impl TypeMember {
                             .and_then(|annotation| annotation.type_annotation().ok())
                             .flatten()
                             .and_then(|annotation| annotation.ty().ok())
-                            .map(|ty| Type::from_any_ts_type(&ty))
-                            .unwrap_or_default(),
+                            .map_or_else(
+                                || {
+                                    member
+                                        .value()
+                                        .and_then(|initializer| initializer.expression().ok())
+                                        .map(|expr| Type::from_any_js_expression(&expr))
+                                        .unwrap_or_default()
+                                },
+                                |ty| Type::from_any_ts_type(&ty),
+                            ),
                         is_optional: member
                             .property_annotation()
                             .as_ref()

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -626,14 +626,14 @@ impl Type {
     }
 
     pub fn from_ts_type_alias_declaration(decl: &TsTypeAliasDeclaration) -> Option<Self> {
-        let inner = TypeInner::Alias(Box::new(TypeAlias {
-            ty: Self::from_any_ts_type(&decl.ty().ok()?),
-            type_parameters: GenericTypeParameter::params_from_ts_type_parameters(
-                &decl.type_parameters()?,
-            ),
-        }));
-
-        Some(inner.into())
+        Some(match decl.type_parameters() {
+            Some(params) => TypeInner::Alias(Box::new(TypeAlias {
+                ty: Self::from_any_ts_type(&decl.ty().ok()?),
+                type_parameters: GenericTypeParameter::params_from_ts_type_parameters(&params),
+            }))
+            .into(),
+            None => Self::from_any_ts_type(&decl.ty().ok()?),
+        })
     }
 
     pub fn from_ts_typeof_type(ty: &TsTypeofType) -> Self {

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: expr_ty
+---
+Type(
+    Object(
+        Object {
+            prototype: Some(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Unknown,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+            members: [],
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -9,9 +9,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_direct_promise_instance.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: expr_ty
+---
+Type(
+    Object(
+        Object {
+            prototype: Some(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Unknown,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+            members: [],
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_direct_promise_instance.snap
@@ -9,9 +9,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: expr_ty
+---
+Type(
+    Object(
+        Object {
+            prototype: Some(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Unknown,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+            members: [],
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -9,9 +9,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_invocation_of_promise_returning_function.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: expr_ty
+---
+Type(
+    Object(
+        Object {
+            prototype: Some(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Number,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+            members: [],
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_invocation_of_promise_returning_function.snap
@@ -9,9 +9,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_static_promise_function.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: expr_ty
+---
+Type(
+    Object(
+        Object {
+            prototype: Some(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Unknown,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+            members: [],
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_from_static_promise_function.snap
@@ -9,9 +9,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_async_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_async_function.snap
@@ -17,9 +17,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_async_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_async_function.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: ty
+---
+Type(
+    Function(
+        Function {
+            is_async: true,
+            type_parameters: [],
+            name: Some(
+                Borrowed(
+                    "returnsPromise",
+                ),
+            ),
+            parameters: [],
+            return_type: Type(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        String,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_promise_returning_function.snap
@@ -17,9 +17,7 @@ Type(
                 Type(
                     Class(
                         Class {
-                            id: TypeId(
-                                1,
-                            ),
+                            id: TypeId,
                             name: Some(
                                 Static(
                                     "Promise",

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__flattening__tests__infer_flattened_type_of_promise_returning_function.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_type_info/src/flattening.tests.rs
+expression: ty
+---
+Type(
+    Function(
+        Function {
+            is_async: false,
+            type_parameters: [],
+            name: Some(
+                Borrowed(
+                    "returnsPromise",
+                ),
+            ),
+            parameters: [],
+            return_type: Type(
+                Type(
+                    Class(
+                        Class {
+                            id: TypeId(
+                                1,
+                            ),
+                            name: Some(
+                                Static(
+                                    "Promise",
+                                ),
+                            ),
+                            type_parameters: [
+                                GenericTypeParameter {
+                                    name: Static(
+                                        "T",
+                                    ),
+                                    ty: Type(
+                                        Number,
+                                    ),
+                                },
+                            ],
+                            extends: None,
+                        },
+                    ),
+                ),
+            ),
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__type_info__tests__infer_type_of_async_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__type_info__tests__infer_type_of_async_function.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_type_info/src/type_info.tests.rs
+expression: ty
+---
+Type(
+    Function(
+        Function {
+            is_async: true,
+            type_parameters: [],
+            name: Some(
+                Borrowed(
+                    "returnsPromise",
+                ),
+            ),
+            parameters: [],
+            return_type: Type(
+                Type(
+                    Reference(
+                        TypeReference {
+                            qualifier: TypeReferenceQualifier(
+                                [
+                                    Borrowed(
+                                        "Promise",
+                                    ),
+                                ],
+                            ),
+                            ty: Type(
+                                Unknown,
+                            ),
+                            type_parameters: [
+                                Type(
+                                    String,
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+            ),
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/snapshots/biome_js_type_info__type_info__tests__infer_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/src/snapshots/biome_js_type_info__type_info__tests__infer_type_of_promise_returning_function.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_type_info/src/type_info.tests.rs
+expression: ty
+---
+Type(
+    Function(
+        Function {
+            is_async: false,
+            type_parameters: [],
+            name: Some(
+                Borrowed(
+                    "returnsPromise",
+                ),
+            ),
+            parameters: [],
+            return_type: Type(
+                Type(
+                    Reference(
+                        TypeReference {
+                            qualifier: TypeReferenceQualifier(
+                                [
+                                    Borrowed(
+                                        "Promise",
+                                    ),
+                                ],
+                            ),
+                            ty: Type(
+                                Unknown,
+                            ),
+                            type_parameters: [
+                                Type(
+                                    Number,
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+            ),
+        },
+    ),
+)

--- a/crates/biome_js_type_info/src/test_util.rs
+++ b/crates/biome_js_type_info/src/test_util.rs
@@ -1,0 +1,84 @@
+use biome_js_parser::{JsParserOptions, parse};
+use biome_js_syntax::{
+    AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsExpressionStatement, JsFileSource,
+    JsFunctionDeclaration,
+};
+use biome_rowan::Text;
+
+use crate::{Type, TypeReferenceQualifier, TypeResolver};
+
+/// Test resolver that looks up a single hardcoded symbol.
+pub(crate) struct HardcodedSymbolResolver(pub &'static str, pub Type);
+
+impl TypeResolver for HardcodedSymbolResolver {
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type> {
+        if qualifier.parts().len() == 1 && qualifier.parts()[0] == self.0 {
+            Some(self.1.clone())
+        } else {
+            PromiseResolver.resolve_qualifier(qualifier)
+        }
+    }
+
+    fn resolve_type_of(&self, _identifier: &Text) -> Option<Type> {
+        None
+    }
+}
+
+/// Test resolver that does nothing but resolve type references to `Promise`
+/// without any proper scope lookups.
+pub(crate) struct PromiseResolver;
+
+impl TypeResolver for PromiseResolver {
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type> {
+        qualifier
+            .is_promise()
+            .then(|| Type::promise_of(Type::unknown()))
+    }
+
+    fn resolve_type_of(&self, _identifier: &Text) -> Option<Type> {
+        None
+    }
+}
+
+pub(crate) fn get_expression_statement(root: &AnyJsRoot) -> JsExpressionStatement {
+    let module = root.as_js_module().unwrap();
+    module
+        .items()
+        .into_iter()
+        .filter_map(|item| match item {
+            AnyJsModuleItem::AnyJsStatement(statement) => Some(statement),
+            _ => None,
+        })
+        .find_map(|statement| match statement {
+            AnyJsStatement::JsExpressionStatement(expr) => Some(expr),
+            _ => None,
+        })
+        .expect("cannot find expression statement")
+}
+
+pub(crate) fn get_function_declaration(root: &AnyJsRoot) -> JsFunctionDeclaration {
+    let module = root.as_js_module().unwrap();
+    module
+        .items()
+        .into_iter()
+        .filter_map(|item| match item {
+            AnyJsModuleItem::AnyJsStatement(statement) => Some(statement),
+            _ => None,
+        })
+        .find_map(|statement| match statement {
+            AnyJsStatement::JsFunctionDeclaration(decl) => Some(decl),
+            _ => None,
+        })
+        .expect("cannot find declaration")
+}
+
+pub(crate) fn parse_ts(code: &str) -> AnyJsRoot {
+    let parsed = parse(code, JsFileSource::ts(), JsParserOptions::default());
+    let diagnostics = parsed.diagnostics();
+    assert!(
+        diagnostics.is_empty(),
+        "Unexpected diagnostics: {diagnostics:?}"
+    );
+
+    parsed.tree()
+}

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -786,6 +786,8 @@ pub enum TypeofExpression {
     Call(TypeofCallExpression),
     New(TypeofNewExpression),
     StaticMember(TypeofStaticMemberExpression),
+    Super(TypeofThisOrSuperExpression),
+    This(TypeofThisOrSuperExpression),
 }
 
 #[derive(Clone, Debug, PartialEq, Resolvable)]
@@ -824,9 +826,9 @@ pub struct TypeofStaticMemberExpression {
 }
 
 #[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct NumericExpressionType {
-    pub left: Type,
-    pub right: Type,
+pub struct TypeofThisOrSuperExpression {
+    /// Type from which the `this` or `super` expression should be resolved.
+    pub parent: Type,
 }
 
 /// Reference to the type of a named JavaScript value.

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -22,8 +22,16 @@ use crate::{
 };
 
 /// Unique identifier to distinguish between identically named, complex types.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Resolvable)]
+#[derive(Clone, Copy, Eq, PartialEq, Resolvable)]
 pub(super) struct TypeId(u64);
+
+// FIXME: This implementation is only necessary for test stability. Once we have
+//        better snapshots for types, this won't be necessary anymore.
+impl Debug for TypeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TypeId").finish()
+    }
+}
 
 impl TypeId {
     pub fn new() -> Self {

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -9,12 +9,29 @@
 //! The type information is instantiated and updated inside the Workspace
 //! Server.
 
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{ops::Deref, str::FromStr, sync::Arc};
 
 use biome_js_type_info_macros::Resolvable;
 use biome_rowan::Text;
 
-use crate::Resolvable;
+use crate::{
+    Resolvable,
+    globals::{ARRAY, PROMISE},
+};
+
+/// Unique identifier to distinguish between identically named, complex types.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Resolvable)]
+pub(super) struct TypeId(u64);
+
+impl TypeId {
+    pub fn new() -> Self {
+        static ID: AtomicU64 = AtomicU64::new(1);
+
+        Self(ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
 
 /// Represents an inferred TypeScript type.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -44,8 +61,44 @@ impl From<TypeInner> for Type {
 }
 
 impl Type {
+    pub fn array_of(ty: Type) -> Self {
+        Self(Arc::new(TypeInner::Class(Box::new(ARRAY.clone())))).with_type_parameters(&[ty])
+    }
+
     pub fn boolean() -> Self {
         Self(Arc::new(TypeInner::Boolean))
+    }
+
+    pub fn function(function: Function) -> Self {
+        Self(Arc::new(TypeInner::Function(Box::new(function))))
+    }
+
+    /// Returns a new instance of the given type.
+    pub fn instance_of(ty: Type) -> Self {
+        if matches!(ty.deref(), TypeInner::Class(_)) {
+            TypeInner::Object(Box::new(Object {
+                prototype: Some(ty),
+                members: Arc::new([]),
+            }))
+            .into()
+        } else {
+            ty
+        }
+    }
+
+    /// Takes the owned [TypeInner] from a `Type`.
+    ///
+    /// Returns `None` if the type has other owners.  
+    pub fn into_inner(self) -> Option<TypeInner> {
+        Arc::into_inner(self.0)
+    }
+
+    pub fn number() -> Self {
+        Self(Arc::new(TypeInner::Number))
+    }
+
+    pub fn promise_of(ty: Type) -> Self {
+        Self(Arc::new(TypeInner::Class(Box::new(PROMISE.clone())))).with_type_parameters(&[ty])
     }
 
     pub fn undefined() -> Self {
@@ -54,6 +107,33 @@ impl Type {
 
     pub fn unknown() -> Self {
         Self(Arc::new(TypeInner::Unknown))
+    }
+
+    pub fn void() -> Self {
+        Self(Arc::new(TypeInner::VoidKeyword))
+    }
+
+    pub fn with_type_parameters(&self, type_parameters: &[Self]) -> Self {
+        match self.deref() {
+            TypeInner::Class(class) => TypeInner::Class(Box::new(Class {
+                type_parameters: class
+                    .type_parameters
+                    .iter()
+                    .enumerate()
+                    .map(|(i, param)| GenericTypeParameter {
+                        name: param.name.clone(),
+                        ty: type_parameters
+                            .get(i)
+                            .cloned()
+                            .unwrap_or_else(|| param.ty.clone()),
+                    })
+                    .collect(),
+                ..class.as_ref().clone()
+            }))
+            .into(),
+            // TODO: Which other types do we need to handle here?
+            _ => self.clone(),
+        }
     }
 }
 
@@ -76,13 +156,11 @@ pub enum TypeInner {
     Undefined,
 
     // Complex types
-    Array(Box<Type>),
     Class(Box<Class>),
     Constructor(Box<Constructor>),
     Function(Box<Function>),
     Namespace(Box<Namespace>),
     Object(Box<Object>),
-    Promise(Box<Type>),
     Tuple(Box<Tuple>),
 
     // Compound types
@@ -100,6 +178,9 @@ pub enum TypeInner {
 
     /// Reference to another type.
     Reference(Box<TypeReference>),
+
+    /// Reference to the type of a JavaScript expression.
+    TypeofExpression(Box<TypeofExpression>),
 
     /// Reference to another type through the `typeof` operator.
     TypeofType(Box<TypeReference>),
@@ -141,6 +222,20 @@ pub enum TypeInner {
 }
 
 impl TypeInner {
+    pub fn as_class(&self) -> Option<&Class> {
+        match self {
+            Self::Class(class) => Some(class.as_ref()),
+            _ => None,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&Object> {
+        match self {
+            Self::Object(object) => Some(object.as_ref()),
+            _ => None,
+        }
+    }
+
     /// Returns whether the given type has been inferred.
     ///
     /// A type is considered inferred if it is anything except `Self::Unknown`,
@@ -149,9 +244,22 @@ impl TypeInner {
         !matches!(self, Self::Unknown)
     }
 
-    /// Returns whether the given type is known to reference a `Promise`.
+    /// Returns whether the given type is known to reference the `Promise`
+    /// class.
     pub fn is_promise(&self) -> bool {
-        matches!(self, Self::Promise(_))
+        match self {
+            Self::Class(class) => class.id == PROMISE.id,
+            _ => false,
+        }
+    }
+
+    /// Returns whether the given type is known to reference an instance of a
+    /// `Promise`.
+    pub fn is_promise_instance(&self) -> bool {
+        match self {
+            Self::Object(object) => object.is_promise(),
+            _ => false,
+        }
     }
 
     /// Returns whether the given type is known to reference a function that
@@ -168,54 +276,88 @@ impl TypeInner {
 }
 
 /// A class definition.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
+#[derive(Clone, PartialEq, Resolvable)]
 pub struct Class {
+    pub(super) id: TypeId,
+
     /// Name of the class, if specified in the definition.
     pub name: Option<Text>,
 
+    /// The class's type parameters.
+    pub type_parameters: Arc<[GenericTypeParameter]>,
+
+    /// Type of another class being extended by this one.
+    pub extends: Option<Type>,
+
     /// Class members.
-    pub members: Box<[ClassMember]>,
+    pub members: Arc<[TypeMember]>,
 }
 
-/// Members of a class definition.
-// TODO: Include getters, setters and index signatures.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub enum ClassMember {
-    Constructor(ConstructorTypeMember),
-    Method(MethodTypeMember),
-    Property(PropertyTypeMember),
+impl Debug for Class {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Class")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("type_parameters", &self.type_parameters)
+            .field("extends", &self.extends)
+            .finish()
+    }
+}
+
+impl Class {
+    /// Iterates all member fields, including those belonging to extended
+    /// classes.
+    ///
+    /// Note that members which are inherited and overridden may appear multiple
+    /// times, but the member that is closest to the subclass is guaranteed to
+    /// come first.
+    pub fn all_members(&self) -> impl Iterator<Item = &TypeMember> {
+        TypeMemberIterator {
+            owner: Some(TypeMemberOwner::Class(self)),
+            index: 0,
+        }
+    }
 }
 
 /// A constructor definition.
 #[derive(Clone, Debug, PartialEq, Resolvable)]
 pub struct Constructor {
     /// Generic type parameters used in the call signature.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 
     /// Call parameter of the constructor.
-    pub parameters: Box<[FunctionParameter]>,
+    pub parameters: Arc<[FunctionParameter]>,
 
     /// Return type when the constructor is called.
     pub return_type: Option<Type>,
 }
 
 /// A function definition.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
+#[derive(Clone, Debug, Default, PartialEq, Resolvable)]
 pub struct Function {
     /// Whether the function has an `async` specifier or not.
     pub is_async: bool,
 
     /// Generic type parameters defined in the function signature.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 
     /// Name of the function, if specified in the definition.
     pub name: Option<Text>,
 
     /// Call parameters of the function.
-    pub parameters: Box<[FunctionParameter]>,
+    pub parameters: Arc<[FunctionParameter]>,
 
     /// The function's return type.
     pub return_type: ReturnType,
+}
+
+impl Function {
+    pub fn with_return_type(self, ty: Type) -> Self {
+        Self {
+            return_type: ReturnType::Type(ty),
+            ..self
+        }
+    }
 }
 
 /// Definition of a function argument.
@@ -241,8 +383,10 @@ pub struct GenericTypeParameter {
     /// Name of the type parameter.
     pub name: Text,
 
-    /// Default type to use if the type parameter is not specified.
-    pub default_ty: Type,
+    /// The resolved type to use.
+    ///
+    /// May be the default type from the type definition.
+    pub ty: Type,
 }
 
 /// The intersection between other types.
@@ -274,11 +418,64 @@ impl Namespace {
 
 /// An object definition.
 #[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct Object(pub(super) Box<[TypeMember]>);
+pub struct Object {
+    /// Optional prototype of the object.
+    ///
+    /// The type that would be returned by `Object.getPrototypeOf()` or the
+    /// legacy `object.__proto__`.
+    pub prototype: Option<Type>,
+
+    /// The object's own members.
+    pub members: Arc<[TypeMember]>,
+}
 
 impl Object {
-    pub fn members(&self) -> &[TypeMember] {
-        &self.0
+    /// Iterates all member fields, including those belonging to the prototype
+    /// chain.
+    ///
+    /// Note that members which are inherited and overridden may appear multiple
+    /// times, but the member that is closest to the own object in the prototype
+    /// chain is guaranteed to come first.
+    pub fn all_members(&self) -> impl Iterator<Item = &TypeMember> {
+        TypeMemberIterator {
+            owner: Some(TypeMemberOwner::Object(self)),
+            index: 0,
+        }
+    }
+
+    /// Returns a parent class of this object, if it matches the given `class`.
+    ///
+    /// The returned [Class] will match the given `class`, but may still have
+    /// different type arguments.
+    pub fn find_parent_class(&self, class: &Class) -> Option<&Class> {
+        let mut prototype = self.prototype.as_ref();
+        while let Some(proto) = prototype {
+            match proto.as_class() {
+                Some(proto_class) if proto_class.id == class.id => return Some(proto_class),
+                _ => {}
+            }
+
+            prototype = proto.as_object().and_then(|p| p.prototype.as_ref())
+        }
+
+        None
+    }
+
+    /// Returns the promised type, if this object is an instance of a `Promise`.
+    pub fn find_promise_type(&self) -> Option<Type> {
+        self.find_parent_class(&PROMISE)
+            .map(|class| class.type_parameters[0].ty.clone())
+    }
+
+    /// Returns whether this object has the given `class` in its prototype
+    /// chain.
+    pub fn is_instance_of(&self, class: &Class) -> bool {
+        self.find_parent_class(class).is_some()
+    }
+
+    /// Returns whether this object is an instance of a `Promise`.
+    pub fn is_promise(&self) -> bool {
+        self.is_instance_of(&PROMISE)
     }
 }
 
@@ -318,14 +515,61 @@ pub enum TypeMember {
     Property(PropertyTypeMember),
 }
 
+impl TypeMember {
+    pub fn has_name(&self, name: &str) -> bool {
+        match self {
+            Self::CallSignature(_) => false,
+            Self::Constructor(_) => name == "constructor",
+            Self::Method(member) => member.name == name,
+            Self::Property(member) => member.name == name,
+        }
+    }
+
+    pub fn is_static(&self) -> bool {
+        match self {
+            Self::CallSignature(_) | Self::Constructor(_) => false,
+            Self::Method(member) => member.is_static,
+            Self::Property(member) => member.is_static,
+        }
+    }
+
+    pub fn to_type(&self, object: &Type) -> Type {
+        match self {
+            Self::CallSignature(member) => TypeInner::Function(Box::new(Function {
+                is_async: false,
+                type_parameters: member.type_parameters.clone(),
+                name: None,
+                parameters: member.parameters.clone(),
+                return_type: member.return_type.clone(),
+            }))
+            .into(),
+            Self::Constructor(member) => {
+                member.return_type.clone().unwrap_or_else(|| object.clone())
+            }
+            Self::Method(member) => {
+                // TODO: Create union type with `undefined` if member is optional.
+                TypeInner::Function(Box::new(Function {
+                    is_async: member.is_async,
+                    type_parameters: member.type_parameters.clone(),
+                    name: Some(member.name.clone()),
+                    parameters: member.parameters.clone(),
+                    return_type: member.return_type.clone(),
+                }))
+                .into()
+            }
+            Self::Property(member) => member.ty.clone(),
+        }
+    }
+}
+
 /// Defines a call signature on an object definition.
 #[derive(Clone, Debug, PartialEq, Resolvable)]
 pub struct CallSignatureTypeMember {
     /// Generic type parameters defined in the call signature.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 
     /// Call parameters of the signature.
-    pub parameters: Box<[FunctionParameter]>,
+    pub parameters: Arc<[FunctionParameter]>,
 
     /// Return type when the object is called.
     pub return_type: ReturnType,
@@ -335,45 +579,147 @@ pub struct CallSignatureTypeMember {
 #[derive(Clone, Debug, PartialEq, Resolvable)]
 pub struct ConstructorTypeMember {
     /// Generic type parameters defined in the constructor.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 
     /// Call parameters of the constructor.
-    pub parameters: Box<[FunctionParameter]>,
+    pub parameters: Arc<[FunctionParameter]>,
 
     /// Return type when the constructor is called.
     pub return_type: Option<Type>,
 }
 
 /// Defines a method on an object.
-// TODO: Include modifiers.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
+#[derive(Clone, Debug, Default, PartialEq, Resolvable)]
 pub struct MethodTypeMember {
     /// Whether the function has an `async` specifier or not.
     pub is_async: bool,
 
     /// Generic type parameters defined in the method.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 
     /// Name of the method.
     pub name: Text,
 
     /// Call parameters of the method.
-    pub parameters: Box<[FunctionParameter]>,
+    pub parameters: Arc<[FunctionParameter]>,
 
     /// Return type of the method.
     pub return_type: ReturnType,
 
     /// Whether the method is optional.
     pub is_optional: bool,
+
+    /// Whether the method is static.
+    pub is_static: bool,
+}
+
+impl MethodTypeMember {
+    pub fn with_name(mut self, name: Text) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn with_return_type(mut self, ty: Type) -> Self {
+        self.return_type = ReturnType::Type(ty);
+        self
+    }
+
+    pub fn with_static(mut self) -> Self {
+        self.is_static = true;
+        self
+    }
 }
 
 /// Defines an object property and its type.
-// TODO: Include modifiers.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
+#[derive(Clone, Debug, Default, PartialEq, Resolvable)]
 pub struct PropertyTypeMember {
+    /// Name of the property.
     pub name: Text,
+
+    /// Type of the property.
     pub ty: Type,
+
+    /// Whether the property is optional.
     pub is_optional: bool,
+
+    /// Whether the property is static.
+    pub is_static: bool,
+}
+
+impl PropertyTypeMember {
+    pub fn with_name(mut self, name: Text) -> Self {
+        self.name = name;
+        self
+    }
+
+    pub fn with_type(mut self, ty: Type) -> Self {
+        self.ty = ty;
+        self
+    }
+}
+
+struct TypeMemberIterator<'a> {
+    owner: Option<TypeMemberOwner<'a>>,
+    index: usize,
+}
+
+impl<'a> Iterator for TypeMemberIterator<'a> {
+    type Item = &'a TypeMember;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &self.owner {
+            Some(TypeMemberOwner::Class(class)) => {
+                match (class.members.get(self.index), class.extends.as_ref()) {
+                    (Some(member), _) => {
+                        self.index += 1;
+                        Some(member)
+                    }
+                    (None, Some(extends)) => {
+                        self.owner = extends.into();
+                        self.index = 0;
+                        self.next()
+                    }
+                    (None, None) => {
+                        self.owner = None;
+                        None
+                    }
+                }
+            }
+            Some(TypeMemberOwner::Object(object)) => {
+                match (object.members.get(self.index), object.prototype.as_ref()) {
+                    (Some(member), _) => {
+                        self.index += 1;
+                        Some(member)
+                    }
+                    (None, Some(prototype)) => {
+                        self.owner = prototype.into();
+                        self.index = 0;
+                        self.next()
+                    }
+                    (None, None) => {
+                        self.owner = None;
+                        None
+                    }
+                }
+            }
+            None => None,
+        }
+    }
+}
+
+enum TypeMemberOwner<'a> {
+    Class(&'a Class),
+    Object(&'a Object),
+}
+
+impl<'a> From<&'a Type> for Option<TypeMemberOwner<'a>> {
+    fn from(ty: &'a Type) -> Self {
+        match ty.deref() {
+            TypeInner::Class(class) => Some(TypeMemberOwner::Class(class)),
+            TypeInner::Object(object) => Some(TypeMemberOwner::Object(object)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Resolvable)]
@@ -425,17 +771,68 @@ pub struct TypeAlias {
     pub ty: Type,
 
     /// Generic type parameters that can be passed on the alias itself.
-    pub type_parameters: Box<[GenericTypeParameter]>,
+    pub type_parameters: Arc<[GenericTypeParameter]>,
 }
 
-/// Resolved reference to the type of a named JavaScript value.
+/// Reference to the type of a JavaScript expression.
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub enum TypeofExpression {
+    Addition(TypeofAdditionExpression),
+    Await(TypeofAwaitExpression),
+    Call(TypeofCallExpression),
+    New(TypeofNewExpression),
+    StaticMember(TypeofStaticMemberExpression),
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct TypeofAdditionExpression {
+    pub left: Type,
+    pub right: Type,
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct TypeofAwaitExpression {
+    pub argument: Type,
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct TypeofCallExpression {
+    pub callee: Type,
+    pub arguments: Arc<[CallArgumentType]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct TypeofNewExpression {
+    pub callee: Type,
+    pub arguments: Arc<[CallArgumentType]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub enum CallArgumentType {
+    Argument(Type),
+    Spread(Type),
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct TypeofStaticMemberExpression {
+    pub object: Type,
+    pub member: Text,
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct NumericExpressionType {
+    pub left: Type,
+    pub right: Type,
+}
+
+/// Reference to the type of a named JavaScript value.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypeofValue {
     /// Identifier of the type being referenced.
     ///
     /// We explicitly do not allow full expressions to be used as values,
     /// meaning our inference needs to break down expressions into parts before
-    /// deciding the values to reference.
+    /// deciding the values to reference. See [TypeofExpression] for that.
     pub identifier: Text,
 
     /// The resolved type.
@@ -447,12 +844,12 @@ impl Resolvable for TypeofValue {
         !self.ty.is_inferred() && resolver.resolve_type_of(&self.identifier).is_some()
     }
 
-    fn resolved(&self, resolver: &dyn crate::TypeResolver, _stack: &[&TypeInner]) -> Self {
+    fn resolved(&self, resolver: &dyn crate::TypeResolver, stack: &[&TypeInner]) -> Self {
         let ty = match self.ty.is_inferred() {
             true => self.ty.clone(),
             false => resolver
                 .resolve_type_of(&self.identifier)
-                .unwrap_or_else(Type::unknown),
+                .map_or_else(Type::unknown, |ty| ty.resolved(resolver, stack)),
         };
 
         Self {
@@ -500,7 +897,7 @@ pub struct TypeReference {
     pub ty: Type,
 
     /// Generic type parameters specified in the reference.
-    pub type_parameters: Box<[Type]>,
+    pub type_parameters: Arc<[Type]>,
 }
 
 impl Resolvable for TypeReference {
@@ -517,7 +914,7 @@ impl Resolvable for TypeReference {
             true => self.ty.clone(),
             false => resolver
                 .resolve_qualifier(&self.qualifier)
-                .unwrap_or_else(Type::unknown),
+                .map_or_else(Type::unknown, |ty| ty.resolved(resolver, stack)),
         };
 
         Self {
@@ -537,11 +934,13 @@ impl Resolvable for TypeReference {
 pub struct TypeReferenceQualifier(pub(super) Box<[Text]>);
 
 impl TypeReferenceQualifier {
-    /// HACK: This method simply checks whether the reference is for a literal
-    ///       `Promise`, without considering whether another symbol named
-    ///       `Promise` is in scope. It's a shortcut for getting
-    ///       `noFloatingPromises` to work, but we'd like to do a proper lookup
-    ///       later.
+    /// Checks whether this type qualifier references a `Promise` type.
+    ///
+    /// This method simply checks whether the reference is for a literal
+    /// `Promise`, without considering whether another symbol named `Promise` is
+    /// in scope. It can be used _after_ type resolution has failed to find a
+    /// `Promise` symbol in scope, but should not be used _instead of_ such type
+    /// resolution.
     pub fn is_promise(&self) -> bool {
         self.0.len() == 1 && self.0[0] == "Promise"
     }

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -18,7 +18,7 @@ use biome_rowan::Text;
 
 use crate::{
     Resolvable,
-    globals::{ARRAY, PROMISE},
+    globals::{ARRAY, PROMISE, WINDOW_TYPE},
 };
 
 /// Unique identifier to distinguish between identically named, complex types.
@@ -111,6 +111,10 @@ impl Type {
 
     pub fn void() -> Self {
         Self(Arc::new(TypeInner::VoidKeyword))
+    }
+
+    pub fn window() -> Self {
+        WINDOW_TYPE.clone()
     }
 
     pub fn with_type_parameters(&self, type_parameters: &[Self]) -> Self {

--- a/crates/biome_js_type_info/src/type_info.tests.rs
+++ b/crates/biome_js_type_info/src/type_info.tests.rs
@@ -1,4 +1,32 @@
+use insta::assert_debug_snapshot;
+
+use crate::test_util::{get_function_declaration, parse_ts};
+
 use super::*;
+
+#[test]
+fn infer_type_of_promise_returning_function() {
+    const CODE: &str = r#"function returnsPromise(): Promise<number> {
+    return Promise.resolved(true);
+}"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let ty = Type::from_js_function_declaration(&decl);
+    assert_debug_snapshot!(ty);
+}
+
+#[test]
+fn infer_type_of_async_function() {
+    const CODE: &str = r#"async function returnsPromise(): Promise<string> {
+	return "value";
+}"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let ty = Type::from_js_function_declaration(&decl);
+    assert_debug_snapshot!(ty);
+}
 
 #[test]
 #[cfg(target_pointer_width = "64")]

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -27,6 +27,7 @@ cfg-if               = { workspace = true }
 once_cell            = "1.20.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
 oxc_resolver         = { workspace = true }
 papaya               = { workspace = true }
+rust-lapper          = { workspace = true }
 rustc-hash           = { workspace = true }
 serde_json           = { workspace = true }
 static_assertions    = { workspace = true }

--- a/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
@@ -1,0 +1,71 @@
+use biome_js_type_info::{Type, TypeReferenceQualifier, TypeResolver};
+use biome_rowan::Text;
+
+use crate::ModuleGraph;
+
+use super::{JsModuleInfo, scope::JsScope};
+
+/// Type resolver that is able to resolve types from an arbitrary scope on an
+/// ad-hoc basic.
+///
+/// TODO: The ad-hoc basis of this resolver means we don't cache the lookups it
+///       performs. This probably needs revising still.
+pub(super) struct AdHocScopeResolver<'a> {
+    scope: JsScope,
+    module_info: &'a JsModuleInfo,
+    module_graph: &'a ModuleGraph,
+}
+
+impl<'a> AdHocScopeResolver<'a> {
+    pub(super) fn from_scope_in_module(
+        scope: JsScope,
+        module_info: &'a JsModuleInfo,
+        module_graph: &'a ModuleGraph,
+    ) -> Self {
+        Self {
+            scope,
+            module_info,
+            module_graph,
+        }
+    }
+}
+
+impl TypeResolver for AdHocScopeResolver<'_> {
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type> {
+        if qualifier.parts().len() == 1 {
+            self.resolve_type_of(&qualifier.parts()[0]).or_else(|| {
+                qualifier
+                    .is_promise()
+                    .then(|| Type::promise_of(Type::unknown()))
+            })
+        } else {
+            // TODO: Resolve nested qualifiers
+            None
+        }
+    }
+
+    fn resolve_type_of(&self, identifier: &Text) -> Option<Type> {
+        let mut scope = self.scope.clone();
+        loop {
+            if let Some(binding) = scope.get_binding(identifier.text()) {
+                if binding.is_imported() {
+                    return self
+                        .module_info
+                        .find_exported_symbol(self.module_graph, &binding.name())
+                        .map(|export| export.ty);
+                } else {
+                    let ty = binding.ty();
+                    return match ty.is_inferred() {
+                        true => Some(ty.clone()),
+                        false => None,
+                    };
+                }
+            }
+
+            match scope.parent() {
+                Some(parent) => scope = parent,
+                None => return None,
+            }
+        }
+    }
+}

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use biome_js_semantic::{
     BindingId, ReferenceId, ScopeId, SemanticEvent, SemanticEventExtractor, find_import_node,
@@ -9,6 +12,7 @@ use biome_js_syntax::{
 };
 use biome_js_type_info::Type;
 use biome_rowan::{AstNode, Text, TextSize, TokenText};
+use rust_lapper::{Interval, Lapper};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -18,8 +22,8 @@ use crate::{
 
 use super::{
     JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsModuleInfoInner, JsOwnExport, JsReexport,
-    JsResolvedPath, binding::JsBindingData, scope::JsScopeData,
-    type_resolver::JsModuleTypeResolver,
+    JsResolvedPath, binding::JsBindingData, global_scope_resolver::GlobalScopeResolver,
+    scope::JsScopeData,
 };
 
 /// Responsible for collecting all the information from which to build the
@@ -48,6 +52,9 @@ pub(super) struct JsModuleInfoCollector {
     ///
     /// The first entry is always the module's global scope.
     pub(super) scopes: Vec<JsScopeData>,
+
+    /// Used to build the Lapper lookup tree for finding scopes by text range.
+    scope_range_by_start: FxHashMap<TextSize, BTreeSet<Interval<u32, ScopeId>>>,
 
     /// Used for tracking the scope we are currently in.
     scope_stack: Vec<ScopeId>,
@@ -165,6 +172,16 @@ impl JsModuleInfoCollector {
                     self.scopes[parent_scope_id.index()].children.push(scope_id);
                 }
 
+                let start = range.start();
+                self.scope_range_by_start
+                    .entry(start)
+                    .or_default()
+                    .insert(Interval {
+                        start: start.into(),
+                        stop: range.end().into(),
+                        val: scope_id,
+                    });
+
                 self.scope_stack.push(scope_id);
             }
             ScopeEnded { .. } => {
@@ -194,6 +211,10 @@ impl JsModuleInfoCollector {
                 let name = name_token.as_ref().map(JsSyntaxToken::token_text_trimmed);
 
                 self.bindings.push(JsBindingData {
+                    name: name
+                        .as_ref()
+                        .map(|name| name.clone().into())
+                        .unwrap_or_default(),
                     range,
                     references: Vec::new(),
                     scope_id: *self.scope_stack.last().expect("scope must be present"),
@@ -489,7 +510,7 @@ impl JsModuleInfoBag {
     /// Iterates over all exported symbols in the module and resolves them if
     /// they refer to any other symbols in scope of the module.
     fn resolve_module_types(&mut self, collector: &JsModuleInfoCollector) {
-        let resolver = JsModuleTypeResolver::from_collector(collector);
+        let resolver = GlobalScopeResolver::from_collector(collector);
 
         for export in self.exports.values_mut() {
             if let Some(export) = export.as_own_export_mut() {
@@ -512,6 +533,14 @@ impl JsModuleInfo {
             blanket_reexports: bag.blanket_reexports.into(),
             bindings: collector.bindings.into(),
             scopes: collector.scopes.into(),
+            scope_by_range: Lapper::new(
+                collector
+                    .scope_range_by_start
+                    .iter()
+                    .flat_map(|(_, scopes)| scopes.iter())
+                    .cloned()
+                    .collect(),
+            ),
         }))
     }
 }

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
@@ -12,90 +12,27 @@ expression: data.exports
                 "superComputer",
             ),
             ty: Type(
-                Reference(
-                    TypeReference {
-                        qualifier: TypeReferenceQualifier(
-                            [
-                                Borrowed(
-                                    "DeepThought",
+                Object(
+                    Object {
+                        prototype: Some(
+                            Type(
+                                Class(
+                                    Class {
+                                        id: TypeId(
+                                            1,
+                                        ),
+                                        name: Some(
+                                            Borrowed(
+                                                "DeepThought",
+                                            ),
+                                        ),
+                                        type_parameters: [],
+                                        extends: None,
+                                    },
                                 ),
-                            ],
-                        ),
-                        ty: Type(
-                            Class(
-                                Class {
-                                    name: Some(
-                                        Borrowed(
-                                            "DeepThought",
-                                        ),
-                                    ),
-                                    members: [
-                                        Method(
-                                            MethodTypeMember {
-                                                is_async: false,
-                                                type_parameters: [],
-                                                name: Borrowed(
-                                                    "answerMe",
-                                                ),
-                                                parameters: [],
-                                                return_type: Type(
-                                                    Type(
-                                                        Number,
-                                                    ),
-                                                ),
-                                                is_optional: false,
-                                            },
-                                        ),
-                                        Method(
-                                            MethodTypeMember {
-                                                is_async: false,
-                                                type_parameters: [],
-                                                name: Borrowed(
-                                                    "giveMeABiggerAnswer",
-                                                ),
-                                                parameters: [
-                                                    FunctionParameter {
-                                                        name: Some(
-                                                            Borrowed(
-                                                                "delta",
-                                                            ),
-                                                        ),
-                                                        ty: Type(
-                                                            Number,
-                                                        ),
-                                                        is_optional: false,
-                                                        is_rest: false,
-                                                    },
-                                                ],
-                                                return_type: Type(
-                                                    Type(
-                                                        Unknown,
-                                                    ),
-                                                ),
-                                                is_optional: false,
-                                            },
-                                        ),
-                                        Method(
-                                            MethodTypeMember {
-                                                is_async: false,
-                                                type_parameters: [],
-                                                name: Borrowed(
-                                                    "whatWasTheUltimateQuestion",
-                                                ),
-                                                parameters: [],
-                                                return_type: Type(
-                                                    Type(
-                                                        UnknownKeyword,
-                                                    ),
-                                                ),
-                                                is_optional: false,
-                                            },
-                                        ),
-                                    ],
-                                },
                             ),
                         ),
-                        type_parameters: [],
+                        members: [],
                     },
                 ),
             ),

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_export_types.snap
@@ -18,9 +18,7 @@ expression: data.exports
                             Type(
                                 Class(
                                     Class {
-                                        id: TypeId(
-                                            1,
-                                        ),
+                                        id: TypeId,
                                         name: Some(
                                             Borrowed(
                                                 "DeepThought",

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
@@ -91,10 +91,28 @@ expression: exports
                         parameters: [],
                         return_type: Type(
                             Type(
-                                Promise(
-                                    Type(
-                                        Unknown,
-                                    ),
+                                Class(
+                                    Class {
+                                        id: TypeId(
+                                            2,
+                                        ),
+                                        name: Some(
+                                            Static(
+                                                "Promise",
+                                            ),
+                                        ),
+                                        type_parameters: [
+                                            GenericTypeParameter {
+                                                name: Static(
+                                                    "T",
+                                                ),
+                                                ty: Type(
+                                                    Unknown,
+                                                ),
+                                            },
+                                        ],
+                                        extends: None,
+                                    },
                                 ),
                             ),
                         ),
@@ -252,7 +270,12 @@ expression: exports
                 "quz",
             ),
             ty: Type(
-                Unknown,
+                Object(
+                    Object {
+                        prototype: None,
+                        members: [],
+                    },
+                ),
             ),
         },
     ),

--- a/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
+++ b/crates/biome_module_graph/src/snapshots/biome_module_graph__module_graph__tests__resolve_exports.snap
@@ -93,9 +93,7 @@ expression: exports
                             Type(
                                 Class(
                                     Class {
-                                        id: TypeId(
-                                            2,
-                                        ),
+                                        id: TypeId,
                                         name: Some(
                                             Static(
                                                 "Promise",

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -200,7 +200,11 @@ pub fn get_added_paths<'a>(
                     .unwrap_or_default();
                 let parsed =
                     biome_js_parser::parse(&content, file_source, JsParserOptions::default());
-                assert!(parsed.diagnostics().is_empty());
+                let diagnostics = parsed.diagnostics();
+                assert!(
+                    diagnostics.is_empty(),
+                    "Unexpected diagnostics: {diagnostics:?}"
+                );
                 parsed.try_tree()
             });
             (path, root)


### PR DESCRIPTION
## Summary

This PR updates the implementation of `noFloatingPromises` to swap its ad-hoc, local type inference with a new `Typed` service that looks up types from the module graph.

Note the addition of an `AdHocScopeResolver`. Because the types that are being looked up in the module graph may have unresolved references, some type resolution is still necessary on those. This type resolution is, as the name implies, being done ad-hoc still. I might revise this later.

The good thing about `AdHocScopeResolver` is that it can actually traverse scopes for lookups. It also allows us to verify whether a type reference named `Promise` refers to the global `Promise` type, or a local type that shadows it. This was one of the things that's also part of the extensive tests we already have for `noFloatingPromises`.

Another nice change is that I'm no longer carving out exceptions at the type level for both `Array` and `Promise`. Instead, both are now classes with global definitions. Since we don't actually have `.d.ts` inference yet, those definitions are simply hardcoded now. This resolved some hacks we did in a few places, and has become possible since our inference is now also able to follow prototype chains.

Note I'm still fighting with a few regressions in `noFloatingPromises`, but otherwise this is ready for review.

Another note: I'm not entirely happy with how we do type resolution and flattening yet. I feel there is another refactor on that front coming, but I'm not yet sure how exactly I want to shape it yet. I don't think I should do that in this PR anymore, but suggestions are welcome!

## Test Plan

All test cases that were created for `noFloatingPromises` should pass.

I've also started added more unit tests for our local inference and type flattening logic.
