### PR TITLE
fix(lint): respect preferred JSX quote style and escape conflicting inner quotes in class attributes

### DIFF
--- a/.changeset/major-apes-shout.md
+++ b/.changeset/major-apes-shout.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#5601](https://github.com/biomejs/biome/issues/5601): The linter now properly preserves the original JSX quote style when sorting utility classes, preventing syntax errors.
+Fixed [#5601](https://github.com/biomejs/biome/issues/5601): The [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) rule now properly preserves the original JSX quote style when sorting utility classes, preventing syntax errors.

--- a/.changeset/major-apes-shout.md
+++ b/.changeset/major-apes-shout.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#5601](https://github.com/biomejs/biome/issues/5601): The linter now respects the preferred JSX quote style and safely converts conflicting inner quotes in class attributes, preventing syntax errors when sorting utility classes
+Fixed [#5601](https://github.com/biomejs/biome/issues/5601): The linter now properly preserves the original JSX quote style when sorting utility classes, preventing syntax errors.

--- a/.changeset/major-apes-shout.md
+++ b/.changeset/major-apes-shout.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5601](https://github.com/biomejs/biome/issues/5601): The linter now respects the preferred JSX quote style and safely converts conflicting inner quotes in class attributes, preventing syntax errors when sorting utility classes

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -237,16 +237,14 @@ impl Rule for UseSortedClasses {
                 mutation.replace_node(string_literal.clone(), replacement);
             }
             AnyClassStringLike::JsxString(jsx_string_node) => {
-                let jsx_quote_style_is_double = ctx.as_preferred_jsx_quote().is_double();
-                let quote_safe_state = if jsx_quote_style_is_double {
-                    state.replace('"', "'")
+                let is_double_quote = jsx_string_node
+                    .value_token()
+                    .map(|token| token.text_trimmed().starts_with('"'))
+                    .unwrap_or(ctx.as_preferred_jsx_quote().is_double());
+                let replacement = jsx_string(if is_double_quote {
+                    js_string_literal(state)
                 } else {
-                    state.replace('\'', "\"")
-                };
-                let replacement = jsx_string(if jsx_quote_style_is_double {
-                    js_string_literal(&quote_safe_state)
-                } else {
-                    js_string_literal_single_quotes(&quote_safe_state)
+                    js_string_literal_single_quotes(state)
                 });
                 mutation.replace_node(jsx_string_node.clone(), replacement);
             }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -237,10 +237,16 @@ impl Rule for UseSortedClasses {
                 mutation.replace_node(string_literal.clone(), replacement);
             }
             AnyClassStringLike::JsxString(jsx_string_node) => {
-                let replacement = jsx_string(if ctx.as_preferred_jsx_quote().is_double() {
-                    js_string_literal(state)
+                let jsx_quote_style_is_double = ctx.as_preferred_jsx_quote().is_double();
+                let quote_safe_state = if jsx_quote_style_is_double {
+                    state.replace('"', "'")
                 } else {
-                    js_string_literal_single_quotes(state)
+                    state.replace('\'', "\"")
+                };
+                let replacement = jsx_string(if jsx_quote_style_is_double {
+                    js_string_literal(&quote_safe_state)
+                } else {
+                    js_string_literal_single_quotes(&quote_safe_state)
                 });
                 mutation.replace_node(jsx_string_node.clone(), replacement);
             }

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_4855.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: issue_4855.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -45,7 +44,7 @@ issue_4855.jsx:2:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━�
   
     1 1 │   <div class="content-[''] absolute">Hello</div>;
     2   │ - <div·class='top-0·absolute'>Hello</div>;
-      2 │ + <div·class="absolute·top-0">Hello</div>;
+      2 │ + <div·class='absolute·top-0'>Hello</div>;
     3 3 │   
   
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx
@@ -1,0 +1,17 @@
+{
+	/* SHOULD NOT emit diagnostics (classes are sorted correctly)
+	- with double quotes outside and single quotes inside */
+}
+<div class="m-2 flex items-center gap-2 p-4 [&_svg:not([class*='size-'])]:w-4" />;
+
+{
+	/* SHOULD emit diagnostics (classes are not sorted correctly)
+	- with double quotes outside and single quotes inside */
+}
+<div class="flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" />;
+
+{
+	/* SHOULD emit diagnostics (classes are not sorted correctly)
+	- with single quotes outside and double quotes inside */
+}
+<div class='flex gap-2 p-4 m-2 [&_svg:not([class*="size-"])]:w-4 items-center' />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx.snap
@@ -65,7 +65,7 @@ issue_5601.jsx:17:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━�
     15 15 │   	- with single quotes outside and double quotes inside */
     16 16 │   }
     17    │ - <div·class='flex·gap-2·p-4·m-2·[&_svg:not([class*="size-"])]:w-4·items-center'·/>;
-       17 │ + <div·class="m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*='size-'])]:w-4"·/>;
+       17 │ + <div·class='m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*="size-"])]:w-4'·/>;
     18 18 │   
   
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/issue_5601.jsx.snap
@@ -1,0 +1,72 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_5601.jsx
+---
+# Input
+```jsx
+{
+	/* SHOULD NOT emit diagnostics (classes are sorted correctly)
+	- with double quotes outside and single quotes inside */
+}
+<div class="m-2 flex items-center gap-2 p-4 [&_svg:not([class*='size-'])]:w-4" />;
+
+{
+	/* SHOULD emit diagnostics (classes are not sorted correctly)
+	- with double quotes outside and single quotes inside */
+}
+<div class="flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" />;
+
+{
+	/* SHOULD emit diagnostics (classes are not sorted correctly)
+	- with single quotes outside and double quotes inside */
+}
+<div class='flex gap-2 p-4 m-2 [&_svg:not([class*="size-"])]:w-4 items-center' />;
+
+```
+
+# Diagnostics
+```
+issue_5601.jsx:11:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     9 │ 	- with double quotes outside and single quotes inside */
+    10 │ }
+  > 11 │ <div class="flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ {
+  
+  i Unsafe fix: Sort the classes.
+  
+     9  9 │   	- with double quotes outside and single quotes inside */
+    10 10 │   }
+    11    │ - <div·class="flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·/>;
+       11 │ + <div·class="m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*='size-'])]:w-4"·/>;
+    12 12 │   
+    13 13 │   {
+  
+
+```
+
+```
+issue_5601.jsx:17:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    15 │ 	- with single quotes outside and double quotes inside */
+    16 │ }
+  > 17 │ <div class='flex gap-2 p-4 m-2 [&_svg:not([class*="size-"])]:w-4 items-center' />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    18 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+    15 15 │   	- with single quotes outside and double quotes inside */
+    16 16 │   }
+    17    │ - <div·class='flex·gap-2·p-4·m-2·[&_svg:not([class*="size-"])]:w-4·items-center'·/>;
+       17 │ + <div·class="m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*='size-'])]:w-4"·/>;
+    18 18 │   
+  
+
+```


### PR DESCRIPTION
## Summary

- This PR fixes This PR fixes https://github.com/biomejs/biome/issues/5601
  - The linter now respects the preferred JSX quote style and safely converts conflicting inner quotes in class attributes, preventing syntax errors when sorting utility classes.

## Test Plan
- Added snapshot test

## Checklist
- [x] run `cargo build --bin biome` and check if it works locally
- [x] run `just f`
- [x] run `just l`
- [x] run `just gen-analyzer`
- [x] run `just new-changeset`