### PR TITLE
fix(core): printed directories

### DIFF
--- a/.changeset/five-schools-shave.md
+++ b/.changeset/five-schools-shave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The `rage` command now prints the configuration path relative to the working directory, if applicable.

--- a/.changeset/good-jeans-invite.md
+++ b/.changeset/good-jeans-invite.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug with the `--verbose` CLI flag. Now the printed paths are **relative** to the working directory.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -634,15 +634,18 @@ pub(crate) fn validate_configuration_diagnostics(
     verbose: bool,
 ) -> Result<(), CliDiagnostic> {
     let diagnostics = loaded_configuration.as_diagnostics_iter();
-    for diagnostic in diagnostics {
-        if diagnostic.tags().is_verbose() && verbose {
-            console.error(markup! {{PrintDiagnostic::verbose(diagnostic)}})
-        } else {
-            console.error(markup! {{PrintDiagnostic::simple(diagnostic)}})
-        }
-    }
 
+    // We want to print the diagnostics only if there are errors. Other diagnostics such as
+    // information/warnings will be printed during the traversal
     if loaded_configuration.has_errors() {
+        for diagnostic in diagnostics {
+            if diagnostic.tags().is_verbose() && verbose {
+                console.error(markup! {{PrintDiagnostic::verbose(diagnostic)}})
+            } else {
+                console.error(markup! {{PrintDiagnostic::simple(diagnostic)}})
+            }
+        }
+
         return Err(CliDiagnostic::workspace_error(
             BiomeDiagnostic::invalid_configuration(
                 "Biome exited because the configuration resulted in errors. Please fix them.",

--- a/crates/biome_cli/src/commands/rage.rs
+++ b/crates/biome_cli/src/commands/rage.rs
@@ -238,7 +238,13 @@ impl Display for RageConfiguration<'_> {
 
                     let config_path = file_path.as_ref().map_or_else(
                         || directory_path.as_ref().unwrap().as_str(),
-                        |path| path.as_str(),
+                        |path| {
+                            self.fs
+                                .working_directory()
+                                .and_then(|wd| path.strip_prefix(wd).ok())
+                                .unwrap_or(path)
+                                .as_str()
+                        },
                     );
 
                     markup! (

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -602,6 +602,8 @@ pub fn execute_mode(
     // We join the duration of the scanning with the duration of the traverse.
     summary.scanner_duration = scanner_duration;
     let console = session.app.console;
+    let workspace = &*session.app.workspace;
+    let fs = workspace.fs();
     let errors = summary.errors;
     let skipped = summary.skipped;
     let processed = summary.changed + summary.unchanged;
@@ -629,6 +631,7 @@ pub fn execute_mode(
                     execution: execution.clone(),
                     evaluated_paths,
                     verbose: cli_options.verbose,
+                    working_directory: fs.working_directory().clone(),
                 };
                 reporter.write(&mut ConsoleReporterVisitor(console))?;
             }

--- a/crates/biome_cli/src/reporter/mod.rs
+++ b/crates/biome_cli/src/reporter/mod.rs
@@ -9,6 +9,7 @@ use crate::cli_options::MaxDiagnostics;
 use crate::execute::Execution;
 use biome_diagnostics::{Error, Severity};
 use biome_fs::BiomePath;
+use camino::Utf8PathBuf;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::io;
@@ -51,22 +52,25 @@ pub trait ReporterVisitor {
     /// Writes the summary in the underling writer
     fn report_summary(
         &mut self,
-        execution: &Execution,
-        summary: TraversalSummary,
-        verbose: bool,
+        _execution: &Execution,
+        _summary: TraversalSummary,
+        _verbose: bool,
     ) -> io::Result<()>;
 
-    /// Writes the paths that were handled during a run.
-    fn report_handled_paths(&mut self, evaluated_paths: BTreeSet<BiomePath>) -> io::Result<()> {
-        let _ = evaluated_paths;
+    /// Writes the paths handled during a run.
+    fn report_handled_paths(
+        &mut self,
+        _evaluated_paths: BTreeSet<BiomePath>,
+        _working_directory: Option<Utf8PathBuf>,
+    ) -> io::Result<()> {
         Ok(())
     }
 
     /// Writes a diagnostics
     fn report_diagnostics(
         &mut self,
-        execution: &Execution,
-        payload: DiagnosticsPayload,
-        verbose: bool,
+        _execution: &Execution,
+        _payload: DiagnosticsPayload,
+        _verbose: bool,
     ) -> io::Result<()>;
 }

--- a/crates/biome_cli/tests/cases/mod.rs
+++ b/crates/biome_cli/tests/cases/mod.rs
@@ -25,6 +25,7 @@ mod reporter_github;
 mod reporter_gitlab;
 mod reporter_junit;
 mod reporter_summary;
+mod reporter_terminal;
 mod rules_via_dependencies;
 mod suppressions;
 mod unknown_files;

--- a/crates/biome_cli/tests/cases/reporter_terminal.rs
+++ b/crates/biome_cli/tests/cases/reporter_terminal.rs
@@ -1,0 +1,139 @@
+use crate::run_cli;
+use crate::snap_test::{SnapshotPayload, assert_cli_snapshot};
+use biome_console::BufferConsole;
+use biome_fs::MemoryFileSystem;
+use bpaf::Args;
+use camino::Utf8Path;
+
+const MAIN_1: &str = r#"import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;"#;
+
+const MAIN_2: &str = r#"import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;"#;
+
+const MAIN_3: &str = r#"
+
+.brokenStyle { color: f( }
+
+.style {
+                color:
+                fakeFunction()
+}
+"#;
+
+#[test]
+fn reports_diagnostics_check_command_verbose() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path1 = Utf8Path::new("main.ts");
+    fs.insert(file_path1.into(), MAIN_1.as_bytes());
+
+    let file_path2 = Utf8Path::new("index.ts");
+    fs.insert(file_path2.into(), MAIN_2.as_bytes());
+
+    let file_path3 = Utf8Path::new("index.css");
+    fs.insert(file_path3.into(), MAIN_3.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--max-diagnostics=5",
+                "--verbose",
+                file_path1.as_str(),
+                file_path2.as_str(),
+                file_path3.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_check_command_verbose",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn reports_diagnostics_check_write_command_verbose() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path1 = Utf8Path::new("main.ts");
+    fs.insert(file_path1.into(), MAIN_1.as_bytes());
+
+    let file_path2 = Utf8Path::new("index.ts");
+    fs.insert(file_path2.into(), MAIN_2.as_bytes());
+
+    let file_path3 = Utf8Path::new("index.css");
+    fs.insert(file_path3.into(), MAIN_3.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--write",
+                "--max-diagnostics=5",
+                "--verbose",
+                file_path1.as_str(),
+                file_path2.as_str(),
+                file_path3.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_check_write_command_verbose",
+        fs,
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -3925,7 +3925,11 @@ fn should_report_when_schema_version_mismatch() {
 }
         "#,
     );
-    let (fs, result) = run_cli(fs, &mut console, Args::from([("check")].as_slice()));
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", biome_json.as_str()].as_slice()),
+    );
 
     assert!(result.is_err(), "run_cli returned {result:?}");
     assert_cli_snapshot(SnapshotPayload::new(

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -1,0 +1,195 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `index.css`
+
+```css
+
+
+.brokenStyle { color: f( }
+
+.style {
+                color:
+                fakeFunction()
+}
+
+```
+
+## `index.ts`
+
+```ts
+import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;
+```
+
+## `main.ts`
+
+```ts
+import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declaration item but instead found '}'.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+  i Expected a declaration item here.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+
+```
+
+```block
+index.css:3:23 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected unknown function: f
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                       ^
+    4 │ 
+    5 │ .style {
+  
+  i Use a known function instead.
+  
+  i See MDN web docs for more details.
+  
+
+```
+
+```block
+index.css:7:17 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected unknown function: fakeFunction
+  
+    5 │ .style {
+    6 │                 color:
+  > 7 │                 fakeFunction()
+      │                 ^^^^^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i Use a known function instead.
+  
+  i See MDN web docs for more details.
+  
+
+```
+
+```block
+index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declaration item but instead found '}'.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+  i Expected a declaration item here.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+
+```
+
+```block
+index.css format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
+  
+
+```
+
+```block
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
+Diagnostics not shown: 44.
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 3 files in <TIME>. No fixes applied.
+Found 49 errors.
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files processed:
+  
+  - index.css
+  - index.ts
+  - main.ts
+  
+
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files fixed:
+  
+  ! The list is empty.
+  
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
@@ -1,0 +1,204 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `index.css`
+
+```css
+
+
+.brokenStyle { color: f( }
+
+.style {
+                color:
+                fakeFunction()
+}
+
+```
+
+## `index.ts`
+
+```ts
+import { a, b, z } from "lodash";
+import { z } from "z";
+
+a == b;
+a == b;
+a == b;
+a == b;
+
+debugger;
+debugger;
+debugger;
+debugger;
+
+let f;
+let f;
+let f;
+let f;
+let f;
+let f;
+
+```
+
+## `main.ts`
+
+```ts
+import { a, b, z } from "lodash";
+import { z } from "z";
+
+a == b;
+a == b;
+a == b;
+a == b;
+
+debugger;
+debugger;
+debugger;
+debugger;
+
+let f;
+let f;
+let f;
+let f;
+let f;
+let f;
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while applying fixes.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declaration item but instead found '}'.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+  i Expected a declaration item here.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+
+```
+
+```block
+index.css:3:23 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected unknown function: f
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                       ^
+    4 │ 
+    5 │ .style {
+  
+  i Use a known function instead.
+  
+  i See MDN web docs for more details.
+  
+
+```
+
+```block
+index.css:7:17 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected unknown function: fakeFunction
+  
+    5 │ .style {
+    6 │                 color:
+  > 7 │                 fakeFunction()
+      │                 ^^^^^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i Use a known function instead.
+  
+  i See MDN web docs for more details.
+  
+
+```
+
+```block
+index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declaration item but instead found '}'.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+  i Expected a declaration item here.
+  
+  > 3 │ .brokenStyle { color: f( }
+      │                          ^
+    4 │ 
+    5 │ .style {
+  
+
+```
+
+```block
+index.css format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
+  
+
+```
+
+```block
+Skipped 16 suggested fixes.
+If you wish to apply the suggested (unsafe) fixes, use the command biome check --fix --unsafe
+
+```
+
+```block
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
+Diagnostics not shown: 40.
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 3 files in <TIME>. Fixed 2 files.
+Found 45 errors.
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files processed:
+  
+  - index.css
+  - index.ts
+  - main.ts
+  
+
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files fixed:
+  
+  - index.ts
+  - main.ts
+  
+
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_next_rules_via_dependencies.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_next_rules_via_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `package.json`
 
@@ -34,7 +33,7 @@ export default IndexPage;
 # Emitted Messages
 
 ```block
-/test.jsx:6:13 lint/nursery/noImgElement ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test.jsx:6:13 lint/nursery/noImgElement ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Don't use <img> element.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_react_rules_via_dependencies.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_react_rules_via_dependencies.snap
@@ -42,7 +42,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/test.jsx:6:20 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test.jsx:6:20 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This hook specifies more dependencies than necessary: local
   

--- a/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_test_globals_via_dependencies.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_rules_via_dependencies/enables_test_globals_via_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `package.json`
 
@@ -44,7 +43,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/test.js:5:2 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+test.js:5:2 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Disallow duplicate setup and teardown hooks.
   

--- a/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/ignore_vcs_ignored_file_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/ignore_vcs_ignored_file_via_cli.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `.gitignore`
 
@@ -37,7 +36,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+file1.js:1:1 lint/complexity/useFlatMap  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The call chain .map().flat() can be replaced with a single .flatMap() call.
   

--- a/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/should_show_formatter_diagnostics_for_files_ignored_by_linter.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -41,26 +40,6 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 # Emitted Messages
-
-```block
-biome.json:2:24 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The configuration schema version does not match the CLI version 0.0.0
-  
-    1 │ {
-  > 2 │             "$schema": "https://biomejs.dev/schemas/1.6.1/schema.json",
-      │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │             "assist": {
-    4 │                 "enabled": true
-  
-  i   Expected:                     0.0.0
-      Found:                        1.6.1
-  
-  
-  i Run the command biome migrate to migrate the configuration file.
-  
-
-```
 
 ```block
 build/file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/crates/biome_cli/tests/snapshots/main_commands_format/should_format_files_in_folders_ignored_by_linter.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/should_format_files_in_folders_ignored_by_linter.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -29,26 +28,6 @@ value["optimizelyService"] = optimizelyService;
 ```
 
 # Emitted Messages
-
-```block
-biome.json:2:24 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! The configuration schema version does not match the CLI version 0.0.0
-  
-    1 │ {
-  > 2 │             "$schema": "https://biomejs.dev/schemas/1.6.1/schema.json",
-      │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │             "assist": {
-    4 │                 "enabled": true
-  
-  i   Expected:                     0.0.0
-      Found:                        1.6.1
-  
-  
-  i Run the command biome migrate to migrate the configuration file.
-  
-
-```
 
 ```block
 Formatted 1 file in <TIME>. Fixed 1 file.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 # Termination Message
 
@@ -17,7 +16,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/subdir/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+subdir/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This is an unexpected use of the debugger statement.
   

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 # Termination Message
 
@@ -17,7 +16,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-/symlinked/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+symlinked/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This is an unexpected use of the debugger statement.
   

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_report_when_schema_version_mismatch.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_report_when_schema_version_mismatch.snap
@@ -15,13 +15,7 @@ expression: redactor(content)
 ```block
 check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × No files were processed in the specified paths.
-  
-  i Check your biome.json or biome.jsonc to ensure the paths are not ignored by the configuration.
-  
-  i These paths were provided but ignored:
-  
-  ! The list is empty.
+  × Some errors were emitted while running checks.
   
 
 
@@ -50,5 +44,22 @@ biome.json:2:16 deserialize ━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Checked 0 files in <TIME>. No fixes applied.
+biome.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1 1 │   {
+    2   │ - ····"$schema":·"https://biomejs.dev/schemas/0.0.1/schema.json"
+      2 │ + → "$schema":·"https://biomejs.dev/schemas/0.0.1/schema.json"
+    3 3 │   }
+    4   │ - ········
+      4 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+Found 1 warning.
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/5817
Closes https://github.com/biomejs/biome/issues/5565


- Fixes a bug where the path of CLI diagnostics had a leading slash. This was caused by the fact that the `DiagnosticPrinter` receives file paths in the form of a string, and this caused the bug when doing `strip_prefix`. It's way easier and predictable to convert the file path into `Utf8PathBuf` and then strip the working directory
- The same was done for the "missing handler" diagnostic, which fixes other diagnostics that are usually printed via `--verbose`
- Always with `--verbose`, now the emitted paths are relative. Easier and safer to share
- Same for the configuration path when using `biome rage`
- The first time we load the configuration, we only print diagnostics **if there are errors**
- When formatting, we print only error diagnostics because they are the ones that usually block `biome format`


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the current snapshots

<!-- What demonstrates that your implementation is correct? -->
