### PR TITLE
feat(core): implement type inference for destructuring

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -308,7 +308,7 @@ async function testCallingReturnsPromise(props: Props) {
 const testDestructuringAndCallingReturnsPromise = async ({
 	returnsPromise,
 }: Props) => {
-	returnsPromise(); // FIXME: REGRESSION
+	returnsPromise();
 };
 async function testPassingReturnsPromiseDirectly(
 	returnsPromise: () => Promise<void>

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -314,7 +314,7 @@ async function testCallingReturnsPromise(props: Props) {
 const testDestructuringAndCallingReturnsPromise = async ({
 	returnsPromise,
 }: Props) => {
-	returnsPromise(); // FIXME: REGRESSION
+	returnsPromise();
 };
 async function testPassingReturnsPromiseDirectly(
 	returnsPromise: () => Promise<void>
@@ -1480,6 +1480,27 @@ invalid.ts:306:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━
   
     306 │ → await·props.returnsPromise().then(()·=>·{});
         │   ++++++                                      
+
+```
+
+```
+invalid.ts:311:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    309 │ 	returnsPromise,
+    310 │ }: Props) => {
+  > 311 │ 	returnsPromise();
+        │ 	^^^^^^^^^^^^^^^^^
+    312 │ };
+    313 │ async function testPassingReturnsPromiseDirectly(
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    311 │ → await·returnsPromise();
+        │   ++++++                 
 
 ```
 

--- a/crates/biome_js_type_info/snapshots/infer_type_of_array_element.snap
+++ b/crates/biome_js_type_info/snapshots/infer_type_of_array_element.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_type_info/tests/type_info.rs
+expression: content
+---
+```ts
+const array: Array<string> = [];
+
+```
+
+```
+array => "Array" {
+  params: unknown
+  type_args: string
+}
+
+```

--- a/crates/biome_js_type_info/snapshots/infer_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/snapshots/infer_type_of_destructured_array_element.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_type_info/tests/type_info.rs
+expression: content
+---
+```ts
+const [a]: Array<string> = [];
+
+```
+
+```
+a => "Array" {
+  params: unknown
+  type_args: string
+}[0]
+
+```

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -1,7 +1,8 @@
 use crate::{
-    CallSignatureTypeMember, Class, Function, FunctionParameter, GenericTypeParameter,
-    MethodTypeMember, Object, PropertyTypeMember, ReturnType, Type, TypeInner, TypeMember,
-    TypeReference, TypeReferenceQualifier,
+    CallArgumentType, CallSignatureTypeMember, Class, DestructureField, Function,
+    FunctionParameter, FunctionParameterBinding, GenericTypeParameter, MethodTypeMember, Object,
+    PropertyTypeMember, ReturnType, Type, TypeInner, TypeMember, TypeReference,
+    TypeReferenceQualifier, TypeofAwaitExpression, TypeofExpression,
 };
 use biome_formatter::prelude::*;
 use biome_formatter::{
@@ -98,8 +99,9 @@ impl Format<FormatTypeContext> for TypeInner {
             Self::TypeOperator(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::Alias(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::Literal(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
+            Self::InstanceOf(ty) => write!(f, [text("instanceof"), space(), &ty.as_ref()]),
             Self::Reference(reference) => write!(f, [&reference.as_ref()]),
-            Self::TypeofExpression(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
+            Self::TypeofExpression(expression) => write!(f, [&expression.as_ref()]),
             Self::TypeofType(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::TypeofValue(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::AnyKeyword => write!(f, [text("any")]),
@@ -218,34 +220,55 @@ impl Format<FormatTypeContext> for ReturnType {
 
 impl Format<FormatTypeContext> for FunctionParameter {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        let optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("optional")]])
+        let bindings = format_with(|f| {
+            if !self.bindings.is_empty() {
+                write!(
+                    f,
+                    [&format_args![
+                        space(),
+                        text("(bindings:"),
+                        space(),
+                        FmtFunctionParameterBindings(&self.bindings),
+                        text(")")
+                    ]]
+                )
             } else {
-                write!(f, [&format_args![text("required")]])
+                Ok(())
             }
         });
-        let rest = format_with(|f| {
-            if self.is_rest {
-                write!(f, [&format_args![text("rest")]])
-            } else {
-                write!(f, [&format_args![text("not_rest")]])
-            }
-        });
-        write!(
-            f,
-            [&group(&format_args![
-                text("["),
-                self.name,
-                text(","),
-                space(),
-                optional,
-                text(","),
-                space(),
-                rest,
-                text("]")
-            ])]
-        )
+        if self.is_rest {
+            write!(
+                f,
+                [&group(&format_args![
+                    text("..."),
+                    self.name.as_ref().unwrap_or(&Text::Static("(unnamed)")),
+                    text(":"),
+                    space(),
+                    &self.ty,
+                    bindings
+                ])]
+            )
+        } else {
+            let optional = format_with(|f| {
+                if self.is_optional {
+                    write!(f, [&format_args![text("optional")]])
+                } else {
+                    write!(f, [&format_args![text("required")]])
+                }
+            });
+            write!(
+                f,
+                [&group(&format_args![
+                    optional,
+                    space(),
+                    self.name.as_ref().unwrap_or(&Text::Static("(unnamed)")),
+                    text(":"),
+                    space(),
+                    &self.ty,
+                    bindings
+                ])]
+            )
+        }
     }
 }
 
@@ -278,6 +301,98 @@ impl Format<FormatTypeContext> for TypeMember {
                     ]]
                 )
             }
+        }
+    }
+}
+
+impl Format<FormatTypeContext> for TypeofAwaitExpression {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        write!(
+            f,
+            [&format_args![group(&soft_block_indent(&self.argument)),]]
+        )
+    }
+}
+
+impl Format<FormatTypeContext> for TypeofExpression {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        match self {
+            Self::Addition(_) => todo!(),
+            Self::Await(await_expression) => {
+                write!(
+                    f,
+                    [&format_args![
+                        text("Await"),
+                        text("("),
+                        group(&soft_block_indent(await_expression)),
+                        text(")")
+                    ]]
+                )
+            }
+            Self::Call(call) => {
+                write!(
+                    f,
+                    [&format_args![
+                        text("Call"),
+                        space(),
+                        call.callee,
+                        space(),
+                        text("("),
+                        group(&soft_block_indent(&FmtCallArgumentType(&call.arguments))),
+                        text(")")
+                    ]]
+                )
+            }
+            Self::Destructure(destructure) => match &destructure.destructure_field {
+                DestructureField::Index(index) => {
+                    write!(
+                        f,
+                        [&format_args![
+                            destructure.ty,
+                            text("["),
+                            dynamic_text(&index.to_string(), TextSize::default()),
+                            text("]")
+                        ]]
+                    )
+                }
+                DestructureField::Name(name) => {
+                    write!(f, [&format_args![destructure.ty, text("."), name]])
+                }
+                DestructureField::RestExcept(names) => {
+                    write!(
+                        f,
+                        [&format_args![
+                            text("{"),
+                            FmtNames(names),
+                            text("..."),
+                            destructure.ty,
+                            text("}")
+                        ]]
+                    )
+                }
+                DestructureField::RestFrom(index) => {
+                    write!(
+                        f,
+                        [&format_args![
+                            text("["),
+                            dynamic_text(&std::format!("({index} others)"), TextSize::default()),
+                            text("..."),
+                            destructure.ty,
+                            text("]")
+                        ]]
+                    )
+                }
+            },
+            Self::New(_) => todo!(),
+            Self::StaticMember(_) => todo!(),
+            Self::Super(_) => todo!(),
+            Self::This(_) => todo!(),
         }
     }
 }
@@ -506,6 +621,30 @@ impl Format<FormatTypeContext> for FmtFunctionParameters<'_> {
     }
 }
 
+struct FmtFunctionParameterBindings<'a>(&'a [FunctionParameterBinding]);
+impl Format<FormatTypeContext> for FmtFunctionParameterBindings<'_> {
+    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        if self.0.is_empty() {
+            return Ok(());
+        }
+
+        let function_parameters = format_with(|f| {
+            let separator = format_with(|f| write!(f, [&format_args![text(","), space()]]));
+            let mut joiner = f.join_with(separator);
+            for part in self.0 {
+                joiner.entry(&format_args![&part.name, text(":"), &part.ty]);
+            }
+            joiner.finish()
+        });
+        write!(
+            f,
+            [&format_args![&group(&soft_block_indent(
+                &function_parameters
+            )),]]
+        )
+    }
+}
+
 struct FmtGenericTypeParameters<'a>(&'a [GenericTypeParameter]);
 
 impl Format<FormatTypeContext> for FmtGenericTypeParameters<'_> {
@@ -576,13 +715,56 @@ impl Format<FormatTypeContext> for FmtTypes<'_> {
     }
 }
 
-impl Format<FormatTypeContext> for Option<Text> {
+impl Format<FormatTypeContext> for Text {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        if let Some(name) = self.as_ref() {
-            write!(f, [&format_args![dynamic_text(name, TextSize::default())]])
-        } else {
-            write!(f, [&format_args![text("No name")]])
+        write!(f, [&format_args![dynamic_text(self, TextSize::default())]])
+    }
+}
+
+struct FmtCallArgumentType<'a>(&'a [CallArgumentType]);
+
+impl Format<FormatTypeContext> for FmtCallArgumentType<'_> {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        if self.0.is_empty() {
+            return write!(f, [text("No parameters")]);
         }
+
+        let type_parameters = format_with(|f| {
+            let mut joiner = f.join_with(soft_line_break());
+            for part in self.0 {
+                match part {
+                    CallArgumentType::Argument(ty) => joiner.entry(&format_args![ty]),
+                    CallArgumentType::Spread(ty) => joiner.entry(&format_args![text("..."), ty]),
+                };
+            }
+            joiner.finish()
+        });
+        write!(f, [&format_args![&type_parameters]])
+    }
+}
+
+struct FmtNames<'a>(&'a [Text]);
+
+impl Format<FormatTypeContext> for FmtNames<'_> {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        if self.0.is_empty() {
+            return Ok(());
+        }
+
+        let types = format_with(|f| {
+            let mut joiner = f.join_with(soft_line_break());
+            for part in self.0 {
+                joiner.entry(&format_args![part]);
+            }
+            joiner.finish()
+        });
+        write!(f, [&format_args![&types]])
     }
 }
 

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -520,7 +520,7 @@ impl Format<FormatTypeContext> for TypeReference {
                 space(),
                 text("{"),
                 &group(&block_indent(&format_args![
-                    text("params:"),
+                    text("resolved:"),
                     space(),
                     &self.ty,
                     hard_line_break(),

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -28,11 +28,11 @@ impl Type {
     /// Attempts to resolve all unresolved types using the given resolver.
     pub fn resolve(&mut self, resolver: &dyn TypeResolver) {
         let stack = &[&**self];
-        if self.needs_resolving(resolver, stack) {
-            *self = self.resolved(resolver, stack);
+        *self = if self.needs_resolving(resolver, stack) {
+            self.resolved(resolver, stack)
         } else {
-            self.flattened(resolver, stack);
-        }
+            self.flattened(resolver, stack)
+        };
     }
 }
 
@@ -94,4 +94,4 @@ macro_rules! derive_primitive_resolved {
     };
 }
 
-derive_primitive_resolved!(bool, u64);
+derive_primitive_resolved!(bool, u64, usize);

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_type_info/tests/utils/mod.rs
+expression: content
+---
+```ts
+const [a]: Array<string> = [];
+
+```
+
+```
+a => Union(
+    [
+        Type(
+            String,
+        ),
+        Type(
+            Undefined,
+        ),
+    ],
+)
+
+```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
@@ -9,7 +9,7 @@ const array: Array<string> = [];
 
 ```
 array => instanceof "Array" {
-  params: unknown
+  resolved: unknown
   type_args: string
 }
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_array_element.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_type_info/tests/utils/mod.rs
+expression: content
+---
+```ts
+const array: Array<string> = [];
+
+```
+
+```
+array => instanceof "Array" {
+  params: unknown
+  type_args: string
+}
+
+```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_type_info/tests/utils/mod.rs
 expression: content
-snapshot_kind: text
 ---
 ```ts
 async function returnsPromise(): Promise<string> {
@@ -17,7 +16,7 @@ async Function "returnsPromise" {
     type_args: []
   }
   returns: "Promise" {
-    params: unknown
+    resolved: unknown
     type_args: string
   }
 }

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
@@ -9,7 +9,7 @@ const [a]: Array<string> = [];
 
 ```
 a => instanceof "Array" {
-  params: unknown
+  resolved: unknown
   type_args: string
 }[0]
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
@@ -1,0 +1,16 @@
+---
+source: crates/biome_js_type_info/tests/utils/mod.rs
+expression: content
+---
+```ts
+const [a]: Array<string> = [];
+
+```
+
+```
+a => instanceof "Array" {
+  params: unknown
+  type_args: string
+}[0]
+
+```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_js_type_info/tests/utils/mod.rs
+expression: content
+---
+```ts
+function destruct(
+	{ a, b }: { a: number; b: string },
+	[first, ...rest]: Array<boolean>,
+) {}
+
+```
+
+```
+sync Function "destruct" {
+  accepts: {
+    params: [
+      required (unnamed): Object {
+        prototype: No prototype
+        members: {TypeMembers(
+          Property(
+            [a, required]
+            Type(number)
+          )
+          Property(
+            [b, required]
+            Type(string)
+          )
+        )}
+      } (bindings:
+        a:Object {
+          prototype: No prototype
+          members: {TypeMembers(
+            Property(
+              [a, required]
+              Type(number)
+            )
+            Property(
+              [b, required]
+              Type(string)
+            )
+          )}
+        }.a, b:Object {
+          prototype: No prototype
+          members: {TypeMembers(
+            Property(
+              [a, required]
+              Type(number)
+            )
+            Property(
+              [b, required]
+              Type(string)
+            )
+          )}
+        }.b
+      ), required (unnamed): "Array" {
+        params: unknown
+        type_args: boolean
+      } (bindings:
+        first:"Array" {
+          params: unknown
+          type_args: boolean
+        }[0], rest:[(1 others)..."Array" {
+          params: unknown
+          type_args: boolean
+        }]
+      )
+    ]
+    type_args: []
+  }
+  returns: unknown
+}
+```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
@@ -53,14 +53,14 @@ sync Function "destruct" {
           )}
         }.b
       ), required (unnamed): "Array" {
-        params: unknown
+        resolved: unknown
         type_args: boolean
       } (bindings:
         first:"Array" {
-          params: unknown
+          resolved: unknown
           type_args: boolean
         }[0], rest:[(1 others)..."Array" {
-          params: unknown
+          resolved: unknown
           type_args: boolean
         }]
       )

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_type_info/tests/utils/mod.rs
 expression: content
