### PR TITLE
fix(core): fix incorrect JSDoc detection

### DIFF
--- a/crates/biome_module_graph/src/jsdoc_comment.rs
+++ b/crates/biome_module_graph/src/jsdoc_comment.rs
@@ -59,7 +59,8 @@ impl JsdocComment {
     /// JSDoc comments must start with exactly `/**` and with `*/`. Either more
     /// or less asterisks in the opening are ignored.
     pub fn text_is_jsdoc_comment(text: &str) -> bool {
-        text.starts_with("/**")
+        text.len() >= 6
+            && text.starts_with("/**")
             && text.as_bytes().get(3).is_some_and(|c| *c != b'*')
             && text.ends_with("*/")
     }
@@ -111,5 +112,24 @@ impl TryFrom<JsSyntaxToken> for JsdocComment {
                 _ => None,
             })
             .ok_or(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_text_is_jsdoc_comment() {
+        assert!(JsdocComment::text_is_jsdoc_comment("/** yes */"));
+        assert!(JsdocComment::text_is_jsdoc_comment("/**\n* yes\n*/"));
+        assert!(JsdocComment::text_is_jsdoc_comment("/**\nyes\n*/"));
+        assert!(JsdocComment::text_is_jsdoc_comment("/**\n** yes\n*/"));
+        assert!(JsdocComment::text_is_jsdoc_comment("/** */"));
+
+        assert!(!JsdocComment::text_is_jsdoc_comment("/* no */"));
+        assert!(!JsdocComment::text_is_jsdoc_comment("/*** no */"));
+        assert!(!JsdocComment::text_is_jsdoc_comment("/***/"));
+        assert!(!JsdocComment::text_is_jsdoc_comment("/**/"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5785: JSDoc comments can't be empty or even have a negative length.

## Test Plan

Tests added.
