### PR TITLE
chore: reduce duplication and add formating of object literals

### DIFF
--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -1,8 +1,8 @@
 use crate::{
     CallArgumentType, CallSignatureTypeMember, Class, DestructureField, Function,
-    FunctionParameter, FunctionParameterBinding, GenericTypeParameter, MethodTypeMember, Object,
-    PropertyTypeMember, ReturnType, Type, TypeInner, TypeMember, TypeReference,
-    TypeReferenceQualifier, TypeofAwaitExpression, TypeofExpression,
+    FunctionParameter, FunctionParameterBinding, GenericTypeParameter, Literal, MethodTypeMember,
+    Object, ObjectLiteral, PropertyTypeMember, ReturnType, Type, TypeInner, TypeMember,
+    TypeReference, TypeReferenceQualifier, TypeofAwaitExpression, TypeofExpression,
 };
 use biome_formatter::prelude::*;
 use biome_formatter::{
@@ -15,7 +15,7 @@ use biome_rowan::Text;
 use std::fmt::Debug;
 use std::ops::Deref;
 
-struct FormatTypeOptions;
+pub struct FormatTypeOptions;
 
 impl FormatOptions for FormatTypeOptions {
     fn indent_style(&self) -> IndentStyle {
@@ -44,7 +44,7 @@ impl FormatOptions for FormatTypeOptions {
     }
 }
 
-struct FormatTypeContext;
+pub struct FormatTypeContext;
 
 impl FormatContext for FormatTypeContext {
     type Options = FormatTypeOptions;
@@ -98,8 +98,11 @@ impl Format<FormatTypeContext> for TypeInner {
             Self::Union(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::TypeOperator(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
             Self::Alias(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            Self::Literal(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            Self::InstanceOf(ty) => write!(f, [text("instanceof"), space(), &ty.as_ref()]),
+            Self::Literal(ty) => write!(f, [&ty.as_ref()]),
+            Self::InstanceOf(ty) => write!(
+                f,
+                [&format_args![text("instanceof"), space(), &ty.as_ref()]]
+            ),
             Self::Reference(reference) => write!(f, [&reference.as_ref()]),
             Self::TypeofExpression(expression) => write!(f, [&expression.as_ref()]),
             Self::TypeofType(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
@@ -586,6 +589,41 @@ impl Format<FormatTypeContext> for Class {
                     text("type_args:"),
                     space(),
                     FmtGenericTypeParameters(&self.type_parameters),
+                ])),
+                text("}")
+            ]]
+        )
+    }
+}
+
+impl Format<FormatTypeContext> for Literal {
+    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        write!(f, [&format_args![text("value:"), space()]])?;
+        match self {
+            Literal::BigInt(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Literal::Boolean(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Literal::Null => write!(f, [text("null")]),
+            Literal::Number(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Literal::Object(obj) => write!(f, [&obj]),
+            Literal::RegExp(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Literal::String(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Literal::Template(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+        }
+    }
+}
+
+impl Format<FormatTypeContext> for ObjectLiteral {
+    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        write!(
+            f,
+            [&format_args![
+                text("ObjectLiteral"),
+                space(),
+                text("{"),
+                &group(&soft_block_indent(&format_args![
+                    text("members:"),
+                    space(),
+                    FmtTypeMembers(self.0.as_ref())
                 ])),
                 text("}")
             ]]

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -600,14 +600,14 @@ impl Format<FormatTypeContext> for Literal {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
         write!(f, [&format_args![text("value:"), space()]])?;
         match self {
-            Literal::BigInt(text) => write!(f, [dynamic_text(text, TextSize::default())]),
-            Literal::Boolean(text) => write!(f, [dynamic_text(text, TextSize::default())]),
-            Literal::Null => write!(f, [text("null")]),
-            Literal::Number(text) => write!(f, [dynamic_text(text, TextSize::default())]),
-            Literal::Object(obj) => write!(f, [&obj]),
-            Literal::RegExp(text) => write!(f, [dynamic_text(text, TextSize::default())]),
-            Literal::String(text) => write!(f, [dynamic_text(text, TextSize::default())]),
-            Literal::Template(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::BigInt(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::Boolean(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::Null => write!(f, [text("null")]),
+            Self::Number(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::Object(obj) => write!(f, [&obj]),
+            Self::RegExp(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::String(text) => write!(f, [dynamic_text(text, TextSize::default())]),
+            Self::Template(text) => write!(f, [dynamic_text(text, TextSize::default())]),
         }
     }
 }

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -9,3 +9,5 @@ mod type_info;
 
 pub use resolver::*;
 pub use type_info::*;
+
+pub use format_type_info::{FormatTypeContext, FormatTypeOptions};

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -1,72 +1,18 @@
-use crate::js_module_info::Exports;
+use crate::js_module_info::{Exports, Imports};
 use crate::{
     JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsOwnExport, JsReexport, JsResolvedPath,
     JsdocComment,
 };
 use biome_formatter::prelude::*;
-use biome_formatter::{
-    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, TransformSourceMap,
-    format_args, write,
-};
-use biome_js_type_info::{
-    CallArgumentType, CallSignatureTypeMember, Class, ConstructorTypeMember, DestructureField,
-    Function, FunctionParameter, GenericTypeParameter, Literal, MethodTypeMember, Object,
-    ObjectLiteral, PropertyTypeMember, ReturnType, Type, TypeInner, TypeMember, TypeReference,
-    TypeReferenceQualifier, TypeofAwaitExpression, TypeofExpression,
-};
+use biome_formatter::{format_args, write};
+use biome_js_type_info::FormatTypeContext;
 use biome_rowan::{Text, TextSize};
-use std::fmt::{Debug, Formatter};
+use std::fmt::Formatter;
 use std::ops::Deref;
-
-#[derive(Debug, Default)]
-struct ModuleFormatContext;
-
-#[derive(Debug, Clone, Default)]
-
-struct ModuleFormatContextOptions;
-
-impl FormatOptions for ModuleFormatContextOptions {
-    fn indent_style(&self) -> IndentStyle {
-        IndentStyle::Space
-    }
-
-    fn indent_width(&self) -> IndentWidth {
-        IndentWidth::try_from(2).unwrap()
-    }
-
-    fn line_width(&self) -> LineWidth {
-        LineWidth::default()
-    }
-
-    fn line_ending(&self) -> LineEnding {
-        LineEnding::default()
-    }
-
-    fn as_print_options(&self) -> PrinterOptions {
-        PrinterOptions {
-            indent_width: self.indent_width(),
-            print_width: self.line_width().into(),
-            line_ending: self.line_ending(),
-            indent_style: self.indent_style(),
-        }
-    }
-}
-
-impl biome_formatter::FormatContext for ModuleFormatContext {
-    type Options = ModuleFormatContextOptions;
-
-    fn options(&self) -> &Self::Options {
-        &ModuleFormatContextOptions
-    }
-
-    fn source_map(&self) -> Option<&TransformSourceMap> {
-        None
-    }
-}
 
 impl std::fmt::Display for JsModuleInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let formatted = biome_formatter::format!(ModuleFormatContext, [&self])
+        let formatted = biome_formatter::format!(FormatTypeContext, [&self])
             .expect("Formatting not to throw any FormatErrors");
         f.write_str(
             formatted
@@ -77,16 +23,24 @@ impl std::fmt::Display for JsModuleInfo {
     }
 }
 
-impl Format<ModuleFormatContext> for JsModuleInfo {
+impl Format<FormatTypeContext> for JsModuleInfo {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let exports = format_with(|f| {
             if self.exports.is_empty() {
                 write!(f, [text("No exports")])
             } else {
                 write!(f, [&self.exports])
+            }
+        });
+
+        let static_imports = format_with(|f| {
+            if self.exports.is_empty() {
+                write!(f, [text("No exports")])
+            } else {
+                write!(f, [&self.static_imports])
             }
         });
 
@@ -98,15 +52,21 @@ impl Format<ModuleFormatContext> for JsModuleInfo {
                 text("{"),
                 &group(&block_indent(&exports)),
                 text("}"),
+                hard_line_break(),
+                text("Imports"),
+                space(),
+                text("{"),
+                &group(&block_indent(&static_imports)),
+                text("}"),
             ]]
         )
     }
 }
 
-impl Format<ModuleFormatContext> for Exports {
+impl Format<FormatTypeContext> for Exports {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let mut joiner = f.join();
         for (export_name, export) in self.deref() {
@@ -161,10 +121,78 @@ impl Format<ModuleFormatContext> for Exports {
     }
 }
 
-impl Format<ModuleFormatContext> for JsExport {
+impl Format<FormatTypeContext> for Imports {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        let mut joiner = f.join();
+
+        for (import_name, import) in &self.0 {
+            let name = format_with(|f| match import_name {
+                Text::Borrowed(t) => {
+                    write!(
+                        f,
+                        [dynamic_text(
+                            &std::format!("{:?}", t.text()),
+                            TextSize::default()
+                        ),]
+                    )
+                }
+                Text::Owned(t) => {
+                    write!(
+                        f,
+                        [dynamic_text(
+                            &std::format!("{:?}", t.as_str()),
+                            TextSize::default()
+                        ),]
+                    )
+                }
+                Text::Static(t) => {
+                    write!(
+                        f,
+                        [dynamic_text(&std::format!("{:?}", t), TextSize::default()),]
+                    )
+                }
+            });
+            let arrow = format_with(|f| {
+                write!(
+                    f,
+                    [&format_args![
+                        space(),
+                        biome_formatter::prelude::text("=>"),
+                        space()
+                    ]]
+                )
+            });
+
+            let export = format_with(|f| {
+                write!(
+                    f,
+                    [&format_args![
+                        text("{"),
+                        &group(&block_indent(&format_args![import]),),
+                        text("}")
+                    ]]
+                )
+            });
+            let line = format_with(|f| {
+                write!(
+                    f,
+                    [&format_args![&name, &arrow, &export, soft_line_break()]]
+                )
+            });
+            joiner.entry(&group(&format_args![line, soft_line_break_or_space()]));
+        }
+
+        Ok(())
+    }
+}
+
+impl Format<FormatTypeContext> for JsExport {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         write!(f, [text("Export")])?;
         match self {
@@ -220,10 +248,10 @@ impl Format<ModuleFormatContext> for JsExport {
     }
 }
 
-impl Format<ModuleFormatContext> for JsReexport {
+impl Format<FormatTypeContext> for JsReexport {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let content = format_with(|f| {
             write!(f, [&format_args![&self.import]])?;
@@ -249,10 +277,10 @@ impl Format<ModuleFormatContext> for JsReexport {
     }
 }
 
-impl Format<ModuleFormatContext> for JsOwnExport {
+impl Format<FormatTypeContext> for JsOwnExport {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let content = format_with(|f| {
             write!(f, [&self.ty])?;
@@ -290,10 +318,10 @@ impl Format<ModuleFormatContext> for JsOwnExport {
     }
 }
 
-impl Format<ModuleFormatContext> for JsdocComment {
+impl Format<FormatTypeContext> for JsdocComment {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let comment = self.deref();
 
@@ -320,10 +348,10 @@ impl Format<ModuleFormatContext> for JsdocComment {
     }
 }
 
-impl Format<ModuleFormatContext> for JsImport {
+impl Format<FormatTypeContext> for JsImport {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         write!(
             f,
@@ -356,164 +384,10 @@ impl Format<ModuleFormatContext> for JsImport {
     }
 }
 
-impl Format<ModuleFormatContext> for Type {
+impl Format<FormatTypeContext> for JsResolvedPath {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        match self.deref() {
-            TypeInner::Unknown => write!(f, [&format_args![text("Unknown")]]),
-            TypeInner::Undefined => write!(f, [&format_args![text("Undefined")]]),
-            TypeInner::Null => write!(f, [&format_args![text("Null")]]),
-            TypeInner::Boolean => write!(f, [&format_args![text("Boolean")]]),
-            TypeInner::Number => write!(f, [&format_args![text("Number")]]),
-            TypeInner::BigInt => write!(f, [&format_args![text("BigInt")]]),
-            TypeInner::String => write!(f, [&format_args![text("String")]]),
-            TypeInner::Symbol => write!(f, [&format_args![text("Symbol")]]),
-            TypeInner::Object(obj) => write!(
-                f,
-                [&format_args![
-                    text("Object"),
-                    text("("),
-                    group(&soft_block_indent(&obj.as_ref())),
-                    text(")")
-                ]]
-            ),
-            TypeInner::Function(func) => write!(f, [&func.as_ref(),]),
-            TypeInner::Union(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Intersection(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Tuple(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Namespace(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Class(class) => write!(f, [&class.as_ref()]),
-            TypeInner::Constructor(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::TypeOperator(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Alias(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::Literal(literal) => write!(
-                f,
-                [&format_args![
-                    text("Literal"),
-                    text("("),
-                    group(&soft_block_indent(&literal.as_ref())),
-                    text(")")
-                ]]
-            ),
-            TypeInner::InstanceOf(ty) => write!(f, [text("instanceof"), space(), &ty.as_ref()]),
-            TypeInner::Reference(reference) => write!(f, [&reference.as_ref(),]),
-            TypeInner::TypeofType(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::TypeofValue(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
-            TypeInner::AnyKeyword => write!(f, [&format_args![text("AnyKeyword")]]),
-            TypeInner::NeverKeyword => write!(f, [&format_args![text("NeverKeyword")]]),
-            TypeInner::ObjectKeyword => write!(f, [&format_args![text("ObjectKeyword")]]),
-            TypeInner::ThisKeyword => write!(f, [&format_args![text("ThisKeyword")]]),
-            TypeInner::UnknownKeyword => write!(f, [&format_args![text("UnknownKeyword")]]),
-            TypeInner::VoidKeyword => write!(f, [&format_args![text("VoidKeyword")]]),
-            TypeInner::TypeofExpression(typeof_expression) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("Reference"),
-                        text("("),
-                        group(&soft_block_indent(&typeof_expression.as_ref())),
-                        text(")")
-                    ]]
-                )
-            }
-        }
-    }
-}
-
-impl Format<ModuleFormatContext> for Literal {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        match self {
-            Self::BigInt(value) => write!(
-                f,
-                [&format_args![
-                    text("BigInt"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-            Self::Boolean(value) => write!(
-                f,
-                [&format_args![
-                    text("Boolean"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-            Self::Null => write!(f, [&format_args![text("Null")]]),
-            Self::Number(value) => write!(
-                f,
-                [&format_args![
-                    text("Number"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-            Self::Object(value) => write!(
-                f,
-                [&format_args![
-                    text("Object"),
-                    text("("),
-                    block_indent(&format_args![value]),
-                    text(")")
-                ]]
-            ),
-            Self::RegExp(value) => write!(
-                f,
-                [&format_args![
-                    text("RegExp"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-            Self::String(value) => write!(
-                f,
-                [&format_args![
-                    text("String"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-            Self::Template(value) => write!(
-                f,
-                [&format_args![
-                    text("Template"),
-                    text(":"),
-                    space(),
-                    dynamic_text(value.text(), TextSize::default()),
-                ]]
-            ),
-        }
-    }
-}
-
-impl Format<ModuleFormatContext> for ObjectLiteral {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                text("TypeMembers"),
-                FmtTypeMembers(self.members())
-            ]]
-        )
-    }
-}
-impl Format<ModuleFormatContext> for JsResolvedPath {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let value = self.deref();
         if let Ok(value) = value {
@@ -530,10 +404,10 @@ impl Format<ModuleFormatContext> for JsResolvedPath {
     }
 }
 
-impl Format<ModuleFormatContext> for JsImportSymbol {
+impl Format<FormatTypeContext> for JsImportSymbol {
     fn fmt(
         &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
         let import = format_with(|f| match self {
             Self::Default => write!(f, [&format_args![text("Default")]]),
@@ -545,659 +419,3 @@ impl Format<ModuleFormatContext> for JsImportSymbol {
         write!(f, [&format_args![text("Import Symbol:"), space(), &import]])
     }
 }
-
-impl Format<ModuleFormatContext> for TypeReference {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                &self.qualifier,
-                space(),
-                text("{"),
-                &group(&block_indent(&format_args![
-                    text("params:"),
-                    space(),
-                    &self.ty,
-                    hard_line_break(),
-                    text("type_args:"),
-                    space(),
-                    FmtTypes(self.type_parameters.as_ref())
-                ])),
-                text("}"),
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for TypeReferenceQualifier {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(f, [text("\"")])?;
-        for (index, part) in self.parts().iter().enumerate() {
-            write!(f, [&format_args![dynamic_text(part, TextSize::default())]])?;
-            if index != self.parts().len() - 1 {
-                write!(f, [text(".")])?;
-            }
-        }
-        write!(f, [text("\"")])?;
-        Ok(())
-    }
-}
-
-impl Format<ModuleFormatContext> for Object {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let mut joiner = f.join_with(soft_line_break());
-        for type_member in self.all_members() {
-            joiner.entry(&format_args![&type_member]);
-        }
-        joiner.finish()
-    }
-}
-
-impl Format<ModuleFormatContext> for TypeMember {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        match self {
-            Self::CallSignature(ty) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("CallSignature"),
-                        text("("),
-                        &group(&soft_block_indent(&ty)),
-                        text(")")
-                    ]]
-                )
-            }
-            Self::Constructor(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::Method(method) => {
-                write!(f, [&format_args![&method]])
-            }
-            Self::Property(property) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("Property"),
-                        text("("),
-                        &group(&soft_block_indent(&property)),
-                        text(")")
-                    ]]
-                )
-            }
-        }
-    }
-}
-
-impl Format<ModuleFormatContext> for CallSignatureTypeMember {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                FmtGenericTypeParameters(&self.type_parameters),
-                FmtFunctionParameters(&self.parameters),
-                text("ReturnType"),
-                text("("),
-                group(&soft_block_indent(&self.return_type)),
-                text(")")
-            ]]
-        )?;
-
-        Ok(())
-    }
-}
-
-impl Format<ModuleFormatContext> for GenericTypeParameter {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                text("Name:"),
-                space(),
-                dynamic_text(&self.name, TextSize::default()),
-                text("Type:"),
-                &self.ty
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for FunctionParameter {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("The parameter is optional")]])
-            } else {
-                write!(f, [&format_args![text("The parameter is not optional")]])
-            }
-        });
-        let rest = format_with(|f| {
-            if self.is_rest {
-                write!(f, [&format_args![text("The parameter is rest")]])
-            } else {
-                write!(f, [&format_args![text("The parameter is not rest")]])
-            }
-        });
-        write!(
-            f,
-            [&group(&format_args![
-                text("["),
-                self.name,
-                text(","),
-                space(),
-                optional,
-                text(","),
-                space(),
-                rest,
-                text("]")
-            ])]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for ReturnType {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        match self {
-            Self::Type(ty) => {
-                write!(f, [&ty])
-            }
-            Self::Predicate(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::Asserts(_asset) => {
-                todo!()
-            }
-        }
-    }
-}
-
-impl Format<ModuleFormatContext> for Function {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let is_async = format_with(|f| {
-            if self.is_async {
-                write!(f, [&format_args![text("async")]])
-            } else {
-                write!(f, [&format_args![text("sync")]])
-            }
-        });
-
-        let name = format_with(|f| {
-            if let Some(name) = &self.name {
-                write!(
-                    f,
-                    [dynamic_text(
-                        &std::format!("\"{}\"", name),
-                        TextSize::default()
-                    ),]
-                )
-            } else {
-                Ok(())
-            }
-        });
-
-        write!(
-            f,
-            [&format_args![
-                is_async,
-                space(),
-                text("Function"),
-                space(),
-                name,
-                space(),
-                text("{"),
-                &group(&soft_block_indent(&format_args![
-                    text("accepts:"),
-                    space(),
-                    text("{"),
-                    &group(&block_indent(&format_args![
-                        text("params:"),
-                        space(),
-                        FmtFunctionParameters(&self.parameters),
-                        hard_line_break(),
-                        text("type_args:"),
-                        space(),
-                        FmtGenericTypeParameters(&self.type_parameters),
-                    ])),
-                    text("}"),
-                    hard_line_break(),
-                    text("returns:"),
-                    space(),
-                    &self.return_type,
-                    space(),
-                ])),
-                text("}"),
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for PropertyTypeMember {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let is_optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("The parameter is optional")]])
-            } else {
-                write!(f, [&format_args![text("The parameter is not optional")]])
-            }
-        });
-        write!(
-            f,
-            [&format_args![
-                text("["),
-                dynamic_text(&self.name, TextSize::default()),
-                text(","),
-                space(),
-                is_optional,
-                text("]"),
-                hard_line_break(),
-                text("Type"),
-                text("("),
-                group(&soft_block_indent(&self.ty)),
-                text(")")
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for Class {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let members = format_with(|f| {
-            write!(f, [&format_args![text("Members"), text("("),]])?;
-
-            let types = format_with(|f| {
-                let mut joiner = f.join_with(soft_line_break());
-                for part in self.members.as_ref() {
-                    joiner.entry(&format_args![part]);
-                }
-                joiner.finish()
-            });
-            write!(
-                f,
-                [&format_args![group(&soft_block_indent(&types)), text(")")]]
-            )
-        });
-        write!(
-            f,
-            [&format_args![
-                text("["),
-                self.name,
-                text("]"),
-                hard_line_break(),
-                members
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for ConstructorTypeMember {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                FmtGenericTypeParameters(&self.type_parameters),
-                hard_line_break(),
-                FmtFunctionParameters(&self.parameters),
-                text("ReturnType"),
-                text("("),
-                group(&soft_block_indent(&self.return_type)),
-                text(")")
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for MethodTypeMember {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let is_async = format_with(|f| {
-            if self.is_async {
-                write!(f, [&format_args![text("async")]])
-            } else {
-                write!(f, [&format_args![text("sync")]])
-            }
-        });
-
-        let is_optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("optional")]])
-            } else {
-                write!(f, [&format_args![text("required")]])
-            }
-        });
-        write!(
-            f,
-            [&format_args![
-                is_optional,
-                space(),
-                is_async,
-                space(),
-                text("Method"),
-                space(),
-                dynamic_text(&std::format!("\"{}\"", &self.name), TextSize::default()),
-                space(),
-                text("{"),
-                &group(&soft_block_indent(&format_args![
-                    text("accepts:"),
-                    space(),
-                    text("{"),
-                    &group(&block_indent(&format_args![
-                        text("params:"),
-                        space(),
-                        FmtFunctionParameters(&self.parameters),
-                        hard_line_break(),
-                        text("type_args:"),
-                        space(),
-                        FmtGenericTypeParameters(&self.type_parameters),
-                    ])),
-                    text("}"),
-                    hard_line_break(),
-                    text("returns:"),
-                    space(),
-                    &self.return_type,
-                    space(),
-                ])),
-                text("}"),
-            ]]
-        )
-    }
-}
-
-impl Format<ModuleFormatContext> for TypeofExpression {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        match self {
-            Self::Addition(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::Await(await_expression) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("Await"),
-                        text("("),
-                        group(&soft_block_indent(await_expression)),
-                        text(")")
-                    ]]
-                )
-            }
-            Self::Call(call) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("Call"),
-                        space(),
-                        call.callee,
-                        space(),
-                        text("("),
-                        group(&soft_block_indent(&FmtCallArgumentType(&call.arguments))),
-                        text(")")
-                    ]]
-                )
-            }
-            Self::Destructure(destructure) => match &destructure.destructure_field {
-                DestructureField::Index(index) => {
-                    write!(
-                        f,
-                        [&format_args![
-                            destructure.ty,
-                            text("["),
-                            dynamic_text(&index.to_string(), TextSize::default()),
-                            text("]")
-                        ]]
-                    )
-                }
-                DestructureField::Name(name) => {
-                    write!(f, [&format_args![destructure.ty, text("."), name]])
-                }
-                DestructureField::RestExcept(names) => {
-                    write!(
-                        f,
-                        [&format_args![
-                            text("{"),
-                            FmtNames(names),
-                            text("..."),
-                            destructure.ty,
-                            text("}")
-                        ]]
-                    )
-                }
-                DestructureField::RestFrom(index) => {
-                    write!(
-                        f,
-                        [&format_args![
-                            text("["),
-                            dynamic_text(&std::format!("({index} others)"), TextSize::default()),
-                            text("..."),
-                            destructure.ty,
-                            text("]")
-                        ]]
-                    )
-                }
-            },
-            Self::New(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::StaticMember(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::Super(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::This(ty) => write!(f, [FmtVerbatim(&ty)]),
-        }
-    }
-}
-
-impl Format<ModuleFormatContext> for TypeofAwaitExpression {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![group(&soft_block_indent(&self.argument)),]]
-        )
-    }
-}
-
-// #region Formatting Helpers
-
-struct FmtFunctionParameters<'a>(&'a [FunctionParameter]);
-impl Format<ModuleFormatContext> for FmtFunctionParameters<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return write!(f, [text("[]")]);
-        }
-
-        let function_parameters = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                joiner.entry(&format_args![part]);
-            }
-            joiner.finish()
-        });
-        write!(f, [&function_parameters])
-    }
-}
-
-struct FmtCallArgumentType<'a>(&'a [CallArgumentType]);
-
-impl Format<ModuleFormatContext> for FmtCallArgumentType<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return write!(f, [text("No parameters")]);
-        }
-
-        let type_parameters = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                match part {
-                    CallArgumentType::Argument(ty) => joiner.entry(&format_args![ty]),
-                    CallArgumentType::Spread(ty) => joiner.entry(&format_args![text("..."), ty]),
-                };
-            }
-            joiner.finish()
-        });
-        write!(f, [&format_args![&type_parameters]])
-    }
-}
-
-struct FmtGenericTypeParameters<'a>(&'a [GenericTypeParameter]);
-
-impl Format<ModuleFormatContext> for FmtGenericTypeParameters<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return write!(f, [text("No parameters")]);
-        }
-
-        let type_parameters = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                joiner.entry(&format_args![part]);
-            }
-            joiner.finish()
-        });
-        write!(f, [&format_args![&type_parameters]])
-    }
-}
-
-struct FmtTypeMembers<'a>(&'a [TypeMember]);
-
-impl Format<ModuleFormatContext> for FmtTypeMembers<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return Ok(());
-        }
-
-        write!(f, [&format_args![text("TypeMembers"), text("("),]])?;
-
-        let types = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                joiner.entry(&format_args![part]);
-            }
-            joiner.finish()
-        });
-        write!(
-            f,
-            [&format_args![group(&soft_block_indent(&types)), text(")")]]
-        )
-    }
-}
-
-struct FmtTypes<'a>(&'a [Type]);
-
-impl Format<ModuleFormatContext> for FmtTypes<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return write!(f, [text("No types")]);
-        }
-
-        let types = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                joiner.entry(&format_args![part]);
-            }
-            joiner.finish()
-        });
-        write!(f, [&format_args![&types]])
-    }
-}
-
-struct FmtNames<'a>(&'a [Text]);
-
-impl Format<ModuleFormatContext> for FmtNames<'_> {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return Ok(());
-        }
-
-        let types = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
-            for part in self.0 {
-                joiner.entry(&format_args![part]);
-            }
-            joiner.finish()
-        });
-        write!(f, [&format_args![&types]])
-    }
-}
-
-impl Format<ModuleFormatContext> for Text {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![dynamic_text(
-                self.text(),
-                TextSize::default()
-            )]]
-        )
-    }
-}
-struct FmtVerbatim<'a, T>(&'a T);
-
-impl<T> Format<ModuleFormatContext> for FmtVerbatim<'_, T>
-where
-    T: Debug,
-{
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<ModuleFormatContext>,
-    ) -> FormatResult<()> {
-        let text = std::format!("{:#?}", self.0);
-        write!(
-            f,
-            [&format_args![dynamic_text(&text, TextSize::default()),]]
-        )
-    }
-}
-
-// #endregion

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -108,7 +108,7 @@ pub struct JsModuleInfoInner {
     /// import another module and immediately re-export from that module.
     /// Re-exports are tracked as part of [Self::exports] and
     /// [Self::blanket_reexports].
-    pub static_imports: BTreeMap<Text, JsImport>,
+    pub static_imports: Imports,
 
     /// Map of all the paths from static imports in the module.
     ///
@@ -166,6 +166,16 @@ pub struct Exports(pub(crate) BTreeMap<Text, JsExport>);
 impl Deref for Exports {
     type Target = BTreeMap<Text, JsExport>;
 
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct Imports(pub(crate) BTreeMap<Text, JsImport>);
+
+impl Deref for Imports {
+    type Target = BTreeMap<Text, JsImport>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -22,9 +22,9 @@ use crate::{
 };
 
 use super::{
-    Exports, JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsModuleInfoInner, JsOwnExport,
-    JsReexport, JsResolvedPath, binding::JsBindingData, global_scope_resolver::GlobalScopeResolver,
-    scope::JsScopeData,
+    Exports, Imports, JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsModuleInfoInner,
+    JsOwnExport, JsReexport, JsResolvedPath, binding::JsBindingData,
+    global_scope_resolver::GlobalScopeResolver, scope::JsScopeData,
 };
 
 /// Responsible for collecting all the information from which to build the
@@ -545,7 +545,7 @@ impl JsModuleInfo {
         bag.resolve_module_types(&collector);
 
         Self(Arc::new(JsModuleInfoInner {
-            static_imports: bag.static_imports,
+            static_imports: Imports(bag.static_imports),
             static_import_paths: collector.static_import_paths,
             dynamic_import_paths: collector.dynamic_import_paths,
             exports: Exports(bag.exports),

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -60,7 +60,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
             content.push_str("\n\n");
             content.push_str("```\n");
             content.push_str(&data.to_string());
-            content.push_str("```\n\n");
+            content.push_str("\n```\n\n");
         }
 
         insta::with_settings!({

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
@@ -21,10 +21,10 @@ Exports {
       sync Function "Component" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
         returns: "JSX.Element" {
-          params: Unknown
+          resolved: unknown
           type_args: No types
         }
       }
@@ -35,4 +35,6 @@ Exports {
       )
     )
   }
-}```
+}
+Imports {}
+```

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -22,9 +22,9 @@ Exports {
       sync Function "foo" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
-        returns: Unknown
+        returns: unknown
       }
       Local name: foo
       JsDoc(
@@ -32,4 +32,6 @@ Exports {
       )
     )
   }
-}```
+}
+Imports {}
+```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -42,36 +42,22 @@ export const superComputer = new DeepThought();
 Exports {
   "superComputer" => {
     ExportOwnExport => JsOwnExport(
-      Object(
-        required sync Method "answerMe" {
-          accepts: {
-            params: []
-            type_args: No parameters
-          }
-          returns: Number
+      Object {
+        prototype: "DeepThought" {
+          extends: none
+          type_args: []
         }
-        required sync Method "giveMeABiggerAnswer" {
-          accepts: {
-            params: [delta, The parameter is not optional, The parameter is not rest]
-            type_args: No parameters
-          }
-          returns: Unknown
-        }
-        required sync Method "whatWasTheUltimateQuestion" {
-          accepts: {
-            params: []
-            type_args: No parameters
-          }
-          returns: UnknownKeyword
-        }
-      )
+        members: {}
+      }
       Local name: superComputer
     )
   }
   "theAnswer" => {
     ExportOwnExport => JsOwnExport(
-      Literal(Number: 42)
+      value: 42
       Local name: theAnswer
     )
   }
-}```
+}
+Imports {}
+```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
+snapshot_kind: text
 ---
 ## /src/index.ts
 
@@ -59,15 +60,15 @@ export * as renamed2 from "./renamed-reexports";
 Exports {
   "a" => {
     ExportOwnExport => JsOwnExport(
-      String
+      string
       Local name: a
     )
   }
   "b" => {
     ExportOwnExport => JsOwnExport(
       "Array" {
-        params: Unknown
-        type_args: Number
+        resolved: unknown
+        type_args: number
       }
       Local name: b
     )
@@ -77,9 +78,9 @@ Exports {
       sync Function "bar" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
-        returns: Unknown
+        returns: unknown
       }
       Local name: bar
       JsDoc(
@@ -92,118 +93,19 @@ Exports {
       async Function "baz" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
-        returns: [Promise]
-        Members(
-          required sync Method "all" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "allSettled" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "any" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "race" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "reject" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "resolve" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "try" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "catch" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "finally" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-          required sync Method "then" {
-            accepts: {
-              params: []
-              type_args: No parameters
-            }
-            returns: "Promise" {
-              params: Unknown
-              type_args: Unknown
-            }
-          }
-        )
+        returns: "Promise" {
+          extends: none
+          type_args: [T -> unknown]
+        }
       }
       Local name: baz
     )
   }
   "d" => {
     ExportOwnExport => JsOwnExport(
-      Boolean
+      boolean
       Local name: d
     )
   }
@@ -212,10 +114,10 @@ Exports {
       sync Function "Component" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
         returns: "JSX.Element" {
-          params: Unknown
+          resolved: unknown
           type_args: No types
         }
       }
@@ -246,9 +148,9 @@ Exports {
       sync Function "foo" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
-        returns: Unknown
+        returns: unknown
       }
       Local name: foo
       JsDoc(
@@ -265,13 +167,16 @@ Exports {
   }
   "qux" => {
     ExportOwnExport => JsOwnExport(
-      Literal(Number: 1)
+      value: 1
       Local name: qux
     )
   }
   "quz" => {
     ExportOwnExport => JsOwnExport(
-      Object()
+      Object {
+        prototype: No prototype
+        members: {}
+      }
       Local name: quz
       JsDoc(
         @private
@@ -288,7 +193,9 @@ Exports {
       )
     )
   }
-}```
+}
+Imports {}
+```
 
 ## /src/renamed-reexports.ts
 
@@ -304,14 +211,16 @@ Exports {
       sync Function "ohNo" {
         accepts: {
           params: []
-          type_args: No parameters
+          type_args: []
         }
-        returns: Unknown
+        returns: unknown
       }
       Local name: ohNo
     )
   }
-}```
+}
+Imports {}
+```
 
 ## /src/reexports.ts
 
@@ -335,4 +244,6 @@ Exports {
       )
     )
   }
-}```
+}
+Imports {}
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

It reduces the duplication of code between `biome_module_graph` and `biome_js_type_info`.

Adds formatting of `ObjectLiteral`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan


Updated snapshots 

<!-- What demonstrates that your implementation is correct? -->
