### PR TITLE
feat(lint): add `full` domain

### DIFF
--- a/.changeset/introduce_the_domains_linter_feature.md
+++ b/.changeset/introduce_the_domains_linter_feature.md
@@ -50,5 +50,14 @@ New domains introduced:
   - `useHookAtTopLevel`
 - `solid`: it will enable rules for Solid projects:
   - `noReactSpecificProps`
+- `full`: allows enabling or disabling **all** rules
+- `project`: it will enable rules that require scanning the whole project. These rules are generally slow because Biome needs to collect information across files (modules and types), hence they aren't recommended by default and only enabled via domain:
+  Rules enabled by this domain:
+  - `noPrivateImports` (recommended)
+  - `useImportExtensions`
+  - `noFloatingPromises` (recommended)
+  - `noImportCycles`
+  - `noUnresolvedImports`
+
 
 For more information regarding how Biome enables rules via domains, please refer to the documentation page of each rule.

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -501,6 +501,8 @@ pub enum RuleDomain {
     Next,
     /// For rules that require querying multiple files inside a project
     Project,
+    /// It enables all non-nursery rules
+    Full,
 }
 
 impl Display for RuleDomain {
@@ -512,6 +514,7 @@ impl Display for RuleDomain {
             Self::Solid => fmt.write_str("solid"),
             Self::Next => fmt.write_str("next"),
             Self::Project => fmt.write_str("project"),
+            Self::Full => fmt.write_str("full"),
         }
     }
 }
@@ -544,14 +547,13 @@ impl RuleDomain {
             ],
             Self::Solid => &[&("solid", ">=1.0.0")],
             Self::Next => &[&("next", ">=14.0.0")],
-            Self::Project => &[],
+            Self::Project | Self::Full => &[],
         }
     }
 
     /// Global identifiers that should be added to the `globals` of the [crate::AnalyzerConfiguration] type
     pub const fn globals(self) -> &'static [&'static str] {
         match self {
-            Self::React => &[],
             Self::Test => &[
                 "after",
                 "afterAll",
@@ -564,9 +566,7 @@ impl RuleDomain {
                 "expect",
                 "test",
             ],
-            Self::Solid => &[],
-            Self::Next => &[],
-            Self::Project => &[],
+            Self::React | Self::Solid | Self::Next | Self::Project | Self::Full => &[],
         }
     }
 }

--- a/crates/biome_cli/tests/cases/linter_domains.rs
+++ b/crates/biome_cli/tests/cases/linter_domains.rs
@@ -302,3 +302,50 @@ describe("foo", () => {
         result,
     ));
 }
+
+#[test]
+fn full_domain_enables_all_rules() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+    let config = Utf8Path::new("biome.json");
+    fs.insert(
+        config.into(),
+        r#"{
+    "linter": {
+        "domains": {
+            "full": "recommended"
+        }
+    }
+}
+"#
+        .as_bytes(),
+    );
+
+    let content = r#"
+describe("foo", () => {
+	beforeEach(() => {});
+    beforeEach(() => {});
+    test("bar", () => {
+        someFn();
+    });
+});
+    "#;
+    let test2 = Utf8Path::new("test2.js");
+    fs.insert(test2.into(), content.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", test2.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "full_domain_enables_all_rules",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_domains/full_domain_enables_all_rules.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_domains/full_domain_enables_all_rules.snap
@@ -1,0 +1,65 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+snapshot_kind: text
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "domains": {
+      "full": "recommended"
+    }
+  }
+}
+```
+
+## `test2.js`
+
+```js
+
+describe("foo", () => {
+	beforeEach(() => {});
+    beforeEach(() => {});
+    test("bar", () => {
+        someFn();
+    });
+});
+    
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test2.js:4:5 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Disallow duplicate setup and teardown hooks.
+  
+    2 │ describe("foo", () => {
+    3 │ 	beforeEach(() => {});
+  > 4 │     beforeEach(() => {});
+      │     ^^^^^^^^^^^^^^^^^^^^
+    5 │     test("bar", () => {
+    6 │         someFn();
+  
+  i Disallow beforeEach duplicacy inside the describe function.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, ensure};
 use biome_analyze::{
     AnalysisFilter, AnalyzerOptions, ControlFlow, GroupCategory, Queryable, RegistryVisitor, Rule,
-    RuleCategory, RuleFilter, RuleGroup, RuleMetadata,
+    RuleCategory, RuleDomain, RuleFilter, RuleGroup, RuleMetadata,
 };
 use biome_configuration::Configuration;
 use biome_console::{Console, markup};
@@ -48,6 +48,10 @@ impl Errors {
             rule_name
         ))
     }
+
+    fn no_all_domain() -> Self {
+        Self("Don't use the All domain. This is a special domain to enable all rules and no rule needs to be assigned to this domain.".to_string())
+    }
 }
 
 impl Display for Errors {
@@ -75,6 +79,8 @@ pub fn check_rules() -> anyhow::Result<()> {
                 && R::METADATA.severity != Severity::Information
             {
                 self.errors.push(Errors::action_error(R::METADATA.name));
+            } else if R::METADATA.domains.contains(&RuleDomain::Full) {
+                self.errors.push(Errors::no_all_domain());
             } else {
                 self.groups
                     .entry((<R::Group as RuleGroup>::NAME, R::METADATA.language))


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/5764

This PR implements a new domain called `RuleDomain::Full`. The reason why I chose "full" instead of "all" is that we already have a domain value named "all". This means that the following snippet would be really confusing:

```json
{
	"linter": {
		"domains": {
			"react": "all",
			"all": "all"
		}
	}
}
```

The name "full" isn't as good as "all", so I welcome suggestions. 

This PR also changes the logic:
- of how the new `ScanKind` is computed by taking the new domain into consideration
- of how the rules are enabled/disabled during the linting phase by taking the new domain into consideration

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I added the new tests for the `ScanKind` computation. I added a new CLI test, however I couldn't add a nursery test because it could fail in the future. 

<!-- What demonstrates that your implementation is correct? -->
