### PR TITLE
chore: update preview runners

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -28,28 +28,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: depot-windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: windows-2022
+          - os: depot-windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: macos-14
+          - os: depot-macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-14
+          - os: depot-macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,28 +23,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: depot-windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: windows-2022
+          - os: depot-windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-24.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-24.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-24.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: ubuntu-24.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: macos-14
+          - os: depot-macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-14
+          - os: depot-macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,16 +29,16 @@ jobs:
           - os: windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
           - os: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,28 +80,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: depot-windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: windows-2022
+          - os: depot-windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: macos-14
+          - os: depot-macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-14
+          - os: depot-macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -40,28 +40,28 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: depot-windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: windows-2022
+          - os: depot-windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: ubuntu-20.04
+          - os: depot-ubuntu-22.04-arm
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: macos-14
+          - os: depot-macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-14
+          - os: depot-macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 


### PR DESCRIPTION
## Summary

Fixes #5732.

## Test Plan

Linux preview builds should work again.
