### PR TITLE
fix(core): don't load manifests inside `node_modules` for now

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_jsx_key_in_iterable.rs
@@ -51,7 +51,7 @@ declare_lint_rule! {
     ///         "checkShorthandFragments": true
     ///     }
     /// }
-    /// ```    
+    /// ```
     /// ```jsx,expect_diagnostic,use_options
     /// data.map((x) => <>{x}</>);
     /// ```

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -270,7 +270,7 @@ impl TraversalContext for ScanContext<'_> {
         if self.scan_kind.is_known_files() {
             (path.is_ignore() || path.is_config() || path.is_manifest()) && !path.is_dependency()
         } else if path.is_dependency() {
-            path.is_manifest() || path.is_type_declaration()
+            path.is_type_declaration()
         } else {
             DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
         }

--- a/crates/biome_service/tests/spec_test.rs
+++ b/crates/biome_service/tests/spec_test.rs
@@ -50,15 +50,18 @@ fn test_scanner_only_loads_type_definitions_from_node_modules() {
         })
         .unwrap();
 
-    let manifest_result = workspace.get_file_content(GetFileContentParams {
-        project_key,
-        path: BiomePath::new(format!("{fixtures_path}/node_modules/shared/package.json")),
-    });
-
-    assert!(
-        manifest_result.is_ok_and(|result| !result.is_empty()),
-        "package.json should be loaded"
-    );
+    // FIXME: We should load manifests again in order to actually resolve
+    //        type definitions, but last time we tried we ran into performance
+    //        issues, and a reoccurrence of panics inside `node_semver` (#5829).
+    //let manifest_result = workspace.get_file_content(GetFileContentParams {
+    //    project_key,
+    //    path: BiomePath::new(format!("{fixtures_path}/node_modules/shared/package.json")),
+    //});
+    //
+    //assert!(
+    //    manifest_result.is_ok_and(|result| !result.is_empty()),
+    //    "package.json should be loaded"
+    //);
 
     let d_mts_result = workspace.get_file_content(GetFileContentParams {
         project_key,


### PR DESCRIPTION
## Summary

Seems that loading manifests inside `node_modules` results in some regressions, so we should be more careful about this.

## Test Plan

Uncommented the test that checks for the manifest loading for now.
