### PR TITLE
feat(workspace): add semantic model debug printer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ version = "0.5.7"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
+ "biome_formatter",
  "biome_js_parser",
  "biome_js_syntax",
  "biome_rowan",

--- a/crates/biome_js_semantic/Cargo.toml
+++ b/crates/biome_js_semantic/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 version              = "0.5.7"
 
 [dependencies]
+biome_formatter = { workspace = true }
 biome_js_syntax = { workspace = true }
 biome_rowan     = { workspace = true }
 rust-lapper     = { workspace = true }

--- a/crates/biome_js_semantic/src/format_semantic_model.rs
+++ b/crates/biome_js_semantic/src/format_semantic_model.rs
@@ -1,0 +1,189 @@
+use biome_formatter::prelude::*;
+use biome_formatter::{
+    FormatContext, FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth,
+    TransformSourceMap,
+};
+use biome_formatter::{format_args, write};
+use biome_js_syntax::TextSize;
+
+use crate::{Binding, BindingId, Scope, ScopeId, SemanticModel};
+
+struct FormatSemanticModelOptions;
+
+impl FormatOptions for FormatSemanticModelOptions {
+    fn indent_style(&self) -> IndentStyle {
+        IndentStyle::Space
+    }
+
+    fn indent_width(&self) -> IndentWidth {
+        IndentWidth::try_from(2).unwrap()
+    }
+
+    fn line_width(&self) -> LineWidth {
+        LineWidth::default()
+    }
+
+    fn line_ending(&self) -> LineEnding {
+        LineEnding::Lf
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions {
+            indent_width: self.indent_width(),
+            print_width: self.line_width().into(),
+            line_ending: self.line_ending(),
+            indent_style: self.indent_style(),
+        }
+    }
+}
+
+struct FormatSemanticModelContext;
+
+impl FormatContext for FormatSemanticModelContext {
+    type Options = FormatSemanticModelOptions;
+
+    fn options(&self) -> &Self::Options {
+        &FormatSemanticModelOptions
+    }
+
+    fn source_map(&self) -> Option<&TransformSourceMap> {
+        None
+    }
+}
+
+impl std::fmt::Display for SemanticModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let formatted = biome_formatter::format!(FormatSemanticModelContext, [&self])
+            .expect("Formatting not to throw any FormatErrors");
+        f.write_str(
+            formatted
+                .print()
+                .expect("Expected a valid document")
+                .as_code(),
+        )
+    }
+}
+
+impl Format<FormatSemanticModelContext> for SemanticModel {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        write!(f, [self.global_scope()])
+    }
+}
+
+enum ScopeOrBinding {
+    Scope(Scope),
+    Binding(Binding),
+}
+
+impl Format<FormatSemanticModelContext> for ScopeOrBinding {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        match self {
+            Self::Scope(scope) => scope.fmt(f),
+            Self::Binding(binding) => binding.fmt(f),
+        }
+    }
+}
+
+impl Format<FormatSemanticModelContext> for Scope {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let mut children = self
+            .children()
+            .map(ScopeOrBinding::Scope)
+            .chain(self.bindings().map(ScopeOrBinding::Binding))
+            .collect::<Vec<_>>();
+        // Yes it would be more efficient to just build the vector in the right order, but
+        // this is easier to read and maintain.
+        children.sort_by_key(|item| match item {
+            ScopeOrBinding::Scope(scope) => scope.range().start(),
+            ScopeOrBinding::Binding(binding) => binding.syntax().text_range_with_trivia().start(),
+        });
+
+        let formatted_scope_info = format_with(|f| {
+            let range = std::format!("{:?}", self.range());
+            write!(
+                f,
+                [
+                    text("id: "),
+                    self.id,
+                    text(" @ "),
+                    dynamic_text(range.as_str(), TextSize::default()),
+                    hard_line_break()
+                ]
+            )?;
+
+            Ok(())
+        });
+
+        let formatted_children = format_with(|f| f.join().entries(&children).finish());
+
+        write!(
+            f,
+            [
+                text("Scope {"),
+                group(&block_indent(&format_args![
+                    formatted_scope_info,
+                    text("children: ["),
+                    group(&block_indent(&formatted_children)),
+                    text("]"),
+                ])),
+                text("}"),
+                hard_line_break(),
+            ]
+        )?;
+        Ok(())
+    }
+}
+
+impl Format<FormatSemanticModelContext> for Binding {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let formatted_binding_info = format_with(|f| {
+            let range = std::format!("{:?}", self.syntax().text_trimmed_range());
+            write!(
+                f,
+                [
+                    text("id: "),
+                    self.id,
+                    text(" @ "),
+                    dynamic_text(range.as_str(), TextSize::default()),
+                    hard_line_break()
+                ]
+            )?;
+            write!(f, [text("scope: "), self.scope().id, hard_line_break()])?;
+            let full_text = self.syntax().text_trimmed().into_text();
+            write!(
+                f,
+                [
+                    text("ident: "),
+                    dynamic_text(&full_text, TextSize::default()),
+                    hard_line_break()
+                ]
+            )?;
+            Ok(())
+        });
+        write!(
+            f,
+            [
+                text("Binding {"),
+                group(&block_indent(&formatted_binding_info)),
+                text("}"),
+                hard_line_break(),
+            ]
+        )?;
+
+        Ok(())
+    }
+}
+
+impl Format<FormatSemanticModelContext> for ScopeId {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let text = std::format!("ScopeId({})", self.0);
+        write!(f, [dynamic_text(text.as_str(), TextSize::default())])
+    }
+}
+
+impl Format<FormatSemanticModelContext> for BindingId {
+    fn fmt(&self, f: &mut Formatter<FormatSemanticModelContext>) -> FormatResult<()> {
+        let text = std::format!("BindingId({})", self.0);
+        write!(f, [dynamic_text(text.as_str(), TextSize::default())])
+    }
+}

