### PR TITLE
fix(lsp): related diagnostics

### DIFF
--- a/.changeset/chatty-memes-rule.md
+++ b/.changeset/chatty-memes-rule.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where the related diagnostics attached to the main diagnostics didn't have a correct message.

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{MarkupBuf, Padding, markup};
-use biome_diagnostics::advice::CodeSuggestionAdvice;
 use biome_diagnostics::location::AsSpan;
 use biome_diagnostics::{
     Advices, Category, Diagnostic, DiagnosticTags, Location, LogCategory, MessageAndDescription,
@@ -1288,7 +1287,6 @@ pub struct RuleAdvice {
     pub(crate) details: Vec<Detail>,
     pub(crate) notes: Vec<(LogCategory, MarkupBuf)>,
     pub(crate) suggestion_list: Option<SuggestionList>,
-    pub(crate) code_suggestion_list: Vec<CodeSuggestionAdvice<MarkupBuf>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1324,11 +1322,6 @@ impl Advices for RuleAdvice {
             visitor.record_list(&list)?;
         }
 
-        // finally, we print possible code suggestions on how to fix the issue
-        for suggestion in &self.code_suggestion_list {
-            suggestion.record(visitor)?;
-        }
-
         Ok(())
     }
 }
@@ -1354,12 +1347,6 @@ impl RuleDiagnostic {
             rule_advice: RuleAdvice::default(),
             severity: Severity::default(),
         }
-    }
-
-    /// Set an explicit plain-text summary for this diagnostic.
-    pub fn description(mut self, summary: impl Into<String>) -> Self {
-        self.message.set_description(summary.into());
-        self
     }
 
     /// Marks this diagnostic as deprecated code, which will
