### PR TITLE
fix(cli): fix the link "Biome in IDE" docs in the "Setup an editor extension" CLI doc

### DIFF
--- a/.changeset/public-crabs-laugh.md
+++ b/.changeset/public-crabs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed link to the docs inside CLI markup

--- a/crates/biome_cli/src/commands/init.rs
+++ b/crates/biome_cli/src/commands/init.rs
@@ -25,7 +25,7 @@ Welcome to Biome! Let's get you started...
 
   "<Dim>"1."</Dim>" "<Emphasis>"Setup an editor extension"</Emphasis>"
      Get live errors as you type and format when you save.
-     Learn more at "<Hyperlink href="https://biomejs.dev/guides/integrate-in-editor/">"https://biomejs.dev/guides/integrate-in-editor/"</Hyperlink>"
+     Learn more at "<Hyperlink href="https://biomejs.dev/guides/editors/first-party-extensions/">"https://biomejs.dev/guides/editors/first-party-extensions/"</Hyperlink>"
 
   "<Dim>"2."</Dim>" "<Emphasis>"Try a command"</Emphasis>"
      "<Italic>"biome check"</Italic>"  checks formatting, import sorting, and lint rules.

--- a/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_file.snap
@@ -56,7 +56,7 @@ Next Steps
 
   1. Setup an editor extension
      Get live errors as you type and format when you save.
-     Learn more at https://biomejs.dev/guides/integrate-in-editor/
+     Learn more at https://biomejs.dev/guides/editors/first-party-extensions/
 
   2. Try a command
      biome check  checks formatting, import sorting, and lint rules.

--- a/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_file_when_biome_installed_via_package_manager.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_file_when_biome_installed_via_package_manager.snap
@@ -62,7 +62,7 @@ Next Steps
 
   1. Setup an editor extension
      Get live errors as you type and format when you save.
-     Learn more at https://biomejs.dev/guides/integrate-in-editor/
+     Learn more at https://biomejs.dev/guides/editors/first-party-extensions/
 
   2. Try a command
      biome check  checks formatting, import sorting, and lint rules.

--- a/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_jsonc_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_init/creates_config_jsonc_file.snap
@@ -56,7 +56,7 @@ Next Steps
 
   1. Setup an editor extension
      Get live errors as you type and format when you save.
-     Learn more at https://biomejs.dev/guides/integrate-in-editor/
+     Learn more at https://biomejs.dev/guides/editors/first-party-extensions/
 
   2. Try a command
      biome check  checks formatting, import sorting, and lint rules.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Link in the CLI markup pointing to the Editor extensions -- `https://biomejs.dev/guides/integrate-in-editor/` -- is not working.
Replaced with `https://biomejs.dev/guides/editors/first-party-extensions/`

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

I've run tests and updated snapshots.