### PR TITLE
fix(lint/useNumericSeparators): avoid false positive on single-digit 0

### DIFF
--- a/.changeset/tidy-llamas-glow.md
+++ b/.changeset/tidy-llamas-glow.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5826](https://github.com/biomejs/biome/issues/5826): [`useNumericSeparators`](https://next.biomejs.dev/linter/rules/use-numeric-separators/) no longer reports single-digit `0`.

--- a/crates/biome_js_analyze/src/lint/nursery/use_numeric_separators.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_numeric_separators.rs
@@ -73,6 +73,11 @@ impl Rule for UseNumericSeparators {
         let token = ctx.query().value_token().ok()?;
         let raw = token.text_trimmed();
 
+        // Skip check for short numeric literals where separators don't improve readability.
+        if raw.len() <= 3 {
+            return None;
+        }
+
         let expected = format_numeric_literal(raw);
 
         if raw == expected {

--- a/crates/biome_js_analyze/tests/specs/nursery/useNumericSeparators/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNumericSeparators/valid.js
@@ -40,6 +40,7 @@ foo = 0n;
 // Numbers
 foo = 12_345_678;
 foo = 123;
+foo = 0;
 foo = 1;
 foo = 1234;
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useNumericSeparators/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useNumericSeparators/valid.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
+snapshot_kind: text
 ---
 # Input
 ```js
@@ -46,6 +47,7 @@ foo = 0n;
 // Numbers
 foo = 12_345_678;
 foo = 123;
+foo = 0;
 foo = 1;
 foo = 1234;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/5826, which incorrectly flagged single-digit 0.


## Test Plan
- Added a test for single-digit 0.
- Existing tests pass.
