### PR TITLE
fix(yaml_parser): only allows maximum 2 properties per node

### DIFF
--- a/crates/biome_yaml_factory/src/generated/node_factory.rs
+++ b/crates/biome_yaml_factory/src/generated/node_factory.rs
@@ -18,17 +18,31 @@ pub fn yaml_anchor_property(value_token: SyntaxToken) -> YamlAnchorProperty {
         [Some(SyntaxElement::Token(value_token))],
     ))
 }
-pub fn yaml_block_collection(
-    properties: YamlPropertyList,
+pub fn yaml_block_collection(content: AnyYamlBlockContent) -> YamlBlockCollectionBuilder {
+    YamlBlockCollectionBuilder {
+        content,
+        properties: None,
+    }
+}
+pub struct YamlBlockCollectionBuilder {
     content: AnyYamlBlockContent,
-) -> YamlBlockCollection {
-    YamlBlockCollection::unwrap_cast(SyntaxNode::new_detached(
-        YamlSyntaxKind::YAML_BLOCK_COLLECTION,
-        [
-            Some(SyntaxElement::Node(properties.into_syntax())),
-            Some(SyntaxElement::Node(content.into_syntax())),
-        ],
-    ))
+    properties: Option<AnyYamlPropertiesCombination>,
+}
+impl YamlBlockCollectionBuilder {
+    pub fn with_properties(mut self, properties: AnyYamlPropertiesCombination) -> Self {
+        self.properties = Some(properties);
+        self
+    }
+    pub fn build(self) -> YamlBlockCollection {
+        YamlBlockCollection::unwrap_cast(SyntaxNode::new_detached(
+            YamlSyntaxKind::YAML_BLOCK_COLLECTION,
+            [
+                self.properties
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+                Some(SyntaxElement::Node(self.content.into_syntax())),
+            ],
+        ))
+    }
 }
 pub fn yaml_block_map_explicit_entry(
     key: YamlBlockMapExplicitKey,
@@ -259,17 +273,21 @@ pub fn yaml_double_quoted_scalar(value_token: SyntaxToken) -> YamlDoubleQuotedSc
         [Some(SyntaxElement::Token(value_token))],
     ))
 }