-snapshot_kind: text
 ---
 ```ts
 function returnsPromise(): Promise<number> {
@@ -17,7 +16,7 @@ sync Function "returnsPromise" {
     type_args: []
   }
   returns: "Promise" {
-    params: unknown
+    resolved: unknown
     type_args: number
   }
 }

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -1,7 +1,10 @@
-use crate::utils::{assert_type_snapshot, get_function_declaration, parse_ts};
+mod utils;
+
 use biome_js_type_info::{Type, TypeInner};
 
-mod utils;
+use utils::assert_typed_bindings_snapshot;
+use utils::get_variable_declaration;
+use utils::{assert_type_snapshot, get_function_declaration, parse_ts};
 
 #[test]
 fn infer_type_of_promise_returning_function() {
@@ -25,6 +28,40 @@ fn infer_type_of_async_function() {
     let decl = get_function_declaration(&root);
     let ty = Type::from_js_function_declaration(&decl);
     assert_type_snapshot(CODE, ty, "infer_type_of_async_function");
+}
+
+#[test]
+fn infer_type_of_array_element() {
+    const CODE: &str = r#"const array: Array<string> = [];"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_variable_declaration(&root);
+    let bindings = Type::typed_bindings_from_js_variable_declaration(&decl);
+    assert_typed_bindings_snapshot(CODE, &bindings, "infer_type_of_array_element");
+}
+
+#[test]
+fn infer_type_of_destructured_array_element() {
+    const CODE: &str = r#"const [a]: Array<string> = [];"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_variable_declaration(&root);
+    let bindings = Type::typed_bindings_from_js_variable_declaration(&decl);
+    assert_typed_bindings_snapshot(CODE, &bindings, "infer_type_of_destructured_array_element");
+}
+
+#[test]
+fn infer_type_of_function_with_destructured_arguments() {
+    const CODE: &str = r#"function destruct({ a, b }: { a: number, b: string }, [first, ...rest]: Array<boolean>) {}"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_function_declaration(&root);
+    let ty = Type::from_js_function_declaration(&decl);
+    assert_type_snapshot(
+        CODE,
+        ty,
+        "infer_type_of_function_with_destructured_arguments",
+    );
 }
 
 #[test]

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -31,13 +31,13 @@ fn infer_type_of_async_function() {
 }
 
 #[test]
-fn infer_type_of_array_element() {
+fn infer_type_of_array() {
     const CODE: &str = r#"const array: Array<string> = [];"#;
 
     let root = parse_ts(CODE);
     let decl = get_variable_declaration(&root);
     let bindings = Type::typed_bindings_from_js_variable_declaration(&decl);
-    assert_typed_bindings_snapshot(CODE, &bindings, "infer_type_of_array_element");
+    assert_typed_bindings_snapshot(CODE, &bindings, "infer_type_of_array");
 }
 
 #[test]

--- a/crates/biome_js_type_info/tests/utils/mod.rs
+++ b/crates/biome_js_type_info/tests/utils/mod.rs
@@ -1,13 +1,15 @@
-use crate::Type;
 use biome_js_formatter::context::JsFormatOptions;
 use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse};
+use biome_js_syntax::JsVariableDeclaration;
 use biome_js_syntax::{
     AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsFileSource, JsFunctionDeclaration,
 };
 use biome_js_type_info::{TypeReferenceQualifier, TypeResolver};
 use biome_rowan::AstNode;
 use biome_rowan::Text;
+
+use crate::Type;
 
 pub fn assert_type_snapshot(source_code: &str, ty: Type, test_name: &str) {
     let mut content = String::new();
@@ -38,6 +40,41 @@ pub fn assert_type_snapshot(source_code: &str, ty: Type, test_name: &str) {
     });
 }
 
+pub fn assert_typed_bindings_snapshot(
+    source_code: &str,
+    typed_bindings: &[(Text, Type)],
+    test_name: &str,
+) {
+    let mut content = String::new();
+
+    let source_type = JsFileSource::ts();
+    let tree = parse(source_code, source_type, JsParserOptions::default());
+    let formatted = format_node(JsFormatOptions::default(), tree.tree().syntax())
+        .unwrap()
+        .print()
+        .unwrap();
+
+    content.push_str("```");
+    content.push_str("ts");
+    content.push('\n');
+    content.push_str(formatted.as_code());
+    content.push_str("\n```");
+
+    content.push_str("\n\n");
+    content.push_str("```\n");
+    for (name, ty) in typed_bindings {
+        content.push_str(&format!("{name} => {ty}\n"));
+    }
+    content.push_str("\n```\n\n");
+
+    insta::with_settings!({
+        snapshot_path => "../snapshots",
+        prepend_module_to_snapshot => false,
+    }, {
+        insta::assert_snapshot!(test_name, content);
+    });
+}
+
 /// Test resolver that looks up a single hardcoded symbol.
 pub struct HardcodedSymbolResolver(pub &'static str, pub Type);
 
@@ -46,7 +83,7 @@ impl TypeResolver for HardcodedSymbolResolver {
         if qualifier.parts().len() == 1 && qualifier.parts()[0] == self.0 {
             Some(self.1.clone())
         } else {
-            PromiseResolver.resolve_qualifier(qualifier)
+            GlobalsResolver.resolve_qualifier(qualifier)
         }
     }
 
@@ -55,15 +92,19 @@ impl TypeResolver for HardcodedSymbolResolver {
     }
 }
 