@@ -1390,7 +1377,7 @@ impl RuleDiagnostic {
 
     /// Attaches a label to this [`RuleDiagnostic`].
     ///
-    /// The given span has to be in the file that was provided while creating this [`RuleDiagnostic`].
+    /// The given span has to be in the file provided while creating this [`RuleDiagnostic`].
     pub fn label(mut self, span: impl AsSpan, msg: impl Display) -> Self {
         self.rule_advice.details.push(Detail {
             log_category: LogCategory::Info,
@@ -1454,11 +1441,11 @@ impl RuleDiagnostic {
         self
     }
 
-    /// Assigns an explicit severity.
+    /// Assigns explicit severity.
     ///
     /// In most cases, severity should _not_ be explicitly assigned, since rule
-    /// categories and configuration define the severity. Currently this is only
-    /// used for plugins to allow plugin authors to assign an explicit severity.
+    /// categories and configuration define the severity. Currently, this is only
+    /// used for plugins to allow plugin authors to assign explicit severity.
     pub fn with_severity(mut self, severity: Severity) -> Self {
         self.severity = severity;
         self

--- a/crates/biome_cli/src/execute/process_file/format.rs
+++ b/crates/biome_cli/src/execute/process_file/format.rs
@@ -43,6 +43,7 @@ pub(crate) fn format_with_guard<'ctx>(
             max_diagnostics,
             Vec::new(),
             Vec::new(),
+            false, // NOTE: probably to revisit
         )
         .with_file_path_and_code(workspace_file.path.to_string(), category!("format"))?;
 

--- a/crates/biome_cli/src/execute/process_file/lint_and_assist.rs
+++ b/crates/biome_cli/src/execute/process_file/lint_and_assist.rs
@@ -114,7 +114,7 @@ pub(crate) fn analyze_with_guard<'ctx>(
     let max_diagnostics = ctx.remaining_diagnostics.load(Ordering::Relaxed);
     let pull_diagnostics_result = workspace_file
         .guard()
-        .pull_diagnostics(categories, max_diagnostics, only, skip)
+        .pull_diagnostics(categories, max_diagnostics, only, skip, true)
         .with_file_path_and_code(
             workspace_file.path.to_string(),
             ctx.execution.as_diagnostic_category(),

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_js_files.snap
@@ -31,7 +31,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ <script setup lang="js">
   > 2 │ a == b;
@@ -39,16 +39,9 @@ file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━�
     3 │ delete a.c;
     4 │ 
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-  > 1 │ <script setup lang="js">
-      │   ^^
-    2 │ a == b;
-    3 │ delete a.c;
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     1 │ a·===·b;
       │     +   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/lint_vue_ts_files.snap
@@ -31,7 +31,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ <script setup lang="ts">
   > 2 │ a == b;
@@ -39,16 +39,9 @@ file.vue:2:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━�
     3 │ delete a.c;
     4 │ 
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-  > 1 │ <script setup lang="ts">
-      │   ^^
-    2 │ a == b;
-    3 │ delete a.c;
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     1 │ a·===·b;
       │     +   

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_check_command.snap
@@ -49,7 +49,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block
@@ -81,7 +81,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_ci_command.snap
@@ -49,7 +49,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block
@@ -81,7 +81,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_github/reports_diagnostics_github_lint_command.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 snapshot_kind: text
 ---
 ## `index.ts`
@@ -45,7 +45,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=index.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block
@@ -69,7 +69,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Using == may be unsafe if you are relying on type coercion.
 ```
 
 ```block

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_check_command.snap
@@ -79,7 +79,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "8145265504203493155",
     "severity": "critical",
@@ -91,7 +91,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "9497329216962766751",
     "severity": "critical",
@@ -103,7 +103,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "18366180239442454213",
     "severity": "critical",
@@ -115,7 +115,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "17264185503232320851",
     "severity": "critical",
@@ -331,7 +331,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6143155163249580709",
     "severity": "critical",
@@ -343,7 +343,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "16004470298861036684",
     "severity": "critical",
@@ -355,7 +355,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6844513959367944349",
     "severity": "critical",
@@ -367,7 +367,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "3753031813987153088",
     "severity": "critical",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_ci_command.snap
@@ -79,7 +79,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "8145265504203493155",
     "severity": "critical",
@@ -91,7 +91,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "9497329216962766751",
     "severity": "critical",
@@ -103,7 +103,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "18366180239442454213",
     "severity": "critical",
@@ -115,7 +115,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "17264185503232320851",
     "severity": "critical",
@@ -331,7 +331,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6143155163249580709",
     "severity": "critical",
@@ -343,7 +343,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "16004470298861036684",
     "severity": "critical",
@@ -355,7 +355,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6844513959367944349",
     "severity": "critical",
@@ -367,7 +367,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "3753031813987153088",
     "severity": "critical",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_gitlab/reports_diagnostics_gitlab_lint_command.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
+snapshot_kind: text
 ---
 ## `index.ts`
 
@@ -66,7 +67,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 [
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "8145265504203493155",
     "severity": "critical",
@@ -78,7 +79,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "9497329216962766751",
     "severity": "critical",
@@ -90,7 +91,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "18366180239442454213",
     "severity": "critical",
@@ -102,7 +103,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "17264185503232320851",
     "severity": "critical",
@@ -306,7 +307,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6143155163249580709",
     "severity": "critical",
@@ -318,7 +319,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "16004470298861036684",
     "severity": "critical",
@@ -330,7 +331,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "6844513959367944349",
     "severity": "critical",
@@ -342,7 +343,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     }
   },
   {
-    "description": "Use === instead of ==. == is only allowed when comparing against `null`",
+    "description": "Using == may be unsafe if you are relying on type coercion.",
     "check_name": "lint/suspicious/noDoubleEquals",
     "fingerprint": "3753031813987153088",
     "severity": "critical",

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_check_command.snap
@@ -54,7 +54,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -89,7 +89,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_ci_command.snap
@@ -54,7 +54,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -89,7 +89,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_lint_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_junit/reports_diagnostics_junit_lint_command.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 snapshot_kind: text
 ---
 ## `index.ts`
@@ -49,7 +49,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 <testsuites name="Biome" tests="12" failures="12" errors="12" time="<TIME>">
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="index.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
@@ -79,7 +79,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
         <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
-            <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+            <failure message="Using == may be unsafe if you are relying on type coercion.">line 3, col 2, Using == may be unsafe if you are relying on type coercion.</failure>
         </testcase>
     </testsuite>
     <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">

--- a/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/use_aria_props_for_role.rs
@@ -104,8 +104,6 @@ impl Rule for UseAriaPropsForRole {
         }
         state.attribute.as_ref().map(|(attribute, role_name)| {
             let role_name = role_name.text();
-            let joined_attributes = &state.missing_aria_props.join(", ");
-            let description = format!("The element with the {role_name} ARIA role does not have the required ARIA attributes: {joined_attributes}.");
             RuleDiagnostic::new(
                 rule_category!(),
                 attribute.range(),
@@ -113,7 +111,6 @@ impl Rule for UseAriaPropsForRole {
                 "The element with the "<Emphasis>{role_name}</Emphasis>" ARIA role does not have the required ARIA attributes."
                 },
             )
-            .description(description)
             .footer_list(markup! { "Missing ARIA prop(s):" }, &state.missing_aria_props)
         })
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_const_assign.rs
@@ -87,11 +87,11 @@ impl Rule for NoConstAssign {
             RuleDiagnostic::new(
                 rule_category!(),
                 node.syntax().text_trimmed_range(),
-                markup! {"Can't assign "<Emphasis>{name}</Emphasis>" because it's a constant"},
+                markup! {"Can't assign "<Emphasis>{name}</Emphasis>" because it's a constant."},
             )
             .detail(
                 state,
-                markup! {"This is where the variable is defined as constant"},
+                markup! {"This is where the variable is defined as constant."},
             ),
         )
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_string_case_mismatch.rs
@@ -77,7 +77,6 @@ impl Rule for NoStringCaseMismatch {
             ),
         };
         diagnostic = diagnostic
-            .description("This expression always returns false, because the string is converted and will never match")
             .detail(
                 state.call.range(),
                 markup! {

--- a/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unreachable.rs
@@ -87,7 +87,6 @@ impl Rule for NoUnreachable {
                 "This code will never be reached ..."
             },
         )
-        .description("This code is unreachable")
         .unnecessary();
 
         // Pluralize and adapt the error message accordingly based on the

--- a/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_double_equals.rs
@@ -111,28 +111,21 @@ impl Rule for NoDoubleEquals {
 
     fn diagnostic(ctx: &RuleContext<Self>, op: &Self::State) -> Option<RuleDiagnostic> {
         let text_trimmed = op.text_trimmed();
-        let suggestion = if op.kind() == EQ2 { "===" } else { "!==" };
         let diagnostic = RuleDiagnostic::new(
             rule_category!(),
             op.text_trimmed_range(),
             markup! {
-                "Use "<Emphasis>{suggestion}</Emphasis>" instead of "<Emphasis>{text_trimmed}</Emphasis>
+                "Using "<Emphasis>{text_trimmed}</Emphasis>" may be unsafe if you are relying on type coercion."
             },
-        ).note(markup! {
-            "Using "<Emphasis>{text_trimmed}</Emphasis>" may be unsafe if you are relying on type coercion"
-        });
+        );
 
         Some(if ctx.options().ignore_null {
             diagnostic
-                .detail(
-                op.text_trimmed_range(), markup! {
-                    <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>
-                })        .description(
-             format!(
-            "Use {suggestion} instead of {text_trimmed}. {text_trimmed} is only allowed when comparing against `null`"
-             ))
+                .note(markup! {
+                    <Emphasis>{text_trimmed}</Emphasis>" is only allowed when comparing against "<Emphasis>"null"</Emphasis>"."
+                })
         } else {
-            diagnostic.description(format!("Use {suggestion} instead of {text_trimmed}."))
+            diagnostic
         })
     }
 
@@ -147,7 +140,7 @@ impl Rule for NoDoubleEquals {
             ctx.metadata().applicability(),
             // SAFETY: `suggestion` can only be JsSyntaxKind::EQ3 or JsSyntaxKind::NEQ2,
             // the implementation of `to_string` for these two variants always returns Some
-            markup! { "Use "<Emphasis>{suggestion.to_string()?}</Emphasis> }.to_owned(),
+            markup! { "Use "<Emphasis>{suggestion.to_string()?}</Emphasis>" instead." }.to_owned(),
             mutation,
         ))
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/noConstAssign/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noConstAssign/invalid.js.snap
@@ -69,7 +69,7 @@ a = 1;
 ```
 invalid.js:2:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign a because it's a constant
+  × Can't assign a because it's a constant.
   
     1 │ const a = 1;
   > 2 │ a = 2;
@@ -77,7 +77,7 @@ invalid.js:2:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
     3 │ 
     4 │ const b = 2, c = 43;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     54 │ r = 4;
     55 │ 
@@ -101,7 +101,7 @@ invalid.js:2:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
 ```
 invalid.js:5:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
     4 │ const b = 2, c = 43;
   > 5 │ b = 4;
@@ -109,7 +109,7 @@ invalid.js:5:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
     6 │ ++b;
     7 │ b += 45;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -133,7 +133,7 @@ invalid.js:5:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
 ```
 invalid.js:6:3 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
     4 │ const b = 2, c = 43;
     5 │ b = 4;
@@ -142,7 +142,7 @@ invalid.js:6:3 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
     7 │ b += 45;
     8 │ b--;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -166,7 +166,7 @@ invalid.js:6:3 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
 ```
 invalid.js:7:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
     5 │ b = 4;
     6 │ ++b;
@@ -175,7 +175,7 @@ invalid.js:7:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
     8 │ b--;
     9 │ function f() {
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -199,7 +199,7 @@ invalid.js:7:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
 ```
 invalid.js:8:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
      6 │ ++b;
      7 │ b += 45;
@@ -208,7 +208,7 @@ invalid.js:8:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
      9 │ function f() {
     10 │ 	b++;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -232,7 +232,7 @@ invalid.js:8:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━
 ```
 invalid.js:10:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
      8 │ b--;
      9 │ function f() {
@@ -241,7 +241,7 @@ invalid.js:10:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     11 │ }
     12 │ function f(d) {
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -265,7 +265,7 @@ invalid.js:10:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:13:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign b because it's a constant
+  × Can't assign b because it's a constant.
   
     11 │ }
     12 │ function f(d) {
@@ -274,7 +274,7 @@ invalid.js:13:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     14 │ }
     15 │ const fn = (val) => {
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     2 │ a = 2;
     3 │ 
@@ -298,7 +298,7 @@ invalid.js:13:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:42:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign i because it's a constant
+  × Can't assign i because it's a constant.
   
     40 │ 	j: { l },
     41 │ } = { i: 1, j: { l: 2 } };
@@ -307,7 +307,7 @@ invalid.js:42:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     43 │ l = 4;
     44 │ 
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     38 │ const {
   > 39 │ 	i,
@@ -330,7 +330,7 @@ invalid.js:42:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:43:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign l because it's a constant
+  × Can't assign l because it's a constant.
   
     41 │ } = { i: 1, j: { l: 2 } };
     42 │ i = 4;
@@ -339,7 +339,7 @@ invalid.js:43:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     44 │ 
     45 │ for (const k in [1, 2]) {
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     38 │ const {
     39 │ 	i,
@@ -363,7 +363,7 @@ invalid.js:43:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:46:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign k because it's a constant
+  × Can't assign k because it's a constant.
   
     45 │ for (const k in [1, 2]) {
   > 46 │ 	k = 4;
@@ -371,7 +371,7 @@ invalid.js:46:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     47 │ }
     48 │ 
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     43 │ l = 4;
     44 │ 
@@ -395,7 +395,7 @@ invalid.js:46:2 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:50:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign p because it's a constant
+  × Can't assign p because it's a constant.
   
     49 │ const [p, { q }] = [1, { q: 2 }];
   > 50 │ p = 3;
@@ -403,7 +403,7 @@ invalid.js:50:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     51 │ q = 4;
     52 │ 
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     47 │ }
     48 │ 
@@ -427,7 +427,7 @@ invalid.js:50:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:51:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign q because it's a constant
+  × Can't assign q because it's a constant.
   
     49 │ const [p, { q }] = [1, { q: 2 }];
     50 │ p = 3;
@@ -436,7 +436,7 @@ invalid.js:51:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     52 │ 
     53 │ const { r, ...rest } = s;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     47 │ }
     48 │ 
@@ -460,7 +460,7 @@ invalid.js:51:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:54:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign r because it's a constant
+  × Can't assign r because it's a constant.
   
     53 │ const { r, ...rest } = s;
   > 54 │ r = 4;
@@ -468,7 +468,7 @@ invalid.js:54:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
     55 │ 
     56 │ /*before*/const/*after*/ a = 0;
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     51 │ q = 4;
     52 │ 
@@ -492,14 +492,14 @@ invalid.js:54:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━�
 ```
 invalid.js:57:1 lint/correctness/noConstAssign  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Can't assign a because it's a constant
+  × Can't assign a because it's a constant.
   
     56 │ /*before*/const/*after*/ a = 0;
   > 57 │ a = 1;
        │ ^
     58 │ 
   
-  i This is where the variable is defined as constant
+  i This is where the variable is defined as constant.
   
     54 │ r = 4;
     55 │ 

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.js.snap
@@ -32,7 +32,7 @@ let a = `Output of "biome rage":
 ```
 invalid.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ const foo = `
     2 │ text
@@ -41,18 +41,9 @@ invalid.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
     4 │ `;
     5 │ 
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-    1 │ const foo = `
-    2 │ text
-  > 3 │ ${a == b}
-      │     ^^
-    4 │ `;
-    5 │ 
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     3 │ ${a·===·b}
       │       +   
@@ -62,7 +53,7 @@ invalid.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
 ```
 invalid.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     6 │ // existing comment
   > 7 │ a == b;
@@ -70,17 +61,9 @@ invalid.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
     8 │ 
     9 │ if (a == b) {
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-    6 │ // existing comment
-  > 7 │ a == b;
-      │   ^^
-    8 │ 
-    9 │ if (a == b) {
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     7 │ a·===·b;
       │     +   
@@ -90,7 +73,7 @@ invalid.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
 ```
 invalid.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
      7 │ a == b;
      8 │ 
@@ -99,18 +82,9 @@ invalid.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
     10 │     false;
     11 │ }
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-     7 │ a == b;
-     8 │ 
-   > 9 │ if (a == b) {
-       │       ^^
-    10 │     false;
-    11 │ }
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     9 │ if·(a·===·b)·{
       │         +     
@@ -120,7 +94,7 @@ invalid.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━
 ```
 invalid.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     13 │ if (/** some weird comment
   > 14 │     **/ a == b) {
@@ -128,17 +102,9 @@ invalid.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━�
     15 │ 
     16 │     }
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-    13 │ if (/** some weird comment
-  > 14 │     **/ a == b) {
-       │           ^^
-    15 │ 
-    16 │     }
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     14 │ ····**/·a·===·b)·{
        │             +     
@@ -148,7 +114,7 @@ invalid.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━�
 ```
 invalid.js:19:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     18 │ let a = `Output of "biome rage":
   > 19 │   formatter enabled: ${formatter == true}
@@ -156,17 +122,9 @@ invalid.js:19:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━�
     20 │   linter: ${linter}
     21 │ `;
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-    18 │ let a = `Output of "biome rage":
-  > 19 │   formatter enabled: ${formatter == true}
-       │                                  ^^
-    20 │   linter: ${linter}
-    21 │ `;
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     19 │ ··formatter·enabled:·${formatter·===·true}
        │                                    +      

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.jsonc.snap
@@ -12,19 +12,14 @@ const isZero = a == 0;
 ```
 invalid.jsonc:1:18 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
   > 1 │ const isZero = a == 0;
       │                  ^^
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-  > 1 │ const isZero = a == 0;
-      │                  ^^
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     1 │ const·isZero·=·a·===·0;
       │                    +   
@@ -40,19 +35,14 @@ const isNonZero = a != 0;
 ```
 invalid.jsonc:1:21 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use !== instead of !=
+  × Using != may be unsafe if you are relying on type coercion.
   
   > 1 │ const isNonZero = a != 0;
       │                     ^^
   
-  i != is only allowed when comparing against null
+  i != is only allowed when comparing against null.
   
-  > 1 │ const isNonZero = a != 0;
-      │                     ^^
-  
-  i Using != may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use !==
+  i Unsafe fix: Use !== instead.
   
     1 │ const·isNonZero·=·a·!==·0;
       │                       +   

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalid.jsx.snap
@@ -18,7 +18,7 @@ let a = <button
 ```
 invalid.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ let a = <button
     2 │     className="SomeManyClasses"
@@ -27,18 +27,9 @@ invalid.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━�
     4 │     style="color: red"
     5 │ >
   
-  i == is only allowed when comparing against null
+  i == is only allowed when comparing against null.
   
-    1 │ let a = <button
-    2 │     className="SomeManyClasses"
-  > 3 │     onClick={(event) => console.log(event.ctrlKey == true)}
-      │                                                   ^^
-    4 │     style="color: red"
-    5 │ >
-  
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     3 │ ····onClick={(event)·=>·console.log(event.ctrlKey·===·true)}
       │                                                     +       

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.js.snap
@@ -68,7 +68,7 @@ let a3 = `Output of "biome rage":
 ```
 invalidNoNull.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ const foo1 = `
     2 │ text
@@ -77,9 +77,7 @@ invalidNoNull.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━
     4 │ `;
     5 │ 
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     3 │ ${a·===·b}
       │       +   
@@ -89,7 +87,7 @@ invalidNoNull.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━
 ```
 invalidNoNull.js:8:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
      6 │ const foo2 = `
      7 │ text
@@ -98,9 +96,7 @@ invalidNoNull.js:8:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━
      9 │ `;
     10 │ 
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     8 │ ${a·===·null}
       │       +      
@@ -110,7 +106,7 @@ invalidNoNull.js:8:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━
 ```
 invalidNoNull.js:13:8 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     11 │ const foo3 = `
     12 │ text
@@ -119,9 +115,7 @@ invalidNoNull.js:13:8 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     14 │ `;
     15 │ 
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     13 │ ${null·===·a}
        │          +   
@@ -131,7 +125,7 @@ invalidNoNull.js:13:8 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:17:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     16 │ // existing comment
   > 17 │ a == b;
@@ -139,9 +133,7 @@ invalidNoNull.js:17:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     18 │ 
     19 │ // existing comment
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     17 │ a·===·b;
        │     +   
@@ -151,7 +143,7 @@ invalidNoNull.js:17:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:20:6 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     19 │ // existing comment
   > 20 │ null == a;
@@ -159,9 +151,7 @@ invalidNoNull.js:20:6 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     21 │ 
     22 │ // existing comment
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     20 │ null·===·a;
        │        +   
@@ -171,16 +161,14 @@ invalidNoNull.js:20:6 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:23:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     22 │ // existing comment
   > 23 │ a == null;
        │   ^^
     24 │ 
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     23 │ a·===·null;
        │     +      
@@ -190,16 +178,14 @@ invalidNoNull.js:23:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:26:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
   > 26 │ if (a == b) {
        │       ^^
     27 │     false;
     28 │ }
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     26 │ if·(a·===·b)·{
        │         +     
@@ -209,7 +195,7 @@ invalidNoNull.js:26:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:30:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     28 │ }
     29 │ 
@@ -218,9 +204,7 @@ invalidNoNull.js:30:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     31 │ 	false;
     32 │ }
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     30 │ if·(a·===·null)·{
        │         +        
@@ -230,7 +214,7 @@ invalidNoNull.js:30:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:34:10 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     32 │ }
     33 │ 
@@ -239,9 +223,7 @@ invalidNoNull.js:34:10 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     35 │ 	false;
     36 │ }
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     34 │ if·(null·===·b)·{
        │            +     
@@ -251,7 +233,7 @@ invalidNoNull.js:34:10 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:39:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     38 │ if (/** some weird comment
   > 39 │     **/ a == b) {
@@ -259,9 +241,7 @@ invalidNoNull.js:39:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     40 │ 
     41 │     }
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     39 │ ····**/·a·===·b)·{
        │             +     
@@ -271,7 +251,7 @@ invalidNoNull.js:39:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:44:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     43 │ let a1 = `Output of "biome rage":
   > 44 │   formatter enabled: ${formatter == true}
@@ -279,9 +259,7 @@ invalidNoNull.js:44:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     45 │   linter: ${linter}
     46 │ `;
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     44 │ ··formatter·enabled:·${formatter·===·true}
        │                                    +      
@@ -291,7 +269,7 @@ invalidNoNull.js:44:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:49:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     48 │ let a2 = `Output of "biome rage":
   > 49 │   formatter enabled: ${formatter == null}
@@ -299,9 +277,7 @@ invalidNoNull.js:49:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     50 │   linter: ${linter}
     51 │ `;
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     49 │ ··formatter·enabled:·${formatter·===·null}
        │                                    +      
@@ -311,7 +287,7 @@ invalidNoNull.js:49:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 invalidNoNull.js:54:29 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     53 │ let a3 = `Output of "biome rage":
   > 54 │   formatter enabled: ${null == formatter}
@@ -319,9 +295,7 @@ invalidNoNull.js:54:29 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     55 │   linter: ${linter}
     56 │ `;
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     54 │ ··formatter·enabled:·${null·===·formatter}
        │                               +           

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.jsonc.snap
@@ -12,14 +12,12 @@ const isNull = a == null;
 ```
 invalidNoNull.jsonc:1:18 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
   > 1 │ const isNull = a == null;
       │                  ^^
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     1 │ const·isNull·=·a·===·null;
       │                    +      
@@ -35,14 +33,12 @@ const isNonNull = a != null;
 ```
 invalidNoNull.jsonc:1:21 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use !== instead of !=
+  × Using != may be unsafe if you are relying on type coercion.
   
   > 1 │ const isNonNull = a != null;
       │                     ^^
   
-  i Using != may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use !==
+  i Unsafe fix: Use !== instead.
   
     1 │ const·isNonNull·=·a·!==·null;
       │                       +      

--- a/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noDoubleEquals/invalidNoNull.jsx.snap
@@ -19,7 +19,7 @@ let a = <button
 ```
 invalidNoNull.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ let a = <button
     2 │     className="SomeManyClasses"
@@ -28,9 +28,7 @@ invalidNoNull.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     4 │     style="color: red"
     5 │ >
   
-  i Using == may be unsafe if you are relying on type coercion
-  
-  i Unsafe fix: Use ===
+  i Unsafe fix: Use === instead.
   
     3 │ ····onClick={(event)·=>·console.log(event.ctrlKey·===·null)}
       │                                                     +       

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.js.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noDoubleEquals.js
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -31,7 +32,7 @@ let a = `Output of "biome rage":
 ```
 noDoubleEquals.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ const foo = `
     2 │ text
@@ -40,16 +41,7 @@ noDoubleEquals.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     4 │ `;
     5 │ 
   
-  i == is only allowed when comparing against null
-  
-    1 │ const foo = `
-    2 │ text
-  > 3 │ ${a == b}
-      │     ^^
-    4 │ `;
-    5 │ 
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   
@@ -73,7 +65,7 @@ noDoubleEquals.js:3:5 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 noDoubleEquals.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     6 │ // existing comment
   > 7 │ a == b;
@@ -81,15 +73,7 @@ noDoubleEquals.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     8 │ 
     9 │ if (a == b) {
   
-  i == is only allowed when comparing against null
-  
-    6 │ // existing comment
-  > 7 │ a == b;
-      │   ^^
-    8 │ 
-    9 │ if (a == b) {
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   
@@ -111,7 +95,7 @@ noDoubleEquals.js:7:3 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 noDoubleEquals.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
      7 │ a == b;
      8 │ 
@@ -120,16 +104,7 @@ noDoubleEquals.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
     10 │     false;
     11 │ }
   
-  i == is only allowed when comparing against null
-  
-     7 │ a == b;
-     8 │ 
-   > 9 │ if (a == b) {
-       │       ^^
-    10 │     false;
-    11 │ }
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   
@@ -151,7 +126,7 @@ noDoubleEquals.js:9:7 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━�
 ```
 noDoubleEquals.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     13 │ if (/** some weird comment
   > 14 │     **/ a == b) {
@@ -159,15 +134,7 @@ noDoubleEquals.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
     15 │ 
     16 │     }
   
-  i == is only allowed when comparing against null
-  
-    13 │ if (/** some weird comment
-  > 14 │     **/ a == b) {
-       │           ^^
-    15 │ 
-    16 │     }
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   
@@ -191,7 +158,7 @@ noDoubleEquals.js:14:11 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
 ```
 noDoubleEquals.js:19:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     18 │ let a = `Output of "biome rage":
   > 19 │   formatter enabled: ${formatter == true}
@@ -199,15 +166,7 @@ noDoubleEquals.js:19:34 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
     20 │   linter: ${linter}
     21 │ `;
   
-  i == is only allowed when comparing against null
-  
-    18 │ let a = `Output of "biome rage":
-  > 19 │   formatter enabled: ${formatter == true}
-       │                                  ^^
-    20 │   linter: ${linter}
-    21 │ `;
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   

--- a/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/suspicious/noDoubleEquals/noDoubleEquals.jsx.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: noDoubleEquals.jsx
+snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -17,7 +18,7 @@ let a = <button
 ```
 noDoubleEquals.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Use === instead of ==
+  × Using == may be unsafe if you are relying on type coercion.
   
     1 │ let a = <button
     2 │     className="SomeManyClasses"
@@ -26,16 +27,7 @@ noDoubleEquals.jsx:3:51 lint/suspicious/noDoubleEquals  FIXABLE  ━━━━━
     4 │     style="color: red"
     5 │ >
   
-  i == is only allowed when comparing against null
-  
-    1 │ let a = <button
-    2 │     className="SomeManyClasses"
-  > 3 │     onClick={(event) => console.log(event.ctrlKey == true)}
-      │                                                   ^^
-    4 │     style="color: red"
-    5 │ >
-  
-  i Using == may be unsafe if you are relying on type coercion
+  i == is only allowed when comparing against null.
   
   i Safe fix: Suppress rule lint/suspicious/noDoubleEquals for this line.
   

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -799,7 +799,7 @@ async fn pull_diagnostics() -> Result<()> {
     server.initialize().await?;
     server.initialized().await?;
 
-    server.open_document("if(a == b) {}").await?;
+    server.open_document("const a = 1; a = 2;").await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
@@ -813,32 +813,30 @@ async fn pull_diagnostics() -> Result<()> {
                     range: Range {
                         start: Position {
                             line: 0,
-                            character: 5,
+                            character: 13,
                         },
                         end: Position {
                             line: 0,
-                            character: 7,
+                            character: 14,
                         },
                     },
                     severity: Some(lsp::DiagnosticSeverity::ERROR),
                     code: Some(lsp::NumberOrString::String(String::from(
-                        "lint/suspicious/noDoubleEquals",
+                        "lint/correctness/noConstAssign",
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-double-equals")
+                        href: Url::parse("https://biomejs.dev/linter/rules/no-const-assign")
                             .unwrap()
                     }),
                     source: Some(String::from("biome")),
-                    message: String::from(
-                        "Use === instead of ==. == is only allowed when comparing against `null`",
-                    ),
+                    message: String::from("Can't assign a because it's a constant.",),
                     related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
                             uri: url!("document.js"),
                             range: Range {
                                 start: Position {
                                     line: 0,
-                                    character: 5,
+                                    character: 6,
                                 },
                                 end: Position {
                                     line: 0,
@@ -846,7 +844,7 @@ async fn pull_diagnostics() -> Result<()> {
                                 },
                             },
                         },
-                        message: String::new(),
+                        message: "This is where the variable is defined as constant. ".to_string(),
                     }]),
                     tags: None,
                     data: None,
@@ -933,7 +931,7 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
     server.initialize().await?;
     server.initialized().await?;
 
-    server.open_untitled_document("if(a == b) {}").await?;
+    server.open_untitled_document("const a = 1; a = 2;").await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
 
@@ -947,32 +945,30 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
                     range: Range {
                         start: Position {
                             line: 0,
-                            character: 5,
+                            character: 13,
                         },
                         end: Position {
                             line: 0,
-                            character: 7,
+                            character: 14,
                         },
                     },
                     severity: Some(lsp::DiagnosticSeverity::ERROR),
                     code: Some(lsp::NumberOrString::String(String::from(
-                        "lint/suspicious/noDoubleEquals",
+                        "lint/correctness/noConstAssign",
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-double-equals")
+                        href: Url::parse("https://biomejs.dev/linter/rules/no-const-assign")
                             .unwrap()
                     }),
                     source: Some(String::from("biome")),
-                    message: String::from(
-                        "Use === instead of ==. == is only allowed when comparing against `null`",
-                    ),
+                    message: String::from("Can't assign a because it's a constant.",),
                     related_information: Some(vec![lsp::DiagnosticRelatedInformation {
                         location: lsp::Location {
                             uri: url!("untitled-1"),
                             range: Range {
                                 start: Position {
                                     line: 0,
-                                    character: 5,
+                                    character: 6,
                                 },
                                 end: Position {
                                     line: 0,
@@ -980,7 +976,7 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
                                 },
                             },
                         },
-                        message: String::new(),
+                        message: "This is where the variable is defined as constant. ".to_string(),
                     }]),
                     tags: None,
                     data: None,
@@ -1445,7 +1441,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     );
 
     let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-        title: String::from("Use ==="),
+        title: String::from("Use === instead."),
         kind: Some(lsp::CodeActionKind::new(
             "quickfix.biome.suspicious.noDoubleEquals",
         )),
@@ -3198,6 +3194,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3234,6 +3231,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3266,6 +3264,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3302,6 +3301,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3411,6 +3411,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3451,6 +3452,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?
@@ -3488,6 +3490,7 @@ export function bar() {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                pull_code_actions: false,
             },
         )
         .await?

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -422,6 +422,7 @@ impl Session {
                 only: Vec::new(),
                 skip: Vec::new(),
                 enabled_rules: Vec::new(),
+                pull_code_actions: false,
             })?;
 
             let content = self.workspace.get_file_content(GetFileContentParams {

--- a/crates/biome_lsp/src/utils.rs
+++ b/crates/biome_lsp/src/utils.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result, ensure};
 use biome_analyze::ActionCategory;
-use biome_console::MarkupBuf;
 use biome_console::fmt::Termcolor;
 use biome_console::fmt::{self, Formatter};
+use biome_console::{MarkupBuf, markup};
 use biome_diagnostics::termcolor::NoColor;
 use biome_diagnostics::{
-    Applicability, {Diagnostic, DiagnosticTags, Location, PrintDescription, Severity, Visit},
+    Applicability, LogCategory,
+    {Diagnostic, DiagnosticTags, Location, PrintDescription, Severity, Visit},
 };
 use biome_lsp_converters::line_index::LineIndex;
 use biome_lsp_converters::{PositionEncoding, from_proto, to_proto};
@@ -215,6 +216,8 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
         line_index,
         position_encoding,
         related_information: &mut related_information,
+        current_message: None,
+        last_diagnostic_length: 0,
     };
 
     diagnostic.advices(&mut visitor).unwrap();
@@ -256,9 +259,37 @@ struct RelatedInformationVisitor<'a> {
     line_index: &'a LineIndex,
     position_encoding: PositionEncoding,
     related_information: &'a mut Option<Vec<lsp::DiagnosticRelatedInformation>>,
+    current_message: Option<String>,
+    last_diagnostic_length: usize,
 }
 
 impl Visit for RelatedInformationVisitor<'_> {
+    fn record_log(&mut self, _category: LogCategory, text: &dyn fmt::Display) -> io::Result<()> {
+        let mut message = {
+            let mut message = MarkupBuf::default();
+            let mut fmt = Formatter::new(&mut message);
+            fmt.write_markup(markup!({ { text } }))?;
+            print_markup(&message)
+        };
+        message.push(' ');
+        let current_diagnostic_length = self.related_information.as_ref().map_or(0, |v| v.len());
+
+        if self.last_diagnostic_length != current_diagnostic_length {
+            self.related_information
+                .get_or_insert_with(Vec::new)
+                .last_mut()
+                .unwrap()
+                .message
+                .push_str(&message);
+        } else if let Some(current_message) = self.current_message.as_mut() {
+            current_message.push_str(&message);
+        } else {
+            self.current_message = Some(message);
+        }
+
+        Ok(())
+    }
+
     fn record_frame(&mut self, location: Location<'_>) -> io::Result<()> {
         let span = match location.span {
             Some(span) => span,
@@ -271,13 +302,14 @@ impl Visit for RelatedInformationVisitor<'_> {
         };
 
         let related_information = self.related_information.get_or_insert_with(Vec::new);
+        self.last_diagnostic_length = related_information.len();
 
         related_information.push(lsp::DiagnosticRelatedInformation {
             location: lsp::Location {
                 uri: self.url.clone(),
                 range,
             },
-            message: String::new(),
+            message: self.current_message.take().unwrap_or_default(),
         });
 
         Ok(())

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -476,6 +476,7 @@ pub(crate) struct LintParams<'a> {
     pub(crate) suppression_reason: Option<String>,
     pub(crate) enabled_rules: Vec<RuleSelector>,
     pub(crate) plugins: AnalyzerPluginVec,
+    pub(crate) pull_code_actions: bool,
 }
 
 pub(crate) struct LintResults {
@@ -491,6 +492,7 @@ pub(crate) struct ProcessLint<'a> {
     ignores_suppression_comment: bool,
     rules: Option<Cow<'a, Rules>>,
     max_diagnostics: u32,
+    pull_code_actions: bool,
 }
 
 impl<'a> ProcessLint<'a> {
@@ -510,6 +512,7 @@ impl<'a> ProcessLint<'a> {
                 .as_ref()
                 .and_then(|settings| settings.as_linter_rules(params.path.as_path())),
             max_diagnostics: params.max_diagnostics,
+            pull_code_actions: params.pull_code_actions,
         }
     }
 
@@ -544,9 +547,11 @@ impl<'a> ProcessLint<'a> {
             }
 
             if self.diagnostic_count <= self.max_diagnostics {
-                for action in signal.actions() {
-                    if !action.is_suppression() {
-                        diagnostic = diagnostic.add_code_suggestion(action.into());
+                if self.pull_code_actions {
+                    for action in signal.actions() {
+                        if !action.is_suppression() {
+                            diagnostic = diagnostic.add_code_suggestion(action.into());
+                        }
                     }
                 }
 

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -705,6 +705,8 @@ pub struct PullDiagnosticsParams {
     /// Rules to apply on top of the configuration
     #[serde(default)]
     pub enabled_rules: Vec<RuleSelector>,
+    /// When `false` the diagnostics, don't have code frames of the code actions (fixes, suppressions, etc.)
+    pub pull_code_actions: bool,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -1320,6 +1322,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         max_diagnostics: u32,
         only: Vec<RuleSelector>,
         skip: Vec<RuleSelector>,
+        pull_code_actions: bool,
     ) -> Result<PullDiagnosticsResult, WorkspaceError> {
         self.workspace.pull_diagnostics(PullDiagnosticsParams {
             project_key: self.project_key,
@@ -1329,6 +1332,7 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
             only,
             skip,
             enabled_rules: vec![],
+            pull_code_actions,
         })
     }
 

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -272,6 +272,7 @@ fn correctly_pulls_lint_diagnostics() {
             "useDeprecatedReason",
         )],
         vec![],
+        true,
     );
     assert!(result.is_ok());
     let diagnostics = result.unwrap().diagnostics;
@@ -488,6 +489,7 @@ fn plugins_are_loaded_and_used_during_analysis() {
             only: Vec::new(),
             skip: Vec::new(),
             enabled_rules: Vec::new(),
+            pull_code_actions: true,
         })
         .unwrap();
     assert_debug_snapshot!(result.diagnostics);
@@ -555,6 +557,7 @@ language css;
             only: Vec::new(),
             skip: Vec::new(),
             enabled_rules: Vec::new(),
+            pull_code_actions: true,
         })
         .unwrap();
     assert_debug_snapshot!(result.diagnostics);
@@ -618,6 +621,7 @@ fn plugins_may_use_invalid_span() {
             only: Vec::new(),
             skip: Vec::new(),
             enabled_rules: Vec::new(),
+            pull_code_actions: true,
         })
         .unwrap();
     assert_debug_snapshot!(result.diagnostics);

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1103,6 +1103,7 @@ impl Workspace for WorkspaceServer {
             only,
             skip,
             enabled_rules,
+            pull_code_actions,
         } = params;
         let parse = self.get_parse(&path)?;
         let language = self.get_file_source(&path);
