### PR TITLE
fix: ignore non-existent files during processing (return FileStatus::Ignored)

### DIFF
--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -127,6 +127,10 @@ impl<'ctx, 'app> Deref for SharedTraversalOptions<'ctx, 'app> {
 /// content of the file and emit a diff or write the new content to the disk if
 /// write mode is enabled
 pub(crate) fn process_file(ctx: &TraversalOptions, biome_path: &BiomePath) -> FileResult {
+    if !biome_path.exists() {
+        return Ok(FileStatus::Ignored);
+    }
+
     let _ = tracing::trace_span!("process_file", path = ?biome_path).entered();
     let file_features = ctx
         .workspace


### PR DESCRIPTION


## Summary

This change addresses the issue that occurs when trying to commit file deletions while using `biome` in a React + TypeScript project with Husky to run `pnpm check --staged` as part of the pre-commit hook. Specifically, when deleting a file and attempting to commit the changes, the following error occurs:

```
No files were processed in the specified paths.
```

This issue happens because the `process_file` function didn't account for the case when a file is deleted and no longer exists. This PR adds a check in the `process_file` function to ensure that deleted files (or files that don't exist) are ignored without causing errors. The function will now return `FileStatus::Ignored` if the file is not found, allowing the commit to proceed smoothly, even when files are deleted.

## Test Plan

To verify this change, I:
1. Modified the `process_file` function to check whether a file exists before proceeding. If the file does not exist (e.g., if it was deleted), it returns `FileStatus::Ignored` instead of throwing an error.
2. Attempted to delete a file and commit the change using the pre-commit hook (`pnpm check --staged`).
3. Verified that the deleted file is correctly ignored without causing the "No files were processed" error, and the commit succeeds.
4. Confirmed that this change works with both existing files and deleted files, ensuring the smooth functioning of the pre-commit check.
