### PR TITLE
fix(core): don't scan `node_modules` when using the light scanner

### DIFF
--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -250,9 +250,7 @@ impl BiomePath {
 
     /// Returns `true` if the path is inside `node_modules`
     pub fn is_dependency(&self) -> bool {
-        self.path
-            .components()
-            .any(|component| component.as_str() == "node_modules")
+        self.path.as_str().contains("node_modules")
     }
 }
 impl From<Utf8PathBuf> for BiomePath {

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -265,14 +265,21 @@ impl TraversalContext for ScanContext<'_> {
             return false;
         }
 
-        path.is_dir()
-            || if self.scan_kind.is_known_files() {
-                path.is_ignore() || path.is_manifest() || path.is_config()
-            } else if path.is_dependency() {
-                path.ends_with(".d.ts")
+        if path.is_dir() {
+            return true;
+        }
+        if self.scan_kind.is_known_files() {
+            // we don't need to check files inside node_modules if we are in known files mode
+            if path.is_dependency() {
+                false
             } else {
-                DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
+                path.is_ignore() || path.is_config() || path.is_manifest()
             }
+        } else if path.is_dependency() {
+            path.ends_with(".d.ts")
+        } else {
+            DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
+        }
     }
 
     fn handle_path(&self, path: BiomePath) {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/5820

We were inspecting `package.json` files inside `node_modules` when using the light scanner, which shouldn't be the case.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested manually using the reproduction provided. 

<!-- What demonstrates that your implementation is correct? -->