@@ -1126,6 +1127,7 @@ impl Workspace for WorkspaceServer {
                     project_layout: self.project_layout.clone(),
                     suppression_reason: None,
                     enabled_rules,
+                    pull_code_actions,
                     plugins: self.get_analyzer_plugins_for_project(project_key),
                 });
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3884,6 +3884,10 @@ export interface PullDiagnosticsParams {
 	only?: RuleCode[];
 	path: BiomePath;
 	projectKey: ProjectKey;
+	/**
+	 * When `false` the diagnostics, don't have code frames of the code actions (fixes, suppressions, etc.)
+	 */
+	pullCodeActions: boolean;
 	skip?: RuleCode[];
 }
 export type RuleCategories = RuleCategory[];

--- a/packages/@biomejs/js-api/src/index.ts
+++ b/packages/@biomejs/js-api/src/index.ts
@@ -215,6 +215,7 @@ export class Biome {
 				maxDiagnostics: Number.MAX_SAFE_INTEGER,
 				only: [],
 				skip: [],
+				pullCodeActions: false,
 			});
 
 			const hasErrors = diagnostics.some(
@@ -297,6 +298,7 @@ export class Biome {
 				maxDiagnostics: Number.MAX_SAFE_INTEGER,
 				only: [],
 				skip: [],
+				pullCodeActions: true,
 			});
 
 			return {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes the related diagnostics that are computed inside the LSP. Related diagnostics are a list of *additional* diagnostics that are attached to a main diagnostic. 

We do use "related diagnostics" in our lint rules; however, in our case, they are code frames and messages. We already had some logic to create a list of related diagnostics from the diagnostics emitted by rules/actions, however they were broken because we couldn't compute the message. The absence of the message was causing some issues among editors. Notably Zed where they weren't rendered at all because there wasn't any text, and VSCode where it was rendered by now we have some decent text.

### Changes
- Changed the way the message is computed. We now concatenate all logs until we create a new related diagnostic
- Created a new option to **not** pull the code action when pull the diagnostics. With this option, now we can exclude the code action when pulling the diagnostics **from the LSP**. The CLI still pulls them.
- I did some clean-up inside the `RuleDiagnostic`. We don't need `description()` any more because `MessageAndDescription` type already takes care of everything. We don't need the `code_suggestion_list` because we don't use it.
- I cleaned up the messaging of a couple of rules. Now we have a **strong reason** to have a full stop in each message of our lint rules, because each `.note` we use is contacted with a space.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tested locally

### Before

<img width="697" alt="Screenshot 2025-04-24 at 18 49 18" src="https://github.com/user-attachments/assets/b0cbada2-ff76-42fc-bdfe-3109b094086e" />


### Now 

<img width="772" alt="Screenshot 2025-04-25 at 10 36 17" src="https://github.com/user-attachments/assets/fc23f3fd-534b-4073-8b40-384c9cd333e7" />

<img width="983" alt="Screenshot 2025-04-25 at 10 36 06" src="https://github.com/user-attachments/assets/500ea8eb-3514-4a75-8a59-9127908cbfc5" />


<img width="772" alt="Screenshot 2025-04-25 at 10 47 44" src="https://github.com/user-attachments/assets/b7908070-08d3-4c7e-ab58-a75c94dc7423" />


<!-- What demonstrates that your implementation is correct? -->
