### PR TITLE
feat(core): add `ModuleId` to `ResolvedTypeId`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "biome_js_type_info_macros",
  "biome_rowan",
  "biome_test_utils",
+ "camino",
  "insta",
 ]
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -6,7 +6,7 @@ use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{
     AnyJsImportClause, AnyJsImportLike, AnyJsNamedImportSpecifier, JsModuleSource, JsSyntaxToken,
 };
-use biome_module_graph::{JsModuleInfo, JsResolvedPath, ModuleGraph};
+use biome_module_graph::{JsModuleInfo, ModuleGraph, ResolvedPath};
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
@@ -220,7 +220,7 @@ impl Rule for NoPrivateImports {
         let node = ctx.query();
         let Some(target_path) = module_info
             .get_import_path_by_js_node(node)
-            .and_then(JsResolvedPath::as_path)
+            .and_then(ResolvedPath::as_path)
         else {
             return Vec::new();
         };

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -1,4 +1,4 @@
-use biome_module_graph::JsResolvedPath;
+use biome_module_graph::ResolvedPath;
 use camino::{Utf8Component, Utf8Path};
 use serde::{Deserialize, Serialize};
 
@@ -155,7 +155,7 @@ impl Rule for UseImportExtensions {
         let node = ctx.query();
         let resolved_path = module_info
             .get_import_path_by_js_node(node)
-            .and_then(JsResolvedPath::as_path)?;
+            .and_then(ResolvedPath::as_path)?;
 
         get_extensionless_import(node, resolved_path, force_js_extensions)
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -6,7 +6,7 @@ use biome_analyze::{
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::AnyJsImportLike;
-use biome_module_graph::{JsModuleInfo, JsResolvedPath};
+use biome_module_graph::{JsModuleInfo, ResolvedPath};
 use biome_rowan::AstNode;
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -103,7 +103,7 @@ impl Rule for NoImportCycles {
         let node = ctx.query();
         let resolved_path = module_info
             .get_import_path_by_js_node(node)
-            .and_then(JsResolvedPath::as_path)?;
+            .and_then(ResolvedPath::as_path)?;
 
         let imports = ctx.module_info_for_path(resolved_path)?;
         find_cycle(ctx, resolved_path, imports)

--- a/crates/biome_js_type_info/Cargo.toml
+++ b/crates/biome_js_type_info/Cargo.toml
@@ -18,6 +18,7 @@ biome_formatter           = { workspace = true }
 biome_js_syntax           = { workspace = true }
 biome_js_type_info_macros = { workspace = true }
 biome_rowan               = { workspace = true }
+camino                    = { workspace = true }
 
 [dev-dependencies]
 biome_js_formatter = { workspace = true }

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -59,7 +59,6 @@ impl TypeData {
                             &instance_of.type_parameters,
                         ),
                     }))
-                    .flattened(resolver)
                 }
                 Some(
                     ty @ (Self::Global | Self::Function(_) | Self::Literal(_) | Self::Object(_)),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -22,7 +22,7 @@ pub static GLOBAL_TYPE_MEMBERS: LazyLock<Vec<TypeMember>> = LazyLock::new(|| {
         .map(|id| {
             TypeMember::Property(PropertyTypeMember {
                 name: Text::Static(global_type_name(id)),
-                ty: ResolvedTypeId(GLOBAL_LEVEL, id).into(),
+                ty: ResolvedTypeId::new(GLOBAL_LEVEL, id).into(),
                 is_optional: false,
                 is_static: false,
             })
@@ -39,14 +39,14 @@ pub const PROMISE_ID: TypeId = TypeId::new(5);
 pub const UNDEFINED_ID: TypeId = TypeId::new(6);
 pub const NUM_PREDEFINED_TYPES: usize = 7; // Most be one more than the highest `TypeId` above.
 
-pub const GLOBAL_UNKNOWN_ID: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, UNKNOWN_ID);
-pub const GLOBAL_ARRAY_ID: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, ARRAY_ID);
-pub const GLOBAL_GLOBAL_ID /* :smirk: */: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, GLOBAL_ID);
+pub const GLOBAL_UNKNOWN_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNKNOWN_ID);
+pub const GLOBAL_ARRAY_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, ARRAY_ID);
+pub const GLOBAL_GLOBAL_ID /* :smirk: */: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, GLOBAL_ID);
 pub const GLOBAL_INSTANCEOF_PROMISE_ID: ResolvedTypeId =
