### PR TITLE
fix(core): fix downgrading of project references

### DIFF
--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -3,8 +3,9 @@ use crate::{
     CallArgumentType, CallSignatureTypeMember, Class, DestructureField, Function,
     FunctionParameter, FunctionParameterBinding, GenericTypeParameter, ImportSymbol, Literal,
     MethodTypeMember, NUM_PREDEFINED_TYPES, Object, ObjectLiteral, PropertyTypeMember,
-    ResolvedPath, ReturnType, Type, TypeData, TypeInstance, TypeMember, TypeReference,
-    TypeReferenceQualifier, TypeResolverLevel, TypeofAwaitExpression, TypeofExpression, Union,
+    ResolvedPath, ReturnType, Type, TypeData, TypeImportQualifier, TypeInstance, TypeMember,
+    TypeReference, TypeReferenceQualifier, TypeResolverLevel, TypeofAwaitExpression,
+    TypeofExpression, Union,
 };
 use biome_formatter::prelude::*;
 use biome_formatter::{
@@ -537,7 +538,7 @@ impl Format<FormatTypeContext> for TypeReference {
                     )
                 }
             }
-            Self::Imported(_import) => todo!(),
+            Self::Import(import) => write!(f, [import]),
             Self::Unknown => write!(f, [text("unknown reference")]),
         }
     }
@@ -569,6 +570,21 @@ impl Format<FormatTypeContext> for TypeReferenceQualifier {
         }
         write!(f, [text("\""), type_args])?;
         Ok(())
+    }
+}
+
+impl Format<FormatTypeContext> for TypeImportQualifier {
+    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        write!(
+            f,
+            [
+                self.symbol,
+                space(),
+                text("from"),
+                space(),
+                self.resolved_path
+            ]
+        )
     }
 }
 

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -911,12 +911,12 @@ impl TypeData {
         decl: &TsTypeAliasDeclaration,
     ) -> Option<Self> {
         Some(match decl.type_parameters() {
-            Some(params) => Self::InstanceOf(Box::new(TypeInstance {
+            Some(params) => Self::instance_of(TypeInstance {
                 ty: TypeReference::from_any_ts_type(resolver, &decl.ty().ok()?),
                 type_parameters: GenericTypeParameter::params_from_ts_type_parameters(
                     resolver, &params,
                 ),
-            })),
+            }),
             None => Self::from_any_ts_type(resolver, &decl.ty().ok()?),
         })
     }
@@ -936,11 +936,8 @@ impl TypeData {
             .unwrap_or_default()
     }
 
