### PR TITLE
fix(assist): skip sorting specifiers if it contains any bogus nodes

### DIFF
--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -606,7 +606,8 @@ impl Rule for OrganizeImports {
                 let are_specifiers_unsorted =
                     specifiers.is_some_and(|specifiers| !specifiers.are_sorted());
                 let are_attributes_unsorted = attributes.is_some_and(|attributes| {
-                    !(are_import_attributes_sorted(&attributes).unwrap_or_default())
+                    // Assume the attributes are sorted if there are any bogus nodes.
+                    !(are_import_attributes_sorted(&attributes).unwrap_or(true))
                 });
                 let newline_issue = if leading_newline_count == 1
                     // A chunk must start with a blank line (two newlines)

--- a/crates/biome_js_analyze/src/assist/source/organize_imports/specifiers_attributes.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports/specifiers_attributes.rs
@@ -22,7 +22,9 @@ impl JsNamedSpecifiers {
                 are_export_specifiers_sorted(specifeirs)
             }
         }
-        .unwrap_or_default()
+        // Assume the import is already sorted if there are any bogus nodes, otherwise the `--write`
+        // flag will cause infinite loop.
+        .unwrap_or(true)
     }
 }
 

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js
@@ -1,0 +1,2 @@
+// The last `inject` specifier is a bogus node, so this won't emit any code actions.
+import { inject, Injectable, inject } from '@angular/core';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js
@@ -1,2 +1,5 @@
 // The last `inject` specifier is a bogus node, so this won't emit any code actions.
 import { inject, Injectable, inject } from '@angular/core';
+
+// The last `key` attribute is a bogus node, so this won't emit any code actions.
+import { names } from "module-name" with { key: "data", key2: "data2", key: "data3" };

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
@@ -7,4 +7,7 @@ expression: issue-5710.js
 // The last `inject` specifier is a bogus node, so this won't emit any code actions.
 import { inject, Injectable, inject } from '@angular/core';
 
+// The last `key` attribute is a bogus node, so this won't emit any code actions.
+import { names } from "module-name" with { key: "data", key2: "data2", key: "data3" };
+
 ```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue-5710.js.snap
@@ -1,0 +1,10 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue-5710.js
+---
+# Input
+```js
+// The last `inject` specifier is a bogus node, so this won't emit any code actions.
+import { inject, Injectable, inject } from '@angular/core';
+
+```


### PR DESCRIPTION
## Summary

Fixes #5710 

The `organizeImports` assist assumes the import is unsorted even if there are any bogus nodes. This causes an infinite loop when Biome apply code actions in multipass. Assuming the import is already sorted if any bogus nodes there so we no longer get stuck from the loop.

## Test Plan

Added a snapshot test to ensure any diagnostics won't be emitted for the bogus code.
