### PR TITLE
feat(core): implement full (project-level) inference

### DIFF
--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -82,7 +82,7 @@ impl TypeData {
                 },
                 TypeofExpression::Call(expr) => match resolver.resolve_and_get(&expr.callee) {
                     Some(Self::Function(function)) => match function.return_type.as_type() {
-                        Some(ty) => Self::reference(ty.clone()),
+                        Some(ty) => Self::reference(ty.clone()).flattened(resolver),
                         None => self.clone(),
                     },
                     Some(ty @ Self::Object(object)) => {

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -167,9 +167,9 @@ impl Format<FormatTypeContext> for Function {
                 write!(
                     f,
                     [dynamic_text(
-                        &std::format!("\"{}\"", name),
+                        &std::format!("\"{name}\""),
                         TextSize::default()
-                    ),]
+                    )]
                 )
             } else {
                 Ok(())
@@ -527,6 +527,16 @@ impl Format<FormatTypeContext> for TypeReference {
                 let id = resolved.id();
                 if level == TypeResolverLevel::Global && resolved.index() < NUM_PREDEFINED_TYPES {
                     write!(f, [text(global_type_name(id))])
+                } else if level == TypeResolverLevel::Module {
+                    let module_id = resolved.module_id().index();
+                    write!(
+                        f,
+                        [&format_args![
+                            dynamic_text(&std::format!("Module({module_id})"), TextSize::default()),
+                            space(),
+                            dynamic_text(&std::format!("{id:?}"), TextSize::default()),
+                        ]]
+                    )
                 } else {
                     write!(
                         f,
@@ -726,13 +736,8 @@ impl Format<FormatTypeContext> for ResolvedPath {
     ) -> FormatResult<()> {
         let value = self.deref();
         if let Ok(value) = value {
-            write!(
-                f,
-                [dynamic_text(
-                    value.as_str().replace('\\', "/").as_str(),
-                    TextSize::default()
-                )]
-            )?;
+            let quoted = std::format!("\"{}\"", value.as_str().replace('\\', "/"));
+            write!(f, [dynamic_text(&quoted, TextSize::default())])?;
         }
 
         Ok(())

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -29,7 +29,7 @@ impl Debug for ResolvedTypeId {
                 "Module({:?}) {id:?}",
                 self.module_id().index()
             )),
-            TypeResolverLevel::Project => f.write_fmt(format_args!("Project {id:?}")),
+            TypeResolverLevel::Import => f.write_fmt(format_args!("Import {id:?}")),
             TypeResolverLevel::Global => f.write_fmt(format_args!("Global {id:?}")),
         }
     }
@@ -53,6 +53,10 @@ impl ResolvedTypeId {
         matches!(self.level(), TypeResolverLevel::Global)
     }
 
+    pub const fn is_at_module_level(self) -> bool {
+        matches!(self.level(), TypeResolverLevel::Module)
+    }
+
     pub const fn level(self) -> TypeResolverLevel {
         TypeResolverLevel::from_u2(self.0 >> NUM_MODULE_ID_BITS)
     }
@@ -62,9 +66,13 @@ impl ResolvedTypeId {
     }
 
     pub const fn with_module_id(self, module_id: ModuleId) -> Self {
-        // Clear the bits of the old module ID, while preserving the resolver
-        // level, and OR with the bits from the new module ID.
-        Self((self.0 & LEVEL_MASK) | module_id.0, self.1)
+        if self.is_at_module_level() {
+            // Clear the bits of the old module ID, while preserving the resolver
+            // level, and OR with the bits from the new module ID.
+            Self((self.0 & LEVEL_MASK) | module_id.0, self.1)
+        } else {
+            self
+        }
     }
 }
 
@@ -110,11 +118,14 @@ pub enum TypeResolverLevel {
     /// Used for resolving types that exist across modules within the project.
     ///
     /// Currently, we don't store resolved IDs with this level in the module
-    /// info. Instead, we use it to during a module's type collection to flag
+    /// info. Instead, we use it during a module's type collection to flag
     /// resolved types that require imports from other modules. Such resolved
     /// IDs then get converted to [`TypeReference::Import`] before storing
     /// them in the module info.
-    Project,
+    ///
+    /// **Important:** [`ResolvedTypeId`]s of this level store a `BindingId` in
+    ///                the field that is used for `TypeId`s normally.
+    Import,
 
     /// Used for language- and environment-level globals.
     Global,
@@ -127,11 +138,15 @@ impl TypeResolverLevel {
     /// Only the two least significant bits may be set in order to let the type
     /// fit into `ResolvedTypeId`. If more bits become necessary, we may need to
     /// rebalance the layout of `ResolvedTypeId`.
+    ///
+    /// Note: `from_u2` is not a typo. Even though `u2` isn't a real type, it's
+    ///       named like this to make you, dear reader, more aware of the size
+    ///       constraint ;)
     pub const fn from_u2(bits: u32) -> Self {
         match bits {
             0 => Self::AdHoc,
             1 => Self::Module,
-            2 => Self::Project,
+            2 => Self::Import,
             3 => Self::Global,
             _ => panic!("invalid bits passed to TypeResolverLevel"),
         }
@@ -415,7 +430,7 @@ pub trait Resolvable: Sized {
     /// function on all instances of [`TypeReference`].
     fn resolved_with_mapped_references(
         &self,
-        map: impl Copy + Fn(TypeReference) -> TypeReference,
+        map: impl Copy + Fn(TypeReference, &mut dyn TypeResolver) -> TypeReference,
         resolver: &mut dyn TypeResolver,
     ) -> Self;
 
@@ -427,10 +442,16 @@ pub trait Resolvable: Sized {
         resolver: &mut dyn TypeResolver,
     ) -> Self {
         self.resolved_with_mapped_references(
-            |reference| reference.with_module_id(module_id),
+            |reference, _| reference.with_module_id(module_id),
             resolver,
         )
     }
+
+    /// Returns the instance with all module-level references augmented with the
+    /// given `module_id`.
+    ///
+    /// Does not perform any resolving in the process.
+    fn with_module_id(self, module_id: ModuleId) -> Self;
 }
 
 impl Resolvable for TypeReference {
@@ -488,10 +509,19 @@ impl Resolvable for TypeReference {
 
     fn resolved_with_mapped_references(
         &self,
-        map: impl Copy + Fn(Self) -> Self,
+        map: impl Copy + Fn(Self, &mut dyn TypeResolver) -> Self,
         resolver: &mut dyn TypeResolver,
     ) -> Self {
-        map(self.resolved(resolver))
+        map(self.resolved(resolver), resolver)
+    }
+
+    fn with_module_id(self, module_id: ModuleId) -> Self {
+        match self {
+            Self::Resolved(resolved_type_id) => {
+                Self::Resolved(resolved_type_id.with_module_id(module_id))
+            }
+            other => other,
+        }
     }
 }
 
@@ -511,13 +541,21 @@ impl Resolvable for TypeofValue {
 
     fn resolved_with_mapped_references(
         &self,
-        map: impl Copy + Fn(TypeReference) -> TypeReference,
+        map: impl Copy + Fn(TypeReference, &mut dyn TypeResolver) -> TypeReference,
         resolver: &mut dyn TypeResolver,
     ) -> Self {
         let Self { identifier, ty } = self.resolved(resolver);
         Self {
             identifier,
-            ty: map(ty),
+            ty: map(ty, resolver),
+        }
+    }
+
+    fn with_module_id(self, module_id: ModuleId) -> Self {
+        let Self { identifier, ty } = self;
+        Self {
+            identifier,
+            ty: ty.with_module_id(module_id),
         }
     }
 }
@@ -531,10 +569,14 @@ macro_rules! derive_primitive_resolved {
 
             fn resolved_with_mapped_references(
                 &self,
-                _map: impl Copy + Fn(TypeReference) -> TypeReference,
+                _map: impl Copy + Fn(TypeReference, &mut dyn TypeResolver) -> TypeReference,
                 _resolver: &mut dyn TypeResolver,
             ) -> Self {
                 *self
+            }
+
+            fn with_module_id(self, _module_id: ModuleId) -> Self {
+                self
             }
         })+
     };

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -22,7 +22,7 @@ use crate::globals::{
     GLOBAL_ARRAY_ID, GLOBAL_PROMISE_ID, GLOBAL_TYPE_MEMBERS, GLOBAL_UNKNOWN_ID, PROMISE_ID,
 };
 use crate::type_info::literal::{BooleanLiteral, NumberLiteral, StringLiteral};
-use crate::{GLOBAL_RESOLVER, ModuleId, Resolvable, ResolvedTypeId, TypeResolver};
+use crate::{GLOBAL_RESOLVER, Resolvable, ResolvedTypeId, TypeResolver};
 
 const UNKNOWN: TypeData = TypeData::Unknown;
 
@@ -1131,17 +1131,6 @@ impl TypeReference {
                 .map(|param| param.resolved(resolver))
                 .collect(),
             _ => [].into(),
-        }
-    }
-
-    pub fn with_module_id(&self, module_id: ModuleId) -> Self {
-        match self {
-            Self::Qualifier(qualifier) => Self::Qualifier(qualifier.clone()),
-            Self::Resolved(resolved_type_id) => {
-                Self::Resolved(resolved_type_id.with_module_id(module_id))
-            }
-            Self::Import(import) => Self::Import(import.clone()),
-            Self::Unknown => Self::Unknown,
         }
     }
 }

--- a/crates/biome_js_type_info/tests/local_inference.rs
+++ b/crates/biome_js_type_info/tests/local_inference.rs
@@ -123,13 +123,3 @@ fn infer_type_of_binary_expression_ne() {
         "infer_type_of_binary_expression_ne",
     );
 }
