### PR TITLE
ci: use GitHub hosted runner for publish workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -154,7 +154,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
     needs:
       - build
       - build-wasm

--- a/.github/workflows/beta_js_api.yml
+++ b/.github/workflows/beta_js_api.yml
@@ -80,7 +80,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
     needs: build
     environment: npm-publish
     permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -145,7 +145,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
     needs:
       - build-binaries
       - build-wasm

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -170,7 +170,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
     needs:
       - build
       - build-wasm

--- a/.github/workflows/release_js_api.yml
+++ b/.github/workflows/release_js_api.yml
@@ -105,7 +105,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ubuntu-24.04
     needs: build
     environment: npm-publish
     permissions:


### PR DESCRIPTION
## Summary

Fixed publish jobs to use GitHub hosted runner as npm provenance is not available on self-hosted runners, including depot.

See https://github.com/biomejs/biome/actions/runs/14727707221/job/41335419733 for error details

## Test Plan

The release workflow will be green in the next run
