### PR TITLE
refactor: improve match_ast! and use it

### DIFF
--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -8903,6 +8903,9 @@ impl AnyCssValueAtRuleProperty {
         }
     }
 }
+impl CssAtRule {
+    pub const KIND: SyntaxKind = CSS_AT_RULE;
+}
 impl AstNode for CssAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8950,6 +8953,9 @@ impl From<CssAtRule> for SyntaxElement {
     fn from(n: CssAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssAttributeMatcher {
+    pub const KIND: SyntaxKind = CSS_ATTRIBUTE_MATCHER;
 }
 impl AstNode for CssAttributeMatcher {
     type Language = Language;
@@ -9000,6 +9006,9 @@ impl From<CssAttributeMatcher> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssAttributeMatcherValue {
+    pub const KIND: SyntaxKind = CSS_ATTRIBUTE_MATCHER_VALUE;
+}
 impl AstNode for CssAttributeMatcherValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9046,6 +9055,9 @@ impl From<CssAttributeMatcherValue> for SyntaxElement {
     fn from(n: CssAttributeMatcherValue) -> Self {
         n.syntax.into()
     }
+}
+impl CssAttributeName {
+    pub const KIND: SyntaxKind = CSS_ATTRIBUTE_NAME;
 }
 impl AstNode for CssAttributeName {
     type Language = Language;
@@ -9097,6 +9109,9 @@ impl From<CssAttributeName> for SyntaxElement {
     fn from(n: CssAttributeName) -> Self {
         n.syntax.into()
     }
+}
+impl CssAttributeSelector {
+    pub const KIND: SyntaxKind = CSS_ATTRIBUTE_SELECTOR;
 }
 impl AstNode for CssAttributeSelector {
     type Language = Language;
@@ -9154,6 +9169,9 @@ impl From<CssAttributeSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssBinaryExpression {
+    pub const KIND: SyntaxKind = CSS_BINARY_EXPRESSION;
+}
 impl AstNode for CssBinaryExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9205,6 +9223,9 @@ impl From<CssBinaryExpression> for SyntaxElement {
     fn from(n: CssBinaryExpression) -> Self {
         n.syntax.into()
     }
+}
+impl CssBracketedValue {
+    pub const KIND: SyntaxKind = CSS_BRACKETED_VALUE;
 }
 impl AstNode for CssBracketedValue {
     type Language = Language;
@@ -9261,6 +9282,9 @@ impl From<CssBracketedValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssCharsetAtRule {
+    pub const KIND: SyntaxKind = CSS_CHARSET_AT_RULE;
+}
 impl AstNode for CssCharsetAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9316,6 +9340,9 @@ impl From<CssCharsetAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssClassSelector {
+    pub const KIND: SyntaxKind = CSS_CLASS_SELECTOR;
+}
 impl AstNode for CssClassSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9363,6 +9390,9 @@ impl From<CssClassSelector> for SyntaxElement {
     fn from(n: CssClassSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssColor {
+    pub const KIND: SyntaxKind = CSS_COLOR;
 }
 impl AstNode for CssColor {
     type Language = Language;
@@ -9414,6 +9444,9 @@ impl From<CssColor> for SyntaxElement {
     fn from(n: CssColor) -> Self {
         n.syntax.into()
     }
+}
+impl CssColorProfileAtRule {
+    pub const KIND: SyntaxKind = CSS_COLOR_PROFILE_AT_RULE;
 }
 impl AstNode for CssColorProfileAtRule {
     type Language = Language;
@@ -9467,6 +9500,9 @@ impl From<CssColorProfileAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssComplexSelector {
+    pub const KIND: SyntaxKind = CSS_COMPLEX_SELECTOR;
+}
 impl AstNode for CssComplexSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9516,6 +9552,9 @@ impl From<CssComplexSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssComposesImportSpecifier {
+    pub const KIND: SyntaxKind = CSS_COMPOSES_IMPORT_SPECIFIER;
+}
 impl AstNode for CssComposesImportSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9563,6 +9602,9 @@ impl From<CssComposesImportSpecifier> for SyntaxElement {
     fn from(n: CssComposesImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssComposesProperty {
+    pub const KIND: SyntaxKind = CSS_COMPOSES_PROPERTY;
 }
 impl AstNode for CssComposesProperty {
     type Language = Language;
@@ -9616,6 +9658,9 @@ impl From<CssComposesProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssComposesPropertyValue {
+    pub const KIND: SyntaxKind = CSS_COMPOSES_PROPERTY_VALUE;
+}
 impl AstNode for CssComposesPropertyValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9666,6 +9711,9 @@ impl From<CssComposesPropertyValue> for SyntaxElement {
     fn from(n: CssComposesPropertyValue) -> Self {
         n.syntax.into()
     }
+}
+impl CssCompoundSelector {
+    pub const KIND: SyntaxKind = CSS_COMPOUND_SELECTOR;
 }
 impl AstNode for CssCompoundSelector {
     type Language = Language;
@@ -9719,6 +9767,9 @@ impl From<CssCompoundSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssContainerAndQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_AND_QUERY;
+}
 impl AstNode for CssContainerAndQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9767,6 +9818,9 @@ impl From<CssContainerAndQuery> for SyntaxElement {
     fn from(n: CssContainerAndQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerAtRule {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_AT_RULE;
 }
 impl AstNode for CssContainerAtRule {
     type Language = Language;
@@ -9821,6 +9875,9 @@ impl From<CssContainerAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssContainerNotQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_NOT_QUERY;
+}
 impl AstNode for CssContainerNotQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9868,6 +9925,9 @@ impl From<CssContainerNotQuery> for SyntaxElement {
     fn from(n: CssContainerNotQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerOrQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_OR_QUERY;
 }
 impl AstNode for CssContainerOrQuery {
     type Language = Language;
@@ -9917,6 +9977,9 @@ impl From<CssContainerOrQuery> for SyntaxElement {
     fn from(n: CssContainerOrQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerQueryInParens {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_QUERY_IN_PARENS;
 }
 impl AstNode for CssContainerQueryInParens {
     type Language = Language;
@@ -9973,6 +10036,9 @@ impl From<CssContainerQueryInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssContainerSizeFeatureInParens {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_SIZE_FEATURE_IN_PARENS;
+}
 impl AstNode for CssContainerSizeFeatureInParens {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10028,6 +10094,9 @@ impl From<CssContainerSizeFeatureInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssContainerStyleAndQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_STYLE_AND_QUERY;
+}
 impl AstNode for CssContainerStyleAndQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10076,6 +10145,9 @@ impl From<CssContainerStyleAndQuery> for SyntaxElement {
     fn from(n: CssContainerStyleAndQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerStyleInParens {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_STYLE_IN_PARENS;
 }
 impl AstNode for CssContainerStyleInParens {
     type Language = Language;
@@ -10132,6 +10204,9 @@ impl From<CssContainerStyleInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssContainerStyleNotQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_STYLE_NOT_QUERY;
+}
 impl AstNode for CssContainerStyleNotQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10179,6 +10254,9 @@ impl From<CssContainerStyleNotQuery> for SyntaxElement {
     fn from(n: CssContainerStyleNotQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerStyleOrQuery {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_STYLE_OR_QUERY;
 }
 impl AstNode for CssContainerStyleOrQuery {
     type Language = Language;
@@ -10228,6 +10306,9 @@ impl From<CssContainerStyleOrQuery> for SyntaxElement {
     fn from(n: CssContainerStyleOrQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssContainerStyleQueryInParens {
+    pub const KIND: SyntaxKind = CSS_CONTAINER_STYLE_QUERY_IN_PARENS;
 }
 impl AstNode for CssContainerStyleQueryInParens {
     type Language = Language;
@@ -10288,6 +10369,9 @@ impl From<CssContainerStyleQueryInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssCounterStyleAtRule {
+    pub const KIND: SyntaxKind = CSS_COUNTER_STYLE_AT_RULE;
+}
 impl AstNode for CssCounterStyleAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10340,6 +10424,9 @@ impl From<CssCounterStyleAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssCustomIdentifier {
+    pub const KIND: SyntaxKind = CSS_CUSTOM_IDENTIFIER;
+}
 impl AstNode for CssCustomIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10389,6 +10476,9 @@ impl From<CssCustomIdentifier> for SyntaxElement {
     fn from(n: CssCustomIdentifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssDashedIdentifier {
+    pub const KIND: SyntaxKind = CSS_DASHED_IDENTIFIER;
 }
 impl AstNode for CssDashedIdentifier {
     type Language = Language;
@@ -10440,6 +10530,9 @@ impl From<CssDashedIdentifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssDeclaration {
+    pub const KIND: SyntaxKind = CSS_DECLARATION;
+}
 impl AstNode for CssDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10490,6 +10583,9 @@ impl From<CssDeclaration> for SyntaxElement {
     fn from(n: CssDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl CssDeclarationBlock {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_BLOCK;
 }
 impl AstNode for CssDeclarationBlock {
     type Language = Language;
@@ -10546,6 +10642,9 @@ impl From<CssDeclarationBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssDeclarationImportant {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_IMPORTANT;
+}
 impl AstNode for CssDeclarationImportant {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10596,6 +10695,9 @@ impl From<CssDeclarationImportant> for SyntaxElement {
     fn from(n: CssDeclarationImportant) -> Self {
         n.syntax.into()
     }
+}
+impl CssDeclarationOrAtRuleBlock {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_OR_AT_RULE_BLOCK;
 }
 impl AstNode for CssDeclarationOrAtRuleBlock {
     type Language = Language;
@@ -10652,6 +10754,9 @@ impl From<CssDeclarationOrAtRuleBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssDeclarationOrRuleBlock {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_OR_RULE_BLOCK;
+}
 impl AstNode for CssDeclarationOrRuleBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10707,6 +10812,9 @@ impl From<CssDeclarationOrRuleBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssDeclarationWithSemicolon {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_WITH_SEMICOLON;
+}
 impl AstNode for CssDeclarationWithSemicolon {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10761,6 +10869,9 @@ impl From<CssDeclarationWithSemicolon> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssDocumentAtRule {
+    pub const KIND: SyntaxKind = CSS_DOCUMENT_AT_RULE;
+}
 impl AstNode for CssDocumentAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10812,6 +10923,9 @@ impl From<CssDocumentAtRule> for SyntaxElement {
     fn from(n: CssDocumentAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssDocumentCustomMatcher {
+    pub const KIND: SyntaxKind = CSS_DOCUMENT_CUSTOM_MATCHER;
 }
 impl AstNode for CssDocumentCustomMatcher {
     type Language = Language;
@@ -10869,6 +10983,9 @@ impl From<CssDocumentCustomMatcher> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssEmptyDeclaration {
+    pub const KIND: SyntaxKind = CSS_EMPTY_DECLARATION;
+}
 impl AstNode for CssEmptyDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10918,6 +11035,9 @@ impl From<CssEmptyDeclaration> for SyntaxElement {
     fn from(n: CssEmptyDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl CssFontFaceAtRule {
+    pub const KIND: SyntaxKind = CSS_FONT_FACE_AT_RULE;
 }
 impl AstNode for CssFontFaceAtRule {
     type Language = Language;
@@ -10970,6 +11090,9 @@ impl From<CssFontFaceAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssFontFamilyName {
+    pub const KIND: SyntaxKind = CSS_FONT_FAMILY_NAME;
+}
 impl AstNode for CssFontFamilyName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11016,6 +11139,9 @@ impl From<CssFontFamilyName> for SyntaxElement {
     fn from(n: CssFontFamilyName) -> Self {
         n.syntax.into()
     }
+}
+impl CssFontFeatureValuesAtRule {
+    pub const KIND: SyntaxKind = CSS_FONT_FEATURE_VALUES_AT_RULE;
 }
 impl AstNode for CssFontFeatureValuesAtRule {
     type Language = Language;
@@ -11068,6 +11194,9 @@ impl From<CssFontFeatureValuesAtRule> for SyntaxElement {
     fn from(n: CssFontFeatureValuesAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssFontFeatureValuesBlock {
+    pub const KIND: SyntaxKind = CSS_FONT_FEATURE_VALUES_BLOCK;
 }
 impl AstNode for CssFontFeatureValuesBlock {
     type Language = Language;
@@ -11124,6 +11253,9 @@ impl From<CssFontFeatureValuesBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssFontFeatureValuesItem {
+    pub const KIND: SyntaxKind = CSS_FONT_FEATURE_VALUES_ITEM;
+}
 impl AstNode for CssFontFeatureValuesItem {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11172,6 +11304,9 @@ impl From<CssFontFeatureValuesItem> for SyntaxElement {
     fn from(n: CssFontFeatureValuesItem) -> Self {
         n.syntax.into()
     }
+}
+impl CssFontPaletteValuesAtRule {
+    pub const KIND: SyntaxKind = CSS_FONT_PALETTE_VALUES_AT_RULE;
 }
 impl AstNode for CssFontPaletteValuesAtRule {
     type Language = Language;
@@ -11224,6 +11359,9 @@ impl From<CssFontPaletteValuesAtRule> for SyntaxElement {
     fn from(n: CssFontPaletteValuesAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssFunction {
+    pub const KIND: SyntaxKind = CSS_FUNCTION;
 }
 impl AstNode for CssFunction {
     type Language = Language;
@@ -11281,6 +11419,9 @@ impl From<CssFunction> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssGenericDelimiter {
+    pub const KIND: SyntaxKind = CSS_GENERIC_DELIMITER;
+}
 impl AstNode for CssGenericDelimiter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11327,6 +11468,9 @@ impl From<CssGenericDelimiter> for SyntaxElement {
     fn from(n: CssGenericDelimiter) -> Self {
         n.syntax.into()
     }
+}
+impl CssGenericProperty {
+    pub const KIND: SyntaxKind = CSS_GENERIC_PROPERTY;
 }
 impl AstNode for CssGenericProperty {
     type Language = Language;
@@ -11380,6 +11524,9 @@ impl From<CssGenericProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssIdSelector {
+    pub const KIND: SyntaxKind = CSS_ID_SELECTOR;
+}
 impl AstNode for CssIdSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11427,6 +11574,9 @@ impl From<CssIdSelector> for SyntaxElement {
     fn from(n: CssIdSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssIdentifier {
+    pub const KIND: SyntaxKind = CSS_IDENTIFIER;
 }
 impl AstNode for CssIdentifier {
     type Language = Language;
@@ -11478,6 +11628,9 @@ impl From<CssIdentifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssImportAnonymousLayer {
+    pub const KIND: SyntaxKind = CSS_IMPORT_ANONYMOUS_LAYER;
+}
 impl AstNode for CssImportAnonymousLayer {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11527,6 +11680,9 @@ impl From<CssImportAnonymousLayer> for SyntaxElement {
     fn from(n: CssImportAnonymousLayer) -> Self {
         n.syntax.into()
     }
+}
+impl CssImportAtRule {
+    pub const KIND: SyntaxKind = CSS_IMPORT_AT_RULE;
 }
 impl AstNode for CssImportAtRule {
     type Language = Language;
@@ -11585,6 +11741,9 @@ impl From<CssImportAtRule> for SyntaxElement {
     fn from(n: CssImportAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssImportNamedLayer {
+    pub const KIND: SyntaxKind = CSS_IMPORT_NAMED_LAYER;
 }
 impl AstNode for CssImportNamedLayer {
     type Language = Language;
@@ -11645,6 +11804,9 @@ impl From<CssImportNamedLayer> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssImportSupports {
+    pub const KIND: SyntaxKind = CSS_IMPORT_SUPPORTS;
+}
 impl AstNode for CssImportSupports {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11704,6 +11866,9 @@ impl From<CssImportSupports> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssKeyframesAtRule {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_AT_RULE;
+}
 impl AstNode for CssKeyframesAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11755,6 +11920,9 @@ impl From<CssKeyframesAtRule> for SyntaxElement {
     fn from(n: CssKeyframesAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssKeyframesBlock {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_BLOCK;
 }
 impl AstNode for CssKeyframesBlock {
     type Language = Language;
@@ -11811,6 +11979,9 @@ impl From<CssKeyframesBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssKeyframesIdentSelector {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_IDENT_SELECTOR;
+}
 impl AstNode for CssKeyframesIdentSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11857,6 +12028,9 @@ impl From<CssKeyframesIdentSelector> for SyntaxElement {
     fn from(n: CssKeyframesIdentSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssKeyframesItem {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_ITEM;
 }
 impl AstNode for CssKeyframesItem {
     type Language = Language;
@@ -11906,6 +12080,9 @@ impl From<CssKeyframesItem> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssKeyframesPercentageSelector {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_PERCENTAGE_SELECTOR;
+}
 impl AstNode for CssKeyframesPercentageSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -11952,6 +12129,9 @@ impl From<CssKeyframesPercentageSelector> for SyntaxElement {
     fn from(n: CssKeyframesPercentageSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssKeyframesScopeFunction {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_SCOPE_FUNCTION;
 }
 impl AstNode for CssKeyframesScopeFunction {
     type Language = Language;
@@ -12009,6 +12189,9 @@ impl From<CssKeyframesScopeFunction> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssKeyframesScopePrefix {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_SCOPE_PREFIX;
+}
 impl AstNode for CssKeyframesScopePrefix {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12056,6 +12239,9 @@ impl From<CssKeyframesScopePrefix> for SyntaxElement {
     fn from(n: CssKeyframesScopePrefix) -> Self {
         n.syntax.into()
     }
+}
+impl CssKeyframesScopedName {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_SCOPED_NAME;
 }
 impl AstNode for CssKeyframesScopedName {
     type Language = Language;
@@ -12108,6 +12294,9 @@ impl From<CssKeyframesScopedName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssLayerAtRule {
+    pub const KIND: SyntaxKind = CSS_LAYER_AT_RULE;
+}
 impl AstNode for CssLayerAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12159,6 +12348,9 @@ impl From<CssLayerAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssLayerDeclaration {
+    pub const KIND: SyntaxKind = CSS_LAYER_DECLARATION;
+}
 impl AstNode for CssLayerDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12206,6 +12398,9 @@ impl From<CssLayerDeclaration> for SyntaxElement {
     fn from(n: CssLayerDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl CssLayerReference {
+    pub const KIND: SyntaxKind = CSS_LAYER_REFERENCE;
 }
 impl AstNode for CssLayerReference {
     type Language = Language;
@@ -12258,6 +12453,9 @@ impl From<CssLayerReference> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssListOfComponentValuesExpression {
+    pub const KIND: SyntaxKind = CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION;
+}
 impl AstNode for CssListOfComponentValuesExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
@@ -12306,6 +12504,9 @@ impl From<CssListOfComponentValuesExpression> for SyntaxElement {
     fn from(n: CssListOfComponentValuesExpression) -> Self {
         n.syntax.into()
     }
+}
+impl CssMarginAtRule {
+    pub const KIND: SyntaxKind = CSS_MARGIN_AT_RULE;
 }
 impl AstNode for CssMarginAtRule {
     type Language = Language;
@@ -12356,6 +12557,9 @@ impl From<CssMarginAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssMediaAndCondition {
+    pub const KIND: SyntaxKind = CSS_MEDIA_AND_CONDITION;
+}
 impl AstNode for CssMediaAndCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12405,6 +12609,9 @@ impl From<CssMediaAndCondition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssMediaAndTypeQuery {
+    pub const KIND: SyntaxKind = CSS_MEDIA_AND_TYPE_QUERY;
+}
 impl AstNode for CssMediaAndTypeQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12453,6 +12660,9 @@ impl From<CssMediaAndTypeQuery> for SyntaxElement {
     fn from(n: CssMediaAndTypeQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssMediaAtRule {
+    pub const KIND: SyntaxKind = CSS_MEDIA_AT_RULE;
 }
 impl AstNode for CssMediaAtRule {
     type Language = Language;
@@ -12505,6 +12715,9 @@ impl From<CssMediaAtRule> for SyntaxElement {
     fn from(n: CssMediaAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssMediaConditionInParens {
+    pub const KIND: SyntaxKind = CSS_MEDIA_CONDITION_IN_PARENS;
 }
 impl AstNode for CssMediaConditionInParens {
     type Language = Language;
@@ -12561,6 +12774,9 @@ impl From<CssMediaConditionInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssMediaConditionQuery {
+    pub const KIND: SyntaxKind = CSS_MEDIA_CONDITION_QUERY;
+}
 impl AstNode for CssMediaConditionQuery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12607,6 +12823,9 @@ impl From<CssMediaConditionQuery> for SyntaxElement {
     fn from(n: CssMediaConditionQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssMediaFeatureInParens {
+    pub const KIND: SyntaxKind = CSS_MEDIA_FEATURE_IN_PARENS;
 }
 impl AstNode for CssMediaFeatureInParens {
     type Language = Language;
@@ -12663,6 +12882,9 @@ impl From<CssMediaFeatureInParens> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssMediaNotCondition {
+    pub const KIND: SyntaxKind = CSS_MEDIA_NOT_CONDITION;
+}
 impl AstNode for CssMediaNotCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12710,6 +12932,9 @@ impl From<CssMediaNotCondition> for SyntaxElement {
     fn from(n: CssMediaNotCondition) -> Self {
         n.syntax.into()
     }
+}
+impl CssMediaOrCondition {
+    pub const KIND: SyntaxKind = CSS_MEDIA_OR_CONDITION;
 }
 impl AstNode for CssMediaOrCondition {
     type Language = Language;
@@ -12760,6 +12985,9 @@ impl From<CssMediaOrCondition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssMediaType {
+    pub const KIND: SyntaxKind = CSS_MEDIA_TYPE;
+}
 impl AstNode for CssMediaType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12806,6 +13034,9 @@ impl From<CssMediaType> for SyntaxElement {
     fn from(n: CssMediaType) -> Self {
         n.syntax.into()
     }
+}
+impl CssMediaTypeQuery {
+    pub const KIND: SyntaxKind = CSS_MEDIA_TYPE_QUERY;
 }
 impl AstNode for CssMediaTypeQuery {
     type Language = Language;
@@ -12854,6 +13085,9 @@ impl From<CssMediaTypeQuery> for SyntaxElement {
     fn from(n: CssMediaTypeQuery) -> Self {
         n.syntax.into()
     }
+}
+impl CssMetavariable {
+    pub const KIND: SyntaxKind = CSS_METAVARIABLE;
 }
 impl AstNode for CssMetavariable {
     type Language = Language;
@@ -12905,6 +13139,9 @@ impl From<CssMetavariable> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssNamedNamespacePrefix {
+    pub const KIND: SyntaxKind = CSS_NAMED_NAMESPACE_PREFIX;
+}
 impl AstNode for CssNamedNamespacePrefix {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -12951,6 +13188,9 @@ impl From<CssNamedNamespacePrefix> for SyntaxElement {
     fn from(n: CssNamedNamespacePrefix) -> Self {
         n.syntax.into()
     }
+}
+impl CssNamespace {
+    pub const KIND: SyntaxKind = CSS_NAMESPACE;
 }
 impl AstNode for CssNamespace {
     type Language = Language;
@@ -13002,6 +13242,9 @@ impl From<CssNamespace> for SyntaxElement {
     fn from(n: CssNamespace) -> Self {
         n.syntax.into()
     }
+}
+impl CssNamespaceAtRule {
+    pub const KIND: SyntaxKind = CSS_NAMESPACE_AT_RULE;
 }
 impl AstNode for CssNamespaceAtRule {
     type Language = Language;
@@ -13059,6 +13302,9 @@ impl From<CssNamespaceAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssNestedQualifiedRule {
+    pub const KIND: SyntaxKind = CSS_NESTED_QUALIFIED_RULE;
+}
 impl AstNode for CssNestedQualifiedRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13107,6 +13353,9 @@ impl From<CssNestedQualifiedRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssNestedSelector {
+    pub const KIND: SyntaxKind = CSS_NESTED_SELECTOR;
+}
 impl AstNode for CssNestedSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13153,6 +13402,9 @@ impl From<CssNestedSelector> for SyntaxElement {
     fn from(n: CssNestedSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssNthOffset {
+    pub const KIND: SyntaxKind = CSS_NTH_OFFSET;
 }
 impl AstNode for CssNthOffset {
     type Language = Language;
@@ -13201,6 +13453,9 @@ impl From<CssNthOffset> for SyntaxElement {
     fn from(n: CssNthOffset) -> Self {
         n.syntax.into()
     }
+}
+impl CssNumber {
+    pub const KIND: SyntaxKind = CSS_NUMBER;
 }
 impl AstNode for CssNumber {
     type Language = Language;
@@ -13252,6 +13507,9 @@ impl From<CssNumber> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPageAtRule {
+    pub const KIND: SyntaxKind = CSS_PAGE_AT_RULE;
+}
 impl AstNode for CssPageAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13300,6 +13558,9 @@ impl From<CssPageAtRule> for SyntaxElement {
     fn from(n: CssPageAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssPageAtRuleBlock {
+    pub const KIND: SyntaxKind = CSS_PAGE_AT_RULE_BLOCK;
 }
 impl AstNode for CssPageAtRuleBlock {
     type Language = Language;
@@ -13356,6 +13617,9 @@ impl From<CssPageAtRuleBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPageSelector {
+    pub const KIND: SyntaxKind = CSS_PAGE_SELECTOR;
+}
 impl AstNode for CssPageSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13403,6 +13667,9 @@ impl From<CssPageSelector> for SyntaxElement {
     fn from(n: CssPageSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssPageSelectorPseudo {
+    pub const KIND: SyntaxKind = CSS_PAGE_SELECTOR_PSEUDO;
 }
 impl AstNode for CssPageSelectorPseudo {
     type Language = Language;
@@ -13455,6 +13722,9 @@ impl From<CssPageSelectorPseudo> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssParameter {
+    pub const KIND: SyntaxKind = CSS_PARAMETER;
+}
 impl AstNode for CssParameter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13504,6 +13774,9 @@ impl From<CssParameter> for SyntaxElement {
     fn from(n: CssParameter) -> Self {
         n.syntax.into()
     }
+}
+impl CssParenthesizedExpression {
+    pub const KIND: SyntaxKind = CSS_PARENTHESIZED_EXPRESSION;
 }
 impl AstNode for CssParenthesizedExpression {
     type Language = Language;
@@ -13563,6 +13836,9 @@ impl From<CssParenthesizedExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPercentage {
+    pub const KIND: SyntaxKind = CSS_PERCENTAGE;
+}
 impl AstNode for CssPercentage {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13617,6 +13893,9 @@ impl From<CssPercentage> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPositionTryAtRule {
+    pub const KIND: SyntaxKind = CSS_POSITION_TRY_AT_RULE;
+}
 impl AstNode for CssPositionTryAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13669,6 +13948,9 @@ impl From<CssPositionTryAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPropertyAtRule {
+    pub const KIND: SyntaxKind = CSS_PROPERTY_AT_RULE;
+}
 impl AstNode for CssPropertyAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13720,6 +14002,9 @@ impl From<CssPropertyAtRule> for SyntaxElement {
     fn from(n: CssPropertyAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassFunctionCompoundSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_COMPOUND_SELECTOR;
 }
 impl AstNode for CssPseudoClassFunctionCompoundSelector {
     type Language = Language;
@@ -13779,6 +14064,9 @@ impl From<CssPseudoClassFunctionCompoundSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassFunctionCompoundSelectorList {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_COMPOUND_SELECTOR_LIST;
+}
 impl AstNode for CssPseudoClassFunctionCompoundSelectorList {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
@@ -13837,6 +14125,9 @@ impl From<CssPseudoClassFunctionCompoundSelectorList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassFunctionIdentifier {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_IDENTIFIER;
+}
 impl AstNode for CssPseudoClassFunctionIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13893,6 +14184,9 @@ impl From<CssPseudoClassFunctionIdentifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassFunctionNth {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_NTH;
+}
 impl AstNode for CssPseudoClassFunctionNth {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -13948,6 +14242,9 @@ impl From<CssPseudoClassFunctionNth> for SyntaxElement {
     fn from(n: CssPseudoClassFunctionNth) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassFunctionRelativeSelectorList {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_RELATIVE_SELECTOR_LIST;
 }
 impl AstNode for CssPseudoClassFunctionRelativeSelectorList {
     type Language = Language;
@@ -14007,6 +14304,9 @@ impl From<CssPseudoClassFunctionRelativeSelectorList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassFunctionSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_SELECTOR;
+}
 impl AstNode for CssPseudoClassFunctionSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14062,6 +14362,9 @@ impl From<CssPseudoClassFunctionSelector> for SyntaxElement {
     fn from(n: CssPseudoClassFunctionSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassFunctionSelectorList {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_SELECTOR_LIST;
 }
 impl AstNode for CssPseudoClassFunctionSelectorList {
     type Language = Language;
@@ -14121,6 +14424,9 @@ impl From<CssPseudoClassFunctionSelectorList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassFunctionValueList {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_FUNCTION_VALUE_LIST;
+}
 impl AstNode for CssPseudoClassFunctionValueList {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14177,6 +14483,9 @@ impl From<CssPseudoClassFunctionValueList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassIdentifier {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_IDENTIFIER;
+}
 impl AstNode for CssPseudoClassIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14223,6 +14532,9 @@ impl From<CssPseudoClassIdentifier> for SyntaxElement {
     fn from(n: CssPseudoClassIdentifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassNth {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_NTH;
 }
 impl AstNode for CssPseudoClassNth {
     type Language = Language;
@@ -14277,6 +14589,9 @@ impl From<CssPseudoClassNth> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassNthIdentifier {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_NTH_IDENTIFIER;
+}
 impl AstNode for CssPseudoClassNthIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14323,6 +14638,9 @@ impl From<CssPseudoClassNthIdentifier> for SyntaxElement {
     fn from(n: CssPseudoClassNthIdentifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassNthNumber {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_NTH_NUMBER;
 }
 impl AstNode for CssPseudoClassNthNumber {
     type Language = Language;
@@ -14371,6 +14689,9 @@ impl From<CssPseudoClassNthNumber> for SyntaxElement {
     fn from(n: CssPseudoClassNthNumber) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassNthSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_NTH_SELECTOR;
 }
 impl AstNode for CssPseudoClassNthSelector {
     type Language = Language;
@@ -14423,6 +14744,9 @@ impl From<CssPseudoClassNthSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoClassOfNthSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_OF_NTH_SELECTOR;
+}
 impl AstNode for CssPseudoClassOfNthSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14470,6 +14794,9 @@ impl From<CssPseudoClassOfNthSelector> for SyntaxElement {
     fn from(n: CssPseudoClassOfNthSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoClassSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_CLASS_SELECTOR;
 }
 impl AstNode for CssPseudoClassSelector {
     type Language = Language;
@@ -14521,6 +14848,9 @@ impl From<CssPseudoClassSelector> for SyntaxElement {
     fn from(n: CssPseudoClassSelector) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoElementFunctionIdentifier {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_ELEMENT_FUNCTION_IDENTIFIER;
 }
 impl AstNode for CssPseudoElementFunctionIdentifier {
     type Language = Language;
@@ -14579,6 +14909,9 @@ impl From<CssPseudoElementFunctionIdentifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoElementFunctionSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_ELEMENT_FUNCTION_SELECTOR;
+}
 impl AstNode for CssPseudoElementFunctionSelector {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14635,6 +14968,9 @@ impl From<CssPseudoElementFunctionSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssPseudoElementIdentifier {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_ELEMENT_IDENTIFIER;
+}
 impl AstNode for CssPseudoElementIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14681,6 +15017,9 @@ impl From<CssPseudoElementIdentifier> for SyntaxElement {
     fn from(n: CssPseudoElementIdentifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssPseudoElementSelector {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_ELEMENT_SELECTOR;
 }
 impl AstNode for CssPseudoElementSelector {
     type Language = Language;
@@ -14733,6 +15072,9 @@ impl From<CssPseudoElementSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssQualifiedRule {
+    pub const KIND: SyntaxKind = CSS_QUALIFIED_RULE;
+}
 impl AstNode for CssQualifiedRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14781,6 +15123,9 @@ impl From<CssQualifiedRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssQueryFeatureBoolean {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_BOOLEAN;
+}
 impl AstNode for CssQueryFeatureBoolean {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14827,6 +15172,9 @@ impl From<CssQueryFeatureBoolean> for SyntaxElement {
     fn from(n: CssQueryFeatureBoolean) -> Self {
         n.syntax.into()
     }
+}
+impl CssQueryFeaturePlain {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_PLAIN;
 }
 impl AstNode for CssQueryFeaturePlain {
     type Language = Language;
@@ -14880,6 +15228,9 @@ impl From<CssQueryFeaturePlain> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssQueryFeatureRange {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_RANGE;
+}
 impl AstNode for CssQueryFeatureRange {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14929,6 +15280,9 @@ impl From<CssQueryFeatureRange> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssQueryFeatureRangeComparison {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_RANGE_COMPARISON;
+}
 impl AstNode for CssQueryFeatureRangeComparison {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -14975,6 +15329,9 @@ impl From<CssQueryFeatureRangeComparison> for SyntaxElement {
     fn from(n: CssQueryFeatureRangeComparison) -> Self {
         n.syntax.into()
     }
+}
+impl CssQueryFeatureRangeInterval {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_RANGE_INTERVAL;
 }
 impl AstNode for CssQueryFeatureRangeInterval {
     type Language = Language;
@@ -15033,6 +15390,9 @@ impl From<CssQueryFeatureRangeInterval> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssQueryFeatureReverseRange {
+    pub const KIND: SyntaxKind = CSS_QUERY_FEATURE_REVERSE_RANGE;
+}
 impl AstNode for CssQueryFeatureReverseRange {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15081,6 +15441,9 @@ impl From<CssQueryFeatureReverseRange> for SyntaxElement {
     fn from(n: CssQueryFeatureReverseRange) -> Self {
         n.syntax.into()
     }
+}
+impl CssRatio {
+    pub const KIND: SyntaxKind = CSS_RATIO;
 }
 impl AstNode for CssRatio {
     type Language = Language;
@@ -15137,6 +15500,9 @@ impl From<CssRatio> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssRegularDimension {
+    pub const KIND: SyntaxKind = CSS_REGULAR_DIMENSION;
+}
 impl AstNode for CssRegularDimension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15187,6 +15553,9 @@ impl From<CssRegularDimension> for SyntaxElement {
     fn from(n: CssRegularDimension) -> Self {
         n.syntax.into()
     }
+}
+impl CssRelativeSelector {
+    pub const KIND: SyntaxKind = CSS_RELATIVE_SELECTOR;
 }
 impl AstNode for CssRelativeSelector {
     type Language = Language;
@@ -15239,6 +15608,9 @@ impl From<CssRelativeSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssRoot {
+    pub const KIND: SyntaxKind = CSS_ROOT;
+}
 impl AstNode for CssRoot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15290,6 +15662,9 @@ impl From<CssRoot> for SyntaxElement {
     fn from(n: CssRoot) -> Self {
         n.syntax.into()
     }
+}
+impl CssRuleBlock {
+    pub const KIND: SyntaxKind = CSS_RULE_BLOCK;
 }
 impl AstNode for CssRuleBlock {
     type Language = Language;
@@ -15346,6 +15721,9 @@ impl From<CssRuleBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssScopeAtRule {
+    pub const KIND: SyntaxKind = CSS_SCOPE_AT_RULE;
+}
 impl AstNode for CssScopeAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15397,6 +15775,9 @@ impl From<CssScopeAtRule> for SyntaxElement {
     fn from(n: CssScopeAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssScopeEdge {
+    pub const KIND: SyntaxKind = CSS_SCOPE_EDGE;
 }
 impl AstNode for CssScopeEdge {
     type Language = Language;
@@ -15453,6 +15834,9 @@ impl From<CssScopeEdge> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssScopeRangeEnd {
+    pub const KIND: SyntaxKind = CSS_SCOPE_RANGE_END;
+}
 impl AstNode for CssScopeRangeEnd {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15500,6 +15884,9 @@ impl From<CssScopeRangeEnd> for SyntaxElement {
     fn from(n: CssScopeRangeEnd) -> Self {
         n.syntax.into()
     }
+}
+impl CssScopeRangeInterval {
+    pub const KIND: SyntaxKind = CSS_SCOPE_RANGE_INTERVAL;
 }
 impl AstNode for CssScopeRangeInterval {
     type Language = Language;
@@ -15550,6 +15937,9 @@ impl From<CssScopeRangeInterval> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssScopeRangeStart {
+    pub const KIND: SyntaxKind = CSS_SCOPE_RANGE_START;
+}
 impl AstNode for CssScopeRangeStart {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15596,6 +15986,9 @@ impl From<CssScopeRangeStart> for SyntaxElement {
     fn from(n: CssScopeRangeStart) -> Self {
         n.syntax.into()
     }
+}
+impl CssStartingStyleAtRule {
+    pub const KIND: SyntaxKind = CSS_STARTING_STYLE_AT_RULE;
 }
 impl AstNode for CssStartingStyleAtRule {
     type Language = Language;
@@ -15648,6 +16041,9 @@ impl From<CssStartingStyleAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssString {
+    pub const KIND: SyntaxKind = CSS_STRING;
+}
 impl AstNode for CssString {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15698,6 +16094,9 @@ impl From<CssString> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssSupportsAndCondition {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_AND_CONDITION;
+}
 impl AstNode for CssSupportsAndCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -15746,6 +16145,9 @@ impl From<CssSupportsAndCondition> for SyntaxElement {
     fn from(n: CssSupportsAndCondition) -> Self {
         n.syntax.into()
     }
+}
+impl CssSupportsAtRule {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_AT_RULE;
 }
 impl AstNode for CssSupportsAtRule {
     type Language = Language;
@@ -15798,6 +16200,9 @@ impl From<CssSupportsAtRule> for SyntaxElement {
     fn from(n: CssSupportsAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssSupportsConditionInParens {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_CONDITION_IN_PARENS;
 }
 impl AstNode for CssSupportsConditionInParens {
     type Language = Language;
@@ -15853,6 +16258,9 @@ impl From<CssSupportsConditionInParens> for SyntaxElement {
     fn from(n: CssSupportsConditionInParens) -> Self {
         n.syntax.into()
     }
+}
+impl CssSupportsFeatureDeclaration {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_FEATURE_DECLARATION;
 }
 impl AstNode for CssSupportsFeatureDeclaration {
     type Language = Language;
@@ -15911,6 +16319,9 @@ impl From<CssSupportsFeatureDeclaration> for SyntaxElement {
     fn from(n: CssSupportsFeatureDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl CssSupportsFeatureSelector {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_FEATURE_SELECTOR;
 }
 impl AstNode for CssSupportsFeatureSelector {
     type Language = Language;
@@ -15971,6 +16382,9 @@ impl From<CssSupportsFeatureSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssSupportsNotCondition {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_NOT_CONDITION;
+}
 impl AstNode for CssSupportsNotCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16018,6 +16432,9 @@ impl From<CssSupportsNotCondition> for SyntaxElement {
     fn from(n: CssSupportsNotCondition) -> Self {
         n.syntax.into()
     }
+}
+impl CssSupportsOrCondition {
+    pub const KIND: SyntaxKind = CSS_SUPPORTS_OR_CONDITION;
 }
 impl AstNode for CssSupportsOrCondition {
     type Language = Language;
@@ -16067,6 +16484,9 @@ impl From<CssSupportsOrCondition> for SyntaxElement {
     fn from(n: CssSupportsOrCondition) -> Self {
         n.syntax.into()
     }
+}
+impl CssTypeSelector {
+    pub const KIND: SyntaxKind = CSS_TYPE_SELECTOR;
 }
 impl AstNode for CssTypeSelector {
     type Language = Language;
@@ -16119,6 +16539,9 @@ impl From<CssTypeSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUnicodeCodepoint {
+    pub const KIND: SyntaxKind = CSS_UNICODE_CODEPOINT;
+}
 impl AstNode for CssUnicodeCodepoint {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16168,6 +16591,9 @@ impl From<CssUnicodeCodepoint> for SyntaxElement {
     fn from(n: CssUnicodeCodepoint) -> Self {
         n.syntax.into()
     }
+}
+impl CssUnicodeRange {
+    pub const KIND: SyntaxKind = CSS_UNICODE_RANGE;
 }
 impl AstNode for CssUnicodeRange {
     type Language = Language;
@@ -16219,6 +16645,9 @@ impl From<CssUnicodeRange> for SyntaxElement {
     fn from(n: CssUnicodeRange) -> Self {
         n.syntax.into()
     }
+}
+impl CssUnicodeRangeInterval {
+    pub const KIND: SyntaxKind = CSS_UNICODE_RANGE_INTERVAL;
 }
 impl AstNode for CssUnicodeRangeInterval {
     type Language = Language;
@@ -16272,6 +16701,9 @@ impl From<CssUnicodeRangeInterval> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUnicodeRangeWildcard {
+    pub const KIND: SyntaxKind = CSS_UNICODE_RANGE_WILDCARD;
+}
 impl AstNode for CssUnicodeRangeWildcard {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16322,6 +16754,9 @@ impl From<CssUnicodeRangeWildcard> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUniversalNamespacePrefix {
+    pub const KIND: SyntaxKind = CSS_UNIVERSAL_NAMESPACE_PREFIX;
+}
 impl AstNode for CssUniversalNamespacePrefix {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16368,6 +16803,9 @@ impl From<CssUniversalNamespacePrefix> for SyntaxElement {
     fn from(n: CssUniversalNamespacePrefix) -> Self {
         n.syntax.into()
     }
+}
+impl CssUniversalSelector {
+    pub const KIND: SyntaxKind = CSS_UNIVERSAL_SELECTOR;
 }
 impl AstNode for CssUniversalSelector {
     type Language = Language;
@@ -16420,6 +16858,9 @@ impl From<CssUniversalSelector> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUnknownBlockAtRule {
+    pub const KIND: SyntaxKind = CSS_UNKNOWN_BLOCK_AT_RULE;
+}
 impl AstNode for CssUnknownBlockAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16468,6 +16909,9 @@ impl From<CssUnknownBlockAtRule> for SyntaxElement {
     fn from(n: CssUnknownBlockAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssUnknownDimension {
+    pub const KIND: SyntaxKind = CSS_UNKNOWN_DIMENSION;
 }
 impl AstNode for CssUnknownDimension {
     type Language = Language;
@@ -16520,6 +16964,9 @@ impl From<CssUnknownDimension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUnknownValueAtRule {
+    pub const KIND: SyntaxKind = CSS_UNKNOWN_VALUE_AT_RULE;
+}
 impl AstNode for CssUnknownValueAtRule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16571,6 +17018,9 @@ impl From<CssUnknownValueAtRule> for SyntaxElement {
     fn from(n: CssUnknownValueAtRule) -> Self {
         n.syntax.into()
     }
+}
+impl CssUrlFunction {
+    pub const KIND: SyntaxKind = CSS_URL_FUNCTION;
 }
 impl AstNode for CssUrlFunction {
     type Language = Language;
@@ -16629,6 +17079,9 @@ impl From<CssUrlFunction> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssUrlValueRaw {
+    pub const KIND: SyntaxKind = CSS_URL_VALUE_RAW;
+}
 impl AstNode for CssUrlValueRaw {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16678,6 +17131,9 @@ impl From<CssUrlValueRaw> for SyntaxElement {
     fn from(n: CssUrlValueRaw) -> Self {
         n.syntax.into()
     }
+}
+impl CssValueAtRule {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE;
 }
 impl AstNode for CssValueAtRule {
     type Language = Language;
@@ -16734,6 +17190,9 @@ impl From<CssValueAtRule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssValueAtRuleDeclarationClause {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_DECLARATION_CLAUSE;
+}
 impl AstNode for CssValueAtRuleDeclarationClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16780,6 +17239,9 @@ impl From<CssValueAtRuleDeclarationClause> for SyntaxElement {
     fn from(n: CssValueAtRuleDeclarationClause) -> Self {
         n.syntax.into()
     }
+}
+impl CssValueAtRuleGenericProperty {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_GENERIC_PROPERTY;
 }
 impl AstNode for CssValueAtRuleGenericProperty {
     type Language = Language;
@@ -16833,6 +17295,9 @@ impl From<CssValueAtRuleGenericProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssValueAtRuleImportClause {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_IMPORT_CLAUSE;
+}
 impl AstNode for CssValueAtRuleImportClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16882,6 +17347,9 @@ impl From<CssValueAtRuleImportClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl CssValueAtRuleImportSpecifier {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_IMPORT_SPECIFIER;
+}
 impl AstNode for CssValueAtRuleImportSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16928,6 +17396,9 @@ impl From<CssValueAtRuleImportSpecifier> for SyntaxElement {
     fn from(n: CssValueAtRuleImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssValueAtRuleNamedImportSpecifier {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_NAMED_IMPORT_SPECIFIER;
 }
 impl AstNode for CssValueAtRuleNamedImportSpecifier {
     type Language = Language;
@@ -16979,6 +17450,9 @@ impl From<CssValueAtRuleNamedImportSpecifier> for SyntaxElement {
     fn from(n: CssValueAtRuleNamedImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl CssViewTransitionAtRule {
+    pub const KIND: SyntaxKind = CSS_VIEW_TRANSITION_AT_RULE;
 }
 impl AstNode for CssViewTransitionAtRule {
     type Language = Language;
@@ -24402,6 +24876,7 @@ pub struct CssBogus {
     syntax: SyntaxNode,
 }
 impl CssBogus {
+    pub const KIND: SyntaxKind = CSS_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24458,6 +24933,7 @@ pub struct CssBogusAtRule {
     syntax: SyntaxNode,
 }
 impl CssBogusAtRule {
+    pub const KIND: SyntaxKind = CSS_BOGUS_AT_RULE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24514,6 +24990,7 @@ pub struct CssBogusBlock {
     syntax: SyntaxNode,
 }
 impl CssBogusBlock {
+    pub const KIND: SyntaxKind = CSS_BOGUS_BLOCK;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24570,6 +25047,7 @@ pub struct CssBogusCustomIdentifier {
     syntax: SyntaxNode,
 }
 impl CssBogusCustomIdentifier {
+    pub const KIND: SyntaxKind = CSS_BOGUS_CUSTOM_IDENTIFIER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24626,6 +25104,7 @@ pub struct CssBogusDeclarationItem {
     syntax: SyntaxNode,
 }
 impl CssBogusDeclarationItem {
+    pub const KIND: SyntaxKind = CSS_BOGUS_DECLARATION_ITEM;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24682,6 +25161,7 @@ pub struct CssBogusDocumentMatcher {
     syntax: SyntaxNode,
 }
 impl CssBogusDocumentMatcher {
+    pub const KIND: SyntaxKind = CSS_BOGUS_DOCUMENT_MATCHER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24738,6 +25218,7 @@ pub struct CssBogusFontFamilyName {
     syntax: SyntaxNode,
 }
 impl CssBogusFontFamilyName {
+    pub const KIND: SyntaxKind = CSS_BOGUS_FONT_FAMILY_NAME;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24794,6 +25275,7 @@ pub struct CssBogusFontFeatureValuesItem {
     syntax: SyntaxNode,
 }
 impl CssBogusFontFeatureValuesItem {
+    pub const KIND: SyntaxKind = CSS_BOGUS_FONT_FEATURE_VALUES_ITEM;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24850,6 +25332,7 @@ pub struct CssBogusKeyframesItem {
     syntax: SyntaxNode,
 }
 impl CssBogusKeyframesItem {
+    pub const KIND: SyntaxKind = CSS_BOGUS_KEYFRAMES_ITEM;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24906,6 +25389,7 @@ pub struct CssBogusKeyframesName {
     syntax: SyntaxNode,
 }
 impl CssBogusKeyframesName {
+    pub const KIND: SyntaxKind = CSS_BOGUS_KEYFRAMES_NAME;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -24962,6 +25446,7 @@ pub struct CssBogusLayer {
     syntax: SyntaxNode,
 }
 impl CssBogusLayer {
+    pub const KIND: SyntaxKind = CSS_BOGUS_LAYER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25018,6 +25503,7 @@ pub struct CssBogusMediaQuery {
     syntax: SyntaxNode,
 }
 impl CssBogusMediaQuery {
+    pub const KIND: SyntaxKind = CSS_BOGUS_MEDIA_QUERY;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25074,6 +25560,7 @@ pub struct CssBogusPageSelectorPseudo {
     syntax: SyntaxNode,
 }
 impl CssBogusPageSelectorPseudo {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PAGE_SELECTOR_PSEUDO;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25130,6 +25617,7 @@ pub struct CssBogusParameter {
     syntax: SyntaxNode,
 }
 impl CssBogusParameter {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PARAMETER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25186,6 +25674,7 @@ pub struct CssBogusProperty {
     syntax: SyntaxNode,
 }
 impl CssBogusProperty {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PROPERTY;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25242,6 +25731,7 @@ pub struct CssBogusPropertyValue {
     syntax: SyntaxNode,
 }
 impl CssBogusPropertyValue {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PROPERTY_VALUE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25298,6 +25788,7 @@ pub struct CssBogusPseudoClass {
     syntax: SyntaxNode,
 }
 impl CssBogusPseudoClass {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PSEUDO_CLASS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25354,6 +25845,7 @@ pub struct CssBogusPseudoElement {
     syntax: SyntaxNode,
 }
 impl CssBogusPseudoElement {
+    pub const KIND: SyntaxKind = CSS_BOGUS_PSEUDO_ELEMENT;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25410,6 +25902,7 @@ pub struct CssBogusRule {
     syntax: SyntaxNode,
 }
 impl CssBogusRule {
+    pub const KIND: SyntaxKind = CSS_BOGUS_RULE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25466,6 +25959,7 @@ pub struct CssBogusScopeRange {
     syntax: SyntaxNode,
 }
 impl CssBogusScopeRange {
+    pub const KIND: SyntaxKind = CSS_BOGUS_SCOPE_RANGE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25522,6 +26016,7 @@ pub struct CssBogusSelector {
     syntax: SyntaxNode,
 }
 impl CssBogusSelector {
+    pub const KIND: SyntaxKind = CSS_BOGUS_SELECTOR;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25578,6 +26073,7 @@ pub struct CssBogusSubSelector {
     syntax: SyntaxNode,
 }
 impl CssBogusSubSelector {
+    pub const KIND: SyntaxKind = CSS_BOGUS_SUB_SELECTOR;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25634,6 +26130,7 @@ pub struct CssBogusUnicodeRangeValue {
     syntax: SyntaxNode,
 }
 impl CssBogusUnicodeRangeValue {
+    pub const KIND: SyntaxKind = CSS_BOGUS_UNICODE_RANGE_VALUE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25690,6 +26187,7 @@ pub struct CssBogusUrlModifier {
     syntax: SyntaxNode,
 }
 impl CssBogusUrlModifier {
+    pub const KIND: SyntaxKind = CSS_BOGUS_URL_MODIFIER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25746,6 +26244,7 @@ pub struct CssUnknownAtRuleComponentList {
     syntax: SyntaxNode,
 }
 impl CssUnknownAtRuleComponentList {
+    pub const KIND: SyntaxKind = CSS_UNKNOWN_AT_RULE_COMPONENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25802,6 +26301,7 @@ pub struct CssValueAtRuleGenericValue {
     syntax: SyntaxNode,
 }
 impl CssValueAtRuleGenericValue {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_GENERIC_VALUE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25859,6 +26359,7 @@ pub struct CssBracketedValueList {
     syntax_list: SyntaxList,
 }
 impl CssBracketedValueList {
+    pub const KIND: SyntaxKind = CSS_BRACKETED_VALUE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -25941,6 +26442,7 @@ pub struct CssComponentValueList {
     syntax_list: SyntaxList,
 }
 impl CssComponentValueList {
+    pub const KIND: SyntaxKind = CSS_COMPONENT_VALUE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26023,6 +26525,7 @@ pub struct CssComposesClassList {
     syntax_list: SyntaxList,
 }
 impl CssComposesClassList {
+    pub const KIND: SyntaxKind = CSS_COMPOSES_CLASS_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26105,6 +26608,7 @@ pub struct CssCompoundSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssCompoundSelectorList {
+    pub const KIND: SyntaxKind = CSS_COMPOUND_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26187,6 +26691,7 @@ pub struct CssCustomIdentifierList {
     syntax_list: SyntaxList,
 }
 impl CssCustomIdentifierList {
+    pub const KIND: SyntaxKind = CSS_CUSTOM_IDENTIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26269,6 +26774,7 @@ pub struct CssDeclarationList {
     syntax_list: SyntaxList,
 }
 impl CssDeclarationList {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26351,6 +26857,7 @@ pub struct CssDeclarationOrAtRuleList {
     syntax_list: SyntaxList,
 }
 impl CssDeclarationOrAtRuleList {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_OR_AT_RULE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26433,6 +26940,7 @@ pub struct CssDeclarationOrRuleList {
     syntax_list: SyntaxList,
 }
 impl CssDeclarationOrRuleList {
+    pub const KIND: SyntaxKind = CSS_DECLARATION_OR_RULE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26515,6 +27023,7 @@ pub struct CssDocumentMatcherList {
     syntax_list: SyntaxList,
 }
 impl CssDocumentMatcherList {
+    pub const KIND: SyntaxKind = CSS_DOCUMENT_MATCHER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26597,6 +27106,7 @@ pub struct CssFontFamilyNameList {
     syntax_list: SyntaxList,
 }
 impl CssFontFamilyNameList {
+    pub const KIND: SyntaxKind = CSS_FONT_FAMILY_NAME_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26679,6 +27189,7 @@ pub struct CssFontFeatureValuesItemList {
     syntax_list: SyntaxList,
 }
 impl CssFontFeatureValuesItemList {
+    pub const KIND: SyntaxKind = CSS_FONT_FEATURE_VALUES_ITEM_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26761,6 +27272,7 @@ pub struct CssGenericComponentValueList {
     syntax_list: SyntaxList,
 }
 impl CssGenericComponentValueList {
+    pub const KIND: SyntaxKind = CSS_GENERIC_COMPONENT_VALUE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26843,6 +27355,7 @@ pub struct CssKeyframesItemList {
     syntax_list: SyntaxList,
 }
 impl CssKeyframesItemList {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_ITEM_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -26925,6 +27438,7 @@ pub struct CssKeyframesSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssKeyframesSelectorList {
+    pub const KIND: SyntaxKind = CSS_KEYFRAMES_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27007,6 +27521,7 @@ pub struct CssLayerNameList {
     syntax_list: SyntaxList,
 }
 impl CssLayerNameList {
+    pub const KIND: SyntaxKind = CSS_LAYER_NAME_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27089,6 +27604,7 @@ pub struct CssLayerReferenceList {
     syntax_list: SyntaxList,
 }
 impl CssLayerReferenceList {
+    pub const KIND: SyntaxKind = CSS_LAYER_REFERENCE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27171,6 +27687,7 @@ pub struct CssMediaQueryList {
     syntax_list: SyntaxList,
 }
 impl CssMediaQueryList {
+    pub const KIND: SyntaxKind = CSS_MEDIA_QUERY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27253,6 +27770,7 @@ pub struct CssNestedSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssNestedSelectorList {
+    pub const KIND: SyntaxKind = CSS_NESTED_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27335,6 +27853,7 @@ pub struct CssPageAtRuleItemList {
     syntax_list: SyntaxList,
 }
 impl CssPageAtRuleItemList {
+    pub const KIND: SyntaxKind = CSS_PAGE_AT_RULE_ITEM_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27417,6 +27936,7 @@ pub struct CssPageSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssPageSelectorList {
+    pub const KIND: SyntaxKind = CSS_PAGE_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27499,6 +28019,7 @@ pub struct CssPageSelectorPseudoList {
     syntax_list: SyntaxList,
 }
 impl CssPageSelectorPseudoList {
+    pub const KIND: SyntaxKind = CSS_PAGE_SELECTOR_PSEUDO_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27581,6 +28102,7 @@ pub struct CssParameterList {
     syntax_list: SyntaxList,
 }
 impl CssParameterList {
+    pub const KIND: SyntaxKind = CSS_PARAMETER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27663,6 +28185,7 @@ pub struct CssPseudoValueList {
     syntax_list: SyntaxList,
 }
 impl CssPseudoValueList {
+    pub const KIND: SyntaxKind = CSS_PSEUDO_VALUE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27745,6 +28268,7 @@ pub struct CssRelativeSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssRelativeSelectorList {
+    pub const KIND: SyntaxKind = CSS_RELATIVE_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27827,6 +28351,7 @@ pub struct CssRuleList {
     syntax_list: SyntaxList,
 }
 impl CssRuleList {
+    pub const KIND: SyntaxKind = CSS_RULE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27909,6 +28434,7 @@ pub struct CssSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssSelectorList {
+    pub const KIND: SyntaxKind = CSS_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -27991,6 +28517,7 @@ pub struct CssSubSelectorList {
     syntax_list: SyntaxList,
 }
 impl CssSubSelectorList {
+    pub const KIND: SyntaxKind = CSS_SUB_SELECTOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -28073,6 +28600,7 @@ pub struct CssUrlModifierList {
     syntax_list: SyntaxList,
 }
 impl CssUrlModifierList {
+    pub const KIND: SyntaxKind = CSS_URL_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -28155,6 +28683,7 @@ pub struct CssValueAtRuleImportSpecifierList {
     syntax_list: SyntaxList,
 }
 impl CssValueAtRuleImportSpecifierList {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_IMPORT_SPECIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -28238,6 +28767,7 @@ pub struct CssValueAtRulePropertyList {
     syntax_list: SyntaxList,
 }
 impl CssValueAtRulePropertyList {
+    pub const KIND: SyntaxKind = CSS_VALUE_AT_RULE_PROPERTY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_graphql_syntax/src/generated/nodes.rs
+++ b/crates/biome_graphql_syntax/src/generated/nodes.rs
@@ -3153,6 +3153,9 @@ impl AnyGraphqlValue {
         }
     }
 }
+impl GraphqlAlias {
+    pub const KIND: SyntaxKind = GRAPHQL_ALIAS;
+}
 impl AstNode for GraphqlAlias {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3203,6 +3206,9 @@ impl From<GraphqlAlias> for SyntaxElement {
     fn from(n: GraphqlAlias) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlArgument {
+    pub const KIND: SyntaxKind = GRAPHQL_ARGUMENT;
 }
 impl AstNode for GraphqlArgument {
     type Language = Language;
@@ -3255,6 +3261,9 @@ impl From<GraphqlArgument> for SyntaxElement {
     fn from(n: GraphqlArgument) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlArguments {
+    pub const KIND: SyntaxKind = GRAPHQL_ARGUMENTS;
 }
 impl AstNode for GraphqlArguments {
     type Language = Language;
@@ -3311,6 +3320,9 @@ impl From<GraphqlArguments> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlArgumentsDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_ARGUMENTS_DEFINITION;
+}
 impl AstNode for GraphqlArgumentsDefinition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3366,6 +3378,9 @@ impl From<GraphqlArgumentsDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlBooleanValue {
+    pub const KIND: SyntaxKind = GRAPHQL_BOOLEAN_VALUE;
+}
 impl AstNode for GraphqlBooleanValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3416,6 +3431,9 @@ impl From<GraphqlBooleanValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlDefaultValue {
+    pub const KIND: SyntaxKind = GRAPHQL_DEFAULT_VALUE;
+}
 impl AstNode for GraphqlDefaultValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3463,6 +3481,9 @@ impl From<GraphqlDefaultValue> for SyntaxElement {
     fn from(n: GraphqlDefaultValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlDescription {
+    pub const KIND: SyntaxKind = GRAPHQL_DESCRIPTION;
 }
 impl AstNode for GraphqlDescription {
     type Language = Language;
@@ -3513,6 +3534,9 @@ impl From<GraphqlDescription> for SyntaxElement {
     fn from(n: GraphqlDescription) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlDirective {
+    pub const KIND: SyntaxKind = GRAPHQL_DIRECTIVE;
 }
 impl AstNode for GraphqlDirective {
     type Language = Language;
@@ -3565,6 +3589,9 @@ impl From<GraphqlDirective> for SyntaxElement {
     fn from(n: GraphqlDirective) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlDirectiveDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_DIRECTIVE_DEFINITION;
 }
 impl AstNode for GraphqlDirectiveDefinition {
     type Language = Language;
@@ -3636,6 +3663,9 @@ impl From<GraphqlDirectiveDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlDirectiveLocation {
+    pub const KIND: SyntaxKind = GRAPHQL_DIRECTIVE_LOCATION;
+}
 impl AstNode for GraphqlDirectiveLocation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3685,6 +3715,9 @@ impl From<GraphqlDirectiveLocation> for SyntaxElement {
     fn from(n: GraphqlDirectiveLocation) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlEnumTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlEnumTypeDefinition {
     type Language = Language;
@@ -3743,6 +3776,9 @@ impl From<GraphqlEnumTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlEnumTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlEnumTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3800,6 +3836,9 @@ impl From<GraphqlEnumTypeExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlEnumValue {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_VALUE;
+}
 impl AstNode for GraphqlEnumValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -3846,6 +3885,9 @@ impl From<GraphqlEnumValue> for SyntaxElement {
     fn from(n: GraphqlEnumValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlEnumValueDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_VALUE_DEFINITION;
 }
 impl AstNode for GraphqlEnumValueDefinition {
     type Language = Language;
@@ -3898,6 +3940,9 @@ impl From<GraphqlEnumValueDefinition> for SyntaxElement {
     fn from(n: GraphqlEnumValueDefinition) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlEnumValuesDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_VALUES_DEFINITION;
 }
 impl AstNode for GraphqlEnumValuesDefinition {
     type Language = Language;
@@ -3953,6 +3998,9 @@ impl From<GraphqlEnumValuesDefinition> for SyntaxElement {
     fn from(n: GraphqlEnumValuesDefinition) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlField {
+    pub const KIND: SyntaxKind = GRAPHQL_FIELD;
 }
 impl AstNode for GraphqlField {
     type Language = Language;
@@ -4010,6 +4058,9 @@ impl From<GraphqlField> for SyntaxElement {
     fn from(n: GraphqlField) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlFieldDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_FIELD_DEFINITION;
 }
 impl AstNode for GraphqlFieldDefinition {
     type Language = Language;
@@ -4072,6 +4123,9 @@ impl From<GraphqlFieldDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlFieldsDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_FIELDS_DEFINITION;
+}
 impl AstNode for GraphqlFieldsDefinition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4127,6 +4181,9 @@ impl From<GraphqlFieldsDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlFloatValue {
+    pub const KIND: SyntaxKind = GRAPHQL_FLOAT_VALUE;
+}
 impl AstNode for GraphqlFloatValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4176,6 +4233,9 @@ impl From<GraphqlFloatValue> for SyntaxElement {
     fn from(n: GraphqlFloatValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlFragmentDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_FRAGMENT_DEFINITION;
 }
 impl AstNode for GraphqlFragmentDefinition {
     type Language = Language;
@@ -4237,6 +4297,9 @@ impl From<GraphqlFragmentDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlFragmentSpread {
+    pub const KIND: SyntaxKind = GRAPHQL_FRAGMENT_SPREAD;
+}
 impl AstNode for GraphqlFragmentSpread {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4288,6 +4351,9 @@ impl From<GraphqlFragmentSpread> for SyntaxElement {
     fn from(n: GraphqlFragmentSpread) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlImplementsInterfaces {
+    pub const KIND: SyntaxKind = GRAPHQL_IMPLEMENTS_INTERFACES;
 }
 impl AstNode for GraphqlImplementsInterfaces {
     type Language = Language;
@@ -4343,6 +4409,9 @@ impl From<GraphqlImplementsInterfaces> for SyntaxElement {
     fn from(n: GraphqlImplementsInterfaces) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlInlineFragment {
+    pub const KIND: SyntaxKind = GRAPHQL_INLINE_FRAGMENT;
 }
 impl AstNode for GraphqlInlineFragment {
     type Language = Language;
@@ -4403,6 +4472,9 @@ impl From<GraphqlInlineFragment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlInputFieldsDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_INPUT_FIELDS_DEFINITION;
+}
 impl AstNode for GraphqlInputFieldsDefinition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4457,6 +4529,9 @@ impl From<GraphqlInputFieldsDefinition> for SyntaxElement {
     fn from(n: GraphqlInputFieldsDefinition) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlInputObjectTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_INPUT_OBJECT_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlInputObjectTypeDefinition {
     type Language = Language;
@@ -4518,6 +4593,9 @@ impl From<GraphqlInputObjectTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlInputObjectTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_INPUT_OBJECT_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlInputObjectTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4578,6 +4656,9 @@ impl From<GraphqlInputObjectTypeExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlInputValueDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_INPUT_VALUE_DEFINITION;
+}
 impl AstNode for GraphqlInputValueDefinition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4636,6 +4717,9 @@ impl From<GraphqlInputValueDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlIntValue {
+    pub const KIND: SyntaxKind = GRAPHQL_INT_VALUE;
+}
 impl AstNode for GraphqlIntValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4685,6 +4769,9 @@ impl From<GraphqlIntValue> for SyntaxElement {
     fn from(n: GraphqlIntValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlInterfaceTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_INTERFACE_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlInterfaceTypeDefinition {
     type Language = Language;
@@ -4747,6 +4834,9 @@ impl From<GraphqlInterfaceTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlInterfaceTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_INTERFACE_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlInterfaceTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4808,6 +4898,9 @@ impl From<GraphqlInterfaceTypeExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlListType {
+    pub const KIND: SyntaxKind = GRAPHQL_LIST_TYPE;
+}
 impl AstNode for GraphqlListType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4862,6 +4955,9 @@ impl From<GraphqlListType> for SyntaxElement {
     fn from(n: GraphqlListType) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlListValue {
+    pub const KIND: SyntaxKind = GRAPHQL_LIST_VALUE;
 }
 impl AstNode for GraphqlListValue {
     type Language = Language;
@@ -4918,6 +5014,9 @@ impl From<GraphqlListValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlLiteralName {
+    pub const KIND: SyntaxKind = GRAPHQL_LITERAL_NAME;
+}
 impl AstNode for GraphqlLiteralName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -4967,6 +5066,9 @@ impl From<GraphqlLiteralName> for SyntaxElement {
     fn from(n: GraphqlLiteralName) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlNameBinding {
+    pub const KIND: SyntaxKind = GRAPHQL_NAME_BINDING;
 }
 impl AstNode for GraphqlNameBinding {
     type Language = Language;
@@ -5018,6 +5120,9 @@ impl From<GraphqlNameBinding> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlNameReference {
+    pub const KIND: SyntaxKind = GRAPHQL_NAME_REFERENCE;
+}
 impl AstNode for GraphqlNameReference {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5068,6 +5173,9 @@ impl From<GraphqlNameReference> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlNonNullType {
+    pub const KIND: SyntaxKind = GRAPHQL_NON_NULL_TYPE;
+}
 impl AstNode for GraphqlNonNullType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5116,6 +5224,9 @@ impl From<GraphqlNonNullType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlNullValue {
+    pub const KIND: SyntaxKind = GRAPHQL_NULL_VALUE;
+}
 impl AstNode for GraphqlNullValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5162,6 +5273,9 @@ impl From<GraphqlNullValue> for SyntaxElement {
     fn from(n: GraphqlNullValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlObjectField {
+    pub const KIND: SyntaxKind = GRAPHQL_OBJECT_FIELD;
 }
 impl AstNode for GraphqlObjectField {
     type Language = Language;
@@ -5214,6 +5328,9 @@ impl From<GraphqlObjectField> for SyntaxElement {
     fn from(n: GraphqlObjectField) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlObjectTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_OBJECT_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlObjectTypeDefinition {
     type Language = Language;
@@ -5273,6 +5390,9 @@ impl From<GraphqlObjectTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlObjectTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_OBJECT_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlObjectTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5331,6 +5451,9 @@ impl From<GraphqlObjectTypeExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlObjectValue {
+    pub const KIND: SyntaxKind = GRAPHQL_OBJECT_VALUE;
+}
 impl AstNode for GraphqlObjectValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5385,6 +5508,9 @@ impl From<GraphqlObjectValue> for SyntaxElement {
     fn from(n: GraphqlObjectValue) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlOperationDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_OPERATION_DEFINITION;
 }
 impl AstNode for GraphqlOperationDefinition {
     type Language = Language;
@@ -5443,6 +5569,9 @@ impl From<GraphqlOperationDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlOperationType {
+    pub const KIND: SyntaxKind = GRAPHQL_OPERATION_TYPE;
+}
 impl AstNode for GraphqlOperationType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5492,6 +5621,9 @@ impl From<GraphqlOperationType> for SyntaxElement {
     fn from(n: GraphqlOperationType) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlRoot {
+    pub const KIND: SyntaxKind = GRAPHQL_ROOT;
 }
 impl AstNode for GraphqlRoot {
     type Language = Language;
@@ -5544,6 +5676,9 @@ impl From<GraphqlRoot> for SyntaxElement {
     fn from(n: GraphqlRoot) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlRootOperationTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlRootOperationTypeDefinition {
     type Language = Language;
@@ -5601,6 +5736,9 @@ impl From<GraphqlRootOperationTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlRootOperationTypes {
+    pub const KIND: SyntaxKind = GRAPHQL_ROOT_OPERATION_TYPES;
+}
 impl AstNode for GraphqlRootOperationTypes {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5655,6 +5793,9 @@ impl From<GraphqlRootOperationTypes> for SyntaxElement {
     fn from(n: GraphqlRootOperationTypes) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlScalarTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_SCALAR_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlScalarTypeDefinition {
     type Language = Language;
@@ -5712,6 +5853,9 @@ impl From<GraphqlScalarTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlScalarTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_SCALAR_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlScalarTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5767,6 +5911,9 @@ impl From<GraphqlScalarTypeExtension> for SyntaxElement {
     fn from(n: GraphqlScalarTypeExtension) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlSchemaDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_SCHEMA_DEFINITION;
 }
 impl AstNode for GraphqlSchemaDefinition {
     type Language = Language;
@@ -5827,6 +5974,9 @@ impl From<GraphqlSchemaDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlSchemaExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_SCHEMA_EXTENSION;
+}
 impl AstNode for GraphqlSchemaExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5886,6 +6036,9 @@ impl From<GraphqlSchemaExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlSelectionSet {
+    pub const KIND: SyntaxKind = GRAPHQL_SELECTION_SET;
+}
 impl AstNode for GraphqlSelectionSet {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5941,6 +6094,9 @@ impl From<GraphqlSelectionSet> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlStringValue {
+    pub const KIND: SyntaxKind = GRAPHQL_STRING_VALUE;
+}
 impl AstNode for GraphqlStringValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5991,6 +6147,9 @@ impl From<GraphqlStringValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlTypeCondition {
+    pub const KIND: SyntaxKind = GRAPHQL_TYPE_CONDITION;
+}
 impl AstNode for GraphqlTypeCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6038,6 +6197,9 @@ impl From<GraphqlTypeCondition> for SyntaxElement {
     fn from(n: GraphqlTypeCondition) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlUnionMemberTypes {
+    pub const KIND: SyntaxKind = GRAPHQL_UNION_MEMBER_TYPES;
 }
 impl AstNode for GraphqlUnionMemberTypes {
     type Language = Language;
@@ -6090,6 +6252,9 @@ impl From<GraphqlUnionMemberTypes> for SyntaxElement {
     fn from(n: GraphqlUnionMemberTypes) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlUnionTypeDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_UNION_TYPE_DEFINITION;
 }
 impl AstNode for GraphqlUnionTypeDefinition {
     type Language = Language;
@@ -6151,6 +6316,9 @@ impl From<GraphqlUnionTypeDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlUnionTypeExtension {
+    pub const KIND: SyntaxKind = GRAPHQL_UNION_TYPE_EXTENSION;
+}
 impl AstNode for GraphqlUnionTypeExtension {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6211,6 +6379,9 @@ impl From<GraphqlUnionTypeExtension> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlVariableBinding {
+    pub const KIND: SyntaxKind = GRAPHQL_VARIABLE_BINDING;
+}
 impl AstNode for GraphqlVariableBinding {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6261,6 +6432,9 @@ impl From<GraphqlVariableBinding> for SyntaxElement {
     fn from(n: GraphqlVariableBinding) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlVariableDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_VARIABLE_DEFINITION;
 }
 impl AstNode for GraphqlVariableDefinition {
     type Language = Language;
@@ -6316,6 +6490,9 @@ impl From<GraphqlVariableDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GraphqlVariableDefinitions {
+    pub const KIND: SyntaxKind = GRAPHQL_VARIABLE_DEFINITIONS;
+}
 impl AstNode for GraphqlVariableDefinitions {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6370,6 +6547,9 @@ impl From<GraphqlVariableDefinitions> for SyntaxElement {
     fn from(n: GraphqlVariableDefinitions) -> Self {
         n.syntax.into()
     }
+}
+impl GraphqlVariableReference {
+    pub const KIND: SyntaxKind = GRAPHQL_VARIABLE_REFERENCE;
 }
 impl AstNode for GraphqlVariableReference {
     type Language = Language;
@@ -7626,6 +7806,7 @@ pub struct GraphqlBogus {
     syntax: SyntaxNode,
 }
 impl GraphqlBogus {
+    pub const KIND: SyntaxKind = GRAPHQL_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7682,6 +7863,7 @@ pub struct GraphqlBogusDefinition {
     syntax: SyntaxNode,
 }
 impl GraphqlBogusDefinition {
+    pub const KIND: SyntaxKind = GRAPHQL_BOGUS_DEFINITION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7738,6 +7920,7 @@ pub struct GraphqlBogusSelection {
     syntax: SyntaxNode,
 }
 impl GraphqlBogusSelection {
+    pub const KIND: SyntaxKind = GRAPHQL_BOGUS_SELECTION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7794,6 +7977,7 @@ pub struct GraphqlBogusType {
     syntax: SyntaxNode,
 }
 impl GraphqlBogusType {
+    pub const KIND: SyntaxKind = GRAPHQL_BOGUS_TYPE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7850,6 +8034,7 @@ pub struct GraphqlBogusValue {
     syntax: SyntaxNode,
 }
 impl GraphqlBogusValue {
+    pub const KIND: SyntaxKind = GRAPHQL_BOGUS_VALUE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7907,6 +8092,7 @@ pub struct GraphqlArgumentDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlArgumentDefinitionList {
+    pub const KIND: SyntaxKind = GRAPHQL_ARGUMENT_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -7989,6 +8175,7 @@ pub struct GraphqlArgumentList {
     syntax_list: SyntaxList,
 }
 impl GraphqlArgumentList {
+    pub const KIND: SyntaxKind = GRAPHQL_ARGUMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8071,6 +8258,7 @@ pub struct GraphqlDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlDefinitionList {
+    pub const KIND: SyntaxKind = GRAPHQL_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8153,6 +8341,7 @@ pub struct GraphqlDirectiveList {
     syntax_list: SyntaxList,
 }
 impl GraphqlDirectiveList {
+    pub const KIND: SyntaxKind = GRAPHQL_DIRECTIVE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8235,6 +8424,7 @@ pub struct GraphqlDirectiveLocationList {
     syntax_list: SyntaxList,
 }
 impl GraphqlDirectiveLocationList {
+    pub const KIND: SyntaxKind = GRAPHQL_DIRECTIVE_LOCATION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8317,6 +8507,7 @@ pub struct GraphqlEnumValueList {
     syntax_list: SyntaxList,
 }
 impl GraphqlEnumValueList {
+    pub const KIND: SyntaxKind = GRAPHQL_ENUM_VALUE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8399,6 +8590,7 @@ pub struct GraphqlFieldDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlFieldDefinitionList {
+    pub const KIND: SyntaxKind = GRAPHQL_FIELD_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8481,6 +8673,7 @@ pub struct GraphqlImplementsInterfaceList {
     syntax_list: SyntaxList,
 }
 impl GraphqlImplementsInterfaceList {
+    pub const KIND: SyntaxKind = GRAPHQL_IMPLEMENTS_INTERFACE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8563,6 +8756,7 @@ pub struct GraphqlInputFieldList {
     syntax_list: SyntaxList,
 }
 impl GraphqlInputFieldList {
+    pub const KIND: SyntaxKind = GRAPHQL_INPUT_FIELD_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8645,6 +8839,7 @@ pub struct GraphqlListValueElementList {
     syntax_list: SyntaxList,
 }
 impl GraphqlListValueElementList {
+    pub const KIND: SyntaxKind = GRAPHQL_LIST_VALUE_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8727,6 +8922,7 @@ pub struct GraphqlObjectValueMemberList {
     syntax_list: SyntaxList,
 }
 impl GraphqlObjectValueMemberList {
+    pub const KIND: SyntaxKind = GRAPHQL_OBJECT_VALUE_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8809,6 +9005,7 @@ pub struct GraphqlRootOperationTypeDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlRootOperationTypeDefinitionList {
+    pub const KIND: SyntaxKind = GRAPHQL_ROOT_OPERATION_TYPE_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8892,6 +9089,7 @@ pub struct GraphqlSelectionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlSelectionList {
+    pub const KIND: SyntaxKind = GRAPHQL_SELECTION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -8974,6 +9172,7 @@ pub struct GraphqlUnionMemberTypeList {
     syntax_list: SyntaxList,
 }
 impl GraphqlUnionMemberTypeList {
+    pub const KIND: SyntaxKind = GRAPHQL_UNION_MEMBER_TYPE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -9056,6 +9255,7 @@ pub struct GraphqlVariableDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GraphqlVariableDefinitionList {
+    pub const KIND: SyntaxKind = GRAPHQL_VARIABLE_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_grit_syntax/src/generated/nodes.rs
+++ b/crates/biome_grit_syntax/src/generated/nodes.rs
@@ -5195,6 +5195,9 @@ impl AnyGritVersion {
         }
     }
 }
+impl GritAddOperation {
+    pub const KIND: SyntaxKind = GRIT_ADD_OPERATION;
+}
 impl AstNode for GritAddOperation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5243,6 +5246,9 @@ impl From<GritAddOperation> for SyntaxElement {
     fn from(n: GritAddOperation) -> Self {
         n.syntax.into()
     }
+}
+impl GritAnnotation {
+    pub const KIND: SyntaxKind = GRIT_ANNOTATION;
 }
 impl AstNode for GritAnnotation {
     type Language = Language;
@@ -5294,6 +5300,9 @@ impl From<GritAnnotation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritAssignmentAsPattern {
+    pub const KIND: SyntaxKind = GRIT_ASSIGNMENT_AS_PATTERN;
+}
 impl AstNode for GritAssignmentAsPattern {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5342,6 +5351,9 @@ impl From<GritAssignmentAsPattern> for SyntaxElement {
     fn from(n: GritAssignmentAsPattern) -> Self {
         n.syntax.into()
     }
+}
+impl GritBacktickSnippetLiteral {
+    pub const KIND: SyntaxKind = GRIT_BACKTICK_SNIPPET_LITERAL;
 }
 impl AstNode for GritBacktickSnippetLiteral {
     type Language = Language;
@@ -5393,6 +5405,9 @@ impl From<GritBacktickSnippetLiteral> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritBooleanLiteral {
+    pub const KIND: SyntaxKind = GRIT_BOOLEAN_LITERAL;
+}
 impl AstNode for GritBooleanLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5439,6 +5454,9 @@ impl From<GritBooleanLiteral> for SyntaxElement {
     fn from(n: GritBooleanLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritBracketedPattern {
+    pub const KIND: SyntaxKind = GRIT_BRACKETED_PATTERN;
 }
 impl AstNode for GritBracketedPattern {
     type Language = Language;
@@ -5495,6 +5513,9 @@ impl From<GritBracketedPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritBracketedPredicate {
+    pub const KIND: SyntaxKind = GRIT_BRACKETED_PREDICATE;
+}
 impl AstNode for GritBracketedPredicate {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5550,6 +5571,9 @@ impl From<GritBracketedPredicate> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritBubble {
+    pub const KIND: SyntaxKind = GRIT_BUBBLE;
+}
 impl AstNode for GritBubble {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5601,6 +5625,9 @@ impl From<GritBubble> for SyntaxElement {
     fn from(n: GritBubble) -> Self {
         n.syntax.into()
     }
+}
+impl GritBubbleScope {
+    pub const KIND: SyntaxKind = GRIT_BUBBLE_SCOPE;
 }
 impl AstNode for GritBubbleScope {
     type Language = Language;
@@ -5657,6 +5684,9 @@ impl From<GritBubbleScope> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritCodeSnippet {
+    pub const KIND: SyntaxKind = GRIT_CODE_SNIPPET;
+}
 impl AstNode for GritCodeSnippet {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5703,6 +5733,9 @@ impl From<GritCodeSnippet> for SyntaxElement {
     fn from(n: GritCodeSnippet) -> Self {
         n.syntax.into()
     }
+}
+impl GritCurlyPattern {
+    pub const KIND: SyntaxKind = GRIT_CURLY_PATTERN;
 }
 impl AstNode for GritCurlyPattern {
     type Language = Language;
@@ -5759,6 +5792,9 @@ impl From<GritCurlyPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritDivOperation {
+    pub const KIND: SyntaxKind = GRIT_DIV_OPERATION;
+}
 impl AstNode for GritDivOperation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5811,6 +5847,9 @@ impl From<GritDivOperation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritDot {
+    pub const KIND: SyntaxKind = GRIT_DOT;
+}
 impl AstNode for GritDot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5857,6 +5896,9 @@ impl From<GritDot> for SyntaxElement {
     fn from(n: GritDot) -> Self {
         n.syntax.into()
     }
+}
+impl GritDotdotdot {
+    pub const KIND: SyntaxKind = GRIT_DOTDOTDOT;
 }
 impl AstNode for GritDotdotdot {
     type Language = Language;
@@ -5909,6 +5951,9 @@ impl From<GritDotdotdot> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritDoubleLiteral {
+    pub const KIND: SyntaxKind = GRIT_DOUBLE_LITERAL;
+}
 impl AstNode for GritDoubleLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -5958,6 +6003,9 @@ impl From<GritDoubleLiteral> for SyntaxElement {
     fn from(n: GritDoubleLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritEngineName {
+    pub const KIND: SyntaxKind = GRIT_ENGINE_NAME;
 }
 impl AstNode for GritEngineName {
     type Language = Language;
@@ -6009,6 +6057,9 @@ impl From<GritEngineName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritEvery {
+    pub const KIND: SyntaxKind = GRIT_EVERY;
+}
 impl AstNode for GritEvery {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6059,6 +6110,9 @@ impl From<GritEvery> for SyntaxElement {
     fn from(n: GritEvery) -> Self {
         n.syntax.into()
     }
+}
+impl GritFiles {
+    pub const KIND: SyntaxKind = GRIT_FILES;
 }
 impl AstNode for GritFiles {
     type Language = Language;
@@ -6118,6 +6172,9 @@ impl From<GritFiles> for SyntaxElement {
     fn from(n: GritFiles) -> Self {
         n.syntax.into()
     }
+}
+impl GritFunctionDefinition {
+    pub const KIND: SyntaxKind = GRIT_FUNCTION_DEFINITION;
 }
 impl AstNode for GritFunctionDefinition {
     type Language = Language;
@@ -6180,6 +6237,9 @@ impl From<GritFunctionDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritIntLiteral {
+    pub const KIND: SyntaxKind = GRIT_INT_LITERAL;
+}
 impl AstNode for GritIntLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6230,6 +6290,9 @@ impl From<GritIntLiteral> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritJavascriptBodyWrapper {
+    pub const KIND: SyntaxKind = GRIT_JAVASCRIPT_BODY_WRAPPER;
+}
 impl AstNode for GritJavascriptBodyWrapper {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6279,6 +6342,9 @@ impl From<GritJavascriptBodyWrapper> for SyntaxElement {
     fn from(n: GritJavascriptBodyWrapper) -> Self {
         n.syntax.into()
     }
+}
+impl GritJavascriptFunctionDefinition {
+    pub const KIND: SyntaxKind = GRIT_JAVASCRIPT_FUNCTION_DEFINITION;
 }
 impl AstNode for GritJavascriptFunctionDefinition {
     type Language = Language;
@@ -6345,6 +6411,9 @@ impl From<GritJavascriptFunctionDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritLanguageDeclaration {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_DECLARATION;
+}
 impl AstNode for GritLanguageDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6401,6 +6470,9 @@ impl From<GritLanguageDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritLanguageFlavor {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_FLAVOR;
+}
 impl AstNode for GritLanguageFlavor {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6456,6 +6528,9 @@ impl From<GritLanguageFlavor> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritLanguageFlavorKind {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_FLAVOR_KIND;
+}
 impl AstNode for GritLanguageFlavorKind {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6505,6 +6580,9 @@ impl From<GritLanguageFlavorKind> for SyntaxElement {
     fn from(n: GritLanguageFlavorKind) -> Self {
         n.syntax.into()
     }
+}
+impl GritLanguageName {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_NAME;
 }
 impl AstNode for GritLanguageName {
     type Language = Language;
@@ -6556,6 +6634,9 @@ impl From<GritLanguageName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritLanguageSpecificSnippet {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_SPECIFIC_SNIPPET;
+}
 impl AstNode for GritLanguageSpecificSnippet {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6606,6 +6687,9 @@ impl From<GritLanguageSpecificSnippet> for SyntaxElement {
     fn from(n: GritLanguageSpecificSnippet) -> Self {
         n.syntax.into()
     }
+}
+impl GritLike {
+    pub const KIND: SyntaxKind = GRIT_LIKE;
 }
 impl AstNode for GritLike {
     type Language = Language;
@@ -6667,6 +6751,9 @@ impl From<GritLike> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritLikeThreshold {
+    pub const KIND: SyntaxKind = GRIT_LIKE_THRESHOLD;
+}
 impl AstNode for GritLikeThreshold {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6721,6 +6808,9 @@ impl From<GritLikeThreshold> for SyntaxElement {
     fn from(n: GritLikeThreshold) -> Self {
         n.syntax.into()
     }
+}
+impl GritList {
+    pub const KIND: SyntaxKind = GRIT_LIST;
 }
 impl AstNode for GritList {
     type Language = Language;
@@ -6778,6 +6868,9 @@ impl From<GritList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritListAccessor {
+    pub const KIND: SyntaxKind = GRIT_LIST_ACCESSOR;
+}
 impl AstNode for GritListAccessor {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6834,6 +6927,9 @@ impl From<GritListAccessor> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritMap {
+    pub const KIND: SyntaxKind = GRIT_MAP;
+}
 impl AstNode for GritMap {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6889,6 +6985,9 @@ impl From<GritMap> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritMapAccessor {
+    pub const KIND: SyntaxKind = GRIT_MAP_ACCESSOR;
+}
 impl AstNode for GritMapAccessor {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -6937,6 +7036,9 @@ impl From<GritMapAccessor> for SyntaxElement {
     fn from(n: GritMapAccessor) -> Self {
         n.syntax.into()
     }
+}
+impl GritMapElement {
+    pub const KIND: SyntaxKind = GRIT_MAP_ELEMENT;
 }
 impl AstNode for GritMapElement {
     type Language = Language;
@@ -6990,6 +7092,9 @@ impl From<GritMapElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritModOperation {
+    pub const KIND: SyntaxKind = GRIT_MOD_OPERATION;
+}
 impl AstNode for GritModOperation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7042,6 +7147,9 @@ impl From<GritModOperation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritMulOperation {
+    pub const KIND: SyntaxKind = GRIT_MUL_OPERATION;
+}
 impl AstNode for GritMulOperation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7090,6 +7198,9 @@ impl From<GritMulOperation> for SyntaxElement {
     fn from(n: GritMulOperation) -> Self {
         n.syntax.into()
     }
+}
+impl GritName {
+    pub const KIND: SyntaxKind = GRIT_NAME;
 }
 impl AstNode for GritName {
     type Language = Language;
@@ -7141,6 +7252,9 @@ impl From<GritName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritNamedArg {
+    pub const KIND: SyntaxKind = GRIT_NAMED_ARG;
+}
 impl AstNode for GritNamedArg {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7189,6 +7303,9 @@ impl From<GritNamedArg> for SyntaxElement {
     fn from(n: GritNamedArg) -> Self {
         n.syntax.into()
     }
+}
+impl GritNegativeIntLiteral {
+    pub const KIND: SyntaxKind = GRIT_NEGATIVE_INT_LITERAL;
 }
 impl AstNode for GritNegativeIntLiteral {
     type Language = Language;
@@ -7239,6 +7356,9 @@ impl From<GritNegativeIntLiteral> for SyntaxElement {
     fn from(n: GritNegativeIntLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritNodeLike {
+    pub const KIND: SyntaxKind = GRIT_NODE_LIKE;
 }
 impl AstNode for GritNodeLike {
     type Language = Language;
@@ -7296,6 +7416,9 @@ impl From<GritNodeLike> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritNot {
+    pub const KIND: SyntaxKind = GRIT_NOT;
+}
 impl AstNode for GritNot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7342,6 +7465,9 @@ impl From<GritNot> for SyntaxElement {
     fn from(n: GritNot) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternAccumulate {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_ACCUMULATE;
 }
 impl AstNode for GritPatternAccumulate {
     type Language = Language;
@@ -7395,6 +7521,9 @@ impl From<GritPatternAccumulate> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternAfter {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_AFTER;
+}
 impl AstNode for GritPatternAfter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7445,6 +7574,9 @@ impl From<GritPatternAfter> for SyntaxElement {
     fn from(n: GritPatternAfter) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternAnd {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_AND;
 }
 impl AstNode for GritPatternAnd {
     type Language = Language;
@@ -7502,6 +7634,9 @@ impl From<GritPatternAnd> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternAny {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_ANY;
+}
 impl AstNode for GritPatternAny {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7558,6 +7693,9 @@ impl From<GritPatternAny> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternAs {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_AS;
+}
 impl AstNode for GritPatternAs {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7606,6 +7744,9 @@ impl From<GritPatternAs> for SyntaxElement {
     fn from(n: GritPatternAs) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternBefore {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_BEFORE;
 }
 impl AstNode for GritPatternBefore {
     type Language = Language;
@@ -7657,6 +7798,9 @@ impl From<GritPatternBefore> for SyntaxElement {
     fn from(n: GritPatternBefore) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternContains {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_CONTAINS;
 }
 impl AstNode for GritPatternContains {
     type Language = Language;
@@ -7712,6 +7856,9 @@ impl From<GritPatternContains> for SyntaxElement {
     fn from(n: GritPatternContains) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternDefinition {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_DEFINITION;
 }
 impl AstNode for GritPatternDefinition {
     type Language = Language;
@@ -7779,6 +7926,9 @@ impl From<GritPatternDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternDefinitionBody {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_DEFINITION_BODY;
+}
 impl AstNode for GritPatternDefinitionBody {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7834,6 +7984,9 @@ impl From<GritPatternDefinitionBody> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternElseClause {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_ELSE_CLAUSE;
+}
 impl AstNode for GritPatternElseClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -7884,6 +8037,9 @@ impl From<GritPatternElseClause> for SyntaxElement {
     fn from(n: GritPatternElseClause) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternIfElse {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_IF_ELSE;
 }
 impl AstNode for GritPatternIfElse {
     type Language = Language;
@@ -7952,6 +8108,9 @@ impl From<GritPatternIfElse> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternIncludes {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_INCLUDES;
+}
 impl AstNode for GritPatternIncludes {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8002,6 +8161,9 @@ impl From<GritPatternIncludes> for SyntaxElement {
     fn from(n: GritPatternIncludes) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternLimit {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_LIMIT;
 }
 impl AstNode for GritPatternLimit {
     type Language = Language;
@@ -8055,6 +8217,9 @@ impl From<GritPatternLimit> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternMaybe {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_MAYBE;
+}
 impl AstNode for GritPatternMaybe {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8106,6 +8271,9 @@ impl From<GritPatternMaybe> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternNot {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_NOT;
+}
 impl AstNode for GritPatternNot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8153,6 +8321,9 @@ impl From<GritPatternNot> for SyntaxElement {
     fn from(n: GritPatternNot) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternOr {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_OR;
 }
 impl AstNode for GritPatternOr {
     type Language = Language;
@@ -8209,6 +8380,9 @@ impl From<GritPatternOr> for SyntaxElement {
     fn from(n: GritPatternOr) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternOrElse {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_OR_ELSE;
 }
 impl AstNode for GritPatternOrElse {
     type Language = Language;
@@ -8269,6 +8443,9 @@ impl From<GritPatternOrElse> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPatternUntilClause {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_UNTIL_CLAUSE;
+}
 impl AstNode for GritPatternUntilClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8319,6 +8496,9 @@ impl From<GritPatternUntilClause> for SyntaxElement {
     fn from(n: GritPatternUntilClause) -> Self {
         n.syntax.into()
     }
+}
+impl GritPatternWhere {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_WHERE;
 }
 impl AstNode for GritPatternWhere {
     type Language = Language;
@@ -8375,6 +8555,9 @@ impl From<GritPatternWhere> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateAccumulate {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_ACCUMULATE;
+}
 impl AstNode for GritPredicateAccumulate {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8426,6 +8609,9 @@ impl From<GritPredicateAccumulate> for SyntaxElement {
     fn from(n: GritPredicateAccumulate) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateAnd {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_AND;
 }
 impl AstNode for GritPredicateAnd {
     type Language = Language;
@@ -8486,6 +8672,9 @@ impl From<GritPredicateAnd> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateAny {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_ANY;
+}
 impl AstNode for GritPredicateAny {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8542,6 +8731,9 @@ impl From<GritPredicateAny> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateAssignment {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_ASSIGNMENT;
+}
 impl AstNode for GritPredicateAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8590,6 +8782,9 @@ impl From<GritPredicateAssignment> for SyntaxElement {
     fn from(n: GritPredicateAssignment) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateCall {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_CALL;
 }
 impl AstNode for GritPredicateCall {
     type Language = Language;
@@ -8647,6 +8842,9 @@ impl From<GritPredicateCall> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateCurly {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_CURLY;
+}
 impl AstNode for GritPredicateCurly {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8701,6 +8899,9 @@ impl From<GritPredicateCurly> for SyntaxElement {
     fn from(n: GritPredicateCurly) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateDefinition {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_DEFINITION;
 }
 impl AstNode for GritPredicateDefinition {
     type Language = Language;
@@ -8763,6 +8964,9 @@ impl From<GritPredicateDefinition> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateElseClause {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_ELSE_CLAUSE;
+}
 impl AstNode for GritPredicateElseClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8813,6 +9017,9 @@ impl From<GritPredicateElseClause> for SyntaxElement {
     fn from(n: GritPredicateElseClause) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateEqual {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_EQUAL;
 }
 impl AstNode for GritPredicateEqual {
     type Language = Language;
@@ -8866,6 +9073,9 @@ impl From<GritPredicateEqual> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateGreater {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_GREATER;
+}
 impl AstNode for GritPredicateGreater {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8918,6 +9128,9 @@ impl From<GritPredicateGreater> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateGreaterEqual {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_GREATER_EQUAL;
+}
 impl AstNode for GritPredicateGreaterEqual {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -8969,6 +9182,9 @@ impl From<GritPredicateGreaterEqual> for SyntaxElement {
     fn from(n: GritPredicateGreaterEqual) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateIfElse {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_IF_ELSE;
 }
 impl AstNode for GritPredicateIfElse {
     type Language = Language;
@@ -9037,6 +9253,9 @@ impl From<GritPredicateIfElse> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateLess {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_LESS;
+}
 impl AstNode for GritPredicateLess {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9088,6 +9307,9 @@ impl From<GritPredicateLess> for SyntaxElement {
     fn from(n: GritPredicateLess) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateLessEqual {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_LESS_EQUAL;
 }
 impl AstNode for GritPredicateLessEqual {
     type Language = Language;
@@ -9141,6 +9363,9 @@ impl From<GritPredicateLessEqual> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateMatch {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_MATCH;
+}
 impl AstNode for GritPredicateMatch {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9193,6 +9418,9 @@ impl From<GritPredicateMatch> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateMaybe {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_MAYBE;
+}
 impl AstNode for GritPredicateMaybe {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9244,6 +9472,9 @@ impl From<GritPredicateMaybe> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateNot {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_NOT;
+}
 impl AstNode for GritPredicateNot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9291,6 +9522,9 @@ impl From<GritPredicateNot> for SyntaxElement {
     fn from(n: GritPredicateNot) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateNotEqual {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_NOT_EQUAL;
 }
 impl AstNode for GritPredicateNotEqual {
     type Language = Language;
@@ -9343,6 +9577,9 @@ impl From<GritPredicateNotEqual> for SyntaxElement {
     fn from(n: GritPredicateNotEqual) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateOr {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_OR;
 }
 impl AstNode for GritPredicateOr {
     type Language = Language;
@@ -9400,6 +9637,9 @@ impl From<GritPredicateOr> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritPredicateReturn {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_RETURN;
+}
 impl AstNode for GritPredicateReturn {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9450,6 +9690,9 @@ impl From<GritPredicateReturn> for SyntaxElement {
     fn from(n: GritPredicateReturn) -> Self {
         n.syntax.into()
     }
+}
+impl GritPredicateRewrite {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_REWRITE;
 }
 impl AstNode for GritPredicateRewrite {
     type Language = Language;
@@ -9507,6 +9750,9 @@ impl From<GritPredicateRewrite> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritRawBacktickSnippetLiteral {
+    pub const KIND: SyntaxKind = GRIT_RAW_BACKTICK_SNIPPET_LITERAL;
+}
 impl AstNode for GritRawBacktickSnippetLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9556,6 +9802,9 @@ impl From<GritRawBacktickSnippetLiteral> for SyntaxElement {
     fn from(n: GritRawBacktickSnippetLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritRegexLiteral {
+    pub const KIND: SyntaxKind = GRIT_REGEX_LITERAL;
 }
 impl AstNode for GritRegexLiteral {
     type Language = Language;
@@ -9607,6 +9856,9 @@ impl From<GritRegexLiteral> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritRegexPattern {
+    pub const KIND: SyntaxKind = GRIT_REGEX_PATTERN;
+}
 impl AstNode for GritRegexPattern {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9657,6 +9909,9 @@ impl From<GritRegexPattern> for SyntaxElement {
     fn from(n: GritRegexPattern) -> Self {
         n.syntax.into()
     }
+}
+impl GritRegexPatternVariables {
+    pub const KIND: SyntaxKind = GRIT_REGEX_PATTERN_VARIABLES;
 }
 impl AstNode for GritRegexPatternVariables {
     type Language = Language;
@@ -9712,6 +9967,9 @@ impl From<GritRegexPatternVariables> for SyntaxElement {
     fn from(n: GritRegexPatternVariables) -> Self {
         n.syntax.into()
     }
+}
+impl GritRewrite {
+    pub const KIND: SyntaxKind = GRIT_REWRITE;
 }
 impl AstNode for GritRewrite {
     type Language = Language;
@@ -9769,6 +10027,9 @@ impl From<GritRewrite> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritRoot {
+    pub const KIND: SyntaxKind = GRIT_ROOT;
+}
 impl AstNode for GritRoot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9822,6 +10083,9 @@ impl From<GritRoot> for SyntaxElement {
     fn from(n: GritRoot) -> Self {
         n.syntax.into()
     }
+}
+impl GritSequential {
+    pub const KIND: SyntaxKind = GRIT_SEQUENTIAL;
 }
 impl AstNode for GritSequential {
     type Language = Language;
@@ -9882,6 +10146,9 @@ impl From<GritSequential> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritSnippetRegexLiteral {
+    pub const KIND: SyntaxKind = GRIT_SNIPPET_REGEX_LITERAL;
+}
 impl AstNode for GritSnippetRegexLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9932,6 +10199,9 @@ impl From<GritSnippetRegexLiteral> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritSome {
+    pub const KIND: SyntaxKind = GRIT_SOME;
+}
 impl AstNode for GritSome {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -9979,6 +10249,9 @@ impl From<GritSome> for SyntaxElement {
     fn from(n: GritSome) -> Self {
         n.syntax.into()
     }
+}
+impl GritStringLiteral {
+    pub const KIND: SyntaxKind = GRIT_STRING_LITERAL;
 }
 impl AstNode for GritStringLiteral {
     type Language = Language;
@@ -10029,6 +10302,9 @@ impl From<GritStringLiteral> for SyntaxElement {
     fn from(n: GritStringLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritSubOperation {
+    pub const KIND: SyntaxKind = GRIT_SUB_OPERATION;
 }
 impl AstNode for GritSubOperation {
     type Language = Language;
@@ -10082,6 +10358,9 @@ impl From<GritSubOperation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritUndefinedLiteral {
+    pub const KIND: SyntaxKind = GRIT_UNDEFINED_LITERAL;
+}
 impl AstNode for GritUndefinedLiteral {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10131,6 +10410,9 @@ impl From<GritUndefinedLiteral> for SyntaxElement {
     fn from(n: GritUndefinedLiteral) -> Self {
         n.syntax.into()
     }
+}
+impl GritUnderscore {
+    pub const KIND: SyntaxKind = GRIT_UNDERSCORE;
 }
 impl AstNode for GritUnderscore {
     type Language = Language;
@@ -10182,6 +10464,9 @@ impl From<GritUnderscore> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl GritVariable {
+    pub const KIND: SyntaxKind = GRIT_VARIABLE;
+}
 impl AstNode for GritVariable {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -10231,6 +10516,9 @@ impl From<GritVariable> for SyntaxElement {
     fn from(n: GritVariable) -> Self {
         n.syntax.into()
     }
+}
+impl GritVersion {
+    pub const KIND: SyntaxKind = GRIT_VERSION;
 }
 impl AstNode for GritVersion {
     type Language = Language;
@@ -10294,6 +10582,9 @@ impl From<GritVersion> for SyntaxElement {
     fn from(n: GritVersion) -> Self {
         n.syntax.into()
     }
+}
+impl GritWithin {
+    pub const KIND: SyntaxKind = GRIT_WITHIN;
 }
 impl AstNode for GritWithin {
     type Language = Language;
@@ -13084,6 +13375,7 @@ pub struct GritBogus {
     syntax: SyntaxNode,
 }
 impl GritBogus {
+    pub const KIND: SyntaxKind = GRIT_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13140,6 +13432,7 @@ pub struct GritBogusContainer {
     syntax: SyntaxNode,
 }
 impl GritBogusContainer {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_CONTAINER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13196,6 +13489,7 @@ pub struct GritBogusDefinition {
     syntax: SyntaxNode,
 }
 impl GritBogusDefinition {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_DEFINITION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13252,6 +13546,7 @@ pub struct GritBogusLanguageDeclaration {
     syntax: SyntaxNode,
 }
 impl GritBogusLanguageDeclaration {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_LANGUAGE_DECLARATION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13308,6 +13603,7 @@ pub struct GritBogusLanguageFlavorKind {
     syntax: SyntaxNode,
 }
 impl GritBogusLanguageFlavorKind {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_LANGUAGE_FLAVOR_KIND;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13364,6 +13660,7 @@ pub struct GritBogusLanguageName {
     syntax: SyntaxNode,
 }
 impl GritBogusLanguageName {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_LANGUAGE_NAME;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13420,6 +13717,7 @@ pub struct GritBogusLiteral {
     syntax: SyntaxNode,
 }
 impl GritBogusLiteral {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_LITERAL;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13476,6 +13774,7 @@ pub struct GritBogusMapElement {
     syntax: SyntaxNode,
 }
 impl GritBogusMapElement {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_MAP_ELEMENT;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13532,6 +13831,7 @@ pub struct GritBogusNamedArg {
     syntax: SyntaxNode,
 }
 impl GritBogusNamedArg {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_NAMED_ARG;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13588,6 +13888,7 @@ pub struct GritBogusPattern {
     syntax: SyntaxNode,
 }
 impl GritBogusPattern {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_PATTERN;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13644,6 +13945,7 @@ pub struct GritBogusPredicate {
     syntax: SyntaxNode,
 }
 impl GritBogusPredicate {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_PREDICATE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13700,6 +14002,7 @@ pub struct GritBogusVersion {
     syntax: SyntaxNode,
 }
 impl GritBogusVersion {
+    pub const KIND: SyntaxKind = GRIT_BOGUS_VERSION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13757,6 +14060,7 @@ pub struct GritDefinitionList {
     syntax_list: SyntaxList,
 }
 impl GritDefinitionList {
+    pub const KIND: SyntaxKind = GRIT_DEFINITION_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13839,6 +14143,7 @@ pub struct GritLanguageFlavorList {
     syntax_list: SyntaxList,
 }
 impl GritLanguageFlavorList {
+    pub const KIND: SyntaxKind = GRIT_LANGUAGE_FLAVOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -13921,6 +14226,7 @@ pub struct GritListPatternList {
     syntax_list: SyntaxList,
 }
 impl GritListPatternList {
+    pub const KIND: SyntaxKind = GRIT_LIST_PATTERN_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -14003,6 +14309,7 @@ pub struct GritMapElementList {
     syntax_list: SyntaxList,
 }
 impl GritMapElementList {
+    pub const KIND: SyntaxKind = GRIT_MAP_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -14085,6 +14392,7 @@ pub struct GritNamedArgList {
     syntax_list: SyntaxList,
 }
 impl GritNamedArgList {
+    pub const KIND: SyntaxKind = GRIT_NAMED_ARG_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -14167,6 +14475,7 @@ pub struct GritPatternList {
     syntax_list: SyntaxList,
 }
 impl GritPatternList {
+    pub const KIND: SyntaxKind = GRIT_PATTERN_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -14249,6 +14558,7 @@ pub struct GritPredicateList {
     syntax_list: SyntaxList,
 }
 impl GritPredicateList {
+    pub const KIND: SyntaxKind = GRIT_PREDICATE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -14331,6 +14641,7 @@ pub struct GritVariableList {
     syntax_list: SyntaxList,
 }
 impl GritVariableList {
+    pub const KIND: SyntaxKind = GRIT_VARIABLE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_html_syntax/src/generated/nodes.rs
+++ b/crates/biome_html_syntax/src/generated/nodes.rs
@@ -715,6 +715,9 @@ impl AnyHtmlElement {
         }
     }
 }
+impl HtmlAttribute {
+    pub const KIND: SyntaxKind = HTML_ATTRIBUTE;
+}
 impl AstNode for HtmlAttribute {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -766,6 +769,9 @@ impl From<HtmlAttribute> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlAttributeInitializerClause {
+    pub const KIND: SyntaxKind = HTML_ATTRIBUTE_INITIALIZER_CLAUSE;
+}
 impl AstNode for HtmlAttributeInitializerClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -813,6 +819,9 @@ impl From<HtmlAttributeInitializerClause> for SyntaxElement {
     fn from(n: HtmlAttributeInitializerClause) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlAttributeName {
+    pub const KIND: SyntaxKind = HTML_ATTRIBUTE_NAME;
 }
 impl AstNode for HtmlAttributeName {
     type Language = Language;
@@ -863,6 +872,9 @@ impl From<HtmlAttributeName> for SyntaxElement {
     fn from(n: HtmlAttributeName) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlCdataSection {
+    pub const KIND: SyntaxKind = HTML_CDATA_SECTION;
 }
 impl AstNode for HtmlCdataSection {
     type Language = Language;
@@ -921,6 +933,9 @@ impl From<HtmlCdataSection> for SyntaxElement {
     fn from(n: HtmlCdataSection) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlClosingElement {
+    pub const KIND: SyntaxKind = HTML_CLOSING_ELEMENT;
 }
 impl AstNode for HtmlClosingElement {
     type Language = Language;
@@ -981,6 +996,9 @@ impl From<HtmlClosingElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlComment {
+    pub const KIND: SyntaxKind = HTML_COMMENT;
+}
 impl AstNode for HtmlComment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1039,6 +1057,9 @@ impl From<HtmlComment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlContent {
+    pub const KIND: SyntaxKind = HTML_CONTENT;
+}
 impl AstNode for HtmlContent {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1088,6 +1109,9 @@ impl From<HtmlContent> for SyntaxElement {
     fn from(n: HtmlContent) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlDirective {
+    pub const KIND: SyntaxKind = HTML_DIRECTIVE;
 }
 impl AstNode for HtmlDirective {
     type Language = Language;
@@ -1164,6 +1188,9 @@ impl From<HtmlDirective> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlElement {
+    pub const KIND: SyntaxKind = HTML_ELEMENT;
+}
 impl AstNode for HtmlElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1218,6 +1245,9 @@ impl From<HtmlElement> for SyntaxElement {
     fn from(n: HtmlElement) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlOpeningElement {
+    pub const KIND: SyntaxKind = HTML_OPENING_ELEMENT;
 }
 impl AstNode for HtmlOpeningElement {
     type Language = Language;
@@ -1275,6 +1305,9 @@ impl From<HtmlOpeningElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlRoot {
+    pub const KIND: SyntaxKind = HTML_ROOT;
+}
 impl AstNode for HtmlRoot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1330,6 +1363,9 @@ impl From<HtmlRoot> for SyntaxElement {
     fn from(n: HtmlRoot) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlSelfClosingElement {
+    pub const KIND: SyntaxKind = HTML_SELF_CLOSING_ELEMENT;
 }
 impl AstNode for HtmlSelfClosingElement {
     type Language = Language;
@@ -1391,6 +1427,9 @@ impl From<HtmlSelfClosingElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl HtmlString {
+    pub const KIND: SyntaxKind = HTML_STRING;
+}
 impl AstNode for HtmlString {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1440,6 +1479,9 @@ impl From<HtmlString> for SyntaxElement {
     fn from(n: HtmlString) -> Self {
         n.syntax.into()
     }
+}
+impl HtmlTagName {
+    pub const KIND: SyntaxKind = HTML_TAG_NAME;
 }
 impl AstNode for HtmlTagName {
     type Language = Language;
@@ -1750,6 +1792,7 @@ pub struct HtmlBogus {
     syntax: SyntaxNode,
 }
 impl HtmlBogus {
+    pub const KIND: SyntaxKind = HTML_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1806,6 +1849,7 @@ pub struct HtmlBogusAttribute {
     syntax: SyntaxNode,
 }
 impl HtmlBogusAttribute {
+    pub const KIND: SyntaxKind = HTML_BOGUS_ATTRIBUTE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1862,6 +1906,7 @@ pub struct HtmlBogusElement {
     syntax: SyntaxNode,
 }
 impl HtmlBogusElement {
+    pub const KIND: SyntaxKind = HTML_BOGUS_ELEMENT;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1919,6 +1964,7 @@ pub struct HtmlAttributeList {
     syntax_list: SyntaxList,
 }
 impl HtmlAttributeList {
+    pub const KIND: SyntaxKind = HTML_ATTRIBUTE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -2001,6 +2047,7 @@ pub struct HtmlElementList {
     syntax_list: SyntaxList,
 }
 impl HtmlElementList {
+    pub const KIND: SyntaxKind = HTML_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
@@ -8,12 +8,13 @@ use biome_control_flow::{
 };
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
-    JsBlockStatement, JsCaseClause, JsDefaultClause, JsDoWhileStatement, JsForInStatement,
-    JsForOfStatement, JsForStatement, JsFunctionBody, JsIfStatement, JsLabeledStatement,
-    JsLanguage, JsReturnStatement, JsSwitchStatement, JsSyntaxElement, JsSyntaxKind, JsSyntaxNode,
-    JsTryFinallyStatement, JsTryStatement, JsVariableStatement, JsWhileStatement, TextRange,
+    JsBlockStatement, JsBreakStatement, JsCaseClause, JsContinueStatement, JsDefaultClause,
+    JsDoWhileStatement, JsForInStatement, JsForOfStatement, JsForStatement, JsFunctionBody,
+    JsIfStatement, JsLabeledStatement, JsLanguage, JsReturnStatement, JsSwitchStatement,
+    JsSyntaxElement, JsSyntaxKind, JsSyntaxNode, JsTryFinallyStatement, JsTryStatement,
+    JsVariableStatement, JsWhileStatement, TextRange,
 };
-use biome_rowan::{AstNode, NodeOrToken, declare_node_union};
+use biome_rowan::{AstNode, NodeOrToken, declare_node_union, match_ast};
 use roaring::bitmap::RoaringBitmap;
 use rustc_hash::FxHashMap;
 
@@ -540,13 +541,15 @@ fn has_side_effects(inst: &Instruction<JsLanguage>) -> bool {
         return false;
     };
 
-    match node.kind() {
-        JsSyntaxKind::JS_RETURN_STATEMENT => {
-            let node = JsReturnStatement::unwrap_cast(node.clone());
-            node.argument().is_some()
+    match_ast! {
+        match node {
+            JsReturnStatement(node) => {
+                node.argument().is_some()
+            },
+            JsBreakStatement(_) => false,
+            JsContinueStatement(_) => false,
+            _ => !node.kind().is_literal(),
         }
-        JsSyntaxKind::JS_BREAK_STATEMENT | JsSyntaxKind::JS_CONTINUE_STATEMENT => false,
-        kind => !kind.is_literal(),
     }
 }
 

--- a/crates/biome_js_syntax/src/generated/nodes.rs
+++ b/crates/biome_js_syntax/src/generated/nodes.rs
@@ -16424,6 +16424,9 @@ impl AnyTsVariableAnnotation {
         }
     }
 }
+impl JsAccessorModifier {
+    pub const KIND: SyntaxKind = JS_ACCESSOR_MODIFIER;
+}
 impl AstNode for JsAccessorModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16473,6 +16476,9 @@ impl From<JsAccessorModifier> for SyntaxElement {
     fn from(n: JsAccessorModifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrayAssignmentPattern {
+    pub const KIND: SyntaxKind = JS_ARRAY_ASSIGNMENT_PATTERN;
 }
 impl AstNode for JsArrayAssignmentPattern {
     type Language = Language;
@@ -16529,6 +16535,9 @@ impl From<JsArrayAssignmentPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsArrayAssignmentPatternElement {
+    pub const KIND: SyntaxKind = JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT;
+}
 impl AstNode for JsArrayAssignmentPatternElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16576,6 +16585,9 @@ impl From<JsArrayAssignmentPatternElement> for SyntaxElement {
     fn from(n: JsArrayAssignmentPatternElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrayAssignmentPatternRestElement {
+    pub const KIND: SyntaxKind = JS_ARRAY_ASSIGNMENT_PATTERN_REST_ELEMENT;
 }
 impl AstNode for JsArrayAssignmentPatternRestElement {
     type Language = Language;
@@ -16629,6 +16641,9 @@ impl From<JsArrayAssignmentPatternRestElement> for SyntaxElement {
     fn from(n: JsArrayAssignmentPatternRestElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrayBindingPattern {
+    pub const KIND: SyntaxKind = JS_ARRAY_BINDING_PATTERN;
 }
 impl AstNode for JsArrayBindingPattern {
     type Language = Language;
@@ -16685,6 +16700,9 @@ impl From<JsArrayBindingPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsArrayBindingPatternElement {
+    pub const KIND: SyntaxKind = JS_ARRAY_BINDING_PATTERN_ELEMENT;
+}
 impl AstNode for JsArrayBindingPatternElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16732,6 +16750,9 @@ impl From<JsArrayBindingPatternElement> for SyntaxElement {
     fn from(n: JsArrayBindingPatternElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrayBindingPatternRestElement {
+    pub const KIND: SyntaxKind = JS_ARRAY_BINDING_PATTERN_REST_ELEMENT;
 }
 impl AstNode for JsArrayBindingPatternRestElement {
     type Language = Language;
@@ -16783,6 +16804,9 @@ impl From<JsArrayBindingPatternRestElement> for SyntaxElement {
     fn from(n: JsArrayBindingPatternRestElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrayExpression {
+    pub const KIND: SyntaxKind = JS_ARRAY_EXPRESSION;
 }
 impl AstNode for JsArrayExpression {
     type Language = Language;
@@ -16839,6 +16863,9 @@ impl From<JsArrayExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsArrayHole {
+    pub const KIND: SyntaxKind = JS_ARRAY_HOLE;
+}
 impl AstNode for JsArrayHole {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16874,6 +16901,9 @@ impl From<JsArrayHole> for SyntaxElement {
     fn from(n: JsArrayHole) -> Self {
         n.syntax.into()
     }
+}
+impl JsArrowFunctionExpression {
+    pub const KIND: SyntaxKind = JS_ARROW_FUNCTION_EXPRESSION;
 }
 impl AstNode for JsArrowFunctionExpression {
     type Language = Language;
@@ -16939,6 +16969,9 @@ impl From<JsArrowFunctionExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsAssignmentExpression {
+    pub const KIND: SyntaxKind = JS_ASSIGNMENT_EXPRESSION;
+}
 impl AstNode for JsAssignmentExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -16991,6 +17024,9 @@ impl From<JsAssignmentExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsAwaitExpression {
+    pub const KIND: SyntaxKind = JS_AWAIT_EXPRESSION;
+}
 impl AstNode for JsAwaitExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17042,6 +17078,9 @@ impl From<JsAwaitExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsBigintLiteralExpression {
+    pub const KIND: SyntaxKind = JS_BIGINT_LITERAL_EXPRESSION;
+}
 impl AstNode for JsBigintLiteralExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17091,6 +17130,9 @@ impl From<JsBigintLiteralExpression> for SyntaxElement {
     fn from(n: JsBigintLiteralExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsBinaryExpression {
+    pub const KIND: SyntaxKind = JS_BINARY_EXPRESSION;
 }
 impl AstNode for JsBinaryExpression {
     type Language = Language;
@@ -17143,6 +17185,9 @@ impl From<JsBinaryExpression> for SyntaxElement {
     fn from(n: JsBinaryExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsBlockStatement {
+    pub const KIND: SyntaxKind = JS_BLOCK_STATEMENT;
 }
 impl AstNode for JsBlockStatement {
     type Language = Language;
@@ -17199,6 +17244,9 @@ impl From<JsBlockStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsBooleanLiteralExpression {
+    pub const KIND: SyntaxKind = JS_BOOLEAN_LITERAL_EXPRESSION;
+}
 impl AstNode for JsBooleanLiteralExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17248,6 +17296,9 @@ impl From<JsBooleanLiteralExpression> for SyntaxElement {
     fn from(n: JsBooleanLiteralExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsBreakStatement {
+    pub const KIND: SyntaxKind = JS_BREAK_STATEMENT;
 }
 impl AstNode for JsBreakStatement {
     type Language = Language;
@@ -17304,6 +17355,9 @@ impl From<JsBreakStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsCallArguments {
+    pub const KIND: SyntaxKind = JS_CALL_ARGUMENTS;
+}
 impl AstNode for JsCallArguments {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17358,6 +17412,9 @@ impl From<JsCallArguments> for SyntaxElement {
     fn from(n: JsCallArguments) -> Self {
         n.syntax.into()
     }
+}
+impl JsCallExpression {
+    pub const KIND: SyntaxKind = JS_CALL_EXPRESSION;
 }
 impl AstNode for JsCallExpression {
     type Language = Language;
@@ -17415,6 +17472,9 @@ impl From<JsCallExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsCaseClause {
+    pub const KIND: SyntaxKind = JS_CASE_CLAUSE;
+}
 impl AstNode for JsCaseClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17467,6 +17527,9 @@ impl From<JsCaseClause> for SyntaxElement {
     fn from(n: JsCaseClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsCatchClause {
+    pub const KIND: SyntaxKind = JS_CATCH_CLAUSE;
 }
 impl AstNode for JsCatchClause {
     type Language = Language;
@@ -17522,6 +17585,9 @@ impl From<JsCatchClause> for SyntaxElement {
     fn from(n: JsCatchClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsCatchDeclaration {
+    pub const KIND: SyntaxKind = JS_CATCH_DECLARATION;
 }
 impl AstNode for JsCatchDeclaration {
     type Language = Language;
@@ -17581,6 +17647,9 @@ impl From<JsCatchDeclaration> for SyntaxElement {
     fn from(n: JsCatchDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl JsClassDeclaration {
+    pub const KIND: SyntaxKind = JS_CLASS_DECLARATION;
 }
 impl AstNode for JsClassDeclaration {
     type Language = Language;
@@ -17659,6 +17728,9 @@ impl From<JsClassDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsClassExportDefaultDeclaration {
+    pub const KIND: SyntaxKind = JS_CLASS_EXPORT_DEFAULT_DECLARATION;
+}
 impl AstNode for JsClassExportDefaultDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17736,6 +17808,9 @@ impl From<JsClassExportDefaultDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsClassExpression {
+    pub const KIND: SyntaxKind = JS_CLASS_EXPRESSION;
+}
 impl AstNode for JsClassExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17809,6 +17884,9 @@ impl From<JsClassExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsComputedMemberAssignment {
+    pub const KIND: SyntaxKind = JS_COMPUTED_MEMBER_ASSIGNMENT;
+}
 impl AstNode for JsComputedMemberAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17864,6 +17942,9 @@ impl From<JsComputedMemberAssignment> for SyntaxElement {
     fn from(n: JsComputedMemberAssignment) -> Self {
         n.syntax.into()
     }
+}
+impl JsComputedMemberExpression {
+    pub const KIND: SyntaxKind = JS_COMPUTED_MEMBER_EXPRESSION;
 }
 impl AstNode for JsComputedMemberExpression {
     type Language = Language;
@@ -17925,6 +18006,9 @@ impl From<JsComputedMemberExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsComputedMemberName {
+    pub const KIND: SyntaxKind = JS_COMPUTED_MEMBER_NAME;
+}
 impl AstNode for JsComputedMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -17979,6 +18063,9 @@ impl From<JsComputedMemberName> for SyntaxElement {
     fn from(n: JsComputedMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl JsConditionalExpression {
+    pub const KIND: SyntaxKind = JS_CONDITIONAL_EXPRESSION;
 }
 impl AstNode for JsConditionalExpression {
     type Language = Language;
@@ -18037,6 +18124,9 @@ impl From<JsConditionalExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsConstructorClassMember {
+    pub const KIND: SyntaxKind = JS_CONSTRUCTOR_CLASS_MEMBER;
+}
 impl AstNode for JsConstructorClassMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18086,6 +18176,9 @@ impl From<JsConstructorClassMember> for SyntaxElement {
     fn from(n: JsConstructorClassMember) -> Self {
         n.syntax.into()
     }
+}
+impl JsConstructorParameters {
+    pub const KIND: SyntaxKind = JS_CONSTRUCTOR_PARAMETERS;
 }
 impl AstNode for JsConstructorParameters {
     type Language = Language;
@@ -18142,6 +18235,9 @@ impl From<JsConstructorParameters> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsContinueStatement {
+    pub const KIND: SyntaxKind = JS_CONTINUE_STATEMENT;
+}
 impl AstNode for JsContinueStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18197,6 +18293,9 @@ impl From<JsContinueStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsDebuggerStatement {
+    pub const KIND: SyntaxKind = JS_DEBUGGER_STATEMENT;
+}
 impl AstNode for JsDebuggerStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18251,6 +18350,9 @@ impl From<JsDebuggerStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsDecorator {
+    pub const KIND: SyntaxKind = JS_DECORATOR;
+}
 impl AstNode for JsDecorator {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18298,6 +18400,9 @@ impl From<JsDecorator> for SyntaxElement {
     fn from(n: JsDecorator) -> Self {
         n.syntax.into()
     }
+}
+impl JsDefaultClause {
+    pub const KIND: SyntaxKind = JS_DEFAULT_CLAUSE;
 }
 impl AstNode for JsDefaultClause {
     type Language = Language;
@@ -18354,6 +18459,9 @@ impl From<JsDefaultClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsDefaultImportSpecifier {
+    pub const KIND: SyntaxKind = JS_DEFAULT_IMPORT_SPECIFIER;
+}
 impl AstNode for JsDefaultImportSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18400,6 +18508,9 @@ impl From<JsDefaultImportSpecifier> for SyntaxElement {
     fn from(n: JsDefaultImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsDirective {
+    pub const KIND: SyntaxKind = JS_DIRECTIVE;
 }
 impl AstNode for JsDirective {
     type Language = Language;
@@ -18454,6 +18565,9 @@ impl From<JsDirective> for SyntaxElement {
     fn from(n: JsDirective) -> Self {
         n.syntax.into()
     }
+}
+impl JsDoWhileStatement {
+    pub const KIND: SyntaxKind = JS_DO_WHILE_STATEMENT;
 }
 impl AstNode for JsDoWhileStatement {
     type Language = Language;
@@ -18520,6 +18634,9 @@ impl From<JsDoWhileStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsElseClause {
+    pub const KIND: SyntaxKind = JS_ELSE_CLAUSE;
+}
 impl AstNode for JsElseClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18567,6 +18684,9 @@ impl From<JsElseClause> for SyntaxElement {
     fn from(n: JsElseClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsEmptyClassMember {
+    pub const KIND: SyntaxKind = JS_EMPTY_CLASS_MEMBER;
 }
 impl AstNode for JsEmptyClassMember {
     type Language = Language;
@@ -18618,6 +18738,9 @@ impl From<JsEmptyClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsEmptyStatement {
+    pub const KIND: SyntaxKind = JS_EMPTY_STATEMENT;
+}
 impl AstNode for JsEmptyStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18667,6 +18790,9 @@ impl From<JsEmptyStatement> for SyntaxElement {
     fn from(n: JsEmptyStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsExport {
+    pub const KIND: SyntaxKind = JS_EXPORT;
 }
 impl AstNode for JsExport {
     type Language = Language;
@@ -18723,6 +18849,9 @@ impl From<JsExport> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExportAsClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_AS_CLAUSE;
+}
 impl AstNode for JsExportAsClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18773,6 +18902,9 @@ impl From<JsExportAsClause> for SyntaxElement {
     fn from(n: JsExportAsClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsExportDefaultDeclarationClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_DEFAULT_DECLARATION_CLAUSE;
 }
 impl AstNode for JsExportDefaultDeclarationClause {
     type Language = Language;
@@ -18832,6 +18964,9 @@ impl From<JsExportDefaultDeclarationClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExportDefaultExpressionClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_DEFAULT_EXPRESSION_CLAUSE;
+}
 impl AstNode for JsExportDefaultExpressionClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -18886,6 +19021,9 @@ impl From<JsExportDefaultExpressionClause> for SyntaxElement {
     fn from(n: JsExportDefaultExpressionClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsExportFromClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_FROM_CLAUSE;
 }
 impl AstNode for JsExportFromClause {
     type Language = Language;
@@ -18952,6 +19090,9 @@ impl From<JsExportFromClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExportNamedClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_CLAUSE;
+}
 impl AstNode for JsExportNamedClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19014,6 +19155,9 @@ impl From<JsExportNamedClause> for SyntaxElement {
     fn from(n: JsExportNamedClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsExportNamedFromClause {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_FROM_CLAUSE;
 }
 impl AstNode for JsExportNamedFromClause {
     type Language = Language;
@@ -19084,6 +19228,9 @@ impl From<JsExportNamedFromClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExportNamedFromSpecifier {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_FROM_SPECIFIER;
+}
 impl AstNode for JsExportNamedFromSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19142,6 +19289,9 @@ impl From<JsExportNamedFromSpecifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExportNamedShorthandSpecifier {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_SHORTHAND_SPECIFIER;
+}
 impl AstNode for JsExportNamedShorthandSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19192,6 +19342,9 @@ impl From<JsExportNamedShorthandSpecifier> for SyntaxElement {
     fn from(n: JsExportNamedShorthandSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsExportNamedSpecifier {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_SPECIFIER;
 }
 impl AstNode for JsExportNamedSpecifier {
     type Language = Language;
@@ -19249,6 +19402,9 @@ impl From<JsExportNamedSpecifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsExpressionSnipped {
+    pub const KIND: SyntaxKind = JS_EXPRESSION_SNIPPED;
+}
 impl AstNode for JsExpressionSnipped {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19296,6 +19452,9 @@ impl From<JsExpressionSnipped> for SyntaxElement {
     fn from(n: JsExpressionSnipped) -> Self {
         n.syntax.into()
     }
+}
+impl JsExpressionStatement {
+    pub const KIND: SyntaxKind = JS_EXPRESSION_STATEMENT;
 }
 impl AstNode for JsExpressionStatement {
     type Language = Language;
@@ -19347,6 +19506,9 @@ impl From<JsExpressionStatement> for SyntaxElement {
     fn from(n: JsExpressionStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsExtendsClause {
+    pub const KIND: SyntaxKind = JS_EXTENDS_CLAUSE;
 }
 impl AstNode for JsExtendsClause {
     type Language = Language;
@@ -19406,6 +19568,9 @@ impl From<JsExtendsClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsFinallyClause {
+    pub const KIND: SyntaxKind = JS_FINALLY_CLAUSE;
+}
 impl AstNode for JsFinallyClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19456,6 +19621,9 @@ impl From<JsFinallyClause> for SyntaxElement {
     fn from(n: JsFinallyClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsForInStatement {
+    pub const KIND: SyntaxKind = JS_FOR_IN_STATEMENT;
 }
 impl AstNode for JsForInStatement {
     type Language = Language;
@@ -19518,6 +19686,9 @@ impl From<JsForInStatement> for SyntaxElement {
     fn from(n: JsForInStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsForOfStatement {
+    pub const KIND: SyntaxKind = JS_FOR_OF_STATEMENT;
 }
 impl AstNode for JsForOfStatement {
     type Language = Language;
@@ -19584,6 +19755,9 @@ impl From<JsForOfStatement> for SyntaxElement {
     fn from(n: JsForOfStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsForStatement {
+    pub const KIND: SyntaxKind = JS_FOR_STATEMENT;
 }
 impl AstNode for JsForStatement {
     type Language = Language;
@@ -19655,6 +19829,9 @@ impl From<JsForStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsForVariableDeclaration {
+    pub const KIND: SyntaxKind = JS_FOR_VARIABLE_DECLARATION;
+}
 impl AstNode for JsForVariableDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19706,6 +19883,9 @@ impl From<JsForVariableDeclaration> for SyntaxElement {
     fn from(n: JsForVariableDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl JsFormalParameter {
+    pub const KIND: SyntaxKind = JS_FORMAL_PARAMETER;
 }
 impl AstNode for JsFormalParameter {
     type Language = Language;
@@ -19767,6 +19947,9 @@ impl From<JsFormalParameter> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsFunctionBody {
+    pub const KIND: SyntaxKind = JS_FUNCTION_BODY;
+}
 impl AstNode for JsFunctionBody {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -19822,6 +20005,9 @@ impl From<JsFunctionBody> for SyntaxElement {
     fn from(n: JsFunctionBody) -> Self {
         n.syntax.into()
     }
+}
+impl JsFunctionDeclaration {
+    pub const KIND: SyntaxKind = JS_FUNCTION_DECLARATION;
 }
 impl AstNode for JsFunctionDeclaration {
     type Language = Language;
@@ -19891,6 +20077,9 @@ impl From<JsFunctionDeclaration> for SyntaxElement {
     fn from(n: JsFunctionDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl JsFunctionExportDefaultDeclaration {
+    pub const KIND: SyntaxKind = JS_FUNCTION_EXPORT_DEFAULT_DECLARATION;
 }
 impl AstNode for JsFunctionExportDefaultDeclaration {
     type Language = Language;
@@ -19962,6 +20151,9 @@ impl From<JsFunctionExportDefaultDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsFunctionExpression {
+    pub const KIND: SyntaxKind = JS_FUNCTION_EXPRESSION;
+}
 impl AstNode for JsFunctionExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20031,6 +20223,9 @@ impl From<JsFunctionExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsGetterClassMember {
+    pub const KIND: SyntaxKind = JS_GETTER_CLASS_MEMBER;
+}
 impl AstNode for JsGetterClassMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20093,6 +20288,9 @@ impl From<JsGetterClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsGetterObjectMember {
+    pub const KIND: SyntaxKind = JS_GETTER_OBJECT_MEMBER;
+}
 impl AstNode for JsGetterObjectMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20154,6 +20352,9 @@ impl From<JsGetterObjectMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsIdentifierAssignment {
+    pub const KIND: SyntaxKind = JS_IDENTIFIER_ASSIGNMENT;
+}
 impl AstNode for JsIdentifierAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20200,6 +20401,9 @@ impl From<JsIdentifierAssignment> for SyntaxElement {
     fn from(n: JsIdentifierAssignment) -> Self {
         n.syntax.into()
     }
+}
+impl JsIdentifierBinding {
+    pub const KIND: SyntaxKind = JS_IDENTIFIER_BINDING;
 }
 impl AstNode for JsIdentifierBinding {
     type Language = Language;
@@ -20248,6 +20452,9 @@ impl From<JsIdentifierBinding> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsIdentifierExpression {
+    pub const KIND: SyntaxKind = JS_IDENTIFIER_EXPRESSION;
+}
 impl AstNode for JsIdentifierExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20294,6 +20501,9 @@ impl From<JsIdentifierExpression> for SyntaxElement {
     fn from(n: JsIdentifierExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsIfStatement {
+    pub const KIND: SyntaxKind = JS_IF_STATEMENT;
 }
 impl AstNode for JsIfStatement {
     type Language = Language;
@@ -20356,6 +20566,9 @@ impl From<JsIfStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImport {
+    pub const KIND: SyntaxKind = JS_IMPORT;
+}
 impl AstNode for JsImport {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20414,6 +20627,9 @@ impl From<JsImport> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportAssertion {
+    pub const KIND: SyntaxKind = JS_IMPORT_ASSERTION;
+}
 impl AstNode for JsImportAssertion {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20470,6 +20686,9 @@ impl From<JsImportAssertion> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportAssertionEntry {
+    pub const KIND: SyntaxKind = JS_IMPORT_ASSERTION_ENTRY;
+}
 impl AstNode for JsImportAssertionEntry {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20525,6 +20744,9 @@ impl From<JsImportAssertionEntry> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportBareClause {
+    pub const KIND: SyntaxKind = JS_IMPORT_BARE_CLAUSE;
+}
 impl AstNode for JsImportBareClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20576,6 +20798,9 @@ impl From<JsImportBareClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportCallExpression {
+    pub const KIND: SyntaxKind = JS_IMPORT_CALL_EXPRESSION;
+}
 impl AstNode for JsImportCallExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20626,6 +20851,9 @@ impl From<JsImportCallExpression> for SyntaxElement {
     fn from(n: JsImportCallExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsImportCombinedClause {
+    pub const KIND: SyntaxKind = JS_IMPORT_COMBINED_CLAUSE;
 }
 impl AstNode for JsImportCombinedClause {
     type Language = Language;
@@ -20688,6 +20916,9 @@ impl From<JsImportCombinedClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportDefaultClause {
+    pub const KIND: SyntaxKind = JS_IMPORT_DEFAULT_CLAUSE;
+}
 impl AstNode for JsImportDefaultClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20748,6 +20979,9 @@ impl From<JsImportDefaultClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportMetaExpression {
+    pub const KIND: SyntaxKind = JS_IMPORT_META_EXPRESSION;
+}
 impl AstNode for JsImportMetaExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20799,6 +21033,9 @@ impl From<JsImportMetaExpression> for SyntaxElement {
     fn from(n: JsImportMetaExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsImportNamedClause {
+    pub const KIND: SyntaxKind = JS_IMPORT_NAMED_CLAUSE;
 }
 impl AstNode for JsImportNamedClause {
     type Language = Language;
@@ -20860,6 +21097,9 @@ impl From<JsImportNamedClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsImportNamespaceClause {
+    pub const KIND: SyntaxKind = JS_IMPORT_NAMESPACE_CLAUSE;
+}
 impl AstNode for JsImportNamespaceClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20920,6 +21160,9 @@ impl From<JsImportNamespaceClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsInExpression {
+    pub const KIND: SyntaxKind = JS_IN_EXPRESSION;
+}
 impl AstNode for JsInExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -20969,6 +21212,9 @@ impl From<JsInExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsInitializerClause {
+    pub const KIND: SyntaxKind = JS_INITIALIZER_CLAUSE;
+}
 impl AstNode for JsInitializerClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21016,6 +21262,9 @@ impl From<JsInitializerClause> for SyntaxElement {
     fn from(n: JsInitializerClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsInstanceofExpression {
+    pub const KIND: SyntaxKind = JS_INSTANCEOF_EXPRESSION;
 }
 impl AstNode for JsInstanceofExpression {
     type Language = Language;
@@ -21069,6 +21318,9 @@ impl From<JsInstanceofExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsLabel {
+    pub const KIND: SyntaxKind = JS_LABEL;
+}
 impl AstNode for JsLabel {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21118,6 +21370,9 @@ impl From<JsLabel> for SyntaxElement {
     fn from(n: JsLabel) -> Self {
         n.syntax.into()
     }
+}
+impl JsLabeledStatement {
+    pub const KIND: SyntaxKind = JS_LABELED_STATEMENT;
 }
 impl AstNode for JsLabeledStatement {
     type Language = Language;
@@ -21171,6 +21426,9 @@ impl From<JsLabeledStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsLiteralExportName {
+    pub const KIND: SyntaxKind = JS_LITERAL_EXPORT_NAME;
+}
 impl AstNode for JsLiteralExportName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21218,6 +21476,9 @@ impl From<JsLiteralExportName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsLiteralMemberName {
+    pub const KIND: SyntaxKind = JS_LITERAL_MEMBER_NAME;
+}
 impl AstNode for JsLiteralMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21264,6 +21525,9 @@ impl From<JsLiteralMemberName> for SyntaxElement {
     fn from(n: JsLiteralMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl JsLogicalExpression {
+    pub const KIND: SyntaxKind = JS_LOGICAL_EXPRESSION;
 }
 impl AstNode for JsLogicalExpression {
     type Language = Language;
@@ -21317,6 +21581,9 @@ impl From<JsLogicalExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsMetavariable {
+    pub const KIND: SyntaxKind = JS_METAVARIABLE;
+}
 impl AstNode for JsMetavariable {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21366,6 +21633,9 @@ impl From<JsMetavariable> for SyntaxElement {
     fn from(n: JsMetavariable) -> Self {
         n.syntax.into()
     }
+}
+impl JsMethodClassMember {
+    pub const KIND: SyntaxKind = JS_METHOD_CLASS_MEMBER;
 }
 impl AstNode for JsMethodClassMember {
     type Language = Language;
@@ -21437,6 +21707,9 @@ impl From<JsMethodClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsMethodObjectMember {
+    pub const KIND: SyntaxKind = JS_METHOD_OBJECT_MEMBER;
+}
 impl AstNode for JsMethodObjectMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21502,6 +21775,9 @@ impl From<JsMethodObjectMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsModule {
+    pub const KIND: SyntaxKind = JS_MODULE;
+}
 impl AstNode for JsModule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21559,6 +21835,9 @@ impl From<JsModule> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsModuleSource {
+    pub const KIND: SyntaxKind = JS_MODULE_SOURCE;
+}
 impl AstNode for JsModuleSource {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21609,6 +21888,9 @@ impl From<JsModuleSource> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsName {
+    pub const KIND: SyntaxKind = JS_NAME;
+}
 impl AstNode for JsName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21658,6 +21940,9 @@ impl From<JsName> for SyntaxElement {
     fn from(n: JsName) -> Self {
         n.syntax.into()
     }
+}
+impl JsNamedImportSpecifier {
+    pub const KIND: SyntaxKind = JS_NAMED_IMPORT_SPECIFIER;
 }
 impl AstNode for JsNamedImportSpecifier {
     type Language = Language;
@@ -21711,6 +21996,9 @@ impl From<JsNamedImportSpecifier> for SyntaxElement {
     fn from(n: JsNamedImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsNamedImportSpecifiers {
+    pub const KIND: SyntaxKind = JS_NAMED_IMPORT_SPECIFIERS;
 }
 impl AstNode for JsNamedImportSpecifiers {
     type Language = Language;
@@ -21767,6 +22055,9 @@ impl From<JsNamedImportSpecifiers> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsNamespaceImportSpecifier {
+    pub const KIND: SyntaxKind = JS_NAMESPACE_IMPORT_SPECIFIER;
+}
 impl AstNode for JsNamespaceImportSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21815,6 +22106,9 @@ impl From<JsNamespaceImportSpecifier> for SyntaxElement {
     fn from(n: JsNamespaceImportSpecifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsNewExpression {
+    pub const KIND: SyntaxKind = JS_NEW_EXPRESSION;
 }
 impl AstNode for JsNewExpression {
     type Language = Language;
@@ -21872,6 +22166,9 @@ impl From<JsNewExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsNewTargetExpression {
+    pub const KIND: SyntaxKind = JS_NEW_TARGET_EXPRESSION;
+}
 impl AstNode for JsNewTargetExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21924,6 +22221,9 @@ impl From<JsNewTargetExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsNullLiteralExpression {
+    pub const KIND: SyntaxKind = JS_NULL_LITERAL_EXPRESSION;
+}
 impl AstNode for JsNullLiteralExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -21974,6 +22274,9 @@ impl From<JsNullLiteralExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsNumberLiteralExpression {
+    pub const KIND: SyntaxKind = JS_NUMBER_LITERAL_EXPRESSION;
+}
 impl AstNode for JsNumberLiteralExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22023,6 +22326,9 @@ impl From<JsNumberLiteralExpression> for SyntaxElement {
     fn from(n: JsNumberLiteralExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsObjectAssignmentPattern {
+    pub const KIND: SyntaxKind = JS_OBJECT_ASSIGNMENT_PATTERN;
 }
 impl AstNode for JsObjectAssignmentPattern {
     type Language = Language;
@@ -22079,6 +22385,9 @@ impl From<JsObjectAssignmentPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectAssignmentPatternProperty {
+    pub const KIND: SyntaxKind = JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY;
+}
 impl AstNode for JsObjectAssignmentPatternProperty {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22132,6 +22441,9 @@ impl From<JsObjectAssignmentPatternProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectAssignmentPatternRest {
+    pub const KIND: SyntaxKind = JS_OBJECT_ASSIGNMENT_PATTERN_REST;
+}
 impl AstNode for JsObjectAssignmentPatternRest {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22183,6 +22495,9 @@ impl From<JsObjectAssignmentPatternRest> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectAssignmentPatternShorthandProperty {
+    pub const KIND: SyntaxKind = JS_OBJECT_ASSIGNMENT_PATTERN_SHORTHAND_PROPERTY;
+}
 impl AstNode for JsObjectAssignmentPatternShorthandProperty {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
@@ -22232,6 +22547,9 @@ impl From<JsObjectAssignmentPatternShorthandProperty> for SyntaxElement {
     fn from(n: JsObjectAssignmentPatternShorthandProperty) -> Self {
         n.syntax.into()
     }
+}
+impl JsObjectBindingPattern {
+    pub const KIND: SyntaxKind = JS_OBJECT_BINDING_PATTERN;
 }
 impl AstNode for JsObjectBindingPattern {
     type Language = Language;
@@ -22288,6 +22606,9 @@ impl From<JsObjectBindingPattern> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectBindingPatternProperty {
+    pub const KIND: SyntaxKind = JS_OBJECT_BINDING_PATTERN_PROPERTY;
+}
 impl AstNode for JsObjectBindingPatternProperty {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22341,6 +22662,9 @@ impl From<JsObjectBindingPatternProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectBindingPatternRest {
+    pub const KIND: SyntaxKind = JS_OBJECT_BINDING_PATTERN_REST;
+}
 impl AstNode for JsObjectBindingPatternRest {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22392,6 +22716,9 @@ impl From<JsObjectBindingPatternRest> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsObjectBindingPatternShorthandProperty {
+    pub const KIND: SyntaxKind = JS_OBJECT_BINDING_PATTERN_SHORTHAND_PROPERTY;
+}
 impl AstNode for JsObjectBindingPatternShorthandProperty {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
@@ -22441,6 +22768,9 @@ impl From<JsObjectBindingPatternShorthandProperty> for SyntaxElement {
     fn from(n: JsObjectBindingPatternShorthandProperty) -> Self {
         n.syntax.into()
     }
+}
+impl JsObjectExpression {
+    pub const KIND: SyntaxKind = JS_OBJECT_EXPRESSION;
 }
 impl AstNode for JsObjectExpression {
     type Language = Language;
@@ -22497,6 +22827,9 @@ impl From<JsObjectExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsParameters {
+    pub const KIND: SyntaxKind = JS_PARAMETERS;
+}
 impl AstNode for JsParameters {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22551,6 +22884,9 @@ impl From<JsParameters> for SyntaxElement {
     fn from(n: JsParameters) -> Self {
         n.syntax.into()
     }
+}
+impl JsParenthesizedAssignment {
+    pub const KIND: SyntaxKind = JS_PARENTHESIZED_ASSIGNMENT;
 }
 impl AstNode for JsParenthesizedAssignment {
     type Language = Language;
@@ -22607,6 +22943,9 @@ impl From<JsParenthesizedAssignment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsParenthesizedExpression {
+    pub const KIND: SyntaxKind = JS_PARENTHESIZED_EXPRESSION;
+}
 impl AstNode for JsParenthesizedExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22662,6 +23001,9 @@ impl From<JsParenthesizedExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsPostUpdateExpression {
+    pub const KIND: SyntaxKind = JS_POST_UPDATE_EXPRESSION;
+}
 impl AstNode for JsPostUpdateExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22712,6 +23054,9 @@ impl From<JsPostUpdateExpression> for SyntaxElement {
     fn from(n: JsPostUpdateExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsPreUpdateExpression {
+    pub const KIND: SyntaxKind = JS_PRE_UPDATE_EXPRESSION;
 }
 impl AstNode for JsPreUpdateExpression {
     type Language = Language;
@@ -22764,6 +23109,9 @@ impl From<JsPreUpdateExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsPrivateClassMemberName {
+    pub const KIND: SyntaxKind = JS_PRIVATE_CLASS_MEMBER_NAME;
+}
 impl AstNode for JsPrivateClassMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22811,6 +23159,9 @@ impl From<JsPrivateClassMemberName> for SyntaxElement {
     fn from(n: JsPrivateClassMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl JsPrivateName {
+    pub const KIND: SyntaxKind = JS_PRIVATE_NAME;
 }
 impl AstNode for JsPrivateName {
     type Language = Language;
@@ -22862,6 +23213,9 @@ impl From<JsPrivateName> for SyntaxElement {
     fn from(n: JsPrivateName) -> Self {
         n.syntax.into()
     }
+}
+impl JsPropertyClassMember {
+    pub const KIND: SyntaxKind = JS_PROPERTY_CLASS_MEMBER;
 }
 impl AstNode for JsPropertyClassMember {
     type Language = Language;
@@ -22920,6 +23274,9 @@ impl From<JsPropertyClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsPropertyObjectMember {
+    pub const KIND: SyntaxKind = JS_PROPERTY_OBJECT_MEMBER;
+}
 impl AstNode for JsPropertyObjectMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -22972,6 +23329,9 @@ impl From<JsPropertyObjectMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsReferenceIdentifier {
+    pub const KIND: SyntaxKind = JS_REFERENCE_IDENTIFIER;
+}
 impl AstNode for JsReferenceIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23022,6 +23382,9 @@ impl From<JsReferenceIdentifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsRegexLiteralExpression {
+    pub const KIND: SyntaxKind = JS_REGEX_LITERAL_EXPRESSION;
+}
 impl AstNode for JsRegexLiteralExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23071,6 +23434,9 @@ impl From<JsRegexLiteralExpression> for SyntaxElement {
     fn from(n: JsRegexLiteralExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsRestParameter {
+    pub const KIND: SyntaxKind = JS_REST_PARAMETER;
 }
 impl AstNode for JsRestParameter {
     type Language = Language;
@@ -23128,6 +23494,9 @@ impl From<JsRestParameter> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsReturnStatement {
+    pub const KIND: SyntaxKind = JS_RETURN_STATEMENT;
+}
 impl AstNode for JsReturnStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23182,6 +23551,9 @@ impl From<JsReturnStatement> for SyntaxElement {
     fn from(n: JsReturnStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsScript {
+    pub const KIND: SyntaxKind = JS_SCRIPT;
 }
 impl AstNode for JsScript {
     type Language = Language;
@@ -23240,6 +23612,9 @@ impl From<JsScript> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsSequenceExpression {
+    pub const KIND: SyntaxKind = JS_SEQUENCE_EXPRESSION;
+}
 impl AstNode for JsSequenceExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23291,6 +23666,9 @@ impl From<JsSequenceExpression> for SyntaxElement {
     fn from(n: JsSequenceExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsSetterClassMember {
+    pub const KIND: SyntaxKind = JS_SETTER_CLASS_MEMBER;
 }
 impl AstNode for JsSetterClassMember {
     type Language = Language;
@@ -23355,6 +23733,9 @@ impl From<JsSetterClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsSetterObjectMember {
+    pub const KIND: SyntaxKind = JS_SETTER_OBJECT_MEMBER;
+}
 impl AstNode for JsSetterObjectMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23417,6 +23798,9 @@ impl From<JsSetterObjectMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsShorthandNamedImportSpecifier {
+    pub const KIND: SyntaxKind = JS_SHORTHAND_NAMED_IMPORT_SPECIFIER;
+}
 impl AstNode for JsShorthandNamedImportSpecifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23468,6 +23852,9 @@ impl From<JsShorthandNamedImportSpecifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsShorthandPropertyObjectMember {
+    pub const KIND: SyntaxKind = JS_SHORTHAND_PROPERTY_OBJECT_MEMBER;
+}
 impl AstNode for JsShorthandPropertyObjectMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23514,6 +23901,9 @@ impl From<JsShorthandPropertyObjectMember> for SyntaxElement {
     fn from(n: JsShorthandPropertyObjectMember) -> Self {
         n.syntax.into()
     }
+}
+impl JsSpread {
+    pub const KIND: SyntaxKind = JS_SPREAD;
 }
 impl AstNode for JsSpread {
     type Language = Language;
@@ -23565,6 +23955,9 @@ impl From<JsSpread> for SyntaxElement {
     fn from(n: JsSpread) -> Self {
         n.syntax.into()
     }
+}
+impl JsStaticInitializationBlockClassMember {
+    pub const KIND: SyntaxKind = JS_STATIC_INITIALIZATION_BLOCK_CLASS_MEMBER;
 }
 impl AstNode for JsStaticInitializationBlockClassMember {
     type Language = Language;
@@ -23627,6 +24020,9 @@ impl From<JsStaticInitializationBlockClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsStaticMemberAssignment {
+    pub const KIND: SyntaxKind = JS_STATIC_MEMBER_ASSIGNMENT;
+}
 impl AstNode for JsStaticMemberAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23675,6 +24071,9 @@ impl From<JsStaticMemberAssignment> for SyntaxElement {
     fn from(n: JsStaticMemberAssignment) -> Self {
         n.syntax.into()
     }
+}
+impl JsStaticMemberExpression {
+    pub const KIND: SyntaxKind = JS_STATIC_MEMBER_EXPRESSION;
 }
 impl AstNode for JsStaticMemberExpression {
     type Language = Language;
@@ -23728,6 +24127,9 @@ impl From<JsStaticMemberExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsStaticModifier {
+    pub const KIND: SyntaxKind = JS_STATIC_MODIFIER;
+}
 impl AstNode for JsStaticModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23777,6 +24179,9 @@ impl From<JsStaticModifier> for SyntaxElement {
     fn from(n: JsStaticModifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsStringLiteralExpression {
+    pub const KIND: SyntaxKind = JS_STRING_LITERAL_EXPRESSION;
 }
 impl AstNode for JsStringLiteralExpression {
     type Language = Language;
@@ -23828,6 +24233,9 @@ impl From<JsStringLiteralExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsSuperExpression {
+    pub const KIND: SyntaxKind = JS_SUPER_EXPRESSION;
+}
 impl AstNode for JsSuperExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23877,6 +24285,9 @@ impl From<JsSuperExpression> for SyntaxElement {
     fn from(n: JsSuperExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsSwitchStatement {
+    pub const KIND: SyntaxKind = JS_SWITCH_STATEMENT;
 }
 impl AstNode for JsSwitchStatement {
     type Language = Language;
@@ -23949,6 +24360,9 @@ impl From<JsSwitchStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsTemplateChunkElement {
+    pub const KIND: SyntaxKind = JS_TEMPLATE_CHUNK_ELEMENT;
+}
 impl AstNode for JsTemplateChunkElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -23998,6 +24412,9 @@ impl From<JsTemplateChunkElement> for SyntaxElement {
     fn from(n: JsTemplateChunkElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsTemplateElement {
+    pub const KIND: SyntaxKind = JS_TEMPLATE_ELEMENT;
 }
 impl AstNode for JsTemplateElement {
     type Language = Language;
@@ -24053,6 +24470,9 @@ impl From<JsTemplateElement> for SyntaxElement {
     fn from(n: JsTemplateElement) -> Self {
         n.syntax.into()
     }
+}
+impl JsTemplateExpression {
+    pub const KIND: SyntaxKind = JS_TEMPLATE_EXPRESSION;
 }
 impl AstNode for JsTemplateExpression {
     type Language = Language;
@@ -24114,6 +24534,9 @@ impl From<JsTemplateExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsThisExpression {
+    pub const KIND: SyntaxKind = JS_THIS_EXPRESSION;
+}
 impl AstNode for JsThisExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24160,6 +24583,9 @@ impl From<JsThisExpression> for SyntaxElement {
     fn from(n: JsThisExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsThrowStatement {
+    pub const KIND: SyntaxKind = JS_THROW_STATEMENT;
 }
 impl AstNode for JsThrowStatement {
     type Language = Language;
@@ -24215,6 +24641,9 @@ impl From<JsThrowStatement> for SyntaxElement {
     fn from(n: JsThrowStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsTryFinallyStatement {
+    pub const KIND: SyntaxKind = JS_TRY_FINALLY_STATEMENT;
 }
 impl AstNode for JsTryFinallyStatement {
     type Language = Language;
@@ -24272,6 +24701,9 @@ impl From<JsTryFinallyStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsTryStatement {
+    pub const KIND: SyntaxKind = JS_TRY_STATEMENT;
+}
 impl AstNode for JsTryStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24324,6 +24756,9 @@ impl From<JsTryStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsUnaryExpression {
+    pub const KIND: SyntaxKind = JS_UNARY_EXPRESSION;
+}
 impl AstNode for JsUnaryExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24374,6 +24809,9 @@ impl From<JsUnaryExpression> for SyntaxElement {
     fn from(n: JsUnaryExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsVariableDeclaration {
+    pub const KIND: SyntaxKind = JS_VARIABLE_DECLARATION;
 }
 impl AstNode for JsVariableDeclaration {
     type Language = Language;
@@ -24426,6 +24864,9 @@ impl From<JsVariableDeclaration> for SyntaxElement {
     fn from(n: JsVariableDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl JsVariableDeclarationClause {
+    pub const KIND: SyntaxKind = JS_VARIABLE_DECLARATION_CLAUSE;
 }
 impl AstNode for JsVariableDeclarationClause {
     type Language = Language;
@@ -24480,6 +24921,9 @@ impl From<JsVariableDeclarationClause> for SyntaxElement {
     fn from(n: JsVariableDeclarationClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsVariableDeclarator {
+    pub const KIND: SyntaxKind = JS_VARIABLE_DECLARATOR;
 }
 impl AstNode for JsVariableDeclarator {
     type Language = Language;
@@ -24536,6 +24980,9 @@ impl From<JsVariableDeclarator> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsVariableStatement {
+    pub const KIND: SyntaxKind = JS_VARIABLE_STATEMENT;
+}
 impl AstNode for JsVariableStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24589,6 +25036,9 @@ impl From<JsVariableStatement> for SyntaxElement {
     fn from(n: JsVariableStatement) -> Self {
         n.syntax.into()
     }
+}
+impl JsWhileStatement {
+    pub const KIND: SyntaxKind = JS_WHILE_STATEMENT;
 }
 impl AstNode for JsWhileStatement {
     type Language = Language;
@@ -24650,6 +25100,9 @@ impl From<JsWhileStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsWithStatement {
+    pub const KIND: SyntaxKind = JS_WITH_STATEMENT;
+}
 impl AstNode for JsWithStatement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24707,6 +25160,9 @@ impl From<JsWithStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsYieldArgument {
+    pub const KIND: SyntaxKind = JS_YIELD_ARGUMENT;
+}
 impl AstNode for JsYieldArgument {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24757,6 +25213,9 @@ impl From<JsYieldArgument> for SyntaxElement {
     fn from(n: JsYieldArgument) -> Self {
         n.syntax.into()
     }
+}
+impl JsYieldExpression {
+    pub const KIND: SyntaxKind = JS_YIELD_EXPRESSION;
 }
 impl AstNode for JsYieldExpression {
     type Language = Language;
@@ -24809,6 +25268,9 @@ impl From<JsYieldExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxAttribute {
+    pub const KIND: SyntaxKind = JSX_ATTRIBUTE;
+}
 impl AstNode for JsxAttribute {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24860,6 +25322,9 @@ impl From<JsxAttribute> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxAttributeInitializerClause {
+    pub const KIND: SyntaxKind = JSX_ATTRIBUTE_INITIALIZER_CLAUSE;
+}
 impl AstNode for JsxAttributeInitializerClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -24907,6 +25372,9 @@ impl From<JsxAttributeInitializerClause> for SyntaxElement {
     fn from(n: JsxAttributeInitializerClause) -> Self {
         n.syntax.into()
     }
+}
+impl JsxClosingElement {
+    pub const KIND: SyntaxKind = JSX_CLOSING_ELEMENT;
 }
 impl AstNode for JsxClosingElement {
     type Language = Language;
@@ -24967,6 +25435,9 @@ impl From<JsxClosingElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxClosingFragment {
+    pub const KIND: SyntaxKind = JSX_CLOSING_FRAGMENT;
+}
 impl AstNode for JsxClosingFragment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25025,6 +25496,9 @@ impl From<JsxClosingFragment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxElement {
+    pub const KIND: SyntaxKind = JSX_ELEMENT;
+}
 impl AstNode for JsxElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25080,6 +25554,9 @@ impl From<JsxElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxExpressionAttributeValue {
+    pub const KIND: SyntaxKind = JSX_EXPRESSION_ATTRIBUTE_VALUE;
+}
 impl AstNode for JsxExpressionAttributeValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25134,6 +25611,9 @@ impl From<JsxExpressionAttributeValue> for SyntaxElement {
     fn from(n: JsxExpressionAttributeValue) -> Self {
         n.syntax.into()
     }
+}
+impl JsxExpressionChild {
+    pub const KIND: SyntaxKind = JSX_EXPRESSION_CHILD;
 }
 impl AstNode for JsxExpressionChild {
     type Language = Language;
@@ -25193,6 +25673,9 @@ impl From<JsxExpressionChild> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxFragment {
+    pub const KIND: SyntaxKind = JSX_FRAGMENT;
+}
 impl AstNode for JsxFragment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25248,6 +25731,9 @@ impl From<JsxFragment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxMemberName {
+    pub const KIND: SyntaxKind = JSX_MEMBER_NAME;
+}
 impl AstNode for JsxMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25296,6 +25782,9 @@ impl From<JsxMemberName> for SyntaxElement {
     fn from(n: JsxMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl JsxName {
+    pub const KIND: SyntaxKind = JSX_NAME;
 }
 impl AstNode for JsxName {
     type Language = Language;
@@ -25346,6 +25835,9 @@ impl From<JsxName> for SyntaxElement {
     fn from(n: JsxName) -> Self {
         n.syntax.into()
     }
+}
+impl JsxNamespaceName {
+    pub const KIND: SyntaxKind = JSX_NAMESPACE_NAME;
 }
 impl AstNode for JsxNamespaceName {
     type Language = Language;
@@ -25398,6 +25890,9 @@ impl From<JsxNamespaceName> for SyntaxElement {
     fn from(n: JsxNamespaceName) -> Self {
         n.syntax.into()
     }
+}
+impl JsxOpeningElement {
+    pub const KIND: SyntaxKind = JSX_OPENING_ELEMENT;
 }
 impl AstNode for JsxOpeningElement {
     type Language = Language;
@@ -25459,6 +25954,9 @@ impl From<JsxOpeningElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxOpeningFragment {
+    pub const KIND: SyntaxKind = JSX_OPENING_FRAGMENT;
+}
 impl AstNode for JsxOpeningFragment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25513,6 +26011,9 @@ impl From<JsxOpeningFragment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxReferenceIdentifier {
+    pub const KIND: SyntaxKind = JSX_REFERENCE_IDENTIFIER;
+}
 impl AstNode for JsxReferenceIdentifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25562,6 +26063,9 @@ impl From<JsxReferenceIdentifier> for SyntaxElement {
     fn from(n: JsxReferenceIdentifier) -> Self {
         n.syntax.into()
     }
+}
+impl JsxSelfClosingElement {
+    pub const KIND: SyntaxKind = JSX_SELF_CLOSING_ELEMENT;
 }
 impl AstNode for JsxSelfClosingElement {
     type Language = Language;
@@ -25627,6 +26131,9 @@ impl From<JsxSelfClosingElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxSpreadAttribute {
+    pub const KIND: SyntaxKind = JSX_SPREAD_ATTRIBUTE;
+}
 impl AstNode for JsxSpreadAttribute {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25685,6 +26192,9 @@ impl From<JsxSpreadAttribute> for SyntaxElement {
     fn from(n: JsxSpreadAttribute) -> Self {
         n.syntax.into()
     }
+}
+impl JsxSpreadChild {
+    pub const KIND: SyntaxKind = JSX_SPREAD_CHILD;
 }
 impl AstNode for JsxSpreadChild {
     type Language = Language;
@@ -25745,6 +26255,9 @@ impl From<JsxSpreadChild> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxString {
+    pub const KIND: SyntaxKind = JSX_STRING;
+}
 impl AstNode for JsxString {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25795,6 +26308,9 @@ impl From<JsxString> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsxTagExpression {
+    pub const KIND: SyntaxKind = JSX_TAG_EXPRESSION;
+}
 impl AstNode for JsxTagExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25841,6 +26357,9 @@ impl From<JsxTagExpression> for SyntaxElement {
     fn from(n: JsxTagExpression) -> Self {
         n.syntax.into()
     }
+}
+impl JsxText {
+    pub const KIND: SyntaxKind = JSX_TEXT;
 }
 impl AstNode for JsxText {
     type Language = Language;
@@ -25892,6 +26411,9 @@ impl From<JsxText> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsAbstractModifier {
+    pub const KIND: SyntaxKind = TS_ABSTRACT_MODIFIER;
+}
 impl AstNode for TsAbstractModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -25941,6 +26463,9 @@ impl From<TsAbstractModifier> for SyntaxElement {
     fn from(n: TsAbstractModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsAccessibilityModifier {
+    pub const KIND: SyntaxKind = TS_ACCESSIBILITY_MODIFIER;
 }
 impl AstNode for TsAccessibilityModifier {
     type Language = Language;
@@ -25992,6 +26517,9 @@ impl From<TsAccessibilityModifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsAnyType {
+    pub const KIND: SyntaxKind = TS_ANY_TYPE;
+}
 impl AstNode for TsAnyType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26038,6 +26566,9 @@ impl From<TsAnyType> for SyntaxElement {
     fn from(n: TsAnyType) -> Self {
         n.syntax.into()
     }
+}
+impl TsArrayType {
+    pub const KIND: SyntaxKind = TS_ARRAY_TYPE;
 }
 impl AstNode for TsArrayType {
     type Language = Language;
@@ -26097,6 +26628,9 @@ impl From<TsArrayType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsAsAssignment {
+    pub const KIND: SyntaxKind = TS_AS_ASSIGNMENT;
+}
 impl AstNode for TsAsAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26145,6 +26679,9 @@ impl From<TsAsAssignment> for SyntaxElement {
     fn from(n: TsAsAssignment) -> Self {
         n.syntax.into()
     }
+}
+impl TsAsExpression {
+    pub const KIND: SyntaxKind = TS_AS_EXPRESSION;
 }
 impl AstNode for TsAsExpression {
     type Language = Language;
@@ -26195,6 +26732,9 @@ impl From<TsAsExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsAssertsCondition {
+    pub const KIND: SyntaxKind = TS_ASSERTS_CONDITION;
+}
 impl AstNode for TsAssertsCondition {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26242,6 +26782,9 @@ impl From<TsAssertsCondition> for SyntaxElement {
     fn from(n: TsAssertsCondition) -> Self {
         n.syntax.into()
     }
+}
+impl TsAssertsReturnType {
+    pub const KIND: SyntaxKind = TS_ASSERTS_RETURN_TYPE;
 }
 impl AstNode for TsAssertsReturnType {
     type Language = Language;
@@ -26301,6 +26844,9 @@ impl From<TsAssertsReturnType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsBigintLiteralType {
+    pub const KIND: SyntaxKind = TS_BIGINT_LITERAL_TYPE;
+}
 impl AstNode for TsBigintLiteralType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26355,6 +26901,9 @@ impl From<TsBigintLiteralType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsBigintType {
+    pub const KIND: SyntaxKind = TS_BIGINT_TYPE;
+}
 impl AstNode for TsBigintType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26405,6 +26954,9 @@ impl From<TsBigintType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsBooleanLiteralType {
+    pub const KIND: SyntaxKind = TS_BOOLEAN_LITERAL_TYPE;
+}
 impl AstNode for TsBooleanLiteralType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26451,6 +27003,9 @@ impl From<TsBooleanLiteralType> for SyntaxElement {
     fn from(n: TsBooleanLiteralType) -> Self {
         n.syntax.into()
     }
+}
+impl TsBooleanType {
+    pub const KIND: SyntaxKind = TS_BOOLEAN_TYPE;
 }
 impl AstNode for TsBooleanType {
     type Language = Language;
@@ -26501,6 +27056,9 @@ impl From<TsBooleanType> for SyntaxElement {
     fn from(n: TsBooleanType) -> Self {
         n.syntax.into()
     }
+}
+impl TsCallSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_CALL_SIGNATURE_TYPE_MEMBER;
 }
 impl AstNode for TsCallSignatureTypeMember {
     type Language = Language;
@@ -26560,6 +27118,9 @@ impl From<TsCallSignatureTypeMember> for SyntaxElement {
     fn from(n: TsCallSignatureTypeMember) -> Self {
         n.syntax.into()
     }
+}
+impl TsConditionalType {
+    pub const KIND: SyntaxKind = TS_CONDITIONAL_TYPE;
 }
 impl AstNode for TsConditionalType {
     type Language = Language;
@@ -26626,6 +27187,9 @@ impl From<TsConditionalType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsConstModifier {
+    pub const KIND: SyntaxKind = TS_CONST_MODIFIER;
+}
 impl AstNode for TsConstModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26675,6 +27239,9 @@ impl From<TsConstModifier> for SyntaxElement {
     fn from(n: TsConstModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsConstructSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_CONSTRUCT_SIGNATURE_TYPE_MEMBER;
 }
 impl AstNode for TsConstructSignatureTypeMember {
     type Language = Language;
@@ -26736,6 +27303,9 @@ impl From<TsConstructSignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsConstructorSignatureClassMember {
+    pub const KIND: SyntaxKind = TS_CONSTRUCTOR_SIGNATURE_CLASS_MEMBER;
+}
 impl AstNode for TsConstructorSignatureClassMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26788,6 +27358,9 @@ impl From<TsConstructorSignatureClassMember> for SyntaxElement {
     fn from(n: TsConstructorSignatureClassMember) -> Self {
         n.syntax.into()
     }
+}
+impl TsConstructorType {
+    pub const KIND: SyntaxKind = TS_CONSTRUCTOR_TYPE;
 }
 impl AstNode for TsConstructorType {
     type Language = Language;
@@ -26853,6 +27426,9 @@ impl From<TsConstructorType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsDeclarationModule {
+    pub const KIND: SyntaxKind = TS_DECLARATION_MODULE;
+}
 impl AstNode for TsDeclarationModule {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -26909,6 +27485,9 @@ impl From<TsDeclarationModule> for SyntaxElement {
     fn from(n: TsDeclarationModule) -> Self {
         n.syntax.into()
     }
+}
+impl TsDeclareFunctionDeclaration {
+    pub const KIND: SyntaxKind = TS_DECLARE_FUNCTION_DECLARATION;
 }
 impl AstNode for TsDeclareFunctionDeclaration {
     type Language = Language;
@@ -26977,6 +27556,9 @@ impl From<TsDeclareFunctionDeclaration> for SyntaxElement {
     fn from(n: TsDeclareFunctionDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl TsDeclareFunctionExportDefaultDeclaration {
+    pub const KIND: SyntaxKind = TS_DECLARE_FUNCTION_EXPORT_DEFAULT_DECLARATION;
 }
 impl AstNode for TsDeclareFunctionExportDefaultDeclaration {
     type Language = Language;
@@ -27048,6 +27630,9 @@ impl From<TsDeclareFunctionExportDefaultDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsDeclareModifier {
+    pub const KIND: SyntaxKind = TS_DECLARE_MODIFIER;
+}
 impl AstNode for TsDeclareModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27097,6 +27682,9 @@ impl From<TsDeclareModifier> for SyntaxElement {
     fn from(n: TsDeclareModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsDeclareStatement {
+    pub const KIND: SyntaxKind = TS_DECLARE_STATEMENT;
 }
 impl AstNode for TsDeclareStatement {
     type Language = Language;
@@ -27152,6 +27740,9 @@ impl From<TsDeclareStatement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsDefaultTypeClause {
+    pub const KIND: SyntaxKind = TS_DEFAULT_TYPE_CLAUSE;
+}
 impl AstNode for TsDefaultTypeClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27199,6 +27790,9 @@ impl From<TsDefaultTypeClause> for SyntaxElement {
     fn from(n: TsDefaultTypeClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsDefinitePropertyAnnotation {
+    pub const KIND: SyntaxKind = TS_DEFINITE_PROPERTY_ANNOTATION;
 }
 impl AstNode for TsDefinitePropertyAnnotation {
     type Language = Language;
@@ -27251,6 +27845,9 @@ impl From<TsDefinitePropertyAnnotation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsDefiniteVariableAnnotation {
+    pub const KIND: SyntaxKind = TS_DEFINITE_VARIABLE_ANNOTATION;
+}
 impl AstNode for TsDefiniteVariableAnnotation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27301,6 +27898,9 @@ impl From<TsDefiniteVariableAnnotation> for SyntaxElement {
     fn from(n: TsDefiniteVariableAnnotation) -> Self {
         n.syntax.into()
     }
+}
+impl TsEmptyExternalModuleDeclarationBody {
+    pub const KIND: SyntaxKind = TS_EMPTY_EXTERNAL_MODULE_DECLARATION_BODY;
 }
 impl AstNode for TsEmptyExternalModuleDeclarationBody {
     type Language = Language;
@@ -27353,6 +27953,9 @@ impl From<TsEmptyExternalModuleDeclarationBody> for SyntaxElement {
     fn from(n: TsEmptyExternalModuleDeclarationBody) -> Self {
         n.syntax.into()
     }
+}
+impl TsEnumDeclaration {
+    pub const KIND: SyntaxKind = TS_ENUM_DECLARATION;
 }
 impl AstNode for TsEnumDeclaration {
     type Language = Language;
@@ -27415,6 +28018,9 @@ impl From<TsEnumDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsEnumMember {
+    pub const KIND: SyntaxKind = TS_ENUM_MEMBER;
+}
 impl AstNode for TsEnumMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27465,6 +28071,9 @@ impl From<TsEnumMember> for SyntaxElement {
     fn from(n: TsEnumMember) -> Self {
         n.syntax.into()
     }
+}
+impl TsExportAsNamespaceClause {
+    pub const KIND: SyntaxKind = TS_EXPORT_AS_NAMESPACE_CLAUSE;
 }
 impl AstNode for TsExportAsNamespaceClause {
     type Language = Language;
@@ -27522,6 +28131,9 @@ impl From<TsExportAsNamespaceClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsExportAssignmentClause {
+    pub const KIND: SyntaxKind = TS_EXPORT_ASSIGNMENT_CLAUSE;
+}
 impl AstNode for TsExportAssignmentClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27573,6 +28185,9 @@ impl From<TsExportAssignmentClause> for SyntaxElement {
     fn from(n: TsExportAssignmentClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsExportDeclareClause {
+    pub const KIND: SyntaxKind = TS_EXPORT_DECLARE_CLAUSE;
 }
 impl AstNode for TsExportDeclareClause {
     type Language = Language;
@@ -27628,6 +28243,9 @@ impl From<TsExportDeclareClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsExtendsClause {
+    pub const KIND: SyntaxKind = TS_EXTENDS_CLAUSE;
+}
 impl AstNode for TsExtendsClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27678,6 +28296,9 @@ impl From<TsExtendsClause> for SyntaxElement {
     fn from(n: TsExtendsClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsExternalModuleDeclaration {
+    pub const KIND: SyntaxKind = TS_EXTERNAL_MODULE_DECLARATION;
 }
 impl AstNode for TsExternalModuleDeclaration {
     type Language = Language;
@@ -27730,6 +28351,9 @@ impl From<TsExternalModuleDeclaration> for SyntaxElement {
     fn from(n: TsExternalModuleDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl TsExternalModuleReference {
+    pub const KIND: SyntaxKind = TS_EXTERNAL_MODULE_REFERENCE;
 }
 impl AstNode for TsExternalModuleReference {
     type Language = Language;
@@ -27790,6 +28414,9 @@ impl From<TsExternalModuleReference> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsFunctionType {
+    pub const KIND: SyntaxKind = TS_FUNCTION_TYPE;
+}
 impl AstNode for TsFunctionType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27848,6 +28475,9 @@ impl From<TsFunctionType> for SyntaxElement {
     fn from(n: TsFunctionType) -> Self {
         n.syntax.into()
     }
+}
+impl TsGetterSignatureClassMember {
+    pub const KIND: SyntaxKind = TS_GETTER_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsGetterSignatureClassMember {
     type Language = Language;
@@ -27914,6 +28544,9 @@ impl From<TsGetterSignatureClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsGetterSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_GETTER_SIGNATURE_TYPE_MEMBER;
+}
 impl AstNode for TsGetterSignatureTypeMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -27978,6 +28611,9 @@ impl From<TsGetterSignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsGlobalDeclaration {
+    pub const KIND: SyntaxKind = TS_GLOBAL_DECLARATION;
+}
 impl AstNode for TsGlobalDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28029,6 +28665,9 @@ impl From<TsGlobalDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsIdentifierBinding {
+    pub const KIND: SyntaxKind = TS_IDENTIFIER_BINDING;
+}
 impl AstNode for TsIdentifierBinding {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28075,6 +28714,9 @@ impl From<TsIdentifierBinding> for SyntaxElement {
     fn from(n: TsIdentifierBinding) -> Self {
         n.syntax.into()
     }
+}
+impl TsImplementsClause {
+    pub const KIND: SyntaxKind = TS_IMPLEMENTS_CLAUSE;
 }
 impl AstNode for TsImplementsClause {
     type Language = Language;
@@ -28126,6 +28768,9 @@ impl From<TsImplementsClause> for SyntaxElement {
     fn from(n: TsImplementsClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsImportEqualsDeclaration {
+    pub const KIND: SyntaxKind = TS_IMPORT_EQUALS_DECLARATION;
 }
 impl AstNode for TsImportEqualsDeclaration {
     type Language = Language;
@@ -28191,6 +28836,9 @@ impl From<TsImportEqualsDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsImportType {
+    pub const KIND: SyntaxKind = TS_IMPORT_TYPE;
+}
 impl AstNode for TsImportType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28253,6 +28901,9 @@ impl From<TsImportType> for SyntaxElement {
     fn from(n: TsImportType) -> Self {
         n.syntax.into()
     }
+}
+impl TsImportTypeArguments {
+    pub const KIND: SyntaxKind = TS_IMPORT_TYPE_ARGUMENTS;
 }
 impl AstNode for TsImportTypeArguments {
     type Language = Language;
@@ -28317,6 +28968,9 @@ impl From<TsImportTypeArguments> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsImportTypeAssertion {
+    pub const KIND: SyntaxKind = TS_IMPORT_TYPE_ASSERTION;
+}
 impl AstNode for TsImportTypeAssertion {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28377,6 +29031,9 @@ impl From<TsImportTypeAssertion> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsImportTypeAssertionBlock {
+    pub const KIND: SyntaxKind = TS_IMPORT_TYPE_ASSERTION_BLOCK;
+}
 impl AstNode for TsImportTypeAssertionBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28435,6 +29092,9 @@ impl From<TsImportTypeAssertionBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsImportTypeQualifier {
+    pub const KIND: SyntaxKind = TS_IMPORT_TYPE_QUALIFIER;
+}
 impl AstNode for TsImportTypeQualifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28482,6 +29142,9 @@ impl From<TsImportTypeQualifier> for SyntaxElement {
     fn from(n: TsImportTypeQualifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsInModifier {
+    pub const KIND: SyntaxKind = TS_IN_MODIFIER;
 }
 impl AstNode for TsInModifier {
     type Language = Language;
@@ -28532,6 +29195,9 @@ impl From<TsInModifier> for SyntaxElement {
     fn from(n: TsInModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsIndexSignatureClassMember {
+    pub const KIND: SyntaxKind = TS_INDEX_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsIndexSignatureClassMember {
     type Language = Language;
@@ -28597,6 +29263,9 @@ impl From<TsIndexSignatureClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsIndexSignatureParameter {
+    pub const KIND: SyntaxKind = TS_INDEX_SIGNATURE_PARAMETER;
+}
 impl AstNode for TsIndexSignatureParameter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28647,6 +29316,9 @@ impl From<TsIndexSignatureParameter> for SyntaxElement {
     fn from(n: TsIndexSignatureParameter) -> Self {
         n.syntax.into()
     }
+}
+impl TsIndexSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_INDEX_SIGNATURE_TYPE_MEMBER;
 }
 impl AstNode for TsIndexSignatureTypeMember {
     type Language = Language;
@@ -28715,6 +29387,9 @@ impl From<TsIndexSignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsIndexedAccessType {
+    pub const KIND: SyntaxKind = TS_INDEXED_ACCESS_TYPE;
+}
 impl AstNode for TsIndexedAccessType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28774,6 +29449,9 @@ impl From<TsIndexedAccessType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsInferType {
+    pub const KIND: SyntaxKind = TS_INFER_TYPE;
+}
 impl AstNode for TsInferType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28828,6 +29506,9 @@ impl From<TsInferType> for SyntaxElement {
     fn from(n: TsInferType) -> Self {
         n.syntax.into()
     }
+}
+impl TsInitializedPropertySignatureClassMember {
+    pub const KIND: SyntaxKind = TS_INITIALIZED_PROPERTY_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsInitializedPropertySignatureClassMember {
     type Language = Language;
@@ -28888,6 +29569,9 @@ impl From<TsInitializedPropertySignatureClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsInstantiationExpression {
+    pub const KIND: SyntaxKind = TS_INSTANTIATION_EXPRESSION;
+}
 impl AstNode for TsInstantiationExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -28935,6 +29619,9 @@ impl From<TsInstantiationExpression> for SyntaxElement {
     fn from(n: TsInstantiationExpression) -> Self {
         n.syntax.into()
     }
+}
+impl TsInterfaceDeclaration {
+    pub const KIND: SyntaxKind = TS_INTERFACE_DECLARATION;
 }
 impl AstNode for TsInterfaceDeclaration {
     type Language = Language;
@@ -29004,6 +29691,9 @@ impl From<TsInterfaceDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsIntersectionType {
+    pub const KIND: SyntaxKind = TS_INTERSECTION_TYPE;
+}
 impl AstNode for TsIntersectionType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29055,6 +29745,9 @@ impl From<TsIntersectionType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsLiteralEnumMemberName {
+    pub const KIND: SyntaxKind = TS_LITERAL_ENUM_MEMBER_NAME;
+}
 impl AstNode for TsLiteralEnumMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29101,6 +29794,9 @@ impl From<TsLiteralEnumMemberName> for SyntaxElement {
     fn from(n: TsLiteralEnumMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl TsMappedType {
+    pub const KIND: SyntaxKind = TS_MAPPED_TYPE;
 }
 impl AstNode for TsMappedType {
     type Language = Language;
@@ -29190,6 +29886,9 @@ impl From<TsMappedType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsMappedTypeAsClause {
+    pub const KIND: SyntaxKind = TS_MAPPED_TYPE_AS_CLAUSE;
+}
 impl AstNode for TsMappedTypeAsClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29237,6 +29936,9 @@ impl From<TsMappedTypeAsClause> for SyntaxElement {
     fn from(n: TsMappedTypeAsClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsMappedTypeOptionalModifierClause {
+    pub const KIND: SyntaxKind = TS_MAPPED_TYPE_OPTIONAL_MODIFIER_CLAUSE;
 }
 impl AstNode for TsMappedTypeOptionalModifierClause {
     type Language = Language;
@@ -29294,6 +29996,9 @@ impl From<TsMappedTypeOptionalModifierClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsMappedTypeReadonlyModifierClause {
+    pub const KIND: SyntaxKind = TS_MAPPED_TYPE_READONLY_MODIFIER_CLAUSE;
+}
 impl AstNode for TsMappedTypeReadonlyModifierClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> = SyntaxKindSet::from_raw(RawSyntaxKind(
@@ -29349,6 +30054,9 @@ impl From<TsMappedTypeReadonlyModifierClause> for SyntaxElement {
     fn from(n: TsMappedTypeReadonlyModifierClause) -> Self {
         n.syntax.into()
     }
+}
+impl TsMethodSignatureClassMember {
+    pub const KIND: SyntaxKind = TS_METHOD_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsMethodSignatureClassMember {
     type Language = Language;
@@ -29419,6 +30127,9 @@ impl From<TsMethodSignatureClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsMethodSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_METHOD_SIGNATURE_TYPE_MEMBER;
+}
 impl AstNode for TsMethodSignatureTypeMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29483,6 +30194,9 @@ impl From<TsMethodSignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsModuleBlock {
+    pub const KIND: SyntaxKind = TS_MODULE_BLOCK;
+}
 impl AstNode for TsModuleBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29538,6 +30252,9 @@ impl From<TsModuleBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsModuleDeclaration {
+    pub const KIND: SyntaxKind = TS_MODULE_DECLARATION;
+}
 impl AstNode for TsModuleDeclaration {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29589,6 +30306,9 @@ impl From<TsModuleDeclaration> for SyntaxElement {
     fn from(n: TsModuleDeclaration) -> Self {
         n.syntax.into()
     }
+}
+impl TsNamedTupleTypeElement {
+    pub const KIND: SyntaxKind = TS_NAMED_TUPLE_TYPE_ELEMENT;
 }
 impl AstNode for TsNamedTupleTypeElement {
     type Language = Language;
@@ -29650,6 +30370,9 @@ impl From<TsNamedTupleTypeElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsNeverType {
+    pub const KIND: SyntaxKind = TS_NEVER_TYPE;
+}
 impl AstNode for TsNeverType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29700,6 +30423,9 @@ impl From<TsNeverType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsNonNullAssertionAssignment {
+    pub const KIND: SyntaxKind = TS_NON_NULL_ASSERTION_ASSIGNMENT;
+}
 impl AstNode for TsNonNullAssertionAssignment {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29748,6 +30474,9 @@ impl From<TsNonNullAssertionAssignment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsNonNullAssertionExpression {
+    pub const KIND: SyntaxKind = TS_NON_NULL_ASSERTION_EXPRESSION;
+}
 impl AstNode for TsNonNullAssertionExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29795,6 +30524,9 @@ impl From<TsNonNullAssertionExpression> for SyntaxElement {
     fn from(n: TsNonNullAssertionExpression) -> Self {
         n.syntax.into()
     }
+}
+impl TsNonPrimitiveType {
+    pub const KIND: SyntaxKind = TS_NON_PRIMITIVE_TYPE;
 }
 impl AstNode for TsNonPrimitiveType {
     type Language = Language;
@@ -29846,6 +30578,9 @@ impl From<TsNonPrimitiveType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsNullLiteralType {
+    pub const KIND: SyntaxKind = TS_NULL_LITERAL_TYPE;
+}
 impl AstNode for TsNullLiteralType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29895,6 +30630,9 @@ impl From<TsNullLiteralType> for SyntaxElement {
     fn from(n: TsNullLiteralType) -> Self {
         n.syntax.into()
     }
+}
+impl TsNumberLiteralType {
+    pub const KIND: SyntaxKind = TS_NUMBER_LITERAL_TYPE;
 }
 impl AstNode for TsNumberLiteralType {
     type Language = Language;
@@ -29950,6 +30688,9 @@ impl From<TsNumberLiteralType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsNumberType {
+    pub const KIND: SyntaxKind = TS_NUMBER_TYPE;
+}
 impl AstNode for TsNumberType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -29999,6 +30740,9 @@ impl From<TsNumberType> for SyntaxElement {
     fn from(n: TsNumberType) -> Self {
         n.syntax.into()
     }
+}
+impl TsObjectType {
+    pub const KIND: SyntaxKind = TS_OBJECT_TYPE;
 }
 impl AstNode for TsObjectType {
     type Language = Language;
@@ -30055,6 +30799,9 @@ impl From<TsObjectType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsOptionalPropertyAnnotation {
+    pub const KIND: SyntaxKind = TS_OPTIONAL_PROPERTY_ANNOTATION;
+}
 impl AstNode for TsOptionalPropertyAnnotation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30109,6 +30856,9 @@ impl From<TsOptionalPropertyAnnotation> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsOptionalTupleTypeElement {
+    pub const KIND: SyntaxKind = TS_OPTIONAL_TUPLE_TYPE_ELEMENT;
+}
 impl AstNode for TsOptionalTupleTypeElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30160,6 +30910,9 @@ impl From<TsOptionalTupleTypeElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsOutModifier {
+    pub const KIND: SyntaxKind = TS_OUT_MODIFIER;
+}
 impl AstNode for TsOutModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30210,6 +30963,9 @@ impl From<TsOutModifier> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsOverrideModifier {
+    pub const KIND: SyntaxKind = TS_OVERRIDE_MODIFIER;
+}
 impl AstNode for TsOverrideModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30259,6 +31015,9 @@ impl From<TsOverrideModifier> for SyntaxElement {
     fn from(n: TsOverrideModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsParenthesizedType {
+    pub const KIND: SyntaxKind = TS_PARENTHESIZED_TYPE;
 }
 impl AstNode for TsParenthesizedType {
     type Language = Language;
@@ -30315,6 +31074,9 @@ impl From<TsParenthesizedType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsPredicateReturnType {
+    pub const KIND: SyntaxKind = TS_PREDICATE_RETURN_TYPE;
+}
 impl AstNode for TsPredicateReturnType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30367,6 +31129,9 @@ impl From<TsPredicateReturnType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsPropertyParameter {
+    pub const KIND: SyntaxKind = TS_PROPERTY_PARAMETER;
+}
 impl AstNode for TsPropertyParameter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30418,6 +31183,9 @@ impl From<TsPropertyParameter> for SyntaxElement {
     fn from(n: TsPropertyParameter) -> Self {
         n.syntax.into()
     }
+}
+impl TsPropertySignatureClassMember {
+    pub const KIND: SyntaxKind = TS_PROPERTY_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsPropertySignatureClassMember {
     type Language = Language;
@@ -30474,6 +31242,9 @@ impl From<TsPropertySignatureClassMember> for SyntaxElement {
     fn from(n: TsPropertySignatureClassMember) -> Self {
         n.syntax.into()
     }
+}
+impl TsPropertySignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_PROPERTY_SIGNATURE_TYPE_MEMBER;
 }
 impl AstNode for TsPropertySignatureTypeMember {
     type Language = Language;
@@ -30538,6 +31309,9 @@ impl From<TsPropertySignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsQualifiedModuleName {
+    pub const KIND: SyntaxKind = TS_QUALIFIED_MODULE_NAME;
+}
 impl AstNode for TsQualifiedModuleName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30586,6 +31360,9 @@ impl From<TsQualifiedModuleName> for SyntaxElement {
     fn from(n: TsQualifiedModuleName) -> Self {
         n.syntax.into()
     }
+}
+impl TsQualifiedName {
+    pub const KIND: SyntaxKind = TS_QUALIFIED_NAME;
 }
 impl AstNode for TsQualifiedName {
     type Language = Language;
@@ -30636,6 +31413,9 @@ impl From<TsQualifiedName> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsReadonlyModifier {
+    pub const KIND: SyntaxKind = TS_READONLY_MODIFIER;
+}
 impl AstNode for TsReadonlyModifier {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30685,6 +31465,9 @@ impl From<TsReadonlyModifier> for SyntaxElement {
     fn from(n: TsReadonlyModifier) -> Self {
         n.syntax.into()
     }
+}
+impl TsReferenceType {
+    pub const KIND: SyntaxKind = TS_REFERENCE_TYPE;
 }
 impl AstNode for TsReferenceType {
     type Language = Language;
@@ -30737,6 +31520,9 @@ impl From<TsReferenceType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsRestTupleTypeElement {
+    pub const KIND: SyntaxKind = TS_REST_TUPLE_TYPE_ELEMENT;
+}
 impl AstNode for TsRestTupleTypeElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30788,6 +31574,9 @@ impl From<TsRestTupleTypeElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsReturnTypeAnnotation {
+    pub const KIND: SyntaxKind = TS_RETURN_TYPE_ANNOTATION;
+}
 impl AstNode for TsReturnTypeAnnotation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30838,6 +31627,9 @@ impl From<TsReturnTypeAnnotation> for SyntaxElement {
     fn from(n: TsReturnTypeAnnotation) -> Self {
         n.syntax.into()
     }
+}
+impl TsSatisfiesAssignment {
+    pub const KIND: SyntaxKind = TS_SATISFIES_ASSIGNMENT;
 }
 impl AstNode for TsSatisfiesAssignment {
     type Language = Language;
@@ -30891,6 +31683,9 @@ impl From<TsSatisfiesAssignment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsSatisfiesExpression {
+    pub const KIND: SyntaxKind = TS_SATISFIES_EXPRESSION;
+}
 impl AstNode for TsSatisfiesExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -30942,6 +31737,9 @@ impl From<TsSatisfiesExpression> for SyntaxElement {
     fn from(n: TsSatisfiesExpression) -> Self {
         n.syntax.into()
     }
+}
+impl TsSetterSignatureClassMember {
+    pub const KIND: SyntaxKind = TS_SETTER_SIGNATURE_CLASS_MEMBER;
 }
 impl AstNode for TsSetterSignatureClassMember {
     type Language = Language;
@@ -31009,6 +31807,9 @@ impl From<TsSetterSignatureClassMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsSetterSignatureTypeMember {
+    pub const KIND: SyntaxKind = TS_SETTER_SIGNATURE_TYPE_MEMBER;
+}
 impl AstNode for TsSetterSignatureTypeMember {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31074,6 +31875,9 @@ impl From<TsSetterSignatureTypeMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsStringLiteralType {
+    pub const KIND: SyntaxKind = TS_STRING_LITERAL_TYPE;
+}
 impl AstNode for TsStringLiteralType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31123,6 +31927,9 @@ impl From<TsStringLiteralType> for SyntaxElement {
     fn from(n: TsStringLiteralType) -> Self {
         n.syntax.into()
     }
+}
+impl TsStringType {
+    pub const KIND: SyntaxKind = TS_STRING_TYPE;
 }
 impl AstNode for TsStringType {
     type Language = Language;
@@ -31174,6 +31981,9 @@ impl From<TsStringType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsSymbolType {
+    pub const KIND: SyntaxKind = TS_SYMBOL_TYPE;
+}
 impl AstNode for TsSymbolType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31224,6 +32034,9 @@ impl From<TsSymbolType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTemplateChunkElement {
+    pub const KIND: SyntaxKind = TS_TEMPLATE_CHUNK_ELEMENT;
+}
 impl AstNode for TsTemplateChunkElement {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31273,6 +32086,9 @@ impl From<TsTemplateChunkElement> for SyntaxElement {
     fn from(n: TsTemplateChunkElement) -> Self {
         n.syntax.into()
     }
+}
+impl TsTemplateElement {
+    pub const KIND: SyntaxKind = TS_TEMPLATE_ELEMENT;
 }
 impl AstNode for TsTemplateElement {
     type Language = Language;
@@ -31329,6 +32145,9 @@ impl From<TsTemplateElement> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTemplateLiteralType {
+    pub const KIND: SyntaxKind = TS_TEMPLATE_LITERAL_TYPE;
+}
 impl AstNode for TsTemplateLiteralType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31384,6 +32203,9 @@ impl From<TsTemplateLiteralType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsThisParameter {
+    pub const KIND: SyntaxKind = TS_THIS_PARAMETER;
+}
 impl AstNode for TsThisParameter {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31435,6 +32257,9 @@ impl From<TsThisParameter> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsThisType {
+    pub const KIND: SyntaxKind = TS_THIS_TYPE;
+}
 impl AstNode for TsThisType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31481,6 +32306,9 @@ impl From<TsThisType> for SyntaxElement {
     fn from(n: TsThisType) -> Self {
         n.syntax.into()
     }
+}
+impl TsTupleType {
+    pub const KIND: SyntaxKind = TS_TUPLE_TYPE;
 }
 impl AstNode for TsTupleType {
     type Language = Language;
@@ -31536,6 +32364,9 @@ impl From<TsTupleType> for SyntaxElement {
     fn from(n: TsTupleType) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeAliasDeclaration {
+    pub const KIND: SyntaxKind = TS_TYPE_ALIAS_DECLARATION;
 }
 impl AstNode for TsTypeAliasDeclaration {
     type Language = Language;
@@ -31598,6 +32429,9 @@ impl From<TsTypeAliasDeclaration> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTypeAnnotation {
+    pub const KIND: SyntaxKind = TS_TYPE_ANNOTATION;
+}
 impl AstNode for TsTypeAnnotation {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31648,6 +32482,9 @@ impl From<TsTypeAnnotation> for SyntaxElement {
     fn from(n: TsTypeAnnotation) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeArguments {
+    pub const KIND: SyntaxKind = TS_TYPE_ARGUMENTS;
 }
 impl AstNode for TsTypeArguments {
     type Language = Language;
@@ -31703,6 +32540,9 @@ impl From<TsTypeArguments> for SyntaxElement {
     fn from(n: TsTypeArguments) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeAssertionAssignment {
+    pub const KIND: SyntaxKind = TS_TYPE_ASSERTION_ASSIGNMENT;
 }
 impl AstNode for TsTypeAssertionAssignment {
     type Language = Language;
@@ -31760,6 +32600,9 @@ impl From<TsTypeAssertionAssignment> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTypeAssertionExpression {
+    pub const KIND: SyntaxKind = TS_TYPE_ASSERTION_EXPRESSION;
+}
 impl AstNode for TsTypeAssertionExpression {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31816,6 +32659,9 @@ impl From<TsTypeAssertionExpression> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTypeConstraintClause {
+    pub const KIND: SyntaxKind = TS_TYPE_CONSTRAINT_CLAUSE;
+}
 impl AstNode for TsTypeConstraintClause {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31867,6 +32713,9 @@ impl From<TsTypeConstraintClause> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTypeOperatorType {
+    pub const KIND: SyntaxKind = TS_TYPE_OPERATOR_TYPE;
+}
 impl AstNode for TsTypeOperatorType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -31917,6 +32766,9 @@ impl From<TsTypeOperatorType> for SyntaxElement {
     fn from(n: TsTypeOperatorType) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeParameter {
+    pub const KIND: SyntaxKind = TS_TYPE_PARAMETER;
 }
 impl AstNode for TsTypeParameter {
     type Language = Language;
@@ -31971,6 +32823,9 @@ impl From<TsTypeParameter> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsTypeParameterName {
+    pub const KIND: SyntaxKind = TS_TYPE_PARAMETER_NAME;
+}
 impl AstNode for TsTypeParameterName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -32020,6 +32875,9 @@ impl From<TsTypeParameterName> for SyntaxElement {
     fn from(n: TsTypeParameterName) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeParameters {
+    pub const KIND: SyntaxKind = TS_TYPE_PARAMETERS;
 }
 impl AstNode for TsTypeParameters {
     type Language = Language;
@@ -32075,6 +32933,9 @@ impl From<TsTypeParameters> for SyntaxElement {
     fn from(n: TsTypeParameters) -> Self {
         n.syntax.into()
     }
+}
+impl TsTypeofType {
+    pub const KIND: SyntaxKind = TS_TYPEOF_TYPE;
 }
 impl AstNode for TsTypeofType {
     type Language = Language;
@@ -32134,6 +32995,9 @@ impl From<TsTypeofType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsUndefinedType {
+    pub const KIND: SyntaxKind = TS_UNDEFINED_TYPE;
+}
 impl AstNode for TsUndefinedType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -32183,6 +33047,9 @@ impl From<TsUndefinedType> for SyntaxElement {
     fn from(n: TsUndefinedType) -> Self {
         n.syntax.into()
     }
+}
+impl TsUnionType {
+    pub const KIND: SyntaxKind = TS_UNION_TYPE;
 }
 impl AstNode for TsUnionType {
     type Language = Language;
@@ -32235,6 +33102,9 @@ impl From<TsUnionType> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl TsUnknownType {
+    pub const KIND: SyntaxKind = TS_UNKNOWN_TYPE;
+}
 impl AstNode for TsUnknownType {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -32284,6 +33154,9 @@ impl From<TsUnknownType> for SyntaxElement {
     fn from(n: TsUnknownType) -> Self {
         n.syntax.into()
     }
+}
+impl TsVoidType {
+    pub const KIND: SyntaxKind = TS_VOID_TYPE;
 }
 impl AstNode for TsVoidType {
     type Language = Language;
@@ -41758,6 +42631,7 @@ pub struct JsBogus {
     syntax: SyntaxNode,
 }
 impl JsBogus {
+    pub const KIND: SyntaxKind = JS_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -41814,6 +42688,7 @@ pub struct JsBogusAssignment {
     syntax: SyntaxNode,
 }
 impl JsBogusAssignment {
+    pub const KIND: SyntaxKind = JS_BOGUS_ASSIGNMENT;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -41870,6 +42745,7 @@ pub struct JsBogusBinding {
     syntax: SyntaxNode,
 }
 impl JsBogusBinding {
+    pub const KIND: SyntaxKind = JS_BOGUS_BINDING;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -41926,6 +42802,7 @@ pub struct JsBogusExpression {
     syntax: SyntaxNode,
 }
 impl JsBogusExpression {
+    pub const KIND: SyntaxKind = JS_BOGUS_EXPRESSION;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -41982,6 +42859,7 @@ pub struct JsBogusImportAssertionEntry {
     syntax: SyntaxNode,
 }
 impl JsBogusImportAssertionEntry {
+    pub const KIND: SyntaxKind = JS_BOGUS_IMPORT_ASSERTION_ENTRY;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42038,6 +42916,7 @@ pub struct JsBogusMember {
     syntax: SyntaxNode,
 }
 impl JsBogusMember {
+    pub const KIND: SyntaxKind = JS_BOGUS_MEMBER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42094,6 +42973,7 @@ pub struct JsBogusNamedImportSpecifier {
     syntax: SyntaxNode,
 }
 impl JsBogusNamedImportSpecifier {
+    pub const KIND: SyntaxKind = JS_BOGUS_NAMED_IMPORT_SPECIFIER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42150,6 +43030,7 @@ pub struct JsBogusParameter {
     syntax: SyntaxNode,
 }
 impl JsBogusParameter {
+    pub const KIND: SyntaxKind = JS_BOGUS_PARAMETER;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42206,6 +43087,7 @@ pub struct JsBogusStatement {
     syntax: SyntaxNode,
 }
 impl JsBogusStatement {
+    pub const KIND: SyntaxKind = JS_BOGUS_STATEMENT;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42262,6 +43144,7 @@ pub struct TsBogusType {
     syntax: SyntaxNode,
 }
 impl TsBogusType {
+    pub const KIND: SyntaxKind = TS_BOGUS_TYPE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42319,6 +43202,7 @@ pub struct JsArrayAssignmentPatternElementList {
     syntax_list: SyntaxList,
 }
 impl JsArrayAssignmentPatternElementList {
+    pub const KIND: SyntaxKind = JS_ARRAY_ASSIGNMENT_PATTERN_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42402,6 +43286,7 @@ pub struct JsArrayBindingPatternElementList {
     syntax_list: SyntaxList,
 }
 impl JsArrayBindingPatternElementList {
+    pub const KIND: SyntaxKind = JS_ARRAY_BINDING_PATTERN_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42484,6 +43369,7 @@ pub struct JsArrayElementList {
     syntax_list: SyntaxList,
 }
 impl JsArrayElementList {
+    pub const KIND: SyntaxKind = JS_ARRAY_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42566,6 +43452,7 @@ pub struct JsCallArgumentList {
     syntax_list: SyntaxList,
 }
 impl JsCallArgumentList {
+    pub const KIND: SyntaxKind = JS_CALL_ARGUMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42648,6 +43535,7 @@ pub struct JsClassMemberList {
     syntax_list: SyntaxList,
 }
 impl JsClassMemberList {
+    pub const KIND: SyntaxKind = JS_CLASS_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42730,6 +43618,7 @@ pub struct JsConstructorModifierList {
     syntax_list: SyntaxList,
 }
 impl JsConstructorModifierList {
+    pub const KIND: SyntaxKind = JS_CONSTRUCTOR_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42812,6 +43701,7 @@ pub struct JsConstructorParameterList {
     syntax_list: SyntaxList,
 }
 impl JsConstructorParameterList {
+    pub const KIND: SyntaxKind = JS_CONSTRUCTOR_PARAMETER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42894,6 +43784,7 @@ pub struct JsDecoratorList {
     syntax_list: SyntaxList,
 }
 impl JsDecoratorList {
+    pub const KIND: SyntaxKind = JS_DECORATOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -42976,6 +43867,7 @@ pub struct JsDirectiveList {
     syntax_list: SyntaxList,
 }
 impl JsDirectiveList {
+    pub const KIND: SyntaxKind = JS_DIRECTIVE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43058,6 +43950,7 @@ pub struct JsExportNamedFromSpecifierList {
     syntax_list: SyntaxList,
 }
 impl JsExportNamedFromSpecifierList {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_FROM_SPECIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43140,6 +44033,7 @@ pub struct JsExportNamedSpecifierList {
     syntax_list: SyntaxList,
 }
 impl JsExportNamedSpecifierList {
+    pub const KIND: SyntaxKind = JS_EXPORT_NAMED_SPECIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43222,6 +44116,7 @@ pub struct JsImportAssertionEntryList {
     syntax_list: SyntaxList,
 }
 impl JsImportAssertionEntryList {
+    pub const KIND: SyntaxKind = JS_IMPORT_ASSERTION_ENTRY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43304,6 +44199,7 @@ pub struct JsMethodModifierList {
     syntax_list: SyntaxList,
 }
 impl JsMethodModifierList {
+    pub const KIND: SyntaxKind = JS_METHOD_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43386,6 +44282,7 @@ pub struct JsModuleItemList {
     syntax_list: SyntaxList,
 }
 impl JsModuleItemList {
+    pub const KIND: SyntaxKind = JS_MODULE_ITEM_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43468,6 +44365,7 @@ pub struct JsNamedImportSpecifierList {
     syntax_list: SyntaxList,
 }
 impl JsNamedImportSpecifierList {
+    pub const KIND: SyntaxKind = JS_NAMED_IMPORT_SPECIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43550,6 +44448,7 @@ pub struct JsObjectAssignmentPatternPropertyList {
     syntax_list: SyntaxList,
 }
 impl JsObjectAssignmentPatternPropertyList {
+    pub const KIND: SyntaxKind = JS_OBJECT_ASSIGNMENT_PATTERN_PROPERTY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43633,6 +44532,7 @@ pub struct JsObjectBindingPatternPropertyList {
     syntax_list: SyntaxList,
 }
 impl JsObjectBindingPatternPropertyList {
+    pub const KIND: SyntaxKind = JS_OBJECT_BINDING_PATTERN_PROPERTY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43716,6 +44616,7 @@ pub struct JsObjectMemberList {
     syntax_list: SyntaxList,
 }
 impl JsObjectMemberList {
+    pub const KIND: SyntaxKind = JS_OBJECT_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43798,6 +44699,7 @@ pub struct JsParameterList {
     syntax_list: SyntaxList,
 }
 impl JsParameterList {
+    pub const KIND: SyntaxKind = JS_PARAMETER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43880,6 +44782,7 @@ pub struct JsPropertyModifierList {
     syntax_list: SyntaxList,
 }
 impl JsPropertyModifierList {
+    pub const KIND: SyntaxKind = JS_PROPERTY_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -43962,6 +44865,7 @@ pub struct JsStatementList {
     syntax_list: SyntaxList,
 }
 impl JsStatementList {
+    pub const KIND: SyntaxKind = JS_STATEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44044,6 +44948,7 @@ pub struct JsSwitchCaseList {
     syntax_list: SyntaxList,
 }
 impl JsSwitchCaseList {
+    pub const KIND: SyntaxKind = JS_SWITCH_CASE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44126,6 +45031,7 @@ pub struct JsTemplateElementList {
     syntax_list: SyntaxList,
 }
 impl JsTemplateElementList {
+    pub const KIND: SyntaxKind = JS_TEMPLATE_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44208,6 +45114,7 @@ pub struct JsVariableDeclaratorList {
     syntax_list: SyntaxList,
 }
 impl JsVariableDeclaratorList {
+    pub const KIND: SyntaxKind = JS_VARIABLE_DECLARATOR_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44290,6 +45197,7 @@ pub struct JsxAttributeList {
     syntax_list: SyntaxList,
 }
 impl JsxAttributeList {
+    pub const KIND: SyntaxKind = JSX_ATTRIBUTE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44372,6 +45280,7 @@ pub struct JsxChildList {
     syntax_list: SyntaxList,
 }
 impl JsxChildList {
+    pub const KIND: SyntaxKind = JSX_CHILD_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44454,6 +45363,7 @@ pub struct TsEnumMemberList {
     syntax_list: SyntaxList,
 }
 impl TsEnumMemberList {
+    pub const KIND: SyntaxKind = TS_ENUM_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44536,6 +45446,7 @@ pub struct TsIndexSignatureModifierList {
     syntax_list: SyntaxList,
 }
 impl TsIndexSignatureModifierList {
+    pub const KIND: SyntaxKind = TS_INDEX_SIGNATURE_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44618,6 +45529,7 @@ pub struct TsIntersectionTypeElementList {
     syntax_list: SyntaxList,
 }
 impl TsIntersectionTypeElementList {
+    pub const KIND: SyntaxKind = TS_INTERSECTION_TYPE_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44700,6 +45612,7 @@ pub struct TsMethodSignatureModifierList {
     syntax_list: SyntaxList,
 }
 impl TsMethodSignatureModifierList {
+    pub const KIND: SyntaxKind = TS_METHOD_SIGNATURE_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44782,6 +45695,7 @@ pub struct TsPropertyParameterModifierList {
     syntax_list: SyntaxList,
 }
 impl TsPropertyParameterModifierList {
+    pub const KIND: SyntaxKind = TS_PROPERTY_PARAMETER_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44864,6 +45778,7 @@ pub struct TsPropertySignatureModifierList {
     syntax_list: SyntaxList,
 }
 impl TsPropertySignatureModifierList {
+    pub const KIND: SyntaxKind = TS_PROPERTY_SIGNATURE_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -44946,6 +45861,7 @@ pub struct TsTemplateElementList {
     syntax_list: SyntaxList,
 }
 impl TsTemplateElementList {
+    pub const KIND: SyntaxKind = TS_TEMPLATE_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45028,6 +45944,7 @@ pub struct TsTupleTypeElementList {
     syntax_list: SyntaxList,
 }
 impl TsTupleTypeElementList {
+    pub const KIND: SyntaxKind = TS_TUPLE_TYPE_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45110,6 +46027,7 @@ pub struct TsTypeArgumentList {
     syntax_list: SyntaxList,
 }
 impl TsTypeArgumentList {
+    pub const KIND: SyntaxKind = TS_TYPE_ARGUMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45192,6 +46110,7 @@ pub struct TsTypeList {
     syntax_list: SyntaxList,
 }
 impl TsTypeList {
+    pub const KIND: SyntaxKind = TS_TYPE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45274,6 +46193,7 @@ pub struct TsTypeMemberList {
     syntax_list: SyntaxList,
 }
 impl TsTypeMemberList {
+    pub const KIND: SyntaxKind = TS_TYPE_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45356,6 +46276,7 @@ pub struct TsTypeParameterList {
     syntax_list: SyntaxList,
 }
 impl TsTypeParameterList {
+    pub const KIND: SyntaxKind = TS_TYPE_PARAMETER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45438,6 +46359,7 @@ pub struct TsTypeParameterModifierList {
     syntax_list: SyntaxList,
 }
 impl TsTypeParameterModifierList {
+    pub const KIND: SyntaxKind = TS_TYPE_PARAMETER_MODIFIER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -45520,6 +46442,7 @@ pub struct TsUnionTypeVariantList {
     syntax_list: SyntaxList,
 }
 impl TsUnionTypeVariantList {
+    pub const KIND: SyntaxKind = TS_UNION_TYPE_VARIANT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_json_syntax/src/generated/nodes.rs
+++ b/crates/biome_json_syntax/src/generated/nodes.rs
@@ -428,6 +428,9 @@ impl AnyJsonValue {
         }
     }
 }
+impl JsonArrayValue {
+    pub const KIND: SyntaxKind = JSON_ARRAY_VALUE;
+}
 impl AstNode for JsonArrayValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -483,6 +486,9 @@ impl From<JsonArrayValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsonBooleanValue {
+    pub const KIND: SyntaxKind = JSON_BOOLEAN_VALUE;
+}
 impl AstNode for JsonBooleanValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -532,6 +538,9 @@ impl From<JsonBooleanValue> for SyntaxElement {
     fn from(n: JsonBooleanValue) -> Self {
         n.syntax.into()
     }
+}
+impl JsonMember {
+    pub const KIND: SyntaxKind = JSON_MEMBER;
 }
 impl AstNode for JsonMember {
     type Language = Language;
@@ -585,6 +594,9 @@ impl From<JsonMember> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsonMemberName {
+    pub const KIND: SyntaxKind = JSON_MEMBER_NAME;
+}
 impl AstNode for JsonMemberName {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -634,6 +646,9 @@ impl From<JsonMemberName> for SyntaxElement {
     fn from(n: JsonMemberName) -> Self {
         n.syntax.into()
     }
+}
+impl JsonNullValue {
+    pub const KIND: SyntaxKind = JSON_NULL_VALUE;
 }
 impl AstNode for JsonNullValue {
     type Language = Language;
@@ -685,6 +700,9 @@ impl From<JsonNullValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsonNumberValue {
+    pub const KIND: SyntaxKind = JSON_NUMBER_VALUE;
+}
 impl AstNode for JsonNumberValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -734,6 +752,9 @@ impl From<JsonNumberValue> for SyntaxElement {
     fn from(n: JsonNumberValue) -> Self {
         n.syntax.into()
     }
+}
+impl JsonObjectValue {
+    pub const KIND: SyntaxKind = JSON_OBJECT_VALUE;
 }
 impl AstNode for JsonObjectValue {
     type Language = Language;
@@ -790,6 +811,9 @@ impl From<JsonObjectValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl JsonRoot {
+    pub const KIND: SyntaxKind = JSON_ROOT;
+}
 impl AstNode for JsonRoot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -841,6 +865,9 @@ impl From<JsonRoot> for SyntaxElement {
     fn from(n: JsonRoot) -> Self {
         n.syntax.into()
     }
+}
+impl JsonStringValue {
+    pub const KIND: SyntaxKind = JSON_STRING_VALUE;
 }
 impl AstNode for JsonStringValue {
     type Language = Language;
@@ -1071,6 +1098,7 @@ pub struct JsonBogus {
     syntax: SyntaxNode,
 }
 impl JsonBogus {
+    pub const KIND: SyntaxKind = JSON_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1127,6 +1155,7 @@ pub struct JsonBogusValue {
     syntax: SyntaxNode,
 }
 impl JsonBogusValue {
+    pub const KIND: SyntaxKind = JSON_BOGUS_VALUE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1184,6 +1213,7 @@ pub struct JsonArrayElementList {
     syntax_list: SyntaxList,
 }
 impl JsonArrayElementList {
+    pub const KIND: SyntaxKind = JSON_ARRAY_ELEMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1266,6 +1296,7 @@ pub struct JsonMemberList {
     syntax_list: SyntaxList,
 }
 impl JsonMemberList {
+    pub const KIND: SyntaxKind = JSON_MEMBER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_markdown_syntax/src/generated/nodes.rs
+++ b/crates/biome_markdown_syntax/src/generated/nodes.rs
@@ -1336,6 +1336,9 @@ impl AnyMdInline {
         }
     }
 }
+impl MdBullet {
+    pub const KIND: SyntaxKind = MD_BULLET;
+}
 impl AstNode for MdBullet {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1388,6 +1391,9 @@ impl From<MdBullet> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdBulletListItem {
+    pub const KIND: SyntaxKind = MD_BULLET_LIST_ITEM;
+}
 impl AstNode for MdBulletListItem {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1434,6 +1440,9 @@ impl From<MdBulletListItem> for SyntaxElement {
     fn from(n: MdBulletListItem) -> Self {
         n.syntax.into()
     }
+}
+impl MdDocument {
+    pub const KIND: SyntaxKind = MD_DOCUMENT;
 }
 impl AstNode for MdDocument {
     type Language = Language;
@@ -1486,6 +1495,9 @@ impl From<MdDocument> for SyntaxElement {
     fn from(n: MdDocument) -> Self {
         n.syntax.into()
     }
+}
+impl MdFencedCodeBlock {
+    pub const KIND: SyntaxKind = MD_FENCED_CODE_BLOCK;
 }
 impl AstNode for MdFencedCodeBlock {
     type Language = Language;
@@ -1551,6 +1563,9 @@ impl From<MdFencedCodeBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdHardLine {
+    pub const KIND: SyntaxKind = MD_HARD_LINE;
+}
 impl AstNode for MdHardLine {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1601,6 +1616,9 @@ impl From<MdHardLine> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdHash {
+    pub const KIND: SyntaxKind = MD_HASH;
+}
 impl AstNode for MdHash {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1647,6 +1665,9 @@ impl From<MdHash> for SyntaxElement {
     fn from(n: MdHash) -> Self {
         n.syntax.into()
     }
+}
+impl MdHeader {
+    pub const KIND: SyntaxKind = MD_HEADER;
 }
 impl AstNode for MdHeader {
     type Language = Language;
@@ -1697,6 +1718,9 @@ impl From<MdHeader> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdHtmlBlock {
+    pub const KIND: SyntaxKind = MD_HTML_BLOCK;
+}
 impl AstNode for MdHtmlBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1743,6 +1767,9 @@ impl From<MdHtmlBlock> for SyntaxElement {
     fn from(n: MdHtmlBlock) -> Self {
         n.syntax.into()
     }
+}
+impl MdIndent {
+    pub const KIND: SyntaxKind = MD_INDENT;
 }
 impl AstNode for MdIndent {
     type Language = Language;
@@ -1794,6 +1821,9 @@ impl From<MdIndent> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdIndentCodeBlock {
+    pub const KIND: SyntaxKind = MD_INDENT_CODE_BLOCK;
+}
 impl AstNode for MdIndentCodeBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1840,6 +1870,9 @@ impl From<MdIndentCodeBlock> for SyntaxElement {
     fn from(n: MdIndentCodeBlock) -> Self {
         n.syntax.into()
     }
+}
+impl MdIndentedCodeLine {
+    pub const KIND: SyntaxKind = MD_INDENTED_CODE_LINE;
 }
 impl AstNode for MdIndentedCodeLine {
     type Language = Language;
@@ -1891,6 +1924,9 @@ impl From<MdIndentedCodeLine> for SyntaxElement {
     fn from(n: MdIndentedCodeLine) -> Self {
         n.syntax.into()
     }
+}
+impl MdInlineCode {
+    pub const KIND: SyntaxKind = MD_INLINE_CODE;
 }
 impl AstNode for MdInlineCode {
     type Language = Language;
@@ -1947,6 +1983,9 @@ impl From<MdInlineCode> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdInlineEmphasis {
+    pub const KIND: SyntaxKind = MD_INLINE_EMPHASIS;
+}
 impl AstNode for MdInlineEmphasis {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1995,6 +2034,9 @@ impl From<MdInlineEmphasis> for SyntaxElement {
     fn from(n: MdInlineEmphasis) -> Self {
         n.syntax.into()
     }
+}
+impl MdInlineImage {
+    pub const KIND: SyntaxKind = MD_INLINE_IMAGE;
 }
 impl AstNode for MdInlineImage {
     type Language = Language;
@@ -2054,6 +2096,9 @@ impl From<MdInlineImage> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdInlineImageAlt {
+    pub const KIND: SyntaxKind = MD_INLINE_IMAGE_ALT;
+}
 impl AstNode for MdInlineImageAlt {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2108,6 +2153,9 @@ impl From<MdInlineImageAlt> for SyntaxElement {
     fn from(n: MdInlineImageAlt) -> Self {
         n.syntax.into()
     }
+}
+impl MdInlineImageLink {
+    pub const KIND: SyntaxKind = MD_INLINE_IMAGE_LINK;
 }
 impl AstNode for MdInlineImageLink {
     type Language = Language;
@@ -2164,6 +2212,9 @@ impl From<MdInlineImageLink> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdInlineImageSource {
+    pub const KIND: SyntaxKind = MD_INLINE_IMAGE_SOURCE;
+}
 impl AstNode for MdInlineImageSource {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2219,6 +2270,9 @@ impl From<MdInlineImageSource> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdInlineItalic {
+    pub const KIND: SyntaxKind = MD_INLINE_ITALIC;
+}
 impl AstNode for MdInlineItalic {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2267,6 +2321,9 @@ impl From<MdInlineItalic> for SyntaxElement {
     fn from(n: MdInlineItalic) -> Self {
         n.syntax.into()
     }
+}
+impl MdInlineLink {
+    pub const KIND: SyntaxKind = MD_INLINE_LINK;
 }
 impl AstNode for MdInlineLink {
     type Language = Language;
@@ -2332,6 +2389,9 @@ impl From<MdInlineLink> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdLinkBlock {
+    pub const KIND: SyntaxKind = MD_LINK_BLOCK;
+}
 impl AstNode for MdLinkBlock {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2381,6 +2441,9 @@ impl From<MdLinkBlock> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdOrderListItem {
+    pub const KIND: SyntaxKind = MD_ORDER_LIST_ITEM;
+}
 impl AstNode for MdOrderListItem {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2427,6 +2490,9 @@ impl From<MdOrderListItem> for SyntaxElement {
     fn from(n: MdOrderListItem) -> Self {
         n.syntax.into()
     }
+}
+impl MdParagraph {
+    pub const KIND: SyntaxKind = MD_PARAGRAPH;
 }
 impl AstNode for MdParagraph {
     type Language = Language;
@@ -2475,6 +2541,9 @@ impl From<MdParagraph> for SyntaxElement {
     fn from(n: MdParagraph) -> Self {
         n.syntax.into()
     }
+}
+impl MdQuote {
+    pub const KIND: SyntaxKind = MD_QUOTE;
 }
 impl AstNode for MdQuote {
     type Language = Language;
@@ -2526,6 +2595,9 @@ impl From<MdQuote> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdSetextHeader {
+    pub const KIND: SyntaxKind = MD_SETEXT_HEADER;
+}
 impl AstNode for MdSetextHeader {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2575,6 +2647,9 @@ impl From<MdSetextHeader> for SyntaxElement {
     fn from(n: MdSetextHeader) -> Self {
         n.syntax.into()
     }
+}
+impl MdSoftBreak {
+    pub const KIND: SyntaxKind = MD_SOFT_BREAK;
 }
 impl AstNode for MdSoftBreak {
     type Language = Language;
@@ -2626,6 +2701,9 @@ impl From<MdSoftBreak> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl MdTextual {
+    pub const KIND: SyntaxKind = MD_TEXTUAL;
+}
 impl AstNode for MdTextual {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2675,6 +2753,9 @@ impl From<MdTextual> for SyntaxElement {
     fn from(n: MdTextual) -> Self {
         n.syntax.into()
     }
+}
+impl MdThematicBreakBlock {
+    pub const KIND: SyntaxKind = MD_THEMATIC_BREAK_BLOCK;
 }
 impl AstNode for MdThematicBreakBlock {
     type Language = Language;
@@ -3351,6 +3432,7 @@ pub struct MdBogus {
     syntax: SyntaxNode,
 }
 impl MdBogus {
+    pub const KIND: SyntaxKind = MD_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3408,6 +3490,7 @@ pub struct MdBlockList {
     syntax_list: SyntaxList,
 }
 impl MdBlockList {
+    pub const KIND: SyntaxKind = MD_BLOCK_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3490,6 +3573,7 @@ pub struct MdBulletList {
     syntax_list: SyntaxList,
 }
 impl MdBulletList {
+    pub const KIND: SyntaxKind = MD_BULLET_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3572,6 +3656,7 @@ pub struct MdCodeNameList {
     syntax_list: SyntaxList,
 }
 impl MdCodeNameList {
+    pub const KIND: SyntaxKind = MD_CODE_NAME_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3654,6 +3739,7 @@ pub struct MdHashList {
     syntax_list: SyntaxList,
 }
 impl MdHashList {
+    pub const KIND: SyntaxKind = MD_HASH_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3736,6 +3822,7 @@ pub struct MdIndentedCodeLineList {
     syntax_list: SyntaxList,
 }
 impl MdIndentedCodeLineList {
+    pub const KIND: SyntaxKind = MD_INDENTED_CODE_LINE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3818,6 +3905,7 @@ pub struct MdInlineItemList {
     syntax_list: SyntaxList,
 }
 impl MdInlineItemList {
+    pub const KIND: SyntaxKind = MD_INLINE_ITEM_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3900,6 +3988,7 @@ pub struct MdOrderList {
     syntax_list: SyntaxList,
 }
 impl MdOrderList {
+    pub const KIND: SyntaxKind = MD_ORDER_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/crates/biome_rowan/src/raw_language.rs
+++ b/crates/biome_rowan/src/raw_language.rs
@@ -101,6 +101,10 @@ pub struct RawLanguageRoot {
     node: SyntaxNode<RawLanguage>,
 }
 
+impl RawLanguageRoot {
+    pub const KIND: RawLanguageKind = RawLanguageKind::ROOT;
+}
+
 impl AstNode for RawLanguageRoot {
     type Language = RawLanguage;
 
@@ -135,6 +139,10 @@ impl AstNode for RawLanguageRoot {
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct LiteralExpression {
     node: SyntaxNode<RawLanguage>,
+}
+
+impl LiteralExpression {
+    pub const KIND: RawLanguageKind = RawLanguageKind::LITERAL_EXPRESSION;
 }
 
 impl AstNode for LiteralExpression {

--- a/crates/biome_rowan/src/syntax/node.rs
+++ b/crates/biome_rowan/src/syntax/node.rs
@@ -815,6 +815,12 @@ impl<L: Language> From<cursor::SyntaxNode> for SyntaxNode<L> {
     }
 }
 
+impl<L: Language> From<&Self> for SyntaxNode<L> {
+    fn from(value: &Self) -> Self {
+        value.clone()
+    }
+}
+
 /// Language-agnostic representation of the root node of a syntax tree, can be
 /// sent or shared between threads
 #[derive(Clone, Debug)]

--- a/crates/biome_yaml_syntax/src/generated/nodes.rs
+++ b/crates/biome_yaml_syntax/src/generated/nodes.rs
@@ -1429,6 +1429,9 @@ impl AnyYamlProperty {
         }
     }
 }
+impl YamlAliasNode {
+    pub const KIND: SyntaxKind = YAML_ALIAS_NODE;
+}
 impl AstNode for YamlAliasNode {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1478,6 +1481,9 @@ impl From<YamlAliasNode> for SyntaxElement {
     fn from(n: YamlAliasNode) -> Self {
         n.syntax.into()
     }
+}
+impl YamlAnchorProperty {
+    pub const KIND: SyntaxKind = YAML_ANCHOR_PROPERTY;
 }
 impl AstNode for YamlAnchorProperty {
     type Language = Language;
@@ -1529,6 +1535,9 @@ impl From<YamlAnchorProperty> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockCollection {
+    pub const KIND: SyntaxKind = YAML_BLOCK_COLLECTION;
+}
 impl AstNode for YamlBlockCollection {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1577,6 +1586,9 @@ impl From<YamlBlockCollection> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockMapExplicitEntry {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_EXPLICIT_ENTRY;
+}
 impl AstNode for YamlBlockMapExplicitEntry {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1624,6 +1636,9 @@ impl From<YamlBlockMapExplicitEntry> for SyntaxElement {
     fn from(n: YamlBlockMapExplicitEntry) -> Self {
         n.syntax.into()
     }
+}
+impl YamlBlockMapExplicitKey {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_EXPLICIT_KEY;
 }
 impl AstNode for YamlBlockMapExplicitKey {
     type Language = Language;
@@ -1676,6 +1691,9 @@ impl From<YamlBlockMapExplicitKey> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockMapExplicitValue {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_EXPLICIT_VALUE;
+}
 impl AstNode for YamlBlockMapExplicitValue {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1727,6 +1745,9 @@ impl From<YamlBlockMapExplicitValue> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockMapImplicitEntry {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_IMPLICIT_ENTRY;
+}
 impl AstNode for YamlBlockMapImplicitEntry {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1774,6 +1795,9 @@ impl From<YamlBlockMapImplicitEntry> for SyntaxElement {
     fn from(n: YamlBlockMapImplicitEntry) -> Self {
         n.syntax.into()
     }
+}
+impl YamlBlockMapImplicitValue {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_IMPLICIT_VALUE;
 }
 impl AstNode for YamlBlockMapImplicitValue {
     type Language = Language;
@@ -1825,6 +1849,9 @@ impl From<YamlBlockMapImplicitValue> for SyntaxElement {
     fn from(n: YamlBlockMapImplicitValue) -> Self {
         n.syntax.into()
     }
+}
+impl YamlBlockMapping {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAPPING;
 }
 impl AstNode for YamlBlockMapping {
     type Language = Language;
@@ -1881,6 +1908,9 @@ impl From<YamlBlockMapping> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockSequence {
+    pub const KIND: SyntaxKind = YAML_BLOCK_SEQUENCE;
+}
 impl AstNode for YamlBlockSequence {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1936,6 +1966,9 @@ impl From<YamlBlockSequence> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlBlockSequenceEntry {
+    pub const KIND: SyntaxKind = YAML_BLOCK_SEQUENCE_ENTRY;
+}
 impl AstNode for YamlBlockSequenceEntry {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -1987,6 +2020,9 @@ impl From<YamlBlockSequenceEntry> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlCompactMapping {
+    pub const KIND: SyntaxKind = YAML_COMPACT_MAPPING;
+}
 impl AstNode for YamlCompactMapping {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2034,6 +2070,9 @@ impl From<YamlCompactMapping> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlCompactSequence {
+    pub const KIND: SyntaxKind = YAML_COMPACT_SEQUENCE;
+}
 impl AstNode for YamlCompactSequence {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2080,6 +2119,9 @@ impl From<YamlCompactSequence> for SyntaxElement {
     fn from(n: YamlCompactSequence) -> Self {
         n.syntax.into()
     }
+}
+impl YamlDirective {
+    pub const KIND: SyntaxKind = YAML_DIRECTIVE;
 }
 impl AstNode for YamlDirective {
     type Language = Language;
@@ -2130,6 +2172,9 @@ impl From<YamlDirective> for SyntaxElement {
     fn from(n: YamlDirective) -> Self {
         n.syntax.into()
     }
+}
+impl YamlDocument {
+    pub const KIND: SyntaxKind = YAML_DOCUMENT;
 }
 impl AstNode for YamlDocument {
     type Language = Language;
@@ -2191,6 +2236,9 @@ impl From<YamlDocument> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlDoubleQuotedScalar {
+    pub const KIND: SyntaxKind = YAML_DOUBLE_QUOTED_SCALAR;
+}
 impl AstNode for YamlDoubleQuotedScalar {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2241,6 +2289,9 @@ impl From<YamlDoubleQuotedScalar> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlFlowJsonNode {
+    pub const KIND: SyntaxKind = YAML_FLOW_JSON_NODE;
+}
 impl AstNode for YamlFlowJsonNode {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2288,6 +2339,9 @@ impl From<YamlFlowJsonNode> for SyntaxElement {
     fn from(n: YamlFlowJsonNode) -> Self {
         n.syntax.into()
     }
+}
+impl YamlFlowMapExplicitEntry {
+    pub const KIND: SyntaxKind = YAML_FLOW_MAP_EXPLICIT_ENTRY;
 }
 impl AstNode for YamlFlowMapExplicitEntry {
     type Language = Language;
@@ -2340,6 +2394,9 @@ impl From<YamlFlowMapExplicitEntry> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlFlowMapImplicitEntry {
+    pub const KIND: SyntaxKind = YAML_FLOW_MAP_IMPLICIT_ENTRY;
+}
 impl AstNode for YamlFlowMapImplicitEntry {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2391,6 +2448,9 @@ impl From<YamlFlowMapImplicitEntry> for SyntaxElement {
     fn from(n: YamlFlowMapImplicitEntry) -> Self {
         n.syntax.into()
     }
+}
+impl YamlFlowMapping {
+    pub const KIND: SyntaxKind = YAML_FLOW_MAPPING;
 }
 impl AstNode for YamlFlowMapping {
     type Language = Language;
@@ -2447,6 +2507,9 @@ impl From<YamlFlowMapping> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlFlowSequence {
+    pub const KIND: SyntaxKind = YAML_FLOW_SEQUENCE;
+}
 impl AstNode for YamlFlowSequence {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2502,6 +2565,9 @@ impl From<YamlFlowSequence> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlFlowYamlNode {
+    pub const KIND: SyntaxKind = YAML_FLOW_YAML_NODE;
+}
 impl AstNode for YamlFlowYamlNode {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2549,6 +2615,9 @@ impl From<YamlFlowYamlNode> for SyntaxElement {
     fn from(n: YamlFlowYamlNode) -> Self {
         n.syntax.into()
     }
+}
+impl YamlFoldedScalar {
+    pub const KIND: SyntaxKind = YAML_FOLDED_SCALAR;
 }
 impl AstNode for YamlFoldedScalar {
     type Language = Language;
@@ -2600,6 +2669,9 @@ impl From<YamlFoldedScalar> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlLiteralScalar {
+    pub const KIND: SyntaxKind = YAML_LITERAL_SCALAR;
+}
 impl AstNode for YamlLiteralScalar {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2649,6 +2721,9 @@ impl From<YamlLiteralScalar> for SyntaxElement {
     fn from(n: YamlLiteralScalar) -> Self {
         n.syntax.into()
     }
+}
+impl YamlPlainScalar {
+    pub const KIND: SyntaxKind = YAML_PLAIN_SCALAR;
 }
 impl AstNode for YamlPlainScalar {
     type Language = Language;
@@ -2700,6 +2775,9 @@ impl From<YamlPlainScalar> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlPropertyList {
+    pub const KIND: SyntaxKind = YAML_PROPERTY_LIST;
+}
 impl AstNode for YamlPropertyList {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2750,6 +2828,9 @@ impl From<YamlPropertyList> for SyntaxElement {
         n.syntax.into()
     }
 }
+impl YamlRoot {
+    pub const KIND: SyntaxKind = YAML_ROOT;
+}
 impl AstNode for YamlRoot {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
@@ -2797,6 +2878,9 @@ impl From<YamlRoot> for SyntaxElement {
     fn from(n: YamlRoot) -> Self {
         n.syntax.into()
     }
+}
+impl YamlSingleQuotedScalar {
+    pub const KIND: SyntaxKind = YAML_SINGLE_QUOTED_SCALAR;
 }
 impl AstNode for YamlSingleQuotedScalar {
     type Language = Language;
@@ -2847,6 +2931,9 @@ impl From<YamlSingleQuotedScalar> for SyntaxElement {
     fn from(n: YamlSingleQuotedScalar) -> Self {
         n.syntax.into()
     }
+}
+impl YamlTagProperty {
+    pub const KIND: SyntaxKind = YAML_TAG_PROPERTY;
 }
 impl AstNode for YamlTagProperty {
     type Language = Language;
@@ -3929,6 +4016,7 @@ pub struct YamlBogus {
     syntax: SyntaxNode,
 }
 impl YamlBogus {
+    pub const KIND: SyntaxKind = YAML_BOGUS;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -3985,6 +4073,7 @@ pub struct YamlBogusNode {
     syntax: SyntaxNode,
 }
 impl YamlBogusNode {
+    pub const KIND: SyntaxKind = YAML_BOGUS_NODE;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4042,6 +4131,7 @@ pub struct YamlBlockMapEntryList {
     syntax_list: SyntaxList,
 }
 impl YamlBlockMapEntryList {
+    pub const KIND: SyntaxKind = YAML_BLOCK_MAP_ENTRY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4124,6 +4214,7 @@ pub struct YamlBlockSequenceEntryList {
     syntax_list: SyntaxList,
 }
 impl YamlBlockSequenceEntryList {
+    pub const KIND: SyntaxKind = YAML_BLOCK_SEQUENCE_ENTRY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4206,6 +4297,7 @@ pub struct YamlDirectiveList {
     syntax_list: SyntaxList,
 }
 impl YamlDirectiveList {
+    pub const KIND: SyntaxKind = YAML_DIRECTIVE_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4288,6 +4380,7 @@ pub struct YamlDocumentList {
     syntax_list: SyntaxList,
 }
 impl YamlDocumentList {
+    pub const KIND: SyntaxKind = YAML_DOCUMENT_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4370,6 +4463,7 @@ pub struct YamlFlowMapEntryList {
     syntax_list: SyntaxList,
 }
 impl YamlFlowMapEntryList {
+    pub const KIND: SyntaxKind = YAML_FLOW_MAP_ENTRY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -4452,6 +4546,7 @@ pub struct YamlFlowSequenceEntryList {
     syntax_list: SyntaxList,
 }
 impl YamlFlowSequenceEntryList {
+    pub const KIND: SyntaxKind = YAML_FLOW_SEQUENCE_ENTRY_LIST;
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]

--- a/xtask/codegen/src/generate_nodes.rs
+++ b/xtask/codegen/src/generate_nodes.rs
@@ -296,6 +296,10 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
                     }
                 },
                 quote! {
+                    impl #name {
+                        pub const KIND: SyntaxKind = #node_kind;
+                    }
+
                     impl AstNode for #name {
                         type Language = Language;
 
@@ -653,6 +657,8 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
             }
 
             impl #ident {
+                pub const KIND: SyntaxKind = #kind;
+
                 /// Create an AstNode from a SyntaxNode without checking its kind
                 ///
                 /// # Safety
@@ -745,6 +751,8 @@ pub fn generate_nodes(ast: &AstSrc, language_kind: LanguageKind) -> Result<Strin
 
         let node_impl = quote! {
             impl #list_name {
+                pub const KIND: SyntaxKind = #list_kind;
+
                 /// Create an AstNode from a SyntaxNode without checking its kind
                 ///
                 /// # Safety


### PR DESCRIPTION
## Summary

This PR improves the `match_ast!` macro that allows matching `SyntaxNode` against `AstNode` in a safe way.
This avoids matching against `JsSyntaxKind` and then using `unwrap_cast`.

The PR improves the following:
- expand to a `match` instead of Ifs
  To be able to match against `JsSyntaxKind` I added a `KIND` const on every Ast Nodes (see `xtask/generate_nodes`) 
- Avoid cloning when possible by using `.into()`
  To be able to do this, I added the implementation `From<&Self> for SyntaxNode<L>` that bascially clone the node.
- Allow using `if` in match arms.
- Allow alternation matching

One downside of using `match` instead of ifs is the impossibility to match against node unions (`Any*`).

I used the [Push-down Accumulator pattern](https://danielkeep.github.io/tlborm/book/pat-push-down-accumulation.html) to implement the macro.

## Possible alternative

Alternatively, for every language, we could add an enum that is the union of all Ast nodes.
The tag could correspond to the value of the node kind.
A syntax node could so be turned into this tagged union, making it possible to safely match against.

## Test Plan

CI should pass.
