### PR TITLE
ci: use github runners for npm releases

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -27,29 +27,30 @@ jobs:
     needs: version
     strategy:
       matrix:
+        # We need to use the github runners, because the hosted runners don't support provenance
         include:
-          - os: depot-windows-2022
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: depot-windows-2022
+          - os: windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: depot-ubuntu-22.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: depot-ubuntu-22.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: depot-macos-14
+          - os: macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: depot-macos-14
+          - os: macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -39,29 +39,30 @@ jobs:
   build:
     strategy:
       matrix:
+        # We need to use the github runners, because the hosted runners don't support provenance
         include:
-          - os: depot-windows-2022
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
-          - os: depot-windows-2022
+          - os: windows-2022
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: depot-ubuntu-22.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
-          - os: depot-ubuntu-22.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
-          - os: depot-ubuntu-22.04-arm
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
-          - os: depot-macos-14
+          - os: macos-14
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: depot-macos-14
+          - os: macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

We can't use depot runners because they don't support npm provenance. Only github runners do.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Merge and trigger another beta release

<!-- What demonstrates that your implementation is correct? -->