-pub fn yaml_flow_json_node(properties: YamlPropertyList) -> YamlFlowJsonNodeBuilder {
+pub fn yaml_flow_json_node() -> YamlFlowJsonNodeBuilder {
     YamlFlowJsonNodeBuilder {
-        properties,
+        properties: None,
         content: None,
     }
 }
 pub struct YamlFlowJsonNodeBuilder {
-    properties: YamlPropertyList,
+    properties: Option<AnyYamlPropertiesCombination>,
     content: Option<AnyYamlJsonContent>,
 }
 impl YamlFlowJsonNodeBuilder {
+    pub fn with_properties(mut self, properties: AnyYamlPropertiesCombination) -> Self {
+        self.properties = Some(properties);
+        self
+    }
     pub fn with_content(mut self, content: AnyYamlJsonContent) -> Self {
         self.content = Some(content);
         self
@@ -278,7 +296,8 @@ impl YamlFlowJsonNodeBuilder {
         YamlFlowJsonNode::unwrap_cast(SyntaxNode::new_detached(
             YamlSyntaxKind::YAML_FLOW_JSON_NODE,
             [
-                Some(SyntaxElement::Node(self.properties.into_syntax())),
+                self.properties
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
                 self.content
                     .map(|token| SyntaxElement::Node(token.into_syntax())),
             ],
@@ -373,17 +392,21 @@ pub fn yaml_flow_sequence(
         ],
     ))
 }
-pub fn yaml_flow_yaml_node(properties: YamlPropertyList) -> YamlFlowYamlNodeBuilder {
+pub fn yaml_flow_yaml_node() -> YamlFlowYamlNodeBuilder {
     YamlFlowYamlNodeBuilder {
-        properties,
+        properties: None,
         content: None,
     }
 }
 pub struct YamlFlowYamlNodeBuilder {
-    properties: YamlPropertyList,
+    properties: Option<AnyYamlPropertiesCombination>,
     content: Option<YamlPlainScalar>,
 }
 impl YamlFlowYamlNodeBuilder {
+    pub fn with_properties(mut self, properties: AnyYamlPropertiesCombination) -> Self {
+        self.properties = Some(properties);
+        self
+    }
     pub fn with_content(mut self, content: YamlPlainScalar) -> Self {
         self.content = Some(content);
         self
@@ -392,7 +415,8 @@ impl YamlFlowYamlNodeBuilder {
         YamlFlowYamlNode::unwrap_cast(SyntaxNode::new_detached(
             YamlSyntaxKind::YAML_FLOW_YAML_NODE,
             [
-                Some(SyntaxElement::Node(self.properties.into_syntax())),
+                self.properties
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
                 self.content
                     .map(|token| SyntaxElement::Node(token.into_syntax())),
             ],
@@ -417,11 +441,53 @@ pub fn yaml_plain_scalar(value_token: SyntaxToken) -> YamlPlainScalar {
         [Some(SyntaxElement::Token(value_token))],
     ))
 }
-pub fn yaml_property_list(any_yaml_property: AnyYamlProperty) -> YamlPropertyList {
-    YamlPropertyList::unwrap_cast(SyntaxNode::new_detached(
-        YamlSyntaxKind::YAML_PROPERTY_LIST,
-        [Some(SyntaxElement::Node(any_yaml_property.into_syntax()))],
-    ))
+pub fn yaml_properties_anchor_first(
+    anchor: YamlAnchorProperty,
+) -> YamlPropertiesAnchorFirstBuilder {
+    YamlPropertiesAnchorFirstBuilder { anchor, tag: None }
+}
+pub struct YamlPropertiesAnchorFirstBuilder {
+    anchor: YamlAnchorProperty,
+    tag: Option<YamlTagProperty>,
+}
+impl YamlPropertiesAnchorFirstBuilder {
+    pub fn with_tag(mut self, tag: YamlTagProperty) -> Self {
+        self.tag = Some(tag);
+        self
+    }
+    pub fn build(self) -> YamlPropertiesAnchorFirst {
+        YamlPropertiesAnchorFirst::unwrap_cast(SyntaxNode::new_detached(
+            YamlSyntaxKind::YAML_PROPERTIES_ANCHOR_FIRST,
+            [
+                Some(SyntaxElement::Node(self.anchor.into_syntax())),
+                self.tag
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+            ],
+        ))
+    }
+}
+pub fn yaml_properties_tag_first(tag: YamlTagProperty) -> YamlPropertiesTagFirstBuilder {
+    YamlPropertiesTagFirstBuilder { tag, anchor: None }
+}
+pub struct YamlPropertiesTagFirstBuilder {
+    tag: YamlTagProperty,
+    anchor: Option<YamlAnchorProperty>,
+}
+impl YamlPropertiesTagFirstBuilder {
+    pub fn with_anchor(mut self, anchor: YamlAnchorProperty) -> Self {
+        self.anchor = Some(anchor);
+        self
+    }
+    pub fn build(self) -> YamlPropertiesTagFirst {
+        YamlPropertiesTagFirst::unwrap_cast(SyntaxNode::new_detached(
+            YamlSyntaxKind::YAML_PROPERTIES_TAG_FIRST,
+            [
+                Some(SyntaxElement::Node(self.tag.into_syntax())),
+                self.anchor
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+            ],
+        ))
+    }
 }
 pub fn yaml_root(documents: YamlDocumentList, eof_token: SyntaxToken) -> YamlRoot {
     YamlRoot::unwrap_cast(SyntaxNode::new_detached(

--- a/crates/biome_yaml_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_yaml_factory/src/generated/syntax_factory.rs
@@ -60,7 +60,7 @@ impl SyntaxFactory for YamlSyntaxFactory {
                 let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
-                    if YamlPropertyList::can_cast(element.kind()) {
+                    if AnyYamlPropertiesCombination::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -431,7 +431,7 @@ impl SyntaxFactory for YamlSyntaxFactory {
                 let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
-                    if YamlPropertyList::can_cast(element.kind()) {
+                    if AnyYamlPropertiesCombination::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -582,7 +582,7 @@ impl SyntaxFactory for YamlSyntaxFactory {
                 let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
-                    if YamlPropertyList::can_cast(element.kind()) {
+                    if AnyYamlPropertiesCombination::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -660,12 +660,19 @@ impl SyntaxFactory for YamlSyntaxFactory {
                 }
                 slots.into_node(YAML_PLAIN_SCALAR, children)
             }
-            YAML_PROPERTY_LIST => {
+            YAML_PROPERTIES_ANCHOR_FIRST => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<1usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element {
-                    if AnyYamlProperty::can_cast(element.kind()) {
+                    if YamlAnchorProperty::can_cast(element.kind()) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element {
+                    if YamlTagProperty::can_cast(element.kind()) {
                         slots.mark_present();
                         current_element = elements.next();
                     }
@@ -673,11 +680,37 @@ impl SyntaxFactory for YamlSyntaxFactory {
                 slots.next_slot();
                 if current_element.is_some() {
                     return RawSyntaxNode::new(
-                        YAML_PROPERTY_LIST.to_bogus(),
+                        YAML_PROPERTIES_ANCHOR_FIRST.to_bogus(),
                         children.into_iter().map(Some),
                     );
                 }
-                slots.into_node(YAML_PROPERTY_LIST, children)
+                slots.into_node(YAML_PROPERTIES_ANCHOR_FIRST, children)
+            }
+            YAML_PROPERTIES_TAG_FIRST => {
+                let mut elements = (&children).into_iter();
+                let mut slots: RawNodeSlots<2usize> = RawNodeSlots::default();
+                let mut current_element = elements.next();
+                if let Some(element) = &current_element {
+                    if YamlTagProperty::can_cast(element.kind()) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element {
+                    if YamlAnchorProperty::can_cast(element.kind()) {
+                        slots.mark_present();
+                        current_element = elements.next();
+                    }
+                }
+                slots.next_slot();
+                if current_element.is_some() {
+                    return RawSyntaxNode::new(
+                        YAML_PROPERTIES_TAG_FIRST.to_bogus(),
+                        children.into_iter().map(Some),
+                    );
+                }
+                slots.into_node(YAML_PROPERTIES_TAG_FIRST, children)
             }
             YAML_ROOT => {
                 let mut elements = (&children).into_iter();

--- a/crates/biome_yaml_syntax/src/generated/kind.rs
+++ b/crates/biome_yaml_syntax/src/generated/kind.rs
@@ -72,7 +72,8 @@ pub enum YamlSyntaxKind {
     YAML_PLAIN_SCALAR,
     YAML_LITERAL_SCALAR,
     YAML_FOLDED_SCALAR,
-    YAML_PROPERTY_LIST,
+    YAML_PROPERTIES_ANCHOR_FIRST,
+    YAML_PROPERTIES_TAG_FIRST,
     YAML_ANCHOR_PROPERTY,
     YAML_TAG_PROPERTY,
     YAML_BOGUS,
@@ -122,7 +123,6 @@ impl YamlSyntaxKind {
                 | YAML_FLOW_MAP_ENTRY_LIST
                 | YAML_BLOCK_SEQUENCE_ENTRY_LIST
                 | YAML_BLOCK_MAP_ENTRY_LIST
-                | YAML_PROPERTY_LIST
         )
     }
     pub fn from_keyword(_ident: &str) -> Option<Self> {

--- a/crates/biome_yaml_syntax/src/generated/macros.rs
+++ b/crates/biome_yaml_syntax/src/generated/macros.rs
@@ -120,8 +120,13 @@ macro_rules! map_syntax_node {
                     let $pattern = unsafe { $crate::YamlPlainScalar::new_unchecked(node) };
                     $body
                 }
-                $crate::YamlSyntaxKind::YAML_PROPERTY_LIST => {
-                    let $pattern = unsafe { $crate::YamlPropertyList::new_unchecked(node) };
+                $crate::YamlSyntaxKind::YAML_PROPERTIES_ANCHOR_FIRST => {
+                    let $pattern =
+                        unsafe { $crate::YamlPropertiesAnchorFirst::new_unchecked(node) };
+                    $body
+                }
+                $crate::YamlSyntaxKind::YAML_PROPERTIES_TAG_FIRST => {
+                    let $pattern = unsafe { $crate::YamlPropertiesTagFirst::new_unchecked(node) };
                     $body
                 }
                 $crate::YamlSyntaxKind::YAML_ROOT => {

--- a/crates/biome_yaml_syntax/src/generated/nodes.rs
+++ b/crates/biome_yaml_syntax/src/generated/nodes.rs
@@ -109,8 +109,8 @@ impl YamlBlockCollection {
             content: self.content(),
         }
     }
-    pub fn properties(&self) -> SyntaxResult<YamlPropertyList> {
-        support::required_node(&self.syntax, 0usize)
+    pub fn properties(&self) -> Option<AnyYamlPropertiesCombination> {
+        support::node(&self.syntax, 0usize)
     }
     pub fn content(&self) -> SyntaxResult<AnyYamlBlockContent> {
         support::required_node(&self.syntax, 1usize)
@@ -126,7 +126,7 @@ impl Serialize for YamlBlockCollection {
 }
 #[derive(Serialize)]
 pub struct YamlBlockCollectionFields {
-    pub properties: SyntaxResult<YamlPropertyList>,
+    pub properties: Option<AnyYamlPropertiesCombination>,
     pub content: SyntaxResult<AnyYamlBlockContent>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -674,8 +674,8 @@ impl YamlFlowJsonNode {
             content: self.content(),
         }
     }
-    pub fn properties(&self) -> SyntaxResult<YamlPropertyList> {
-        support::required_node(&self.syntax, 0usize)
+    pub fn properties(&self) -> Option<AnyYamlPropertiesCombination> {
+        support::node(&self.syntax, 0usize)
     }
     pub fn content(&self) -> Option<AnyYamlJsonContent> {
         support::node(&self.syntax, 1usize)
@@ -691,7 +691,7 @@ impl Serialize for YamlFlowJsonNode {
 }
 #[derive(Serialize)]
 pub struct YamlFlowJsonNodeFields {
-    pub properties: SyntaxResult<YamlPropertyList>,
+    pub properties: Option<AnyYamlPropertiesCombination>,
     pub content: Option<AnyYamlJsonContent>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -889,8 +889,8 @@ impl YamlFlowYamlNode {
             content: self.content(),
         }
     }
-    pub fn properties(&self) -> SyntaxResult<YamlPropertyList> {
-        support::required_node(&self.syntax, 0usize)
+    pub fn properties(&self) -> Option<AnyYamlPropertiesCombination> {
+        support::node(&self.syntax, 0usize)
     }
     pub fn content(&self) -> Option<YamlPlainScalar> {
         support::node(&self.syntax, 1usize)
@@ -906,7 +906,7 @@ impl Serialize for YamlFlowYamlNode {
 }
 #[derive(Serialize)]
 pub struct YamlFlowYamlNodeFields {
-    pub properties: SyntaxResult<YamlPropertyList>,
+    pub properties: Option<AnyYamlPropertiesCombination>,
     pub content: Option<YamlPlainScalar>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -1015,10 +1015,10 @@ pub struct YamlPlainScalarFields {
     pub value_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct YamlPropertyList {
+pub struct YamlPropertiesAnchorFirst {
     pub(crate) syntax: SyntaxNode,
 }
-impl YamlPropertyList {
+impl YamlPropertiesAnchorFirst {
     #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
     #[doc = r""]
     #[doc = r" # Safety"]
@@ -1028,16 +1028,20 @@ impl YamlPropertyList {
     pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
         Self { syntax }
     }
-    pub fn as_fields(&self) -> YamlPropertyListFields {
-        YamlPropertyListFields {
-            any_yaml_property: self.any_yaml_property(),
+    pub fn as_fields(&self) -> YamlPropertiesAnchorFirstFields {
+        YamlPropertiesAnchorFirstFields {
+            anchor: self.anchor(),
+            tag: self.tag(),
         }
     }
-    pub fn any_yaml_property(&self) -> SyntaxResult<AnyYamlProperty> {
+    pub fn anchor(&self) -> SyntaxResult<YamlAnchorProperty> {
         support::required_node(&self.syntax, 0usize)
     }
+    pub fn tag(&self) -> Option<YamlTagProperty> {
+        support::node(&self.syntax, 1usize)
+    }
 }
-impl Serialize for YamlPropertyList {
+impl Serialize for YamlPropertiesAnchorFirst {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -1046,8 +1050,49 @@ impl Serialize for YamlPropertyList {
     }
 }
 #[derive(Serialize)]
-pub struct YamlPropertyListFields {
-    pub any_yaml_property: SyntaxResult<AnyYamlProperty>,
+pub struct YamlPropertiesAnchorFirstFields {
+    pub anchor: SyntaxResult<YamlAnchorProperty>,
+    pub tag: Option<YamlTagProperty>,
+}
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct YamlPropertiesTagFirst {
+    pub(crate) syntax: SyntaxNode,
+}
+impl YamlPropertiesTagFirst {
+    #[doc = r" Create an AstNode from a SyntaxNode without checking its kind"]
+    #[doc = r""]
+    #[doc = r" # Safety"]
+    #[doc = r" This function must be guarded with a call to [AstNode::can_cast]"]
+    #[doc = r" or a match on [SyntaxNode::kind]"]
+    #[inline]
+    pub const unsafe fn new_unchecked(syntax: SyntaxNode) -> Self {
+        Self { syntax }
+    }
+    pub fn as_fields(&self) -> YamlPropertiesTagFirstFields {
+        YamlPropertiesTagFirstFields {
+            tag: self.tag(),
+            anchor: self.anchor(),
+        }
+    }
+    pub fn tag(&self) -> SyntaxResult<YamlTagProperty> {
+        support::required_node(&self.syntax, 0usize)
+    }
+    pub fn anchor(&self) -> Option<YamlAnchorProperty> {
+        support::node(&self.syntax, 1usize)
+    }
+}
+impl Serialize for YamlPropertiesTagFirst {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_fields().serialize(serializer)
+    }
+}
+#[derive(Serialize)]
+pub struct YamlPropertiesTagFirstFields {
+    pub tag: SyntaxResult<YamlTagProperty>,
+    pub anchor: Option<YamlAnchorProperty>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct YamlRoot {
@@ -1411,20 +1456,20 @@ impl AnyYamlNode {
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, Serialize)]
-pub enum AnyYamlProperty {
-    YamlAnchorProperty(YamlAnchorProperty),
-    YamlTagProperty(YamlTagProperty),
+pub enum AnyYamlPropertiesCombination {
+    YamlPropertiesAnchorFirst(YamlPropertiesAnchorFirst),
+    YamlPropertiesTagFirst(YamlPropertiesTagFirst),
 }
-impl AnyYamlProperty {
-    pub fn as_yaml_anchor_property(&self) -> Option<&YamlAnchorProperty> {
+impl AnyYamlPropertiesCombination {
+    pub fn as_yaml_properties_anchor_first(&self) -> Option<&YamlPropertiesAnchorFirst> {
         match &self {
-            Self::YamlAnchorProperty(item) => Some(item),
+            Self::YamlPropertiesAnchorFirst(item) => Some(item),
             _ => None,
         }
     }
-    pub fn as_yaml_tag_property(&self) -> Option<&YamlTagProperty> {
+    pub fn as_yaml_properties_tag_first(&self) -> Option<&YamlPropertiesTagFirst> {
         match &self {
-            Self::YamlTagProperty(item) => Some(item),
+            Self::YamlPropertiesTagFirst(item) => Some(item),
             _ => None,
         }
     }
@@ -1557,7 +1602,10 @@ impl std::fmt::Debug for YamlBlockCollection {
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
             f.debug_struct("YamlBlockCollection")
-                .field("properties", &support::DebugSyntaxResult(self.properties()))
+                .field(
+                    "properties",
+                    &support::DebugOptionalElement(self.properties()),
+                )
                 .field("content", &support::DebugSyntaxResult(self.content()))
                 .finish()
         } else {
@@ -2269,7 +2317,10 @@ impl std::fmt::Debug for YamlFlowJsonNode {
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
             f.debug_struct("YamlFlowJsonNode")
-                .field("properties", &support::DebugSyntaxResult(self.properties()))
+                .field(
+                    "properties",
+                    &support::DebugOptionalElement(self.properties()),
+                )
                 .field("content", &support::DebugOptionalElement(self.content()))
                 .finish()
         } else {
@@ -2530,7 +2581,10 @@ impl std::fmt::Debug for YamlFlowYamlNode {
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
             f.debug_struct("YamlFlowYamlNode")
-                .field("properties", &support::DebugSyntaxResult(self.properties()))
+                .field(
+                    "properties",
+                    &support::DebugOptionalElement(self.properties()),
+                )
                 .field("content", &support::DebugOptionalElement(self.content()))
                 .finish()
         } else {
@@ -2700,12 +2754,12 @@ impl From<YamlPlainScalar> for SyntaxElement {
         n.syntax.into()
     }
 }
-impl AstNode for YamlPropertyList {
+impl AstNode for YamlPropertiesAnchorFirst {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
-        SyntaxKindSet::from_raw(RawSyntaxKind(YAML_PROPERTY_LIST as u16));
+        SyntaxKindSet::from_raw(RawSyntaxKind(YAML_PROPERTIES_ANCHOR_FIRST as u16));
     fn can_cast(kind: SyntaxKind) -> bool {
-        kind == YAML_PROPERTY_LIST
+        kind == YAML_PROPERTIES_ANCHOR_FIRST
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2721,32 +2775,78 @@ impl AstNode for YamlPropertyList {
         self.syntax
     }
 }
-impl std::fmt::Debug for YamlPropertyList {
+impl std::fmt::Debug for YamlPropertiesAnchorFirst {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         thread_local! { static DEPTH : std :: cell :: Cell < u8 > = const { std :: cell :: Cell :: new (0) } };
         let current_depth = DEPTH.get();
         let result = if current_depth < 16 {
             DEPTH.set(current_depth + 1);
-            f.debug_struct("YamlPropertyList")
-                .field(
-                    "any_yaml_property",
-                    &support::DebugSyntaxResult(self.any_yaml_property()),
-                )
+            f.debug_struct("YamlPropertiesAnchorFirst")
+                .field("anchor", &support::DebugSyntaxResult(self.anchor()))
+                .field("tag", &support::DebugOptionalElement(self.tag()))
                 .finish()
         } else {
-            f.debug_struct("YamlPropertyList").finish()
+            f.debug_struct("YamlPropertiesAnchorFirst").finish()
         };
         DEPTH.set(current_depth);
         result
     }
 }
-impl From<YamlPropertyList> for SyntaxNode {
-    fn from(n: YamlPropertyList) -> Self {
+impl From<YamlPropertiesAnchorFirst> for SyntaxNode {
+    fn from(n: YamlPropertiesAnchorFirst) -> Self {
         n.syntax
     }
 }
-impl From<YamlPropertyList> for SyntaxElement {
-    fn from(n: YamlPropertyList) -> Self {
+impl From<YamlPropertiesAnchorFirst> for SyntaxElement {
+    fn from(n: YamlPropertiesAnchorFirst) -> Self {
+        n.syntax.into()
+    }
+}
+impl AstNode for YamlPropertiesTagFirst {
+    type Language = Language;
+    const KIND_SET: SyntaxKindSet<Language> =
+        SyntaxKindSet::from_raw(RawSyntaxKind(YAML_PROPERTIES_TAG_FIRST as u16));
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == YAML_PROPERTIES_TAG_FIRST
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl std::fmt::Debug for YamlPropertiesTagFirst {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        thread_local! { static DEPTH : std :: cell :: Cell < u8 > = const { std :: cell :: Cell :: new (0) } };
+        let current_depth = DEPTH.get();
+        let result = if current_depth < 16 {
+            DEPTH.set(current_depth + 1);
+            f.debug_struct("YamlPropertiesTagFirst")
+                .field("tag", &support::DebugSyntaxResult(self.tag()))
+                .field("anchor", &support::DebugOptionalElement(self.anchor()))
+                .finish()
+        } else {
+            f.debug_struct("YamlPropertiesTagFirst").finish()
+        };
+        DEPTH.set(current_depth);
+        result
+    }
+}
+impl From<YamlPropertiesTagFirst> for SyntaxNode {
+    fn from(n: YamlPropertiesTagFirst) -> Self {
+        n.syntax
+    }
+}
+impl From<YamlPropertiesTagFirst> for SyntaxElement {
+    fn from(n: YamlPropertiesTagFirst) -> Self {
         n.syntax.into()
     }
 }
@@ -3659,62 +3759,69 @@ impl From<AnyYamlNode> for SyntaxElement {
         node.into()
     }
 }
-impl From<YamlAnchorProperty> for AnyYamlProperty {
-    fn from(node: YamlAnchorProperty) -> Self {
-        Self::YamlAnchorProperty(node)
+impl From<YamlPropertiesAnchorFirst> for AnyYamlPropertiesCombination {
+    fn from(node: YamlPropertiesAnchorFirst) -> Self {
+        Self::YamlPropertiesAnchorFirst(node)
     }
 }
-impl From<YamlTagProperty> for AnyYamlProperty {
-    fn from(node: YamlTagProperty) -> Self {
-        Self::YamlTagProperty(node)
+impl From<YamlPropertiesTagFirst> for AnyYamlPropertiesCombination {
+    fn from(node: YamlPropertiesTagFirst) -> Self {
+        Self::YamlPropertiesTagFirst(node)
     }
 }
-impl AstNode for AnyYamlProperty {
+impl AstNode for AnyYamlPropertiesCombination {
     type Language = Language;
     const KIND_SET: SyntaxKindSet<Language> =
-        YamlAnchorProperty::KIND_SET.union(YamlTagProperty::KIND_SET);
+        YamlPropertiesAnchorFirst::KIND_SET.union(YamlPropertiesTagFirst::KIND_SET);
     fn can_cast(kind: SyntaxKind) -> bool {
-        matches!(kind, YAML_ANCHOR_PROPERTY | YAML_TAG_PROPERTY)
+        matches!(
+            kind,
+            YAML_PROPERTIES_ANCHOR_FIRST | YAML_PROPERTIES_TAG_FIRST
+        )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
-            YAML_ANCHOR_PROPERTY => Self::YamlAnchorProperty(YamlAnchorProperty { syntax }),
-            YAML_TAG_PROPERTY => Self::YamlTagProperty(YamlTagProperty { syntax }),
+            YAML_PROPERTIES_ANCHOR_FIRST => {
+                Self::YamlPropertiesAnchorFirst(YamlPropertiesAnchorFirst { syntax })
+            }
+            YAML_PROPERTIES_TAG_FIRST => {
+                Self::YamlPropertiesTagFirst(YamlPropertiesTagFirst { syntax })
+            }
             _ => return None,
         };
         Some(res)
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Self::YamlAnchorProperty(it) => &it.syntax,
-            Self::YamlTagProperty(it) => &it.syntax,
+            Self::YamlPropertiesAnchorFirst(it) => &it.syntax,
+            Self::YamlPropertiesTagFirst(it) => &it.syntax,
         }
     }
     fn into_syntax(self) -> SyntaxNode {
         match self {
-            Self::YamlAnchorProperty(it) => it.syntax,
-            Self::YamlTagProperty(it) => it.syntax,
+            Self::YamlPropertiesAnchorFirst(it) => it.syntax,
+            Self::YamlPropertiesTagFirst(it) => it.syntax,
         }
     }
 }
-impl std::fmt::Debug for AnyYamlProperty {
+impl std::fmt::Debug for AnyYamlPropertiesCombination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::YamlAnchorProperty(it) => std::fmt::Debug::fmt(it, f),
-            Self::YamlTagProperty(it) => std::fmt::Debug::fmt(it, f),
+            Self::YamlPropertiesAnchorFirst(it) => std::fmt::Debug::fmt(it, f),
+            Self::YamlPropertiesTagFirst(it) => std::fmt::Debug::fmt(it, f),
         }
     }
 }
-impl From<AnyYamlProperty> for SyntaxNode {
-    fn from(n: AnyYamlProperty) -> Self {
+impl From<AnyYamlPropertiesCombination> for SyntaxNode {
+    fn from(n: AnyYamlPropertiesCombination) -> Self {
         match n {
-            AnyYamlProperty::YamlAnchorProperty(it) => it.into(),
-            AnyYamlProperty::YamlTagProperty(it) => it.into(),
+            AnyYamlPropertiesCombination::YamlPropertiesAnchorFirst(it) => it.into(),
+            AnyYamlPropertiesCombination::YamlPropertiesTagFirst(it) => it.into(),
         }
     }
 }
-impl From<AnyYamlProperty> for SyntaxElement {
-    fn from(n: AnyYamlProperty) -> Self {
+impl From<AnyYamlPropertiesCombination> for SyntaxElement {
+    fn from(n: AnyYamlPropertiesCombination) -> Self {
         let node: SyntaxNode = n.into();
         node.into()
     }
@@ -3774,7 +3881,7 @@ impl std::fmt::Display for AnyYamlNode {
         std::fmt::Display::fmt(self.syntax(), f)
     }
 }
-impl std::fmt::Display for AnyYamlProperty {
+impl std::fmt::Display for AnyYamlPropertiesCombination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }
@@ -3904,7 +4011,12 @@ impl std::fmt::Display for YamlPlainScalar {
         std::fmt::Display::fmt(self.syntax(), f)
     }
 }
-impl std::fmt::Display for YamlPropertyList {
+impl std::fmt::Display for YamlPropertiesAnchorFirst {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for YamlPropertiesTagFirst {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/biome_yaml_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_yaml_syntax/src/generated/nodes_mut.rs
@@ -20,11 +20,11 @@ impl YamlAnchorProperty {
     }
 }
 impl YamlBlockCollection {
-    pub fn with_properties(self, element: YamlPropertyList) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
-        )
+    pub fn with_properties(self, element: Option<AnyYamlPropertiesCombination>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            0usize..=0usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
     pub fn with_content(self, element: AnyYamlBlockContent) -> Self {
         Self::unwrap_cast(
@@ -222,11 +222,11 @@ impl YamlDoubleQuotedScalar {
     }
 }
 impl YamlFlowJsonNode {
-    pub fn with_properties(self, element: YamlPropertyList) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
-        )
+    pub fn with_properties(self, element: Option<AnyYamlPropertiesCombination>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            0usize..=0usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
     pub fn with_content(self, element: Option<AnyYamlJsonContent>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
@@ -310,11 +310,11 @@ impl YamlFlowSequence {
     }
 }
 impl YamlFlowYamlNode {
-    pub fn with_properties(self, element: YamlPropertyList) -> Self {
-        Self::unwrap_cast(
-            self.syntax
-                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
-        )
+    pub fn with_properties(self, element: Option<AnyYamlPropertiesCombination>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            0usize..=0usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
     pub fn with_content(self, element: Option<YamlPlainScalar>) -> Self {
         Self::unwrap_cast(self.syntax.splice_slots(
@@ -347,12 +347,32 @@ impl YamlPlainScalar {
         )
     }
 }
-impl YamlPropertyList {
-    pub fn with_any_yaml_property(self, element: AnyYamlProperty) -> Self {
+impl YamlPropertiesAnchorFirst {
+    pub fn with_anchor(self, element: YamlAnchorProperty) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
+    }
+    pub fn with_tag(self, element: Option<YamlTagProperty>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            1usize..=1usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
+    }
+}
+impl YamlPropertiesTagFirst {
+    pub fn with_tag(self, element: YamlTagProperty) -> Self {
+        Self::unwrap_cast(
+            self.syntax
+                .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
+        )
+    }
+    pub fn with_anchor(self, element: Option<YamlAnchorProperty>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            1usize..=1usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
     }
 }
 impl YamlRoot {

--- a/xtask/codegen/src/yaml_kinds_src.rs
+++ b/xtask/codegen/src/yaml_kinds_src.rs
@@ -70,7 +70,8 @@ pub const YAML_KINDS_SRC: KindsSrc = KindsSrc {
         "YAML_PLAIN_SCALAR",
         "YAML_LITERAL_SCALAR",
         "YAML_FOLDED_SCALAR",
-        "YAML_PROPERTY_LIST",
+        "YAML_PROPERTIES_ANCHOR_FIRST",
+        "YAML_PROPERTIES_TAG_FIRST",
         "YAML_ANCHOR_PROPERTY",
         "YAML_TAG_PROPERTY",
         // Bogus nodes

--- a/xtask/codegen/yaml.ungram
+++ b/xtask/codegen/yaml.ungram
@@ -77,13 +77,13 @@ YamlAliasNode = value: 'alias_literal'
 // e.g {a: b, c: [d, {e: f}]}
 // https://yaml.org/spec/1.2.2/#rule-c-flow-json-node
 YamlFlowJsonNode =
-	properties: YamlPropertyList
+	properties: AnyYamlPropertiesCombination?
 	content: AnyYamlJsonContent?
 
 // Plain YAML node
 // https://yaml.org/spec/1.2.2/#rule-ns-flow-yaml-node
 YamlFlowYamlNode =
-	properties: YamlPropertyList
+	properties: AnyYamlPropertiesCombination?
 	content: YamlPlainScalar?
 
 // Yaml in JSON style
@@ -151,7 +151,7 @@ AnyYamlBlockNode =
 
 // https://yaml.org/spec/1.2.2/#rule-s-l+block-collection
 YamlBlockCollection =
-	properties: YamlPropertyList
+	properties: AnyYamlPropertiesCombination?
 	content: AnyYamlBlockContent
 
 AnyYamlBlockContent =
@@ -244,11 +244,17 @@ YamlBlockMapImplicitValue =
 	value: AnyYamlNode
 
 // https://yaml.org/spec/1.2.2/#rule-c-ns-properties
-YamlPropertyList = AnyYamlProperty
+AnyYamlPropertiesCombination =
+	YamlPropertiesTagFirst
+	| YamlPropertiesAnchorFirst
 
-AnyYamlProperty =
-	YamlAnchorProperty
-	| YamlTagProperty
+YamlPropertiesTagFirst =
+	tag: YamlTagProperty
+	anchor: YamlAnchorProperty?
+
+YamlPropertiesAnchorFirst =
+	anchor: YamlAnchorProperty
+	tag: YamlTagProperty?
 
 // &abc
 // https://yaml.org/spec/1.2.2/#rule-c-ns-anchor-property


### PR DESCRIPTION
## Summary

YAML specification states that one node may have two properties: one anchor and one tag. However, the current implementation allows an arbitrary number of properties.

## Test Plan

Everything should still remain green