-
-#[test]
-#[cfg(target_pointer_width = "64")]
-fn verify_type_sizes() {
-    assert_eq!(
-        std::mem::size_of::<TypeData>(),
-        16,
-        "`TypeData` should not be bigger than 16 bytes"
-    );
-}

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -22,7 +22,6 @@ instanceof Promise
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -31,7 +30,7 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(7)
 }
 
-Module TypeId(1) => Global TypeId(7)
+Module TypeId(1) => instanceof Promise<T = number>
 
 Module TypeId(2) => sync Function "then" {
   accepts: {
@@ -60,5 +59,4 @@ Module TypeId(4) => sync Function "then" {
 Global TypeId(7) => instanceof Promise<T = number>
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
@@ -18,7 +18,6 @@ instanceof Promise
 ## Registered types
 
 ```
-
 Global TypeId(7) => sync Function {
   accepts: {
     params: [
@@ -28,5 +27,4 @@ Global TypeId(7) => sync Function {
   }
   returns: unknown reference
 }
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -24,7 +24,6 @@ instanceof Promise
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -33,7 +32,7 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(7)
 }
 
-Module TypeId(1) => Global TypeId(7)
+Module TypeId(1) => instanceof Promise<T = number>
 
 Module TypeId(2) => sync Function "then" {
   accepts: {
@@ -80,5 +79,4 @@ Module TypeId(7) => sync Function "finally" {
 Global TypeId(7) => instanceof Promise<T = number>
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
@@ -16,13 +16,12 @@ returnsPromise();
 ## Result
 
 ```
-Global TypeId(7)
+instanceof unresolved reference "Promise"<number>
 ```
 
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -32,5 +31,4 @@ Module TypeId(0) => sync Function "returnsPromise" {
 }
 
 Global TypeId(7) => instanceof unresolved reference "Promise"<number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
@@ -18,7 +18,6 @@ instanceof Promise
 ## Registered types
 
 ```
-
 Global TypeId(7) => Global TypeId(9)
 
 Global TypeId(8) => value: value
@@ -30,5 +29,4 @@ Global TypeId(9) => sync Function "resolve" {
   }
   returns: instanceof Promise
 }
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_async_function.snap
@@ -26,9 +26,7 @@ async Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof unresolved reference "Promise"<Global TypeId(7)>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
@@ -19,7 +19,6 @@ a => Global TypeId(7) | undefined
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof Array<T = Global TypeId(7)>
@@ -29,5 +28,4 @@ Global TypeId(9) => Global TypeId(7) | undefined
 Global TypeId(10) => instanceof Array<T = Global TypeId(7)>
 
 Global TypeId(11) => Global TypeId(7) | undefined
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_promise_returning_function.snap
@@ -26,7 +26,5 @@ sync Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => instanceof unresolved reference "Promise"<number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
@@ -16,13 +16,12 @@ returnsPromise().then(() => {});
 ## Result
 
 ```
-Call Module TypeId(2)(Module TypeId(3))
+Call Module(0) TypeId(2)(Module(0) TypeId(3))
 ```
 
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -31,9 +30,9 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(7)
 }
 
-Module TypeId(1) => Call Module TypeId(0)(No parameters)
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
-Module TypeId(2) => Module TypeId(1).then
+Module TypeId(2) => Module(0) TypeId(1).then
 
 Module TypeId(3) => sync Function {
   accepts: {
@@ -46,5 +45,4 @@ Module TypeId(3) => sync Function {
 Global TypeId(7) => instanceof Global TypeId(8)
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
@@ -18,7 +18,6 @@ new Promise
 ## Registered types
 
 ```
-
 Global TypeId(7) => sync Function {
   accepts: {
     params: [
@@ -28,5 +27,4 @@ Global TypeId(7) => sync Function {
   }
   returns: unknown reference
 }
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -18,13 +18,12 @@ returnsPromise()
 ## Result
 
 ```
-Call Module TypeId(5)(Module TypeId(3))
+Call Module(0) TypeId(5)(Module(0) TypeId(3))
 ```
 
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -33,9 +32,9 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(7)
 }
 
-Module TypeId(1) => Call Module TypeId(0)(No parameters)
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
-Module TypeId(2) => Module TypeId(1).then
+Module TypeId(2) => Module(0) TypeId(1).then
 
 Module TypeId(3) => sync Function {
   accepts: {
@@ -45,12 +44,11 @@ Module TypeId(3) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(4) => Call Module TypeId(2)(Module TypeId(3))
+Module TypeId(4) => Call Module(0) TypeId(2)(Module(0) TypeId(3))
 
-Module TypeId(5) => Module TypeId(4).finally
+Module TypeId(5) => Module(0) TypeId(4).finally
 
 Global TypeId(7) => instanceof Global TypeId(8)
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
@@ -16,13 +16,12 @@ returnsPromise();
 ## Result
 
 ```
-Call Module TypeId(0)(No parameters)
+Call Module(0) TypeId(0)(No parameters)
 ```
 
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
@@ -34,5 +33,4 @@ Module TypeId(0) => sync Function "returnsPromise" {
 Global TypeId(7) => instanceof Global TypeId(8)
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_static_promise_function.snap
@@ -18,9 +18,7 @@ Call Global TypeId(7)(Global TypeId(8))
 ## Registered types
 
 ```
-
 Global TypeId(7) => Promise.resolve
 
 Global TypeId(8) => value: value
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_function.snap
@@ -26,11 +26,9 @@ async Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof Global TypeId(9)
 
 Global TypeId(9) => instanceof Promise<T = Global TypeId(7)>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_destructured_array_element.snap
@@ -19,7 +19,6 @@ a => Global TypeId(8)[0]
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof Global TypeId(10)
@@ -27,5 +26,4 @@ Global TypeId(8) => instanceof Global TypeId(10)
 Global TypeId(9) => Global TypeId(8)[0]
 
 Global TypeId(10) => instanceof Array<T = Global TypeId(7)>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_promise_returning_function.snap
@@ -26,9 +26,7 @@ sync Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => instanceof Global TypeId(8)
 
 Global TypeId(8) => instanceof Promise<T = number>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
@@ -19,7 +19,5 @@ array => instanceof unresolved reference "Array"<Global TypeId(7)>
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
@@ -26,9 +26,7 @@ async Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof unresolved reference "Promise"<Global TypeId(7)>
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
@@ -19,11 +19,9 @@ a => Global TypeId(8)[0]
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => instanceof unresolved reference "Array"<Global TypeId(7)>
 
 Global TypeId(9) => Global TypeId(8)[0]
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
@@ -32,7 +32,6 @@ sync Function "destruct" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => string
 
 Global TypeId(8) => Object {
@@ -54,5 +53,4 @@ Global TypeId(12) => instanceof unresolved reference "Array"<Global TypeId(11)>
 Global TypeId(13) => Global TypeId(12)[0]
 
 Global TypeId(14) => [(1 others)...Global TypeId(12)]
-
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
@@ -26,7 +26,5 @@ sync Function "returnsPromise" {
 ## Registered types
 
 ```
-
 Global TypeId(7) => instanceof unresolved reference "Promise"<number>
-
 ```

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -17,3 +17,19 @@ fn test_resolved_type_id() {
     assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(7));
 }
+
+#[test]
+fn verify_type_sizes() {
+    assert_eq!(
+        std::mem::size_of::<ResolvedTypeId>(),
+        8,
+        "`ResolvedTypeId` should not be bigger than 8 bytes"
+    );
+
+    #[cfg(target_pointer_width = "64")]
+    assert_eq!(
+        std::mem::size_of::<biome_js_type_info::TypeData>(),
+        16,
+        "`TypeData` should not be bigger than 16 bytes"
+    );
+}

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -10,10 +10,16 @@ fn test_resolved_type_id() {
     let id = id.with_module_id(ModuleId::new(5));
     assert_eq!(id.level(), TypeResolverLevel::Global);
     assert_eq!(id.id(), TypeId::new(3));
+    assert_eq!(id.module_id(), ModuleId::new(0)); // Module ID shouldn't be applied to global level.
+
+    let id = ResolvedTypeId::new(TypeResolverLevel::Module, TypeId::new(3));
+    let id = id.with_module_id(ModuleId::new(5));
+    assert_eq!(id.level(), TypeResolverLevel::Module);
+    assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(5));
 
     let id = id.with_module_id(ModuleId::new(7));
-    assert_eq!(id.level(), TypeResolverLevel::Global);
+    assert_eq!(id.level(), TypeResolverLevel::Module);
     assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(7));
 }

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -151,8 +151,8 @@ impl TypeResolver for HardcodedSymbolResolver {
                 panic!("Ad-hoc references unsupported by resolver")
             }
             TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
-            TypeResolverLevel::Project => {
-                panic!("Project-level references unsupported by resolver")
+            TypeResolverLevel::Import => {
+                panic!("Import references unsupported by resolver")
             }
             TypeResolverLevel::Global => Some(self.globals.get_by_id(id.id())),
         }

--- a/crates/biome_js_type_info_macros/src/resolvable_derive.rs
+++ b/crates/biome_js_type_info_macros/src/resolvable_derive.rs
@@ -123,6 +123,14 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
             None => quote! { Self::#ident => Self::#ident },
         });
 
+    let variants_with_module_id = variants.iter().map(|VariantData { ident, ty }| match ty {
+        Some(ty) => {
+            let ty_with_module_id = unit_type_with_module_id(ty);
+            quote! { Self::#ident(ty) => Self::#ident(#ty_with_module_id) }
+        }
+        None => quote! { Self::#ident => Self::#ident },
+    });
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
@@ -133,11 +141,17 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
 
             fn resolved_with_mapped_references(
                 &self,
-                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                map: impl Copy + Fn(crate::TypeReference, &mut dyn crate::TypeResolver) -> crate::TypeReference,
                 resolver: &mut dyn crate::TypeResolver
             ) -> Self {
                 match self {
                     #( #resolved_variants_with_mapped_references ),*
+                }
+            }
+
+            fn with_module_id(self, module_id: crate::ModuleId) -> Self {
+                match self {
+                    #( #variants_with_module_id ),*
                 }
             }
         }
@@ -155,6 +169,11 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
         quote! { #ident: #resolved_ty }
     });
 
+    let fields_with_module_id = fields.iter().map(|FieldData { ident, ty }| {
+        let ty_with_module_id = type_with_module_id(IdentOrZero::Ident(ident), ty);
+        quote! { #ident: #ty_with_module_id }
+    });
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
@@ -165,11 +184,17 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
 
             fn resolved_with_mapped_references(
                 &self,
-                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                map: impl Copy + Fn(crate::TypeReference, &mut dyn crate::TypeResolver) -> crate::TypeReference,
                 resolver: &mut dyn crate::TypeResolver
             ) -> Self {
                 Self {
                     #( #resolved_fields_with_mapped_references ),*
+                }
+            }
+
+            fn with_module_id(self, module_id: crate::ModuleId) -> Self {
+                Self {
+                    #( #fields_with_module_id ),*
                 }
             }
         }
@@ -182,6 +207,8 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
     let resolved_field_with_mapped_references =
         resolved_type_with_mapped_references(IdentOrZero::Zero, &ty);
 
+    let field_with_module_id = type_with_module_id(IdentOrZero::Zero, &ty);
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
@@ -190,10 +217,14 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
 
             fn resolved_with_mapped_references(
                 &self,
-                map: impl Copy + Fn(crate::TypeReference) -> crate::TypeReference,
+                map: impl Copy + Fn(crate::TypeReference, &mut dyn crate::TypeResolver) -> crate::TypeReference,
                 resolver: &mut dyn crate::TypeResolver
             ) -> Self {
                 Self(#resolved_field_with_mapped_references)
+            }
+
+            fn with_module_id(self, module_id: crate::ModuleId) -> Self {
+                Self(#field_with_module_id)
             }
         }
     }
@@ -366,9 +397,6 @@ fn resolved_unit_type(ty: &Type) -> TokenStream {
                 match args.args.iter().next().unwrap() {
                     GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
                         Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
-                        Type::Path(_) => quote! {
-                            ty.iter().any(|elem| elem.needs_resolving(resolver))
-                        },
                         _ => abort!(args, "Unsupported arguments"),
                     },
                     GenericArgument::Type(Type::Path(ty)) => {
@@ -424,9 +452,6 @@ fn resolved_unit_type_with_mapped_references(ty: &Type) -> TokenStream {
                 match args.args.iter().next().unwrap() {
                     GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
                         Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
-                        Type::Path(_) => quote! {
-                            ty.iter().any(|elem| elem.needs_resolving(resolver))
-                        },
                         _ => abort!(args, "Unsupported arguments"),
                     },
                     GenericArgument::Type(Type::Path(ty)) => {
@@ -467,6 +492,123 @@ fn resolved_unit_type_with_mapped_references(ty: &Type) -> TokenStream {
         },
         _ => {
             quote! { ty.resolved_with_mapped_references(map, resolver) }
+        }
+    }
+}
+
+fn type_with_module_id(ident: IdentOrZero, ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { self.#ident }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => {
+                            quote! { self.#ident }
+                        }
+                        Type::Path(_) => quote! {
+                            self.#ident.into_iter().map(|elem| elem.with_module_id(module_id)).collect()
+                        },
+                        _ => abort!(slice, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident }
+                        } else {
+                            quote! {
+                                Box::new(self.#ident.with_module_id(module_id))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident }
+                        } else {
+                            quote! { self.#ident.map(|f| f.with_module_id(module_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { self.#ident.with_module_id(module_id) }
+        }
+    }
+}
+
+fn unit_type_with_module_id(ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { ty }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
+                        _ => abort!(args, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty }
+                        } else {
+                            quote! { Box::new(ty.with_module_id(module_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty }
+                        } else {
+                            quote! { ty.map(|f| f.with_module_id(module_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { ty.with_module_id(module_id) }
         }
     }
 }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -16,10 +16,10 @@ use biome_rowan::{AstNode, Text, TextRange, TokenText};
 
 use crate::{ModuleGraph, jsdoc_comment::JsdocComment};
 
-use ad_hoc_scope_resolver::AdHocScopeResolver;
 use binding::{BindingId, JsBindingData};
 use scope::{JsScope, JsScopeData};
 
+pub use ad_hoc_scope_resolver::AdHocScopeResolver;
 pub(crate) use visitor::JsModuleVisitor;
 
 /// Information restricted to a single module in the [ModuleGraph].
@@ -171,7 +171,7 @@ pub struct JsModuleInfoInner {
     pub(crate) types: Box<[TypeData]>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Exports(pub(crate) BTreeMap<Text, JsExport>);
 
 impl Deref for Exports {
@@ -182,7 +182,7 @@ impl Deref for Exports {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Imports(pub(crate) BTreeMap<Text, JsImport>);
 
 impl Deref for Imports {
@@ -232,7 +232,7 @@ impl TypeResolver for JsModuleInfoInner {
         match id.level() {
             TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
             TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
-            TypeResolverLevel::AdHoc | TypeResolverLevel::Project => None,
+            TypeResolverLevel::AdHoc | TypeResolverLevel::Import => None,
         }
     }
 

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -8,6 +8,8 @@ mod resolver_cache;
 
 pub use biome_js_type_info::{ImportSymbol, ResolvedPath};
 
-pub use js_module_info::{JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport};
+pub use js_module_info::{
+    AdHocScopeResolver, JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport,
+};
 pub use jsdoc_comment::JsdocComment;
 pub use module_graph::{ModuleGraph, SUPPORTED_EXTENSIONS};

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -3,7 +3,8 @@ use biome_js_formatter::context::JsFormatOptions;
 use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::JsFileSource;
-use biome_module_graph::ModuleGraph;
+use biome_js_type_info::ResolvedPath;
+use biome_module_graph::{AdHocScopeResolver, ModuleGraph};
 use biome_rowan::AstNode;
 use biome_test_utils::dump_registered_types;
 use camino::Utf8PathBuf;
@@ -11,11 +12,23 @@ use camino::Utf8PathBuf;
 pub struct ModuleGraphSnapshot<'a> {
     module_graph: &'a ModuleGraph,
     fs: &'a MemoryFileSystem,
+    resolver: Option<&'a AdHocScopeResolver>,
 }
 
 impl<'a> ModuleGraphSnapshot<'a> {
     pub fn new(module_graph: &'a ModuleGraph, fs: &'a MemoryFileSystem) -> Self {
-        Self { module_graph, fs }
+        Self {
+            module_graph,
+            fs,
+            resolver: None,
+        }
+    }
+
+    pub fn with_resolver(self, resolver: &'a AdHocScopeResolver) -> Self {
+        Self {
+            resolver: Some(resolver),
+            ..self
+        }
     }
 
     pub fn assert_snapshot(&self, test_name: &str) {
@@ -47,24 +60,43 @@ impl<'a> ModuleGraphSnapshot<'a> {
                 .print()
                 .unwrap();
 
-            content.push_str("## ");
+            content.push_str("\n# `");
             content.push_str(file_name.as_str());
-            content.push_str("\n\n");
+            content.push('`');
+            if let Some(resolver) = self.resolver {
+                content.push_str(" (");
+                match resolver
+                    .modules_by_path
+                    .get(&ResolvedPath::from_path(&file_name))
+                {
+                    Some(module_id) => {
+                        content.push_str("Module ");
+                        content.push_str(&module_id.index().to_string());
+                    }
+                    None => content.push_str("Not imported by resolver"),
+                }
+                content.push(')');
+            }
+            content.push_str("\n\n## Source\n\n");
             content.push_str("```");
             content.push_str(extension);
             content.push('\n');
-            content.push_str(formatted.as_code());
+            content.push_str(formatted.as_code().trim());
             content.push_str("\n```");
 
             let data = dependency_data.get(file_name.as_path()).unwrap().clone();
 
-            content.push_str("\n\n");
-            content.push_str("## Module Info\n\n");
+            content.push_str("\n\n## Module Info\n\n");
             content.push_str("```\n");
             content.push_str(&data.to_string());
             content.push_str("\n```\n\n");
 
             dump_registered_types(&mut content, data.as_resolver());
+        }
+
+        if let Some(resolver) = self.resolver {
+            content.push_str("\n# Ad-Hoc Type Resolver\n\n");
+            dump_registered_types(&mut content, resolver);
         }
 
         insta::with_settings!({

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 /**
@@ -10,7 +12,6 @@ expression: content
  * @returns {JSX.Element}
  */
 export default function Component(): JSX.Element {}
-
 ```
 
 ## Module Info
@@ -19,7 +20,7 @@ export default function Component(): JSX.Element {}
 Exports {
   "default" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(1)
+      Module(0) TypeId(1)
       Local name: Component
       JsDoc(
         @public
@@ -36,7 +37,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => instanceof unresolved reference "JSX.Element"
 
 Module TypeId(1) => sync Function "Component" {
@@ -44,7 +44,6 @@ Module TypeId(1) => sync Function "Component" {
     params: []
     type_args: []
   }
-  returns: Module TypeId(0)
+  returns: Module(0) TypeId(0)
 }
-
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 /**
@@ -11,7 +13,6 @@ expression: content
 function foo() {}
 
 export { foo };
-
 ```
 
 ## Module Info
@@ -20,7 +21,7 @@ export { foo };
 Exports {
   "foo" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(0)
+      Module(0) TypeId(0)
       Local name: foo
       JsDoc(
         @returns {string}
@@ -36,7 +37,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "foo" {
   accepts: {
     params: []
@@ -44,5 +44,4 @@ Module TypeId(0) => sync Function "foo" {
   }
   returns: unknown reference
 }
-
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 import type { PromisedResult } from "./promisedResult.ts";
@@ -12,7 +14,6 @@ function returnPromiseResult(): PromisedResult {
 }
 
 export { returnPromiseResult };
-
 ```
 
 ## Module Info
@@ -21,7 +22,7 @@ export { returnPromiseResult };
 Exports {
   "returnPromiseResult" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(2)
+      Module(0) TypeId(2)
       Local name: returnPromiseResult
     )
   }
@@ -29,7 +30,7 @@ Exports {
 Imports {
   "PromisedResult" => {
     Specifier: "./promisedResult.ts"
-    Resolved path: /src/promisedResult.ts
+    Resolved path: "/src/promisedResult.ts"
     Import Symbol: PromisedResult
   }
 }
@@ -38,25 +39,25 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => unknown
 
-Module TypeId(1) => instanceof Import Symbol: PromisedResult from /src/promisedResult.ts
+Module TypeId(1) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
 
 Module TypeId(2) => sync Function "returnPromiseResult" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module TypeId(1)
+  returns: Module(0) TypeId(1)
 }
-
 ```
-## /src/promisedResult.ts
+
+# `/src/promisedResult.ts`
+
+## Source
 
 ```ts
 export type PromisedResult = Promise<{ result: true | false }>;
-
 ```
 
 ## Module Info
@@ -65,7 +66,7 @@ export type PromisedResult = Promise<{ result: true | false }>;
 Exports {
   "PromisedResult" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(4)
+      Module(0) TypeId(4)
       Local name: PromisedResult
     )
   }
@@ -78,20 +79,18 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => value: true
 
 Module TypeId(1) => value: false
 
-Module TypeId(2) => Module TypeId(0) | Module TypeId(1)
+Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
 
 Module TypeId(3) => Object {
   prototype: No prototype
-  members: {TypeMembers(required property "result": Module TypeId(2))}
+  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
 }
 
-Module TypeId(4) => instanceof Promise<T = Module TypeId(3)>
+Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>
 
-Module TypeId(5) => instanceof Promise<T = Module TypeId(3)>
-
+Module TypeId(5) => instanceof Promise<T = Module(0) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 export const theAnswer = 42;
@@ -34,7 +36,6 @@ class DeepThought {
 }
 
 export const superComputer = new DeepThought();
-
 ```
 
 ## Module Info
@@ -43,13 +44,13 @@ export const superComputer = new DeepThought();
 Exports {
   "superComputer" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(4)
+      Module(0) TypeId(4)
       Local name: superComputer
     )
   }
   "theAnswer" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(0)
+      Module(0) TypeId(0)
       Local name: theAnswer
     )
   }
@@ -62,7 +63,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => value: 42
 
 Module TypeId(1) => number
@@ -74,6 +74,5 @@ Module TypeId(3) => class "DeepThought" {
   type_args: []
 }
 
-Module TypeId(4) => instanceof Module TypeId(3)
-
+Module TypeId(4) => instanceof Module(0) TypeId(3)
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 /**
@@ -52,7 +54,6 @@ export { ohNo as "oh\x0Ano" } from "./renamed-reexports";
  * Hello, namespace 2.
  */
 export * as renamed2 from "./renamed-reexports";
-
 ```
 
 ## Module Info
@@ -61,19 +62,19 @@ export * as renamed2 from "./renamed-reexports";
 Exports {
   "a" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(7)
+      Module(0) TypeId(7)
       Local name: a
     )
   }
   "b" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(8)
+      Module(0) TypeId(8)
       Local name: b
     )
   }
   "bar" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(1)
+      Module(0) TypeId(1)
       Local name: bar
       JsDoc(
         @package
@@ -82,19 +83,19 @@ Exports {
   }
   "baz" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(4)
+      Module(0) TypeId(4)
       Local name: baz
     )
   }
   "d" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(10)
+      Module(0) TypeId(10)
       Local name: d
     )
   }
   "default" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(23)
+      Module(0) TypeId(23)
       Local name: Component
       JsDoc(
         @public
@@ -104,13 +105,13 @@ Exports {
   }
   "e" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(11)
+      Module(0) TypeId(11)
       Local name: e
     )
   }
   "foo" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(0)
+      Module(0) TypeId(0)
       Local name: foo
       JsDoc(
         @returns {string}
@@ -120,19 +121,19 @@ Exports {
   "oh\nno" => {
     ExportReexport => Reexport(
       Specifier: "./renamed-reexports"
-      Resolved path: /src/renamed-reexports.ts
+      Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: ohNo
     )
   }
   "qux" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(5)
+      Module(0) TypeId(5)
       Local name: qux
     )
   }
   "quz" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(2)
+      Module(0) TypeId(2)
       Local name: quz
       JsDoc(
         @private
@@ -142,7 +143,7 @@ Exports {
   "renamed2" => {
     ExportReexport => Reexport(
       Specifier: "./renamed-reexports"
-      Resolved path: /src/renamed-reexports.ts
+      Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
       JsDoc(
         Hello, namespace 2.
@@ -158,7 +159,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "foo" {
   accepts: {
     params: []
@@ -187,16 +187,23 @@ Module TypeId(4) => async Function "baz" {
     params: []
     type_args: []
   }
-  returns: Module TypeId(3)
+  returns: Module(0) TypeId(3)
 }
 
 Module TypeId(5) => value: 1
 
-Module TypeId(6) => Module TypeId(20)
+Module TypeId(6) => Object {
+  prototype: No prototype
+  members: {TypeMembers(
+    required property "a": Module(0) TypeId(12)
+    required property "b": Module(0) TypeId(14)
+    required property "c": Module(0) TypeId(18)
+  )}
+}
 
 Module TypeId(7) => string
 
-Module TypeId(8) => instanceof Module TypeId(24)
+Module TypeId(8) => instanceof Module(0) TypeId(24)
 
 Module TypeId(9) => Tuple(
     [
@@ -227,21 +234,21 @@ Module TypeId(9) => Tuple(
     ],
 )
 
-Module TypeId(10) => Module TypeId(15)
+Module TypeId(10) => Module(0) TypeId(15)
 
-Module TypeId(11) => Module TypeId(17)
+Module TypeId(11) => Module(0) TypeId(17)
 
 Module TypeId(12) => string
 
 Module TypeId(13) => number
 
-Module TypeId(14) => instanceof Array<T = Module TypeId(13)>
+Module TypeId(14) => instanceof Array<T = Module(0) TypeId(13)>
 
 Module TypeId(15) => boolean
 
 Module TypeId(16) => undefined
 
-Module TypeId(17) => Module TypeId(15) | Module TypeId(16)
+Module TypeId(17) => Module(0) TypeId(15) | Module(0) TypeId(16)
 
 Module TypeId(18) => Tuple(
     [
@@ -275,18 +282,18 @@ Module TypeId(18) => Tuple(
 Module TypeId(19) => Object {
   prototype: No prototype
   members: {TypeMembers(
-    required property "a": Module TypeId(12)
-    required property "b": Module TypeId(14)
-    required property "c": Module TypeId(18)
+    required property "a": Module(0) TypeId(12)
+    required property "b": Module(0) TypeId(14)
+    required property "c": Module(0) TypeId(18)
   )}
 }
 
 Module TypeId(20) => Object {
   prototype: No prototype
   members: {TypeMembers(
-    required property "a": Module TypeId(12)
-    required property "b": Module TypeId(14)
-    required property "c": Module TypeId(18)
+    required property "a": Module(0) TypeId(12)
+    required property "b": Module(0) TypeId(14)
+    required property "c": Module(0) TypeId(18)
   )}
 }
 
@@ -295,7 +302,7 @@ Module TypeId(21) => sync Function "getObject" {
     params: []
     type_args: []
   }
-  returns: Module TypeId(20)
+  returns: Module(0) TypeId(20)
 }
 
 Module TypeId(22) => instanceof unresolved reference "JSX.Element"
@@ -305,21 +312,22 @@ Module TypeId(23) => sync Function "Component" {
     params: []
     type_args: []
   }
-  returns: Module TypeId(22)
+  returns: Module(0) TypeId(22)
 }
 
-Module TypeId(24) => instanceof Array<T = Module TypeId(13)>
+Module TypeId(24) => instanceof Array<T = Module(0) TypeId(13)>
 
 Module TypeId(25) => boolean
 
-Module TypeId(26) => Module TypeId(15) | Module TypeId(16)
-
+Module TypeId(26) => Module(0) TypeId(15) | Module(0) TypeId(16)
 ```
-## /src/renamed-reexports.ts
+
+# `/src/renamed-reexports.ts`
+
+## Source
 
 ```ts
 export function ohNo() {}
-
 ```
 
 ## Module Info
@@ -328,7 +336,7 @@ export function ohNo() {}
 Exports {
   "ohNo" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(0)
+      Module(0) TypeId(0)
       Local name: ohNo
     )
   }
@@ -341,7 +349,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => sync Function "ohNo" {
   accepts: {
     params: []
@@ -349,16 +356,17 @@ Module TypeId(0) => sync Function "ohNo" {
   }
   returns: unknown reference
 }
-
 ```
-## /src/reexports.ts
+
+# `/src/reexports.ts`
+
+## Source
 
 ```ts
 /**
  * Hello, namespace 1.
  */
 export * as renamed from "./renamed-reexports";
-
 ```
 
 ## Module Info
@@ -368,7 +376,7 @@ Exports {
   "renamed" => {
     ExportReexport => Reexport(
       Specifier: "./renamed-reexports"
-      Resolved path: /src/renamed-reexports.ts
+      Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: All
       JsDoc(
         Hello, namespace 1.

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -2,7 +2,9 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts`
+
+## Source
 
 ```ts
 async function returnsPromise() {
@@ -10,7 +12,6 @@ async function returnsPromise() {
 }
 
 export const promise = returnsPromise();
-
 ```
 
 ## Module Info
@@ -19,7 +20,7 @@ export const promise = returnsPromise();
 Exports {
   "promise" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(2)
+      Module(0) TypeId(2)
       Local name: promise
     )
   }
@@ -32,7 +33,6 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => instanceof Promise
 
 Module TypeId(1) => async Function "returnsPromise" {
@@ -40,9 +40,8 @@ Module TypeId(1) => async Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Module TypeId(0)
+  returns: Module(0) TypeId(0)
 }
 
-Module TypeId(2) => Module TypeId(0)
-
+Module TypeId(2) => instanceof Promise
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -2,13 +2,14 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-## /src/index.ts
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
 
 ```ts
 import { returnPromiseResult } from "./returnPromiseResult.ts";
 
 const promise = returnPromiseResult();
-
 ```
 
 ## Module Info
@@ -20,7 +21,7 @@ Exports {
 Imports {
   "returnPromiseResult" => {
     Specifier: "./returnPromiseResult.ts"
-    Resolved path: /src/returnPromiseResult.ts
+    Resolved path: "/src/returnPromiseResult.ts"
     Import Symbol: returnPromiseResult
   }
 }
@@ -29,19 +30,19 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => unknown
 
-Module TypeId(1) => Call Import Symbol: returnPromiseResult from /src/returnPromiseResult.ts(
+Module TypeId(1) => Call Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"(
   No parameters
 )
-
 ```
-## /src/promisedResult.ts
+
+# `/src/promisedResult.ts` (Module 2)
+
+## Source
 
 ```ts
 export type PromisedResult = Promise<{ result: true | false }>;
-
 ```
 
 ## Module Info
@@ -50,7 +51,7 @@ export type PromisedResult = Promise<{ result: true | false }>;
 Exports {
   "PromisedResult" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(4)
+      Module(0) TypeId(4)
       Local name: PromisedResult
     )
   }
@@ -63,24 +64,25 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => value: true
 
 Module TypeId(1) => value: false
 
-Module TypeId(2) => Module TypeId(0) | Module TypeId(1)
+Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
 
 Module TypeId(3) => Object {
   prototype: No prototype
-  members: {TypeMembers(required property "result": Module TypeId(2))}
+  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
 }
 
-Module TypeId(4) => instanceof Promise<T = Module TypeId(3)>
+Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>
 
-Module TypeId(5) => instanceof Promise<T = Module TypeId(3)>
-
+Module TypeId(5) => instanceof Promise<T = Module(0) TypeId(3)>
 ```
-## /src/returnPromiseResult.ts
+
+# `/src/returnPromiseResult.ts` (Module 1)
+
+## Source
 
 ```ts
 import type { PromisedResult } from "./promisedResult.ts";
@@ -90,7 +92,6 @@ function returnPromiseResult(): PromisedResult {
 }
 
 export { returnPromiseResult };
-
 ```
 
 ## Module Info
@@ -99,7 +100,7 @@ export { returnPromiseResult };
 Exports {
   "returnPromiseResult" => {
     ExportOwnExport => JsOwnExport(
-      Module TypeId(2)
+      Module(0) TypeId(2)
       Local name: returnPromiseResult
     )
   }
@@ -107,7 +108,7 @@ Exports {
 Imports {
   "PromisedResult" => {
     Specifier: "./promisedResult.ts"
-    Resolved path: /src/promisedResult.ts
+    Resolved path: "/src/promisedResult.ts"
     Import Symbol: PromisedResult
   }
 }
@@ -116,17 +117,31 @@ Imports {
 ## Registered types
 
 ```
-
 Module TypeId(0) => unknown
 
-Module TypeId(1) => instanceof Import Symbol: PromisedResult from /src/promisedResult.ts
+Module TypeId(1) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
 
 Module TypeId(2) => sync Function "returnPromiseResult" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module TypeId(1)
+  returns: Module(0) TypeId(1)
+}
+```
+
+# Ad-Hoc Type Resolver
+
+## Registered types
+
+```
+AdHoc TypeId(0) => sync Function "returnPromiseResult" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(1) TypeId(1)
 }
 
+AdHoc TypeId(1) => instanceof Promise<T = Module(2) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -1,11 +1,16 @@
 mod snap;
 
+use std::sync::Arc;
+
 use crate::snap::ModuleGraphSnapshot;
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem};
+use biome_js_type_info::{Type, TypeResolver};
 use biome_json_parser::JsonParserOptions;
 use biome_json_value::JsonString;
-use biome_module_graph::{ImportSymbol, JsImport, JsReexport, ModuleGraph, ResolvedPath};
+use biome_module_graph::{
+    AdHocScopeResolver, ImportSymbol, JsImport, JsReexport, ModuleGraph, ResolvedPath,
+};
 use biome_module_graph::{JsExport, JsdocComment};
 use biome_package::{Dependencies, PackageJson, Version};
 use biome_project_layout::ProjectLayout;
@@ -567,12 +572,32 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     ];
     let added_paths = get_added_paths(&fs, &added_paths);
 
-    let module_graph = ModuleGraph::default();
+    let module_graph = Arc::new(ModuleGraph::default());
     module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, &[]);
 
-    let snapshot = ModuleGraphSnapshot::new(&module_graph, &fs);
+    let index_module = module_graph
+        .module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let global_scope = index_module.global_scope();
+    let mut resolver =
+        AdHocScopeResolver::from_scope_in_module(global_scope, index_module, module_graph.clone());
+    resolver.run_inference();
 
+    let snapshot = ModuleGraphSnapshot::new(module_graph.as_ref(), &fs).with_resolver(&resolver);
     snapshot.assert_snapshot(
         "test_resolve_promise_from_imported_function_returning_imported_promise_type",
     );
+
+    let resolved_id = resolver
+        .resolve_type_of(&Text::Static("promise"))
+        .expect("promise variable not found");
+    let ty = resolver
+        .get_by_resolved_id(resolved_id)
+        .expect("cannot find type data")
+        .clone();
+    let _ty_string = format!("{ty:?}"); // for debugging
+    let ty = ty.inferred(&mut resolver);
+    let _ty_string = format!("{ty:?}"); // for debugging
+    let ty = Type::from_data(Box::new(resolver), ty);
+    assert!(ty.is_promise_instance());
 }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -305,9 +305,9 @@ pub fn dump_registered_types(content: &mut String, resolver: &dyn TypeResolver) 
     if !registered_types.is_empty() {
         content.push_str("## Registered types\n\n");
 
-        content.push_str("```\n");
+        content.push_str("```");
         content.push_str(&registered_types);
-        content.push_str("\n```\n");
+        content.push_str("```\n");
     }
 }
 


### PR DESCRIPTION
## Summary

This is the first time we can do real project-level inference, meaning we can look across multiple modules, combine their types, and perform analysis on them (the previous approach was limited to following a single import from the module being analysed).

Some minor tweaking of the module graph snapshots is included to make cross-module references more visible.

Note that I created a test case in the previous PR already, and it is now passing. But there's already another test case inside the `noFloatingPromises` cases, which doesn't pass yet. So it seems some work is still to be done. Also, I'm totally unsure of the performance impact of the current approach. Fingers crossed :crossed_fingers: 

## Test Plan

Test for full inference is now passing, snapshots updated.
