### PR TITLE
perf(scanner): update type info in worker threads

### DIFF
--- a/crates/biome_module_graph/src/resolver_cache.rs
+++ b/crates/biome_module_graph/src/resolver_cache.rs
@@ -92,11 +92,15 @@ impl<'a> ResolverCache<'a> {
     }
 
     fn path_kind(&self, path: &Utf8Path) -> Option<PathKind> {
+        // If the path is updated, prefer the real filesystem to get fresh data.
         if self.added_paths.contains(path) {
-            self.fs.path_kind(path).ok()
-        } else {
-            self.module_graph.path_kind(path)
+            return self.fs.path_kind(path).ok();
         }
+
+        // Otherwise, prefer the cached data, the fallback to the real filesystem.
+        self.module_graph
+            .path_kind(path)
+            .or_else(|| self.fs.path_kind(path).ok())
     }
 
     /// Returns the canonical path, resolving all symbolic links.

--- a/crates/biome_module_graph/src/resolver_cache.rs
+++ b/crates/biome_module_graph/src/resolver_cache.rs
@@ -97,7 +97,7 @@ impl<'a> ResolverCache<'a> {
             return self.fs.path_kind(path).ok();
         }
 
-        // Otherwise, prefer the cached data, the fallback to the real filesystem.
+        // Otherwise, prefer the cached data, then fallback to the real filesystem.
         self.module_graph
             .path_kind(path)
             .or_else(|| self.fs.path_kind(path).ok())

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -8,12 +8,10 @@
 //! In other words, the scanner is both the scanning logic in this module as
 //! well as the watcher to allow continuous scanning.
 
-use super::ServiceDataNotification;
 use super::server::WorkspaceServer;
 use crate::diagnostics::Panic;
 use crate::projects::ProjectKey;
 use crate::workspace::{DocumentFileSource, FileContent, OpenFileParams};
-use crate::workspace_watcher::WatcherSignalKind;
 use crate::{Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
 use biome_diagnostics::{Diagnostic as _, Error, Severity};
@@ -124,10 +122,6 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> Duration {
         }
     }));
 
-    let mut paths = configs;
-    paths.append(&mut manifests);
-    ctx.workspace
-        .update_project_layout_for_paths(WatcherSignalKind::AddedOrChanged, &paths);
     let result = ctx
         .workspace
         .update_project_ignore_files(ctx.project_key, &ignore_paths);
@@ -141,11 +135,6 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> Duration {
             scope.handle(ctx_ref, path.to_path_buf());
         }
     }));
-
-    let _ = ctx
-        .workspace
-        .notification_tx
-        .send(ServiceDataNotification::Updated);
 
     start.elapsed()
 }
@@ -290,9 +279,6 @@ impl TraversalContext for ScanContext<'_> {
 
     fn handle_path(&self, path: BiomePath) {
         open_file(self, &path);
-
-        self.workspace
-            .update_module_graph(WatcherSignalKind::AddedOrChanged, &[path]);
     }
 
     fn store_path(&self, path: BiomePath) {

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -142,9 +142,6 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> Duration {
         }
     }));
 
-    ctx.workspace
-        .update_module_graph(WatcherSignalKind::AddedOrChanged, &handleable_paths);
-
     let _ = ctx
         .workspace
         .notification_tx
@@ -292,7 +289,10 @@ impl TraversalContext for ScanContext<'_> {
     }
 
     fn handle_path(&self, path: BiomePath) {
-        open_file(self, &path)
+        open_file(self, &path);
+
+        self.workspace
+            .update_module_graph(WatcherSignalKind::AddedOrChanged, &[path]);
     }
 
     fn store_path(&self, path: BiomePath) {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -30,7 +30,7 @@ use crossbeam::channel::Sender;
 use papaya::{Compute, HashMap, HashSet, Operation};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use tokio::sync::watch;
-use tracing::{error, info, instrument, warn};
+use tracing::{info, instrument, warn};
 
 use crate::diagnostics::FileTooLarge;
 use crate::file_handlers::{
@@ -547,19 +547,6 @@ impl WorkspaceServer {
             .get(&project_key)
             .map(|cache| cache.get_analyzer_plugins())
             .unwrap_or_default()
-    }
-
-    /// Updates the [ProjectLayout] for multiple `paths` at once.
-    pub(super) fn update_project_layout_for_paths(
-        &self,
-        signal_kind: WatcherSignalKind,
-        paths: &[BiomePath],
-    ) {
-        for path in paths {
-            if let Err(error) = self.update_project_layout(signal_kind, path) {
-                error!("Error while updating project layout: {error}");
-            }
-        }
     }
 
     /// It accepts a list of ignore files. If the VCS integration is enabled, the files


### PR DESCRIPTION
## Summary

The scanner opens files in the worker threads powered by rayon, but collecting type info is run in the main thread after the traversal. It contains type inference, which is CPU-heavy operation. Plus, it can be moved to threads safely.

You can see only the main thread is busy while scanning in the following screenshot:

<img width="1669" alt="image" src="https://github.com/user-attachments/assets/c1d6c8ba-1dc0-40d3-9797-664013d698f1" />

During investigation, I noticed that `ctx.workspace.update_module_graph()` is also called in the traversal. It tried to resolve the imported modules to update the graph, but it always fail due to a small bug in the resolver cache. Finally I removed duplicated calls of `ctx.workspace.update_module_graph()`, so now the graph is updated in the first call during the traversal. After this, all worker threads are used to collecting module graph and infering types:

<img width="1664" alt="image" src="https://github.com/user-attachments/assets/c22fc75d-cdfa-4fc6-bb30-cf602d9cde5d" />


## Test Plan

Existing tests should pass.

Locally tested to see the execution time.

Before (from #5839):

```
❯ time ~/Projects/github.com/biomejs/biome/target/release-with-debug/biome check
Checked 5243 files in 6s. No fixes applied.

________________________________________________________
Executed in    7.36 secs    fish           external
   usr time   31.41 secs    0.24 millis   31.41 secs
   sys time   17.50 secs    2.30 millis   17.50 secs
```

After

```
❯ time ~/Projects/github.com/biomejs/biome/target/release-with-debug/biome check
Checked 5243 files in 5s. No fixes applied.

________________________________________________________
Executed in    6.33 secs    fish           external
   usr time   32.88 secs  105.00 micros   32.88 secs
   sys time   16.60 secs  783.00 micros   16.60 secs
```