### PR TITLE
fix(core): fix incorrect module ID in reexport

### DIFF
--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -1,0 +1,165 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/reexport.ts` (Module 2)
+
+## Source
+
+```ts
+export * from "./promisedResult.ts";
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+import { returnPromiseResult } from "./returnPromiseResult.ts";
+
+const promise = returnPromiseResult();
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "returnPromiseResult" => {
+    Specifier: "./returnPromiseResult.ts"
+    Resolved path: "/src/returnPromiseResult.ts"
+    Import Symbol: returnPromiseResult
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => unknown
+
+Module TypeId(1) => Call Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"(
+  No parameters
+)
+```
+
+# `/src/promisedResult.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+export type PromisedResult = Promise<{ result: true | false }>;
+```
+
+## Module Info
+
+```
+Exports {
+  "PromisedResult" => {
+    ExportOwnExport => JsOwnExport(
+      Module(0) TypeId(4)
+      Local name: PromisedResult
+    )
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => value: true
+
+Module TypeId(1) => value: false
+
+Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
+
+Module TypeId(3) => Object {
+  prototype: No prototype
+  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
+}
+
+Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>
+
+Module TypeId(5) => instanceof Promise<T = Module(0) TypeId(3)>
+```
+
+# `/src/returnPromiseResult.ts` (Module 1)
+
+## Source
+
+```ts
+import type { PromisedResult } from "./reexport.ts";
+
+function returnPromiseResult(): PromisedResult {
+	return new Promise((resolve) => resolve({ result: true }));
+}
+
+export { returnPromiseResult };
+```
+
+## Module Info
+
+```
+Exports {
+  "returnPromiseResult" => {
+    ExportOwnExport => JsOwnExport(
+      Module(0) TypeId(2)
+      Local name: returnPromiseResult
+    )
+  }
+}
+Imports {
+  "PromisedResult" => {
+    Specifier: "./reexport.ts"
+    Resolved path: "/src/reexport.ts"
+    Import Symbol: PromisedResult
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => unknown
+
+Module TypeId(1) => instanceof Import Symbol: PromisedResult from "/src/reexport.ts"
+
+Module TypeId(2) => sync Function "returnPromiseResult" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(1)
+}
+```
+
+# Ad-Hoc Type Resolver
+
+## Registered types
+
+```
+AdHoc TypeId(0) => sync Function "returnPromiseResult" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(1) TypeId(1)
+}
+```

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -601,3 +601,72 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     let ty = Type::from_data(Box::new(resolver), ty);
     assert!(ty.is_promise_instance());
 }
+
+#[test]
+fn test_resolve_promise_from_imported_function_returning_reexported_promise_type() {
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/promisedResult.ts".into(),
+        "export type PromisedResult = Promise<{ result: true | false }>;\n",
+    );
+    fs.insert(
+        "/src/reexport.ts".into(),
+        "export * from \"./promisedResult.ts\";\n",
+    );
+    fs.insert(
+        "/src/returnPromiseResult.ts".into(),
+        r#"import type { PromisedResult } from "./reexport.ts";
+
+        function returnPromiseResult(): PromisedResult {
+            return new Promise(resolve => resolve({ result: true }));
+        }
+
+        export { returnPromiseResult };
+        "#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"import { returnPromiseResult } from "./returnPromiseResult.ts";
+
+        const promise = returnPromiseResult();
+        "#,
+    );
+
+    let added_paths = [
+        BiomePath::new("/src/index.ts"),
+        BiomePath::new("/src/promisedResult.ts"),
+        BiomePath::new("/src/reexport.ts"),
+        BiomePath::new("/src/returnPromiseResult.ts"),
+    ];
+    let added_paths = get_added_paths(&fs, &added_paths);
+
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, &[]);
+
+    let index_module = module_graph
+        .module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let global_scope = index_module.global_scope();
+    let mut resolver =
+        AdHocScopeResolver::from_scope_in_module(global_scope, index_module, module_graph.clone());
+    resolver.run_inference();
+
+    let snapshot = ModuleGraphSnapshot::new(module_graph.as_ref(), &fs).with_resolver(&resolver);
+    snapshot.assert_snapshot(
+        "test_resolve_promise_from_imported_function_returning_reexported_promise_type",
+    );
+
+    let resolved_id = resolver
+        .resolve_type_of(&Text::Static("promise"))
+        .expect("promise variable not found");
+    let ty = resolver
+        .get_by_resolved_id(resolved_id)
+        .expect("cannot find type data")
+        .clone();
+    let _ty_string = format!("{ty:?}"); // for debugging
+    let ty = ty.inferred(&mut resolver);
+    let _ty_string = format!("{ty:?}"); // for debugging
+    let _ty = Type::from_data(Box::new(resolver), ty);
+    // FIXME: This assertion should hold, but one step at a time...
+    //assert!(ty.is_promise_instance());
+}


### PR DESCRIPTION
## Summary

Fix panics that occurred due to incorrect indexing in module/type vectors. At least one consistent method of triggering such panics was by using reexports, which is now fixed.

## Test Plan

Test added. At the end of the test is still a failing assertion which I commented out, but at least the panics triggered by the test are resolved, so I'd like to merge this first.
