### PR TITLE
ci: fix binary path when building on Windows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -107,12 +107,12 @@ jobs:
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome.exe ./dist/biome-${{ matrix.code-target }}.exe
       - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,12 +97,12 @@ jobs:
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome.exe ./dist/biome-${{ matrix.code-target }}.exe
       - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,12 +154,12 @@ jobs:
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome.exe ./dist/biome-${{ matrix.code-target }}.exe
       - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -122,12 +122,12 @@ jobs:
 
       # Copy the CLI binary and rename it to include the name of the target platform
       - name: Copy CLI binary
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome.exe ./dist/biome-${{ matrix.code-target }}.exe
       - name: Copy CLI binary
-        if: matrix.os != 'windows-2022'
+        if: matrix.os != 'depot-windows-2022'
         run: |
           mkdir dist
           cp target/${{ matrix.target }}/release/biome ./dist/biome-${{ matrix.code-target }}


### PR DESCRIPTION
## Summary

Fixed `if` condition to test the runner is Windows, that was changed by adopting depot runner in #5734.

## Test Plan

The preview workflow will be green in the next run.