--- a/crates/biome_js_semantic/src/lib.rs
+++ b/crates/biome_js_semantic/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::use_self)]
 
 mod events;
+mod format_semantic_model;
 
 mod semantic_model;
 #[cfg(test)]

--- a/crates/biome_js_semantic/src/semantic_model/model.rs
+++ b/crates/biome_js_semantic/src/semantic_model/model.rs
@@ -2,7 +2,7 @@ use super::*;
 use biome_js_syntax::{AnyJsFunction, AnyJsRoot};
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct BindingId(u32);
+pub struct BindingId(pub(crate) u32);
 
 impl BindingId {
     pub fn new(index: usize) -> Self {
@@ -38,7 +38,7 @@ impl ReferenceId {
 
 // We use `NonZeroU32` to allow niche optimizations.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct ScopeId(std::num::NonZeroU32);
+pub struct ScopeId(pub(crate) std::num::NonZeroU32);
 
 // We don't implement `From<usize> for ScopeId` and `From<ScopeId> for usize`
 // to ensure that the API consumers don't create `ScopeId`.

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -82,6 +82,7 @@ impl ExtensionHandler for AstroFileHandler {
                 debug_formatter_ir: None,
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -330,6 +330,7 @@ impl ExtensionHandler for CssFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -277,6 +277,7 @@ impl ExtensionHandler for GraphqlFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -249,6 +249,7 @@ impl ExtensionHandler for GritFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -208,6 +208,7 @@ impl ExtensionHandler for HtmlFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -485,6 +485,7 @@ impl ExtensionHandler for JsFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: Some(debug_type_info),
                 debug_registered_types: Some(debug_registered_types),
+                debug_semantic_model: Some(debug_semantic_model),
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),
@@ -704,6 +705,12 @@ fn debug_registered_types(_path: &BiomePath, parse: AnyParse) -> Result<String, 
     }
 
     Ok(result)
+}
+
+fn debug_semantic_model(_path: &BiomePath, parse: AnyParse) -> Result<String, WorkspaceError> {
+    let tree: AnyJsRoot = parse.tree();
+    let model = semantic_model(&tree, SemanticModelOptions::default());
+    Ok(model.to_string())
 }
 
 pub(crate) fn lint(params: LintParams) -> LintResults {

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -329,6 +329,7 @@ impl ExtensionHandler for JsonFileHandler {
                 debug_formatter_ir: Some(debug_formatter_ir),
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -452,6 +452,7 @@ type DebugFormatterIR = fn(
 ) -> Result<String, WorkspaceError>;
 type DebugTypeInfo = fn(&BiomePath, AnyParse) -> Result<String, WorkspaceError>;
 type DebugRegisteredTypes = fn(&BiomePath, AnyParse) -> Result<String, WorkspaceError>;
+type DebugSemanticModel = fn(&BiomePath, AnyParse) -> Result<String, WorkspaceError>;
 
 #[derive(Default)]
 pub struct DebugCapabilities {
@@ -465,6 +466,8 @@ pub struct DebugCapabilities {
     pub(crate) debug_type_info: Option<DebugTypeInfo>,
     /// Prints the registered types
     pub(crate) debug_registered_types: Option<DebugRegisteredTypes>,
+    /// Prints the binding/scope tree of the semantic model
+    pub(crate) debug_semantic_model: Option<DebugSemanticModel>,
 }
 
 #[derive(Debug)]

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -95,6 +95,7 @@ impl ExtensionHandler for SvelteFileHandler {
                 debug_formatter_ir: None,
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -95,6 +95,7 @@ impl ExtensionHandler for VueFileHandler {
                 debug_formatter_ir: None,
                 debug_type_info: None,
                 debug_registered_types: None,
+                debug_semantic_model: None,
             },
             analyzer: AnalyzerCapabilities {
                 lint: Some(lint),

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_semantic_model.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_service/src/workspace.tests.rs
+expression: result.unwrap()
+---
+Scope {
+  id: ScopeId(1) @ 1..242
+  children: [
+    Scope {
+      id: ScopeId(2) @ 1..87
+      children: [
+        Binding {
+          id: BindingId(1) @ 14..18
+          scope: ScopeId(2)
+          ident: name
+        }
+        Binding {
+          id: BindingId(2) @ 28..31
+          scope: ScopeId(2)
+          ident: age
+        }
+        Scope {
+          id: ScopeId(3) @ 49..87
+          children: []
+        }
+      ]
+    }
+    Binding {
+      id: BindingId(0) @ 10..13
+      scope: ScopeId(2)
+      ident: foo
+    }
+    Scope {
+      id: ScopeId(4) @ 88..242
+      children: [
+        Scope {
+          id: ScopeId(5) @ 142..240
+          children: [
+            Binding {
+              id: BindingId(4) @ 154..158
+              scope: ScopeId(5)
+              ident: name
+            }
+            Binding {
+              id: BindingId(5) @ 168..171
+              scope: ScopeId(5)
+              ident: age
+            }
+            Scope {
+              id: ScopeId(6) @ 181..240
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+    Binding {
+      id: BindingId(3) @ 94..100
+      scope: ScopeId(4)
+      ident: Person
+    }
+  ]
+}

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -655,6 +655,14 @@ pub struct GetRegisteredTypesParams {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
+pub struct GetSemanticModelParams {
+    pub project_key: ProjectKey,
+    pub path: BiomePath,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
 pub struct GetFormatterIRParams {
     pub project_key: ProjectKey,
     pub path: BiomePath,
@@ -1180,6 +1188,9 @@ pub trait Workspace: Send + Sync + RefUnwindSafe {
         params: GetRegisteredTypesParams,
     ) -> Result<String, WorkspaceError>;
 
+    /// Returns a textual, debug representation of the semantic model for the document.
+    fn get_semantic_model(&self, params: GetSemanticModelParams) -> Result<String, WorkspaceError>;
+
     /// Returns the content of a given file.
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError>;
 
@@ -1338,6 +1349,13 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
                 project_key: self.project_key,
                 path: self.path.clone(),
             })
+    }
+
+    pub fn get_semantic_model(&self) -> Result<String, WorkspaceError> {
+        self.workspace.get_semantic_model(GetSemanticModelParams {
+            project_key: self.project_key,
+            path: self.path.clone(),
+        })
     }
 
     pub fn change_file(&self, version: i32, content: String) -> Result<(), WorkspaceError> {

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -698,3 +698,37 @@ class Person {
     assert!(result.is_ok());
     assert_snapshot!(result.unwrap());
 }
+
+#[test]
+fn debug_semantic_model() {
+    let (workspace, project_key) = create_server();
+
+    let file = FileGuard::open(
+        workspace.as_ref(),
+        OpenFileParams {
+            project_key,
+            path: BiomePath::new("file.ts"),
+            content: FileContent::from_client(
+                r#"
+function foo(name: string, age: number): Person {
+    return new Person(string, age)
+}
+class Person {
+    #name: string
+    #age: number
+    constructor(name: string, age: number) {
+        this.#name = name;
+        this.#age = age;
+    }
+}
+"#,
+            ),
+            document_file_source: None,
+            persist_node_cache: false,
+        },
+    )
+    .unwrap();
+    let result = file.get_semantic_model();
+    assert!(result.is_ok());
+    assert_snapshot!(result.unwrap());
+}

--- a/crates/biome_service/src/workspace/client.rs
+++ b/crates/biome_service/src/workspace/client.rs
@@ -16,10 +16,11 @@ use std::{
 use super::{
     ChangeFileParams, CloseFileParams, FixFileParams, FixFileResult, FormatFileParams,
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
-    GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, PullActionsParams, PullActionsResult,
-    PullDiagnosticsParams, PullDiagnosticsResult, RenameParams, RenameResult,
-    ScanProjectFolderParams, ScanProjectFolderResult, SearchPatternParams, SearchResults,
-    SupportsFeatureParams, UpdateSettingsParams, UpdateSettingsResult,
+    GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams,
+    PullActionsParams, PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult,
+    RenameParams, RenameResult, ScanProjectFolderParams, ScanProjectFolderResult,
+    SearchPatternParams, SearchResults, SupportsFeatureParams, UpdateSettingsParams,
+    UpdateSettingsResult,
 };
 
 pub struct WorkspaceClient<T> {
@@ -169,6 +170,10 @@ where
         params: GetRegisteredTypesParams,
     ) -> Result<String, WorkspaceError> {
         self.request("biome/get_registered_types", params)
+    }
+
+    fn get_semantic_model(&self, params: GetSemanticModelParams) -> Result<String, WorkspaceError> {
+        self.request("biome/get_semantic_model", params)
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -51,11 +51,12 @@ use super::{
     ChangeFileParams, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams,
     CloseProjectParams, FeatureName, FileContent, FixFileParams, FixFileResult, FormatFileParams,
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFormatterIRParams,
-    GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams, OpenProjectParams,
-    ParsePatternParams, ParsePatternResult, PatternId, ProjectKey, PullActionsParams,
-    PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult, RenameResult,
-    ScanProjectFolderParams, ScanProjectFolderResult, SearchPatternParams, SearchResults,
-    ServiceDataNotification, SupportsFeatureParams, UpdateSettingsParams, UpdateSettingsResult,
+    GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult, OpenFileParams,
+    OpenProjectParams, ParsePatternParams, ParsePatternResult, PatternId, ProjectKey,
+    PullActionsParams, PullActionsResult, PullDiagnosticsParams, PullDiagnosticsResult,
+    RenameResult, ScanProjectFolderParams, ScanProjectFolderResult, SearchPatternParams,
+    SearchResults, ServiceDataNotification, SupportsFeatureParams, UpdateSettingsParams,
+    UpdateSettingsResult,
 };
 
 pub struct WorkspaceServer {
@@ -995,6 +996,17 @@ impl Workspace for WorkspaceServer {
         let parse = self.get_parse(&params.path)?;
 
         debug_registered_types(&params.path, parse)
+    }
+
+    fn get_semantic_model(&self, params: GetSemanticModelParams) -> Result<String, WorkspaceError> {
+        let capabilities = self.get_file_capabilities(&params.path);
+        let debug_semantic_model = capabilities
+            .debug
+            .debug_semantic_model
+            .ok_or_else(self.build_capability_error(&params.path))?;
+        let parse = self.get_parse(&params.path)?;
+
+        debug_semantic_model(&params.path, parse)
     }
 
     fn get_file_content(&self, params: GetFileContentParams) -> Result<String, WorkspaceError> {

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -587,7 +587,7 @@ macro_rules! workspace_method {
 }
 
 /// Returns a list of signature for all the methods in the [Workspace] trait
-pub fn methods() -> [WorkspaceMethod; 23] {
+pub fn methods() -> [WorkspaceMethod; 24] {
     [
         workspace_method!(file_features),
         workspace_method!(update_settings),
@@ -602,6 +602,7 @@ pub fn methods() -> [WorkspaceMethod; 23] {
         workspace_method!(get_formatter_ir),
         workspace_method!(get_type_info),
         workspace_method!(get_registered_types),
+        workspace_method!(get_semantic_model),
         workspace_method!(pull_diagnostics),
         workspace_method!(pull_actions),
         workspace_method!(format_file),

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -7,8 +7,9 @@ use biome_fs::MemoryFileSystem;
 use biome_service::workspace::{
     self, ChangeFileParams, CloseFileParams, FixFileParams, FormatFileParams, FormatOnTypeParams,
     FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams, GetFormatterIRParams,
-    GetRegisteredTypesParams, GetSyntaxTreeParams, GetTypeInfoParams, OpenProjectParams,
-    PullActionsParams, PullDiagnosticsParams, RenameParams, UpdateSettingsParams,
+    GetRegisteredTypesParams, GetSemanticModelParams, GetSyntaxTreeParams, GetTypeInfoParams,
+    OpenProjectParams, PullActionsParams, PullDiagnosticsParams, RenameParams,
+    UpdateSettingsParams,
 };
 use biome_service::workspace::{OpenFileParams, SupportsFeatureParams};
 
@@ -131,6 +132,13 @@ impl Workspace {
         let params: GetRegisteredTypesParams =
             serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
         self.inner.get_registered_types(params).map_err(into_error)
+    }
+
+    #[wasm_bindgen(js_name = getSemanticModel)]
+    pub fn get_semantic_model(&self, params: IGetSemanticModelParams) -> Result<String, Error> {
+        let params: GetSemanticModelParams =
+            serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
+        self.inner.get_semantic_model(params).map_err(into_error)
     }
 
     #[wasm_bindgen(js_name = changeFile)]

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3892,6 +3892,10 @@ export interface GetRegisteredTypesParams {
 	path: BiomePath;
 	projectKey: ProjectKey;
 }
+export interface GetSemanticModelParams {
+	path: BiomePath;
+	projectKey: ProjectKey;
+}
 export interface PullDiagnosticsParams {
 	categories: RuleCategories;
 	/**
@@ -4112,6 +4116,7 @@ export interface Workspace {
 	getFormatterIr(params: GetFormatterIRParams): Promise<string>;
 	getTypeInfo(params: GetTypeInfoParams): Promise<string>;
 	getRegisteredTypes(params: GetRegisteredTypesParams): Promise<string>;
+	getSemanticModel(params: GetSemanticModelParams): Promise<string>;
 	pullDiagnostics(
 		params: PullDiagnosticsParams,
 	): Promise<PullDiagnosticsResult>;
@@ -4166,6 +4171,9 @@ export function createWorkspace(transport: Transport): Workspace {
 		},
 		getRegisteredTypes(params) {
 			return transport.request("biome/get_registered_types", params);
+		},
+		getSemanticModel(params) {
+			return transport.request("biome/get_semantic_model", params);
 		},
 		pullDiagnostics(params) {
 			return transport.request("biome/pull_diagnostics", params);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
While working on `noShadow`, I found it kinda difficult to work with the semantic model because of the lack of a visual representation. This PR aims to resolve that by adding a debug printer for the semantic model.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
I've added this printer to the quick test for the analyzer. I didn't make any explicit tests since it's just debug output and not functionality that end users will be engaging with.