-    pub fn instance_of(ty: TypeReference) -> Self {
-        Self::InstanceOf(Box::new(TypeInstance {
-            ty,
-            type_parameters: [].into(),
-        }))
+    pub fn instance_of(instance: impl Into<TypeInstance>) -> Self {
+        Self::InstanceOf(Box::new(instance.into()))
     }
 
     pub fn object_with_members(members: Box<[TypeMember]>) -> Self {

--- a/crates/biome_js_type_info/tests/flattening.rs
+++ b/crates/biome_js_type_info/tests/flattening.rs
@@ -1,7 +1,7 @@
 mod utils;
 
 use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsExpressionStatement};
-use biome_js_type_info::{GlobalsResolver, TypeData, TypeResolver};
+use biome_js_type_info::{GlobalsResolver, TypeData};
 
 use utils::{
     HardcodedSymbolResolver, assert_type_data_snapshot, assert_typed_bindings_snapshot,

--- a/crates/biome_js_type_info/tests/resolver.rs
+++ b/crates/biome_js_type_info/tests/resolver.rs
@@ -1,7 +1,7 @@
 mod utils;
 
 use biome_js_syntax::{AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsExpressionStatement};
-use biome_js_type_info::{GlobalsResolver, Resolvable, TypeData, TypeResolver};
+use biome_js_type_info::{GlobalsResolver, Resolvable, TypeData};
 
 use utils::{
     HardcodedSymbolResolver, assert_type_data_snapshot, assert_typed_bindings_snapshot,

--- a/crates/biome_js_type_info_macros/src/resolvable_derive.rs
+++ b/crates/biome_js_type_info_macros/src/resolvable_derive.rs
@@ -72,7 +72,10 @@ impl DeriveInput {
                     .map(|variant| {
                         let ident = variant.ident;
                         let ty = match variant.fields {
-                            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Some(fields.unnamed.into_iter().next().unwrap().ty),
+                            Fields::Unnamed(fields)
+                                if fields.unnamed.len() == 1 => Some(
+                                    fields.unnamed.into_iter().next().unwrap().ty
+                                ),
                             Fields::Unit => None,
                             fields => abort!(
                                 fields,
@@ -111,11 +114,30 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
         None => quote! { Self::#ident => Self::#ident },
     });
 
+    let resolved_variants_with_mapped_references =
+        variants.iter().map(|VariantData { ident, ty }| match ty {
+            Some(ty) => {
+                let resolved_ty = resolved_unit_type_with_mapped_references(ty);
+                quote! { Self::#ident(ty) => Self::#ident(#resolved_ty) }
+            }
+            None => quote! { Self::#ident => Self::#ident },
+        });
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
                 match self {
                     #( #resolved_variants ),*
+                }
+            }
+
+            fn resolved_with_mapped_references(
+                &self,
+                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                resolver: &mut dyn crate::TypeResolver
+            ) -> Self {
+                match self {
+                    #( #resolved_variants_with_mapped_references ),*
                 }
             }
         }
@@ -128,11 +150,26 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
         quote! { #ident: #resolved_ty }
     });
 
+    let resolved_fields_with_mapped_references = fields.iter().map(|FieldData { ident, ty }| {
+        let resolved_ty = resolved_type_with_mapped_references(IdentOrZero::Ident(ident), ty);
+        quote! { #ident: #resolved_ty }
+    });
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
                 Self {
                     #( #resolved_fields ),*
+                }
+            }
+
+            fn resolved_with_mapped_references(
+                &self,
+                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                resolver: &mut dyn crate::TypeResolver
+            ) -> Self {
+                Self {
+                    #( #resolved_fields_with_mapped_references ),*
                 }
             }
         }
@@ -142,10 +179,21 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
 fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
     let resolved_field = resolved_type(IdentOrZero::Zero, &ty);
 
+    let resolved_field_with_mapped_references =
+        resolved_type_with_mapped_references(IdentOrZero::Zero, &ty);
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
                 Self(#resolved_field)
+            }
+
+            fn resolved_with_mapped_references(
+                &self,
+                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                resolver: &mut dyn crate::TypeResolver
+            ) -> Self {
+                Self(#resolved_field_with_mapped_references)
             }
         }
     }
@@ -213,6 +261,78 @@ fn resolved_type(ident: IdentOrZero, ty: &Type) -> TokenStream {
         },
         _ => {
             quote! { self.#ident.resolved(resolver) }
+        }
+    }
+}
+
+fn resolved_type_with_mapped_references(ident: IdentOrZero, ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { self.#ident.clone() }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => {
+                            quote! {
+                                self.#ident.clone()
+                            }
+                        }
+                        Type::Path(_) => quote! {
+                            self.#ident.iter()
+                                .map(|elem| elem.resolved_with_mapped_references(map, resolver))
+                                .collect()
+                        },
+                        _ => abort!(slice, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! {
+                                self.#ident.clone()
+                            }
+                        } else {
+                            quote! {
+                                Box::new(self.#ident.resolved_with_mapped_references(map, resolver))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident.clone() }
+                        } else {
+                            quote! {
+                                self.#ident
+                                    .as_ref()
+                                    .map(|f| f.resolved_with_mapped_references(map, resolver))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { self.#ident.resolved_with_mapped_references(map, resolver) }
         }
     }
 }
@@ -285,6 +405,68 @@ fn resolved_unit_type(ty: &Type) -> TokenStream {
         },
         _ => {
             quote! { ty.resolved(resolver) }
+        }
+    }
+}
+
+fn resolved_unit_type_with_mapped_references(ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { ty.clone() }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
+                        Type::Path(_) => quote! {
+                            ty.iter().any(|elem| elem.needs_resolving(resolver))
+                        },
+                        _ => abort!(args, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty.clone() }
+                        } else {
+                            quote! { Box::new(ty.resolved_with_mapped_references(map, resolver)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty.clone() }
+                        } else {
+                            quote! {
+                                ty
+                                    .as_ref()
+                                    .map(|f| f.resolved_with_mapped_references(map, resolver))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { ty.resolved_with_mapped_references(map, resolver) }
         }
     }
 }

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -34,8 +34,8 @@ impl Format<FormatTypeContext> for JsModuleInfo {
         });
 
         let static_imports = format_with(|f| {
-            if self.exports.is_empty() {
-                write!(f, [text("No exports")])
+            if self.static_imports.is_empty() {
+                write!(f, [text("No imports")])
             } else {
                 write!(f, [&self.static_imports])
             }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -244,7 +244,7 @@ impl TypeResolver for JsModuleInfoInner {
         match ty {
             TypeReference::Qualifier(qualifier) => self.resolve_qualifier(qualifier),
             TypeReference::Resolved(resolved_id) => Some(*resolved_id),
-            TypeReference::Imported(_) => None,
+            TypeReference::Import(_) => None,
             TypeReference::Unknown => Some(GLOBAL_UNKNOWN_ID),
         }
     }
@@ -271,14 +271,6 @@ impl TypeResolver for JsModuleInfoInner {
 
     fn registered_types(&self) -> &[TypeData] {
         &self.types
-    }
-
-    fn resolve_all(&mut self) {
-        panic!("Types must already be resolved");
-    }
-
-    fn flatten_all(&mut self) {
-        panic!("Types must already be flattened");
     }
 }
 

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -40,10 +40,9 @@ impl From<TypeId> for BindingId {
 }
 
 /// Internal type with all the semantic data of a specific binding
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct JsBindingData {
     pub name: Text,
-    pub range: TextRange,
     pub references: Vec<JsBindingReference>,
     pub scope_id: ScopeId,
     pub declaration_kind: JsDeclarationKind,
@@ -59,7 +58,7 @@ pub enum JsBindingReferenceKind {
 }
 
 /// Internal type with all the semantic data of a specific reference
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[expect(unused)]
 pub struct JsBindingReference {
     pub range_start: TextSize,

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
@@ -28,7 +28,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -28,7 +28,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -41,7 +41,7 @@ Imports {
 
 Module TypeId(0) => unknown
 
-Module TypeId(1) => instanceof Project TypeId(0)
+Module TypeId(1) => instanceof Import Symbol: PromisedResult from /src/promisedResult.ts
 
 Module TypeId(2) => sync Function "returnPromiseResult" {
   accepts: {
@@ -70,7 +70,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -54,7 +54,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -150,7 +150,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types
@@ -331,7 +333,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types
@@ -372,5 +376,7 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -24,7 +24,9 @@ Exports {
     )
   }
 }
-Imports {}
+Imports {
+  No imports
+}
 ```
 
 ## Registered types

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -1,0 +1,132 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+## /src/index.ts
+
+```ts
+import { returnPromiseResult } from "./returnPromiseResult.ts";
+
+const promise = returnPromiseResult();
+
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "returnPromiseResult" => {
+    Specifier: "./returnPromiseResult.ts"
+    Resolved path: /src/returnPromiseResult.ts
+    Import Symbol: returnPromiseResult
+  }
+}
+```
+
+## Registered types
+
+```
+
+Module TypeId(0) => unknown
+
+Module TypeId(1) => Call Import Symbol: returnPromiseResult from /src/returnPromiseResult.ts(
+  No parameters
+)
+
+```
+## /src/promisedResult.ts
+
+```ts
+export type PromisedResult = Promise<{ result: true | false }>;
+
+```
+
+## Module Info
+
+```
+Exports {
+  "PromisedResult" => {
+    ExportOwnExport => JsOwnExport(
+      Module TypeId(4)
+      Local name: PromisedResult
+    )
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+
+Module TypeId(0) => value: true
+
+Module TypeId(1) => value: false
+
+Module TypeId(2) => Module TypeId(0) | Module TypeId(1)
+
+Module TypeId(3) => Object {
+  prototype: No prototype
+  members: {TypeMembers(required property "result": Module TypeId(2))}
+}
+
+Module TypeId(4) => instanceof Promise<T = Module TypeId(3)>
+
+Module TypeId(5) => instanceof Promise<T = Module TypeId(3)>
+
+```
+## /src/returnPromiseResult.ts
+
+```ts
+import type { PromisedResult } from "./promisedResult.ts";
+
+function returnPromiseResult(): PromisedResult {
+	return new Promise((resolve) => resolve({ result: true }));
+}
+
+export { returnPromiseResult };
+
+```
+
+## Module Info
+
+```
+Exports {
+  "returnPromiseResult" => {
+    ExportOwnExport => JsOwnExport(
+      Module TypeId(2)
+      Local name: returnPromiseResult
+    )
+  }
+}
+Imports {
+  "PromisedResult" => {
+    Specifier: "./promisedResult.ts"
+    Resolved path: /src/promisedResult.ts
+    Import Symbol: PromisedResult
+  }
+}
+```
+
+## Registered types
+
+```
+
+Module TypeId(0) => unknown
+
+Module TypeId(1) => instanceof Import Symbol: PromisedResult from /src/promisedResult.ts
+
+Module TypeId(2) => sync Function "returnPromiseResult" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module TypeId(1)
+}
+
+```

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -533,3 +533,46 @@ fn test_resolve_export_type_referencing_imported_type() {
 
     snapshot.assert_snapshot("test_resolve_export_type_referencing_imported_type");
 }
+
+#[test]
+fn test_resolve_promise_from_imported_function_returning_imported_promise_type() {
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/promisedResult.ts".into(),
+        "export type PromisedResult = Promise<{ result: true | false }>;\n",
+    );
+    fs.insert(
+        "/src/returnPromiseResult.ts".into(),
+        r#"import type { PromisedResult } from "./promisedResult.ts";
+
+        function returnPromiseResult(): PromisedResult {
+            return new Promise(resolve => resolve({ result: true }));
+        }
+
+        export { returnPromiseResult };
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"import { returnPromiseResult } from "./returnPromiseResult.ts";
+
+        const promise = returnPromiseResult();
+        "#,
+    );
+
+    let added_paths = [
+        BiomePath::new("/src/index.ts"),
+        BiomePath::new("/src/promisedResult.ts"),
+        BiomePath::new("/src/returnPromiseResult.ts"),
+    ];
+    let added_paths = get_added_paths(&fs, &added_paths);
+
+    let module_graph = ModuleGraph::default();
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, &[]);
+
+    let snapshot = ModuleGraphSnapshot::new(&module_graph, &fs);
+
+    snapshot.assert_snapshot(
+        "test_resolve_promise_from_imported_function_returning_imported_promise_type",
+    );
+}


### PR DESCRIPTION
## Summary

Another fix in preparation for full project-level inference.

The last PR introduced the concept of "downgrading" project references into `TypeReference::Import`, but it missed a lot of cases still. This fix allows this downgrading to be performed during the resolution phase of the inference, so that it can traverse all references in the types. This required an upgrade of the derive macro as well.

I have also removed the `run_inference()`, `resolve_all()` and `flatten_all()` methods from the `TypeResolver` trait. While they were similar between implementations, there were already some deviations, and they were getting bigger in this PR. By convention, they're still similarly named across trait implementations, but it's no longer part of the trait.

Also included is a new implementation of `AdHocTypeResolver::resolve_import()` that uses the same mechanism for traversing all references to add module IDs across types registered from resolved modules. This is still untested though, but more is coming in that direction :)

## Test Plan

Test case added and snapshots updated.
