### PR TITLE
feat(useExplicitType): cover function parameters

### DIFF
--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -185,6 +185,10 @@ pub(crate) fn migrate_eslint_any_rule(
             rule.set_level(rule.level().max(rule_severity.into()));
         }
         "@typescript-eslint/explicit-function-return-type" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
             if !options.include_nursery {
                 return false;
             }
@@ -203,6 +207,21 @@ pub(crate) fn migrate_eslint_any_rule(
             let rule = group
                 .unwrap_group_as_mut()
                 .use_consistent_member_accessibility
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "@typescript-eslint/explicit-module-boundary-types" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
+            if !options.include_nursery {
+                return false;
+            }
+            let group = rules.nursery.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .use_explicit_type
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3363,7 +3363,7 @@ pub struct Nursery {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_deprecated_reason:
         Option<RuleConfiguration<biome_graphql_analyze::options::UseDeprecatedReason>>,
-    #[doc = "Require explicit return types on functions and class methods."]
+    #[doc = "Enforce types in functions, methods, variables, and parameters."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_explicit_type: Option<RuleConfiguration<biome_js_analyze::options::UseExplicitType>>,
     #[doc = "Require that all exports are declared after all non-export statements."]

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
@@ -162,7 +162,7 @@ invalid.ts:1:1 lint/nursery/useExplicitType ━━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -181,7 +181,7 @@ invalid.ts:5:1 lint/nursery/useExplicitType ━━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -200,7 +200,7 @@ invalid.ts:9:7 lint/nursery/useExplicitType ━━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -222,7 +222,7 @@ invalid.ts:9:12 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -241,7 +241,7 @@ invalid.ts:13:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -260,7 +260,7 @@ invalid.ts:13:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -268,7 +268,7 @@ invalid.ts:13:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:17:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     15 │ class Test {
     16 │ 	constructor() {}
@@ -282,7 +282,7 @@ invalid.ts:17:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -290,7 +290,7 @@ invalid.ts:17:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:21:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     19 │ 	}
     20 │ 	set prop() {}
@@ -304,7 +304,7 @@ invalid.ts:21:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -323,7 +323,7 @@ invalid.ts:24:10 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -331,7 +331,7 @@ invalid.ts:24:10 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:25:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     23 │ 	}
     24 │ 	arrow = () => "arrow";
@@ -345,7 +345,7 @@ invalid.ts:25:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -364,7 +364,7 @@ invalid.ts:30:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -372,7 +372,7 @@ invalid.ts:30:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:31:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     30 │ const obj = {
   > 31 │ 	method() {
@@ -385,7 +385,7 @@ invalid.ts:31:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -404,7 +404,7 @@ invalid.ts:36:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -412,7 +412,7 @@ invalid.ts:36:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:37:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     36 │ const obj = {
   > 37 │ 	get method() {
@@ -425,7 +425,7 @@ invalid.ts:37:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -444,7 +444,7 @@ invalid.ts:42:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -463,7 +463,7 @@ invalid.ts:42:14 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -481,7 +481,7 @@ invalid.ts:43:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -499,7 +499,7 @@ invalid.ts:43:14 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -518,7 +518,7 @@ invalid.ts:45:16 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -536,7 +536,7 @@ invalid.ts:46:16 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -554,7 +554,7 @@ invalid.ts:49:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -572,7 +572,7 @@ invalid.ts:49:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -591,7 +591,7 @@ invalid.ts:50:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -610,7 +610,7 @@ invalid.ts:50:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -629,7 +629,7 @@ invalid.ts:51:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -648,7 +648,7 @@ invalid.ts:52:9 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -667,7 +667,7 @@ invalid.ts:57:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -691,7 +691,7 @@ invalid.ts:57:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -710,7 +710,7 @@ invalid.ts:66:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -734,7 +734,7 @@ invalid.ts:66:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -753,7 +753,7 @@ invalid.ts:80:1 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -772,7 +772,7 @@ invalid.ts:87:1 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -791,7 +791,7 @@ invalid.ts:94:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -810,7 +810,7 @@ invalid.ts:94:29 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -829,7 +829,7 @@ invalid.ts:94:69 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -846,7 +846,7 @@ invalid.ts:95:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -863,7 +863,7 @@ invalid.ts:95:36 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -880,7 +880,7 @@ invalid.ts:95:76 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -899,7 +899,7 @@ invalid.ts:107:16 lint/nursery/useExplicitType ━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -907,7 +907,7 @@ invalid.ts:107:16 lint/nursery/useExplicitType ━━━━━━━━━━━
 ```
 invalid.ts:115:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     113 │ 	pop(): Type | undefined;
     114 │ 	push(...items: Type[]): number;
@@ -918,7 +918,7 @@ invalid.ts:115:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -926,7 +926,7 @@ invalid.ts:115:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:119:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     118 │ type MyObject = {
   > 119 │ 	(input: string);
@@ -936,7 +936,7 @@ invalid.ts:119:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -944,7 +944,7 @@ invalid.ts:119:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:124:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     123 │ abstract class MyClass {
   > 124 │ 	public abstract method();
@@ -954,7 +954,7 @@ invalid.ts:124:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -962,7 +962,7 @@ invalid.ts:124:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:129:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on member.
   
     127 │ abstract class P<T> {
     128 │ 	abstract method(): T;
@@ -973,7 +973,7 @@ invalid.ts:129:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the member.
   
 
 ```
@@ -981,7 +981,7 @@ invalid.ts:129:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:133:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on function declaration.
   
     132 │ declare namespace myLib {
   > 133 │ 	function makeGreeting(s: string);
@@ -991,7 +991,7 @@ invalid.ts:133:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function declaration.
   
 
 ```
@@ -999,7 +999,7 @@ invalid.ts:133:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 invalid.ts:137:17 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Missing return type on function.
+  × Missing return type on function declaration.
   
     136 │ declare module "foo" {
   > 137 │ 	export default function bar();
@@ -1009,7 +1009,7 @@ invalid.ts:137:17 lint/nursery/useExplicitType ━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function declaration.
   
 
 ```
@@ -1028,7 +1028,7 @@ invalid.ts:140:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -1047,7 +1047,7 @@ invalid.ts:140:19 lint/nursery/useExplicitType ━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```
@@ -1064,7 +1064,7 @@ invalid.ts:141:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -1081,7 +1081,7 @@ invalid.ts:141:26 lint/nursery/useExplicitType ━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a return type to the function.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts
@@ -1,0 +1,32 @@
+// argument without type
+export var arrowFn = (arg): string => `test ${arg}`;
+
+// argument with any type
+export var arrowFn = (arg: any): string => `test ${arg}`;
+
+var foo = arr.map((i) => i * i);
+new Promise((resolve) => resolve(1));
+
+// js binding argument
+new Promise(resolve => resolve(1));
+
+
+class Test {
+	constructor(foo) {}
+	get prop(): number {
+		return 1;
+	}
+	set prop(foo) {}
+	method(foo): void {
+		return;
+	}
+	arrow = (foo): string => "arrow";
+}
+
+var obj = {
+	method(foo): string {
+		return "test";
+	},
+	set prop(foo) {}
+};
+

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts.snap
@@ -1,0 +1,244 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidArguments.ts
+snapshot_kind: text
+---
+# Input
+```ts
+// argument without type
+export var arrowFn = (arg): string => `test ${arg}`;
+
+// argument with any type
+export var arrowFn = (arg: any): string => `test ${arg}`;
+
+var foo = arr.map((i) => i * i);
+new Promise((resolve) => resolve(1));
+
+// js binding argument
+new Promise(resolve => resolve(1));
+
+
+class Test {
+	constructor(foo) {}
+	get prop(): number {
+		return 1;
+	}
+	set prop(foo) {}
+	method(foo): void {
+		return;
+	}
+	arrow = (foo): string => "arrow";
+}
+
+var obj = {
+	method(foo): string {
+		return "test";
+	},
+	set prop(foo) {}
+};
+
+
+```
+
+# Diagnostics
+```
+invalidArguments.ts:2:23 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    1 │ // argument without type
+  > 2 │ export var arrowFn = (arg): string => `test ${arg}`;
+      │                       ^^^
+    3 │ 
+    4 │ // argument with any type
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:5:28 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter has an any type.
+  
+    4 │ // argument with any type
+  > 5 │ export var arrowFn = (arg: any): string => `test ${arg}`;
+      │                            ^^^
+    6 │ 
+    7 │ var foo = arr.map((i) => i * i);
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Replace any with unknown or a more specific type.
+  
+
+```
+
+```
+invalidArguments.ts:7:20 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    5 │ export var arrowFn = (arg: any): string => `test ${arg}`;
+    6 │ 
+  > 7 │ var foo = arr.map((i) => i * i);
+      │                    ^
+    8 │ new Promise((resolve) => resolve(1));
+    9 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:8:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+     7 │ var foo = arr.map((i) => i * i);
+   > 8 │ new Promise((resolve) => resolve(1));
+       │              ^^^^^^^
+     9 │ 
+    10 │ // js binding argument
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:11:13 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    10 │ // js binding argument
+  > 11 │ new Promise(resolve => resolve(1));
+       │             ^^^^^^^
+    12 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:15:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    14 │ class Test {
+  > 15 │ 	constructor(foo) {}
+       │ 	            ^^^
+    16 │ 	get prop(): number {
+    17 │ 		return 1;
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:19:11 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    17 │ 		return 1;
+    18 │ 	}
+  > 19 │ 	set prop(foo) {}
+       │ 	         ^^^
+    20 │ 	method(foo): void {
+    21 │ 		return;
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:20:9 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    18 │ 	}
+    19 │ 	set prop(foo) {}
+  > 20 │ 	method(foo): void {
+       │ 	       ^^^
+    21 │ 		return;
+    22 │ 	}
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:23:11 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    21 │ 		return;
+    22 │ 	}
+  > 23 │ 	arrow = (foo): string => "arrow";
+       │ 	         ^^^
+    24 │ }
+    25 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:27:9 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    26 │ var obj = {
+  > 27 │ 	method(foo): string {
+       │ 	       ^^^
+    28 │ 		return "test";
+    29 │ 	},
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```
+
+```
+invalidArguments.ts:30:11 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The parameter doesn't have a type defined.
+  
+    28 │ 		return "test";
+    29 │ 	},
+  > 30 │ 	set prop(foo) {}
+       │ 	         ^^^
+    31 │ };
+    32 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the parameter.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
@@ -28,7 +28,7 @@ invalidDeclarationStatements.ts:1:14 lint/nursery/useExplicitType ━━━━�
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```
@@ -45,7 +45,7 @@ invalidDeclarationStatements.ts:4:7 lint/nursery/useExplicitType ━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/namespace.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/namespace.ts.snap
@@ -25,7 +25,7 @@ namespace.ts:2:15 lint/nursery/useExplicitType ━━━━━━━━━━━
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
-  i Add a return type annotation.
+  i Add a type to the variable.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
@@ -43,11 +43,11 @@ var func = () => x as const;
 // check allow expressions
 node.addEventListener("click", () => {});
 node.addEventListener("click", function () {});
-var foo = arr.map((i) => i * i);
 fn(() => {});
 fn(function () {});
-new Promise((resolve) => {});
+new Promise(() => {});
 new Foo(1, () => {});
+[function () {}, () => {}];
 [function () {}, () => {}];
 (function () {
 	console.log("This is an IIFE");

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
@@ -50,11 +50,11 @@ var func = () => x as const;
 // check allow expressions
 node.addEventListener("click", () => {});
 node.addEventListener("click", function () {});
-var foo = arr.map((i) => i * i);
 fn(() => {});
 fn(function () {});
-new Promise((resolve) => {});
+new Promise(() => {});
 new Foo(1, () => {});
+[function () {}, () => {}];
 [function () {}, () => {}];
 (function () {
 	console.log("This is an IIFE");

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/validInferrable.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/validInferrable.ts
@@ -1,3 +1,4 @@
+/* should not generate diagnostics */
 const x: 1n = 1n;
 const x: -1n = -1n;
 const x: false = false;

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/validInferrable.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/validInferrable.ts.snap
@@ -5,6 +5,7 @@ snapshot_kind: text
 ---
 # Input
 ```ts
+/* should not generate diagnostics */
 const x: 1n = 1n;
 const x: -1n = -1n;
 const x: false = false;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1698,7 +1698,7 @@ export interface Nursery {
 	 */
 	useDeprecatedReason?: RuleConfiguration_for_Null;
 	/**
-	 * Require explicit return types on functions and class methods.
+	 * Enforce types in functions, methods, variables, and parameters.
 	 */
 	useExplicitType?: RuleConfiguration_for_Null;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3026,7 +3026,7 @@
 					]
 				},
 				"useExplicitType": {
-					"description": "Require explicit return types on functions and class methods.",
+					"description": "Enforce types in functions, methods, variables, and parameters.",
 					"anyOf": [
 						{ "$ref": "#/definitions/RuleConfiguration" },
 						{ "type": "null" }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of https://github.com/biomejs/biome/issues/2017

With this PR, now the function cover this rule: https://typescript-eslint.io/rules/explicit-module-boundary-types/#examples, in particular the arguments of the functions.

Since the rule is taking a different turn compared to the original design, I took the opportunity to revisit the messages and the advice. 

I will make a follow-up PR to revisit the documentation, because it talks about function return types.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Some cases that were valid, aren't valid anymore, so I removed them. I added

<!-- What demonstrates that your implementation is correct? -->
