### PR TITLE
perf(lint): use `Arc<T>` to share `PackageJson` among analyzer rules

### DIFF
--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -150,7 +150,11 @@ where
     services.insert_service(source_type);
     services.insert_service(module_graph);
     services.insert_service(options.file_path.clone());
-    services.insert_service(project_layout.get_node_manifest_for_path(options.file_path.as_ref()));
+    services.insert_service(
+        project_layout
+            .get_node_manifest_for_path(options.file_path.as_ref())
+            .map(|(path, manifest)| (path, Arc::new(manifest))),
+    );
     services.insert_service(project_layout);
 
     (

--- a/crates/biome_js_analyze/src/services/manifest.rs
+++ b/crates/biome_js_analyze/src/services/manifest.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use biome_analyze::{
     AddVisitor, FromServices, Phase, Phases, QueryKey, Queryable, RuleKey, RuleMetadata,
     ServiceBag, ServicesDiagnostic, SyntaxVisitor,
@@ -10,35 +12,35 @@ use camino::Utf8PathBuf;
 #[derive(Debug, Clone)]
 pub struct ManifestServices {
     pub(crate) package_path: Option<Utf8PathBuf>,
-    pub(crate) manifest: Option<PackageJson>,
+    pub(crate) manifest: Option<Arc<PackageJson>>,
 }
 
 impl ManifestServices {
     pub(crate) fn name(&self) -> Option<&str> {
-        self.manifest.as_ref().and_then(|pkg| pkg.name.as_deref())
+        self.manifest.as_deref().and_then(|pkg| pkg.name.as_deref())
     }
 
     pub(crate) fn is_dependency(&self, specifier: &str) -> bool {
         self.manifest
-            .as_ref()
+            .as_deref()
             .is_some_and(|pkg| pkg.dependencies.contains(specifier))
     }
 
     pub(crate) fn is_dev_dependency(&self, specifier: &str) -> bool {
         self.manifest
-            .as_ref()
+            .as_deref()
             .is_some_and(|pkg| pkg.dev_dependencies.contains(specifier))
     }
 
     pub(crate) fn is_peer_dependency(&self, specifier: &str) -> bool {
         self.manifest
-            .as_ref()
+            .as_deref()
             .is_some_and(|pkg| pkg.peer_dependencies.contains(specifier))
     }
 
     pub(crate) fn is_optional_dependency(&self, specifier: &str) -> bool {
         self.manifest
-            .as_ref()
+            .as_deref()
             .is_some_and(|pkg| pkg.optional_dependencies.contains(specifier))
     }
 }
@@ -47,10 +49,9 @@ impl FromServices for ManifestServices {
     fn from_services(
         rule_key: &RuleKey,
         _rule_metadata: &RuleMetadata,
-
         services: &ServiceBag,
     ) -> biome_diagnostics::Result<Self, ServicesDiagnostic> {
-        let manifest_info: &Option<(Utf8PathBuf, PackageJson)> = services
+        let manifest_info: &Option<(Utf8PathBuf, Arc<PackageJson>)> = services
             .get_service()
             .ok_or_else(|| ServicesDiagnostic::new(rule_key.rule_name(), &["PackageJson"]))?;
 


### PR DESCRIPTION
## Summary

I instrumented Biome running in a large repository (~ 5,200 files) in my company, and observed a hotspot that `<ManifestServices as FromServices>::from_services` is relatively heavy. It is executed in every rule that queries `Manifest<T>`. 

Here is a screenshot of the hotspot in the instrumentation:

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/5eedf105-b41b-4eee-8466-faea83745e00" />

In this pull request, `ManifestJson` will be wrapped in an `Arc<T>`. The heavy clone no longer happen.

## Test Plan

Existing tests should pass.

Also locally tested in the same repository to see the execution time:

Before

```
❯ time ./node_modules/.pnpm/@biomejs+cli-darwin-arm64@2.0.0-beta.2/node_modules/@biomejs/cli-darwin-arm64/biome check
Checked 5243 files in 7s. No fixes applied.

________________________________________________________
Executed in    8.16 secs    fish           external
   usr time   41.30 secs    0.19 millis   41.30 secs
   sys time   16.02 secs    1.23 millis   16.01 secs
```

After

```
❯ time ~/Projects/github.com/biomejs/biome/target/release-with-debug/biome check
Checked 5243 files in 6s. No fixes applied.

________________________________________________________
Executed in    7.36 secs    fish           external
   usr time   31.41 secs    0.24 millis   31.41 secs
   sys time   17.50 secs    2.30 millis   17.50 secs
```