-    ResolvedTypeId(GLOBAL_LEVEL, INSTANCEOF_PROMISE_ID);
-pub const GLOBAL_NUMBER_ID: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, NUMBER_ID);
-pub const GLOBAL_PROMISE_ID: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, PROMISE_ID);
-pub const GLOBAL_UNDEFINED_ID: ResolvedTypeId = ResolvedTypeId(GLOBAL_LEVEL, UNDEFINED_ID);
+    ResolvedTypeId::new(GLOBAL_LEVEL, INSTANCEOF_PROMISE_ID);
+pub const GLOBAL_NUMBER_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, NUMBER_ID);
+pub const GLOBAL_PROMISE_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, PROMISE_ID);
+pub const GLOBAL_UNDEFINED_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNDEFINED_ID);
 
 /// Returns a string for formatting global IDs in test snapshots.
 pub fn global_type_name(id: TypeId) -> &'static str {
@@ -172,8 +172,8 @@ impl TypeResolver for GlobalsResolver {
     fn resolve_reference(&self, ty: &TypeReference) -> Option<ResolvedTypeId> {
         match ty {
             TypeReference::Qualifier(qualifier) => self.resolve_qualifier(qualifier),
-            TypeReference::Resolved(resolved_id @ ResolvedTypeId(level, _id)) => {
-                (*level == GLOBAL_LEVEL).then_some(*resolved_id)
+            TypeReference::Resolved(resolved_id) => {
+                (resolved_id.level() == GLOBAL_LEVEL).then_some(*resolved_id)
             }
             TypeReference::Imported(_) => None,
             TypeReference::Unknown => Some(GLOBAL_UNKNOWN_ID),

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -1669,9 +1669,7 @@ impl TypeofThisOrSuperExpression {
 
                 let binding = binding.as_js_identifier_binding()?;
                 let name = text_from_token(binding.name_token())?;
-                Some(TypeReference::Qualifier(TypeReferenceQualifier::from_name(
-                    name,
-                )))
+                Some(TypeReferenceQualifier::from_name(name).into())
             })
             .unwrap_or_default();
 

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -3,10 +3,9 @@ use std::fmt::Debug;
 use biome_rowan::Text;
 
 use crate::{
-    Class, DestructureField, Function, GenericTypeParameter, Type, TypeData, TypeId,
-    TypeImportQualifier, TypeInstance, TypeMember, TypeReference, TypeReferenceQualifier,
-    TypeofDestructureExpression, TypeofExpression, TypeofValue, Union,
-    globals::GLOBAL_UNDEFINED_ID,
+    Class, DestructureField, Function, GenericTypeParameter, TypeData, TypeId, TypeImportQualifier,
+    TypeInstance, TypeMember, TypeReference, TypeReferenceQualifier, TypeofDestructureExpression,
+    TypeofExpression, TypeofValue, Union, globals::GLOBAL_UNDEFINED_ID,
 };
 
 const NUM_MODULE_ID_BITS: i32 = 30;
@@ -238,7 +237,7 @@ pub trait TypeResolver {
     }
 
     /// Resolves a type by its import `qualifier`.
-    fn resolve_import(&mut self, _qualifier: &TypeImportQualifier) -> Option<Type> {
+    fn resolve_import(&mut self, _qualifier: &TypeImportQualifier) -> Option<ResolvedTypeId> {
         None
     }
 

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -1163,10 +1163,9 @@ impl ResolvedPath {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ImportSymbol {
     /// Imports the `default` export.
-    #[default]
     Default,
 
     /// Imports a named symbol.

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -1,0 +1,19 @@
+use biome_js_type_info::{ModuleId, ResolvedTypeId, TypeId, TypeResolverLevel};
+
+#[test]
+fn test_resolved_type_id() {
+    let id = ResolvedTypeId::new(TypeResolverLevel::Global, TypeId::new(3));
+    assert_eq!(id.level(), TypeResolverLevel::Global);
+    assert_eq!(id.id(), TypeId::new(3));
+    assert_eq!(id.module_id(), ModuleId::new(0));
+
+    let id = id.with_module_id(ModuleId::new(5));
+    assert_eq!(id.level(), TypeResolverLevel::Global);
+    assert_eq!(id.id(), TypeId::new(3));
+    assert_eq!(id.module_id(), ModuleId::new(5));
+
+    let id = id.with_module_id(ModuleId::new(7));
+    assert_eq!(id.level(), TypeResolverLevel::Global);
+    assert_eq!(id.id(), TypeId::new(3));
+    assert_eq!(id.module_id(), ModuleId::new(7));
+}

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -157,7 +157,7 @@ impl TypeResolver for HardcodedSymbolResolver {
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
         if qualifier.path.len() == 1 && qualifier.path[0] == self.name {
-            Some(ResolvedTypeId(self.level(), TypeId::new(0)))
+            Some(ResolvedTypeId::new(self.level(), TypeId::new(0)))
         } else {
             self.globals.resolve_qualifier(qualifier)
         }

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -1,8 +1,5 @@
 use crate::js_module_info::{Exports, Imports};
-use crate::{
-    JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsOwnExport, JsReexport, JsResolvedPath,
-    JsdocComment,
-};
+use crate::{JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, JsdocComment};
 use biome_formatter::prelude::*;
 use biome_formatter::{format_args, write};
 use biome_js_type_info::FormatTypeContext;
@@ -381,41 +378,5 @@ impl Format<FormatTypeContext> for JsImport {
 
         write!(f, [hard_line_break()])?;
         Ok(())
-    }
-}
-
-impl Format<FormatTypeContext> for JsResolvedPath {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
-    ) -> FormatResult<()> {
-        let value = self.deref();
-        if let Ok(value) = value {
-            write!(
-                f,
-                [format_args![dynamic_text(
-                    value.as_str().replace('\\', "/").as_str(),
-                    TextSize::default()
-                )]]
-            )?;
-        }
-
-        Ok(())
-    }
-}
-
-impl Format<FormatTypeContext> for JsImportSymbol {
-    fn fmt(
-        &self,
-        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
-    ) -> FormatResult<()> {
-        let import = format_with(|f| match self {
-            Self::Default => write!(f, [&format_args![text("Default")]]),
-            Self::Named(name) => {
-                write!(f, [&format_args![dynamic_text(name, TextSize::default())]])
-            }
-            Self::All => write!(f, [&format_args![text("All")]]),
-        });
-        write!(f, [&format_args![text("Import Symbol:"), space(), &import]])
     }
 }

--- a/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
@@ -1,8 +1,9 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use biome_js_type_info::{
-    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeId, TypeData, TypeId,
-    TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, Resolvable, ResolvedTypeId, Type, TypeData,
+    TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolver,
+    TypeResolverLevel,
 };
 use biome_rowan::Text;
 
@@ -19,8 +20,8 @@ use super::{JsModuleInfo, scope::JsScope};
 /// applies to.
 pub(super) struct AdHocScopeResolver {
     scope: JsScope,
-    module_info: JsModuleInfo,
     module_graph: Arc<ModuleGraph>,
+    modules: Vec<JsModuleInfo>,
     types: Vec<TypeData>,
 }
 
@@ -32,7 +33,7 @@ impl AdHocScopeResolver {
     ) -> Self {
         Self {
             scope,
-            module_info,
+            modules: vec![module_info],
             module_graph,
             types: Vec::new(),
         }
@@ -55,12 +56,15 @@ impl TypeResolver for AdHocScopeResolver {
         &self.types[id.index()]
     }
 
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
-        match id.level() {
-            TypeResolverLevel::AdHoc => Some(self.get_by_id(id.id())),
-            TypeResolverLevel::Module => Some(&self.module_info.types[id.index()]),
+    fn get_by_resolved_id(&self, resolved_id: ResolvedTypeId) -> Option<&TypeData> {
+        match resolved_id.level() {
+            TypeResolverLevel::AdHoc => Some(self.get_by_id(resolved_id.id())),
+            TypeResolverLevel::Module => {
+                let module_id = resolved_id.module_id();
+                Some(&self.modules[module_id.index()].types[resolved_id.index()])
+            }
             TypeResolverLevel::Project => todo!("Project-level inference not yet implemented"),
-            TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
+            TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(resolved_id.id())),
         }
     }
 
@@ -101,7 +105,7 @@ impl TypeResolver for AdHocScopeResolver {
         loop {
             if let Some(binding) = scope.get_binding(identifier.text()) {
                 return if binding.is_imported() {
-                    self.module_info
+                    self.modules[0]
                         .find_exported_symbol(self.module_graph.as_ref(), &binding.name())
                         .and_then(|export| self.resolve_reference(&export.ty))
                 } else {
@@ -116,6 +120,54 @@ impl TypeResolver for AdHocScopeResolver {
         }
 
         GLOBAL_RESOLVER.resolve_type_of(identifier)
+    }
+
+    fn resolve_import(&mut self, qualifier: &TypeImportQualifier) -> Option<Type> {
+        const MAX_DEPTH: usize = 10;
+
+        let mut qualifier = Cow::Borrowed(qualifier);
+        for _ in 0..MAX_DEPTH {
+            let module = qualifier
+                .resolved_path
+                .as_path()
+                .and_then(|path| self.module_graph.module_info_for_path(path))?;
+            let name = match &qualifier.symbol {
+                ImportSymbol::Default => "default",
+                ImportSymbol::Named(name) => name.text(),
+                ImportSymbol::All => {
+                    // TODO: Register type for imported namespace.
+                    break;
+                }
+            };
+            let export = module.find_exported_symbol(self.module_graph.as_ref(), name)?;
+            match export.ty {
+                TypeReference::Qualifier(_qualifier) => {
+                    // If it wasn't resolved before exporting, we can't
+                    // help it anymore.
+                    break;
+                }
+                TypeReference::Resolved(resolved) => {
+                    match module.resolve_and_get(&resolved.into()) {
+                        Some(data) => {
+                            let data = data.clone();
+                            let resolver = Self::from_scope_in_module(
+                                module.global_scope(),
+                                module,
+                                self.module_graph.clone(),
+                            );
+                            return Some(Type::from_data(Box::new(resolver), data));
+                        }
+                        None => break,
+                    }
+                }
+                TypeReference::Imported(import) => {
+                    qualifier = Cow::Owned(import);
+                }
+                TypeReference::Unknown => break,
+            }
+        }
+
+        None
     }
 
     fn fallback_resolver(&self) -> Option<&dyn TypeResolver> {

--- a/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/ad_hoc_scope_resolver.rs
@@ -1,9 +1,8 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use biome_js_type_info::{
-    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, Resolvable, ResolvedTypeId, Type, TypeData,
-    TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolver,
-    TypeResolverLevel,
+    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeId, TypeData, TypeId,
+    TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 use biome_rowan::Text;
 
@@ -33,9 +32,9 @@ impl AdHocScopeResolver {
     ) -> Self {
         Self {
             scope,
-            modules: vec![module_info],
             module_graph,
-            types: Vec::new(),
+            modules: vec![module_info],
+            types: Default::default(),
         }
     }
 }
@@ -120,54 +119,6 @@ impl TypeResolver for AdHocScopeResolver {
         }
 
         GLOBAL_RESOLVER.resolve_type_of(identifier)
-    }
-
-    fn resolve_import(&mut self, qualifier: &TypeImportQualifier) -> Option<Type> {
-        const MAX_DEPTH: usize = 10;
-
-        let mut qualifier = Cow::Borrowed(qualifier);
-        for _ in 0..MAX_DEPTH {
-            let module = qualifier
-                .resolved_path
-                .as_path()
-                .and_then(|path| self.module_graph.module_info_for_path(path))?;
-            let name = match &qualifier.symbol {
-                ImportSymbol::Default => "default",
-                ImportSymbol::Named(name) => name.text(),
-                ImportSymbol::All => {
-                    // TODO: Register type for imported namespace.
-                    break;
-                }
-            };
-            let export = module.find_exported_symbol(self.module_graph.as_ref(), name)?;
-            match export.ty {
-                TypeReference::Qualifier(_qualifier) => {
-                    // If it wasn't resolved before exporting, we can't
-                    // help it anymore.
-                    break;
-                }
-                TypeReference::Resolved(resolved) => {
-                    match module.resolve_and_get(&resolved.into()) {
-                        Some(data) => {
-                            let data = data.clone();
-                            let resolver = Self::from_scope_in_module(
-                                module.global_scope(),
-                                module,
-                                self.module_graph.clone(),
-                            );
-                            return Some(Type::from_data(Box::new(resolver), data));
-                        }
-                        None => break,
-                    }
-                }
-                TypeReference::Imported(import) => {
-                    qualifier = Cow::Owned(import);
-                }
-                TypeReference::Unknown => break,
-            }
-        }
-
-        None
     }
 
     fn fallback_resolver(&self) -> Option<&dyn TypeResolver> {

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -1,13 +1,43 @@
 use std::sync::Arc;
 
-use biome_js_semantic::{BindingId, ScopeId};
+use biome_js_semantic::ScopeId;
 use biome_js_syntax::{AnyJsDeclaration, JsImport, JsSyntaxNode, JsVariableKind, TextRange};
-use biome_js_type_info::TypeReference;
+use biome_js_type_info::{TypeId, TypeReference};
 use biome_rowan::{AstNode, Text, TextSize};
 
 use crate::jsdoc_comment::JsdocComment;
 
 use super::{JsModuleInfoInner, scope::JsScope};
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BindingId(u32);
+
+impl BindingId {
+    pub const fn new(index: usize) -> Self {
+        // SAFETY: We don't handle files exceeding `u32::MAX` bytes.
+        // Thus, it isn't possible to exceed `u32::MAX` bindings.
+        Self(index as u32)
+    }
+
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+// We allow conversion from `BindingId` into `TypeId`, and vice versa, because
+// for project-level `ResolvedTypeId` instances, the `TypeId` is an indirection
+// that is resolved through a binding.
+impl From<BindingId> for TypeId {
+    fn from(id: BindingId) -> Self {
+        Self::new(id.0 as usize)
+    }
+}
+
+impl From<TypeId> for BindingId {
+    fn from(id: TypeId) -> Self {
+        Self::new(id.index())
+    }
+}
 
 /// Internal type with all the semantic data of a specific binding
 #[derive(Debug)]

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -1,11 +1,14 @@
 use std::{collections::VecDeque, iter::FusedIterator, sync::Arc};
 
-use biome_js_semantic::{BindingId, ReferenceId, ScopeId};
+use biome_js_semantic::ScopeId;
 use biome_js_syntax::TextRange;
 use biome_rowan::TokenText;
 use rustc_hash::FxHashMap;
 
-use super::{JsModuleInfoInner, binding::JsBinding};
+use super::{
+    JsModuleInfoInner,
+    binding::{BindingId, JsBinding},
+};
 
 #[derive(Debug)]
 pub struct JsScopeData {
@@ -19,12 +22,6 @@ pub struct JsScopeData {
     pub bindings: Vec<BindingId>,
     // Map pointing to the [bindings] vec of each bindings by its name
     pub bindings_by_name: FxHashMap<TokenText, BindingId>,
-    // All read references of a scope
-    pub read_references: Vec<ReferenceId>,
-    // All write references of a scope
-    pub _write_references: Vec<ReferenceId>,
-    // Identify if this scope is from a closure or not
-    pub _is_closure: bool,
 }
 
 /// Provides all information regarding a specific scope.

--- a/crates/biome_module_graph/src/js_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/js_module_info/visitor.rs
@@ -5,17 +5,17 @@ use biome_js_syntax::{
     JsExportDefaultExpressionClause, JsExportFromClause, JsExportNamedFromClause,
     JsExportNamedSpecifierList, JsIdentifierBinding, JsVariableDeclaratorList, unescape_js_string,
 };
-use biome_js_type_info::{TypeData, TypeResolver};
+use biome_js_type_info::{ImportSymbol, TypeData, TypeResolver};
 use biome_rowan::{AstNode, TokenText, WalkEvent};
 use camino::{Utf8Path, Utf8PathBuf};
 use oxc_resolver::{ResolveError, ResolverGeneric};
 
 use crate::{
-    JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsOwnExport, JsReexport,
-    jsdoc_comment::JsdocComment, resolver_cache::ResolverCache,
+    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, jsdoc_comment::JsdocComment,
+    resolver_cache::ResolverCache,
 };
 
-use super::{JsResolvedPath, collector::JsModuleInfoCollector};
+use super::{ResolvedPath, collector::JsModuleInfoCollector};
 
 pub(crate) struct JsModuleVisitor<'a> {
     root: AnyJsRoot,
@@ -214,7 +214,7 @@ impl<'a> JsModuleVisitor<'a> {
         let import = JsImport {
             resolved_path: self.resolved_path_from_specifier(&specifier),
             specifier: specifier.into(),
-            symbol: JsImportSymbol::All,
+            symbol: ImportSymbol::All,
         };
         let jsdoc_comment = node
             .syntax()
@@ -277,7 +277,7 @@ impl<'a> JsModuleVisitor<'a> {
                     import: JsImport {
                         specifier: import_specifier.clone().into(),
                         resolved_path: resolved_path.clone(),
-                        symbol: JsImportSymbol::Named(imported_name),
+                        symbol: ImportSymbol::Named(imported_name),
                     },
                     jsdoc_comment: None,
                 }),
@@ -403,7 +403,7 @@ impl<'a> JsModuleVisitor<'a> {
         collector.register_export_with_name(name.clone(), Some(name))
     }
 
-    fn resolved_path_from_specifier(&self, specifier: &str) -> JsResolvedPath {
+    fn resolved_path_from_specifier(&self, specifier: &str) -> ResolvedPath {
         let resolved_path = self
             .resolver
             .resolve(self.directory, specifier)
@@ -412,7 +412,7 @@ impl<'a> JsModuleVisitor<'a> {
                     .map_err(|path| ResolveError::NotFound(path.to_string_lossy().to_string()))
             })
             .map_err(|error| error.to_string());
-        JsResolvedPath::new(resolved_path)
+        ResolvedPath::new(resolved_path)
     }
 }
 

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -6,8 +6,8 @@ mod jsdoc_comment;
 mod module_graph;
 mod resolver_cache;
 
-pub use js_module_info::{
-    JsExport, JsImport, JsImportSymbol, JsModuleInfo, JsOwnExport, JsReexport, JsResolvedPath,
-};
+pub use biome_js_type_info::{ImportSymbol, ResolvedPath};
+
+pub use js_module_info::{JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport};
 pub use jsdoc_comment::JsdocComment;
 pub use module_graph::{ModuleGraph, SUPPORTED_EXTENSIONS};

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -9,7 +9,7 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use biome_fs::{BiomePath, FileSystem, PathKind};
 use biome_js_syntax::AnyJsRoot;
-use biome_js_type_info::TypeReference;
+use biome_js_type_info::{ImportSymbol, TypeReference};
 use biome_project_layout::ProjectLayout;
 use camino::{Utf8Path, Utf8PathBuf};
 use oxc_resolver::{EnforceExtension, ResolveOptions, ResolverGeneric};
@@ -17,7 +17,7 @@ use papaya::{HashMap, HashMapRef, LocalGuard};
 use rustc_hash::FxBuildHasher;
 
 use crate::{
-    JsExport, JsImportSymbol, JsModuleInfo, JsOwnExport, js_module_info::JsModuleVisitor,
+    JsExport, JsModuleInfo, JsOwnExport, js_module_info::JsModuleVisitor,
     resolver_cache::ResolverCache,
 };
 
@@ -160,7 +160,7 @@ impl ModuleGraph {
                     Some(own_export.clone())
                 }
                 Some(JsExport::Reexport(reexport) | JsExport::ReexportType(reexport)) => {
-                    if reexport.import.symbol == JsImportSymbol::All {
+                    if reexport.import.symbol == ImportSymbol::All {
                         Some(JsOwnExport {
                             jsdoc_comment: reexport.jsdoc_comment.clone(),
                             local_name: None,

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -41,7 +41,7 @@ Imports {
 
 Module TypeId(0) => unknown
 
-Module TypeId(1) => instanceof unresolved reference "PromisedResult"
+Module TypeId(1) => instanceof Project TypeId(0)
 
 Module TypeId(2) => sync Function "returnPromiseResult" {
   accepts: {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -200,12 +200,7 @@ Module TypeId(9) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                ResolvedTypeId(
-                    Module,
-                    TypeId(
-                        15,
-                    ),
-                ),
+                Module(0) TypeId(15),
             ),
             name: Some(
                 Borrowed(
@@ -217,12 +212,7 @@ Module TypeId(9) => Tuple(
         },
         TupleElementType {
             ty: Resolved(
-                ResolvedTypeId(
-                    Module,
-                    TypeId(
-                        17,
-                    ),
-                ),
+                Module(0) TypeId(17),
             ),
             name: Some(
                 Borrowed(
@@ -255,12 +245,7 @@ Module TypeId(18) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                ResolvedTypeId(
-                    Module,
-                    TypeId(
-                        15,
-                    ),
-                ),
+                Module(0) TypeId(15),
             ),
             name: Some(
                 Borrowed(
@@ -272,12 +257,7 @@ Module TypeId(18) => Tuple(
         },
         TupleElementType {
             ty: Resolved(
-                ResolvedTypeId(
-                    Module,
-                    TypeId(
-                        17,
-                    ),
-                ),
+                Module(0) TypeId(17),
             ),
             name: Some(
                 Borrowed(

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -5,8 +5,8 @@ use biome_deserialize::json::deserialize_from_json_str;
 use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem};
 use biome_json_parser::JsonParserOptions;
 use biome_json_value::JsonString;
+use biome_module_graph::{ImportSymbol, JsImport, JsReexport, ModuleGraph, ResolvedPath};
 use biome_module_graph::{JsExport, JsdocComment};
-use biome_module_graph::{JsImport, JsImportSymbol, JsReexport, JsResolvedPath, ModuleGraph};
 use biome_package::{Dependencies, PackageJson, Version};
 use biome_project_layout::ProjectLayout;
 use biome_rowan::Text;
@@ -101,7 +101,7 @@ fn test_resolve_relative_import() {
         file_imports.static_imports.get("bar"),
         Some(&JsImport {
             specifier: "./bar.ts".into(),
-            resolved_path: JsResolvedPath::from_path("/src/bar.ts"),
+            resolved_path: ResolvedPath::from_path("/src/bar.ts"),
             symbol: "bar".into()
         })
     );
@@ -127,7 +127,7 @@ fn test_resolve_package_import() {
         file_imports.static_imports.get("foo"),
         Some(&JsImport {
             specifier: "shared".into(),
-            resolved_path: JsResolvedPath::from_path("/node_modules/shared/dist/index.js"),
+            resolved_path: ResolvedPath::from_path("/node_modules/shared/dist/index.js"),
             symbol: "foo".into()
         })
     );
@@ -209,9 +209,7 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
         file_imports.static_imports.get("sharedFoo"),
         Some(&JsImport {
             specifier: "shared".into(),
-            resolved_path: JsResolvedPath::from_path(format!(
-                "{fixtures_path}/shared/dist/index.js"
-            )),
+            resolved_path: ResolvedPath::from_path(format!("{fixtures_path}/shared/dist/index.js")),
             symbol: "sharedFoo".into()
         })
     );
@@ -219,9 +217,7 @@ fn test_resolve_package_import_in_monorepo_fixtures() {
         file_imports.static_imports.get("bar"),
         Some(&JsImport {
             specifier: "./bar".into(),
-            resolved_path: JsResolvedPath::from_path(format!(
-                "{fixtures_path}/frontend/src/bar.ts"
-            )),
+            resolved_path: ResolvedPath::from_path(format!("{fixtures_path}/frontend/src/bar.ts")),
             symbol: "bar".into()
         })
     );
@@ -376,7 +372,7 @@ fn test_resolve_exports() {
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
-                resolved_path: JsResolvedPath::from_path("/src/renamed-reexports.ts"),
+                resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
                 symbol: "ohNo".into()
             },
             jsdoc_comment: None
@@ -387,8 +383,8 @@ fn test_resolve_exports() {
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
-                resolved_path: JsResolvedPath::from_path("/src/renamed-reexports.ts"),
-                symbol: JsImportSymbol::All,
+                resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
+                symbol: ImportSymbol::All,
             },
             jsdoc_comment: Some(JsdocComment::from_comment_text(
                 "/**\n* Hello, namespace 2.\n*/"
@@ -405,8 +401,8 @@ fn test_resolve_exports() {
         &[JsReexport {
             import: JsImport {
                 specifier: "./reexports".into(),
-                resolved_path: JsResolvedPath::from_path("/src/reexports.ts"),
-                symbol: JsImportSymbol::All,
+                resolved_path: ResolvedPath::from_path("/src/reexports.ts"),
+                symbol: ImportSymbol::All,
             },
             jsdoc_comment: None
         }]
@@ -421,8 +417,8 @@ fn test_resolve_exports() {
         Some(&JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
-                resolved_path: JsResolvedPath::from_path("/src/renamed-reexports.ts"),
-                symbol: JsImportSymbol::All,
+                resolved_path: ResolvedPath::from_path("/src/renamed-reexports.ts"),
+                symbol: ImportSymbol::All,
             },
             jsdoc_comment: Some(JsdocComment::from_comment_text(
                 "/**\n* Hello, namespace 1.\n*/"


### PR DESCRIPTION
## Summary

I'm trying to avoid another huge PR, so I'm taking some smaller steps here :)

The main change in this PR is that `ResolvedTypeId` can now contain a `ModuleId` in addition to a `TypeId`. Such a `ModuleId` would only be used in combination with `TypeResolverLevel::Module`, but with a catch: The types stored in the module graph would not contain these module IDs, because it brings all kinds of complexity if a module needs to know its own ID. So the idea for now is that the `AdHocTypeResolver` will attach these module IDs at resolution time in order to keep track of which modules given types came from. I'm not yet sure it will be as easy as this, but that's the direction I'm going in.

Other changes are:
* `JsResolvedPath` and `JsImportSymbol` have been moved from `biome_module_graph` to `biome_js_type_info`. This allows us to store the information from where to resolve a given type reference directly into `TypeReference` itself. The `JsModuleInfoCollector` now converts `ResolvedTypeId`s of `TypeResolverLevel::Project` into such `TypeReference::Imported` variants.
* To make the above possible, we need to interpret the type ID stored in a `ResolvedTypeId` with `TypeResolverLevel::Project` as binding ID. It feels a little bit hacky, but it still feels better than introducing another `TypeData` variant for such a temporary purpose, because then it would leak into the rest of the type system.
* Because of this, `biome_module_graph` now has its own `BindingId` instead of using the `BindingId` from `biome_js_semantic`. This `BindingId` has a `From<TypeId>` implementation, and vice versa.
* I cleaned up a little bit of info we were tracking in the semantic data inside `biome_module_graph` that we weren't actually using.

## Test Plan

CI should remain green.
