### PR TITLE
chore: fix Windows CI

### DIFF
--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3419,6 +3419,9 @@ export function bar() {
         "This import is part of a cycle."
     );
 
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(Duration::from_secs(1));
+
     clear_notifications!(factory.service_data_rx);
 
     // ARRANGE: Move `utils` directory.
@@ -3455,6 +3458,9 @@ export function bar() {
     // ASSERT: Diagnostic should've disappeared because `utils/bar.ts` is no
     //         longer there.
     assert_eq!(result.diagnostics.len(), 0);
+
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(Duration::from_secs(1));
 
     // ARRANGE: Move `utils` back.
     clear_notifications!(factory.service_data_rx);


### PR DESCRIPTION
## Summary

It's a bit of a shot in the dark, but given that the reason the `watcher_updates_module_graph_with_directories` test fails on Windows seems to be a timing issue, I'm adding some sleeps to see if it fixes the CI.

## Test Plan

Windows CI should become green.
