### PR TITLE
feat(lint): implement code action for useConsistentObjectDefinition

### DIFF
--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3359,7 +3359,7 @@ pub struct Nursery {
     #[doc = "Require the consistent declaration of object literals. Defaults to explicit definitions."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_consistent_object_definition:
-        Option<RuleConfiguration<biome_js_analyze::options::UseConsistentObjectDefinition>>,
+        Option<RuleFixConfiguration<biome_js_analyze::options::UseConsistentObjectDefinition>>,
     #[doc = "Require specifying the reason argument when using @deprecated directive"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_deprecated_reason:

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentObjectDefinition/invalidExplicit.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentObjectDefinition/invalidExplicit.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalidExplicit.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -30,7 +29,7 @@ const invalidExplicit = {
 
 # Diagnostics
 ```
-invalidExplicit.js:3:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:3:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -43,11 +42,15 @@ invalidExplicit.js:3:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    3 │ ····foo:·foo,
+      │        ----- 
 
 ```
 
 ```
-invalidExplicit.js:4:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:4:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -60,11 +63,15 @@ invalidExplicit.js:4:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    4 │ ····bar:·bar,
+      │        ----- 
 
 ```
 
 ```
-invalidExplicit.js:5:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:5:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -77,11 +84,15 @@ invalidExplicit.js:5:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    5 │ ····baz:·baz,
+      │        ----- 
 
 ```
 
 ```
-invalidExplicit.js:8:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:8:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -93,11 +104,15 @@ invalidExplicit.js:8:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    8 │ ····method:·function·()·{·return·"method";·},
+      │           -----------                        
 
 ```
 
 ```
-invalidExplicit.js:9:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:9:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -110,11 +125,15 @@ invalidExplicit.js:9:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    9 │ ····async:·async·function·()·{·return·"async";·},
+      │          -      ----------                       
 
 ```
 
 ```
-invalidExplicit.js:10:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:10:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -127,11 +146,20 @@ invalidExplicit.js:10:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+     8  8 │       method: function () { return "method"; },
+     9  9 │       async: async function () { return "async"; },
+    10    │ - ····generator:·function*·()·{·yield·"gen";·},
+       10 │ + ····*generator()·{·yield·"gen";·},
+    11 11 │       asyncGenerator: async function* () { yield "async gen"; },
+    12 12 │   
+  
 
 ```
 
 ```
-invalidExplicit.js:11:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:11:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -144,11 +172,20 @@ invalidExplicit.js:11:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+     9  9 │       async: async function () { return "async"; },
+    10 10 │       generator: function* () { yield "gen"; },
+    11    │ - ····asyncGenerator:·async·function*·()·{·yield·"async·gen";·},
+       11 │ + ····async·*asyncGenerator()·{·yield·"async·gen";·},
+    12 12 │   
+    13 13 │       // Computed methods shorthand violations
+  
 
 ```
 
 ```
-invalidExplicit.js:14:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:14:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -160,11 +197,15 @@ invalidExplicit.js:14:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    14 │ ····[computed]:·function·()·{·return·"computed";·},
+       │               -----------                          
 
 ```
 
 ```
-invalidExplicit.js:15:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:15:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -177,11 +218,20 @@ invalidExplicit.js:15:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    13 13 │       // Computed methods shorthand violations
+    14 14 │       [computed]: function () { return "computed"; },
+    15    │ - ····[computed]:·async·function·()·{·return·"async·computed";·},
+       15 │ + ····async·[computed]()·{·return·"async·computed";·},
+    16 16 │       [computed]: function* () { yield "computed gen"; },
+    17 17 │       ["computed-string"]: function () { return "computed string"; },
+  
 
 ```
 
 ```
-invalidExplicit.js:16:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:16:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -194,11 +244,20 @@ invalidExplicit.js:16:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    14 14 │       [computed]: function () { return "computed"; },
+    15 15 │       [computed]: async function () { return "async computed"; },
+    16    │ - ····[computed]:·function*·()·{·yield·"computed·gen";·},
+       16 │ + ····*[computed]()·{·yield·"computed·gen";·},
+    17 17 │       ["computed-string"]: function () { return "computed string"; },
+    18 18 │       ["comp" + "uted" + "-con" + "cat"]: function () { return "computed concat"; },
+  
 
 ```
 
 ```
-invalidExplicit.js:17:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:17:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -211,11 +270,15 @@ invalidExplicit.js:17:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    17 │ ····["computed-string"]:·function·()·{·return·"computed·string";·},
+       │                        -----------                                 
 
 ```
 
 ```
-invalidExplicit.js:18:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:18:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -228,11 +291,15 @@ invalidExplicit.js:18:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    18 │ ····["comp"·+·"uted"·+·"-con"·+·"cat"]:·function·()·{·return·"computed·concat";·},
+       │                                       -----------                                 
 
 ```
 
 ```
-invalidExplicit.js:19:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidExplicit.js:19:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use explicit object property syntax when shorthand syntax is possible.
   
@@ -245,5 +312,9 @@ invalidExplicit.js:19:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using shorthand object property syntax makes object definitions more concise.
   
+  i Safe fix: Use shorthand object property syntax.
+  
+    19 │ ····[computed()]:·function·()·{·return·"computed·dynamic";·},
+       │                 -----------                                  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useConsistentObjectDefinition/invalidShorthand.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useConsistentObjectDefinition/invalidShorthand.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalidShorthand.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -34,7 +33,7 @@ const invalidShorthand = {
 
 # Diagnostics
 ```
-invalidShorthand.js:3:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:3:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -47,11 +46,15 @@ invalidShorthand.js:3:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    3 │ ····prop:·prop,
+      │         ++++++ 
 
 ```
 
 ```
-invalidShorthand.js:4:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:4:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -64,11 +67,15 @@ invalidShorthand.js:4:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    4 │ ····shortProp:·shortProp,
+      │              +++++++++++ 
 
 ```
 
 ```
-invalidShorthand.js:7:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:7:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -80,11 +87,15 @@ invalidShorthand.js:7:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    7 │ ····method:·function·()·{·return·"method";·},
+      │           +++++++++++                        
 
 ```
 
 ```
-invalidShorthand.js:8:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:8:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -97,11 +108,15 @@ invalidShorthand.js:8:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    8 │ ····async:·async·function·()·{·return·"async";·},
+      │          +      ++++++++++                       
 
 ```
 
 ```
-invalidShorthand.js:9:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:9:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -114,11 +129,20 @@ invalidShorthand.js:9:5 lint/nursery/useConsistentObjectDefinition ━━━━�
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+     7  7 │       method() { return "method"; },
+     8  8 │       async async() { return "async"; },
+     9    │ - ····*generator()·{·yield·"gen";·},
+        9 │ + ····generator:·function*·()·{·yield·"gen";·},
+    10 10 │       async *asyncGenerator() { yield "async gen"; },
+    11 11 │   
+  
 
 ```
 
 ```
-invalidShorthand.js:10:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:10:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -131,11 +155,20 @@ invalidShorthand.js:10:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+     8  8 │       async async() { return "async"; },
+     9  9 │       *generator() { yield "gen"; },
+    10    │ - ····async·*asyncGenerator()·{·yield·"async·gen";·},
+       10 │ + ····asyncGenerator:·async·function*·()·{·yield·"async·gen";·},
+    11 11 │   
+    12 12 │       // Computed methods
+  
 
 ```
 
 ```
-invalidShorthand.js:13:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:13:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -147,11 +180,15 @@ invalidShorthand.js:13:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    13 │ ····[computed]:·function·()·{·return·"computed";·},
+       │               +++++++++++                          
 
 ```
 
 ```
-invalidShorthand.js:14:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:14:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -164,11 +201,20 @@ invalidShorthand.js:14:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    12 12 │       // Computed methods
+    13 13 │       [computed]() { return "computed"; },
+    14    │ - ····async·[computed]()·{·return·"async·computed";·},
+       14 │ + ····[computed]:·async·function·()·{·return·"async·computed";·},
+    15 15 │       *[computed]() { yield "computed gen"; },
+    16 16 │       ["computed-string"]() { return "computed string"; },
+  
 
 ```
 
 ```
-invalidShorthand.js:15:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:15:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -181,11 +227,20 @@ invalidShorthand.js:15:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    13 13 │       [computed]() { return "computed"; },
+    14 14 │       async [computed]() { return "async computed"; },
+    15    │ - ····*[computed]()·{·yield·"computed·gen";·},
+       15 │ + ····[computed]:·function*·()·{·yield·"computed·gen";·},
+    16 16 │       ["computed-string"]() { return "computed string"; },
+    17 17 │       ["comp" + "uted" + "-con" + "cat"]() { return "computed concat"; },
+  
 
 ```
 
 ```
-invalidShorthand.js:16:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:16:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -198,11 +253,15 @@ invalidShorthand.js:16:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    16 │ ····["computed-string"]:·function·()·{·return·"computed·string";·},
+       │                        +++++++++++                                 
 
 ```
 
 ```
-invalidShorthand.js:17:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:17:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -215,11 +274,15 @@ invalidShorthand.js:17:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    17 │ ····["comp"·+·"uted"·+·"-con"·+·"cat"]:·function·()·{·return·"computed·concat";·},
+       │                                       +++++++++++                                 
 
 ```
 
 ```
-invalidShorthand.js:18:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:18:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -232,11 +295,15 @@ invalidShorthand.js:18:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    18 │ ····[computed()]:·function·()·{·return·"computed·dynamic";·},
+       │                 +++++++++++                                  
 
 ```
 
 ```
-invalidShorthand.js:21:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:21:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -248,11 +315,15 @@ invalidShorthand.js:21:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    21 │ ····'quotedMethod':·function·()·{·return·"quoted";·},
+       │                   +++++++++++                        
 
 ```
 
 ```
-invalidShorthand.js:22:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:22:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -265,11 +336,15 @@ invalidShorthand.js:22:5 lint/nursery/useConsistentObjectDefinition ━━━━
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
   
+  i Safe fix: Use explicit object property syntax.
+  
+    22 │ ····"doubleQuoted":·function·()·{·return·"double·quoted";·},
+       │                   +++++++++++                               
 
 ```
 
 ```
-invalidShorthand.js:23:5 lint/nursery/useConsistentObjectDefinition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalidShorthand.js:23:5 lint/nursery/useConsistentObjectDefinition  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
 
   × Do not use shorthand object property syntax.
   
@@ -281,6 +356,15 @@ invalidShorthand.js:23:5 lint/nursery/useConsistentObjectDefinition ━━━━
     25 │ 
   
   i Using explicit object property syntax makes object definitions more readable and consistent.
+  
+  i Safe fix: Use explicit object property syntax.
+  
+    21 21 │       'quotedMethod'() { return "quoted"; },
+    22 22 │       "doubleQuoted"() { return "double quoted"; },
+    23    │ - ····async·'asyncQuoted'()·{·return·"async·quoted";·},
+       23 │ + ····'asyncQuoted':·async·function·()·{·return·"async·quoted";·},
+    24 24 │   };
+    25 25 │   
   
 
 ```

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1688,7 +1688,7 @@ export interface Nursery {
 	/**
 	 * Require the consistent declaration of object literals. Defaults to explicit definitions.
 	 */
-	useConsistentObjectDefinition?: RuleConfiguration_for_UseConsistentObjectDefinitionOptions;
+	useConsistentObjectDefinition?: RuleFixConfiguration_for_UseConsistentObjectDefinitionOptions;
 	/**
 	 * Require specifying the reason argument when using @deprecated directive
 	 */
@@ -2363,9 +2363,9 @@ export type RuleConfiguration_for_UseComponentExportOnlyModulesOptions =
 export type RuleConfiguration_for_ConsistentMemberAccessibilityOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_ConsistentMemberAccessibilityOptions;
-export type RuleConfiguration_for_UseConsistentObjectDefinitionOptions =
+export type RuleFixConfiguration_for_UseConsistentObjectDefinitionOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_UseConsistentObjectDefinitionOptions;
+	| RuleWithFixOptions_for_UseConsistentObjectDefinitionOptions;
 export type RuleFixConfiguration_for_UtilityClassSortingOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_UtilityClassSortingOptions;
@@ -2627,7 +2627,11 @@ export interface RuleWithOptions_for_ConsistentMemberAccessibilityOptions {
 	 */
 	options: ConsistentMemberAccessibilityOptions;
 }
-export interface RuleWithOptions_for_UseConsistentObjectDefinitionOptions {
+export interface RuleWithFixOptions_for_UseConsistentObjectDefinitionOptions {
+	/**
+	 * The kind of the code actions emitted by the rule
+	 */
+	fix?: FixKind;
 	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3926,6 +3926,10 @@
 			"type": "object",
 			"required": ["level"],
 			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
 				"level": {
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]


### PR DESCRIPTION
## Summary

Closes #5686 

`useConsistentObjectDefinition` now have a code action to auto-fix the object definition to shorthand or explicit syntax.

## Test Plan

Test snapshots are updated.