-/// Test resolver that does nothing but resolve type references to `Promise`
-/// without any proper scope lookups.
-pub struct PromiseResolver;
+/// Test resolver that does nothing but resolve type references to globals
+/// defined in `globals.rs`.
+pub struct GlobalsResolver;
 
-impl TypeResolver for PromiseResolver {
+impl TypeResolver for GlobalsResolver {
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<Type> {
-        qualifier
-            .is_promise()
-            .then(|| Type::promise_of(Type::unknown()))
+        if qualifier.is_array() {
+            Some(Type::array_of(Type::unknown()))
+        } else if qualifier.is_promise() {
+            Some(Type::promise_of(Type::unknown()))
+        } else {
+            None
+        }
     }
 
     fn resolve_type_of(&self, _identifier: &Text) -> Option<Type> {
@@ -84,7 +125,23 @@ pub fn get_function_declaration(root: &AnyJsRoot) -> JsFunctionDeclaration {
             AnyJsStatement::JsFunctionDeclaration(decl) => Some(decl),
             _ => None,
         })
-        .expect("cannot find declaration")
+        .expect("cannot find function declaration")
+}
+
+pub fn get_variable_declaration(root: &AnyJsRoot) -> JsVariableDeclaration {
+    let module = root.as_js_module().unwrap();
+    module
+        .items()
+        .into_iter()
+        .filter_map(|item| match item {
+            AnyJsModuleItem::AnyJsStatement(statement) => Some(statement),
+            _ => None,
+        })
+        .find_map(|statement| match statement {
+            AnyJsStatement::JsVariableStatement(statement) => statement.declaration().ok(),
+            _ => None,
+        })
+        .expect("cannot find variable declaration")
 }
 
 pub fn parse_ts(code: &str) -> AnyJsRoot {

--- a/crates/biome_module_graph/src/js_module_info/global_scope_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/global_scope_resolver.rs
@@ -23,7 +23,7 @@ impl TypeResolver for GlobalScopeResolver<'_> {
         if qualifier.parts().len() == 1 {
             self.resolve_type_of(&qualifier.parts()[0]).or_else(|| {
                 qualifier
-                    .is_promise()
+                    .is_array()
                     .then(|| Type::promise_of(Type::unknown()))
             })
         } else {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
-snapshot_kind: text
 ---
 ## /src/index.ts
 
@@ -24,14 +23,21 @@ export async function baz() {}
 
 var qux = 1;
 
-/**
- * TODO: No types can be detected on these yet.
- */
 export const {
 	a,
 	b,
 	c: [d, e],
 } = getObject();
+
+type GetObjectResult = {
+	a: string;
+	b: Array<number>;
+	c: [first: boolean, last: boolean | undefined];
+};
+
+function getObject(): GetObjectResult {
+	return {}; // We're not a type checker, so this is a-okay.
+}
 
 /**
  * @public
@@ -53,20 +59,17 @@ export * as renamed2 from "./renamed-reexports";
 Exports {
   "a" => {
     ExportOwnExport => JsOwnExport(
-      Unknown
+      String
       Local name: a
-      JsDoc(
-        TODO: No types can be detected on these yet.
-      )
     )
   }
   "b" => {
     ExportOwnExport => JsOwnExport(
-      Unknown
+      "Array" {
+        params: Unknown
+        type_args: Number
+      }
       Local name: b
-      JsDoc(
-        TODO: No types can be detected on these yet.
-      )
     )
   }
   "bar" => {
@@ -200,11 +203,8 @@ Exports {
   }
   "d" => {
     ExportOwnExport => JsOwnExport(
-      Unknown
+      Boolean
       Local name: d
-      JsDoc(
-        TODO: No types can be detected on these yet.
-      )
     )
   }
   "default" => {
@@ -228,11 +228,17 @@ Exports {
   }
   "e" => {
     ExportOwnExport => JsOwnExport(
-      Unknown
+      Union(
+    [
+        Type(
+            Boolean,
+        ),
+        Type(
+            Undefined,
+        ),
+    ],
+)
       Local name: e
-      JsDoc(
-        TODO: No types can be detected on these yet.
-      )
     )
   }
   "foo" => {

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -302,10 +302,17 @@ fn test_resolve_exports() {
 
             var qux = 1;
 
-            /**
-             * TODO: No types can be detected on these yet.
-             */
             export const { a, b, c: [d, e] } = getObject();
+
+            type GetObjectResult = {
+                a: string,
+                b: Array<number>,
+                c: [first: boolean, last: boolean | undefined],
+            };
+
+            function getObject(): GetObjectResult {
+                return {}; // We're not a type checker, so this is a-okay.
+            }
 
             /**
              * @public


### PR DESCRIPTION
## Summary

My last PR left one regression in `noFloatingPromises`: The inability for our inference to track types across destructured properties. This is now resolved.

## Test Plan

Test case updated, unit tests added.