### PR TITLE
fix(lint): use correct `node:process` import

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_process_global.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_process_global.rs
@@ -118,10 +118,10 @@ impl Rule for NoProcessGlobal {
 
         if let Some(import) = most_recent_import {
             slot = import.index();
-            new_items = smallvec![import, create_porcess_import(false).into()];
+            new_items = smallvec![import, create_process_import(false).into()];
         } else {
             new_items = smallvec![
-                create_porcess_import(true).into(),
+                create_process_import(true).into(),
                 module_item_list
                     .first_child()?
                     .with_leading_trivia_pieces([])?,
@@ -153,7 +153,7 @@ fn is_top_level_statement(node: &SyntaxNode<JsLanguage>) -> bool {
         .is_some_and(|node| JsModuleItemList::can_cast(node.kind()))
 }
 
-fn create_porcess_import(with_trailing_new_line: bool) -> JsImport {
+fn create_process_import(with_trailing_new_line: bool) -> JsImport {
     let whitespace = [(TriviaPieceKind::Whitespace, " ")];
     let new_line = [(TriviaPieceKind::Newline, "\n")];
     let mut semicolon = make::token(T![;]);
@@ -161,7 +161,7 @@ fn create_porcess_import(with_trailing_new_line: bool) -> JsImport {
         semicolon = semicolon.with_trailing_trivia(new_line);
     }
 
-    let source = make::js_module_source(make::js_string_literal("node::process"));
+    let source = make::js_module_source(make::js_string_literal("node:process"));
     let binding =
         make::js_identifier_binding(make::ident("process").with_trailing_trivia(whitespace));
     let specifier = make::js_default_import_specifier(binding.into());

--- a/crates/biome_js_analyze/tests/specs/nursery/noProcessGlobal/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noProcessGlobal/invalid.js.snap
@@ -43,7 +43,7 @@ invalid.js:5:11 lint/nursery/noProcessGlobal  FIXABLE  ━━━━━━━━�
   
      3  3 │    * head comment
      4  4 │    */
-        5 │ + import·process·from·"node::process";
+        5 │ + import·process·from·"node:process";
      5  6 │   const c = process.env;
      6  7 │   
   
@@ -68,7 +68,7 @@ invalid.js:7:11 lint/nursery/noProcessGlobal  FIXABLE  ━━━━━━━━�
   
      3  3 │    * head comment
      4  4 │    */
-        5 │ + import·process·from·"node::process";
+        5 │ + import·process·from·"node:process";
      5  6 │   const c = process.env;
      6  7 │   
   
@@ -93,7 +93,7 @@ invalid.js:9:11 lint/nursery/noProcessGlobal  FIXABLE  ━━━━━━━━�
   
      3  3 │    * head comment
      4  4 │    */
-        5 │ + import·process·from·"node::process";
+        5 │ + import·process·from·"node:process";
      5  6 │   const c = process.env;
      6  7 │   
   
@@ -117,7 +117,7 @@ invalid.js:12:11 lint/nursery/noProcessGlobal  FIXABLE  ━━━━━━━━
   
      3  3 │    * head comment
      4  4 │    */
-        5 │ + import·process·from·"node::process";
+        5 │ + import·process·from·"node:process";
      5  6 │   const c = process.env;
      6  7 │   
   
@@ -141,7 +141,7 @@ invalid.js:15:19 lint/nursery/noProcessGlobal  FIXABLE  ━━━━━━━━
   
      3  3 │    * head comment
      4  4 │    */
-        5 │ + import·process·from·"node::process";
+        5 │ + import·process·from·"node:process";
      5  6 │   const c = process.env;
      6  7 │   
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noProcessGlobal/invalid_with_import.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noProcessGlobal/invalid_with_import.js.snap
@@ -28,7 +28,7 @@ invalid_with_import.js:4:11 lint/nursery/noProcessGlobal  FIXABLE  ━━━━�
   
     1 1 │   // head comment
     2 2 │   import a from 'b';
-      3 │ + import·process·from·"node::process";
+      3 │ + import·process·from·"node:process";
     3 4 │   
     4 5 │   const c = process.env;
   


### PR DESCRIPTION
## Summary

This PR fixes #5778 

Additionally, it fixes a typo in the name of the `create_porcess_import` function.

## Test Plan

Automated tests pass
