### PR TITLE
docs: add @vitest/eslint-plugin as rule source

### DIFF
--- a/.changeset/floppy-beers-shave.md
+++ b/.changeset/floppy-beers-shave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Add @vitest/eslint-plugin to list of Biome rule sources

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -294,6 +294,8 @@ pub enum RuleSource {
     EslintRegexp(&'static str),
     /// Rules from [deno lint](https://github.com/denoland/deno_lint)
     DenoLint(&'static str),
+    /// Rules from [Eslint Plugin Vitest](https://github.com/vitest-dev/eslint-plugin-vitest)
+    EslintVitest(&'static str),
 }
 
 impl PartialEq for RuleSource {
@@ -330,6 +332,7 @@ impl std::fmt::Display for RuleSource {
             Self::EslintNoSecrets(_) => write!(f, "eslint-plugin-no-secrets"),
             Self::EslintRegexp(_) => write!(f, "eslint-plugin-regexp"),
             Self::DenoLint(_) => write!(f, "deno-lint"),
+            Self::EslintVitest(_) => write!(f, "@vitest/eslint-plugin"),
         }
     }
 }
@@ -383,7 +386,8 @@ impl RuleSource {
             | Self::EslintNoSecrets(rule_name)
             | Self::EslintRegexp(rule_name)
             | Self::Stylelint(rule_name)
-            | Self::DenoLint(rule_name) => rule_name,
+            | Self::DenoLint(rule_name)
+            | Self::EslintVitest(rule_name) => rule_name,
         }
     }
 
@@ -413,6 +417,7 @@ impl RuleSource {
             Self::EslintNoSecrets(rule_name) => format!("no-secrets/{rule_name}"),
             Self::EslintRegexp(rule_name) => format!("regexp/{rule_name}"),
             Self::DenoLint(rule_name) => format!("deno-lint/{rule_name}"),
+            Self::EslintVitest(rule_name) => format!("vitest/{rule_name}"),
         }
     }
 
@@ -443,6 +448,7 @@ impl RuleSource {
             Self::EslintNoSecrets(_) => "https://github.com/nickdeis/eslint-plugin-no-secrets/blob/master/README.md".to_string(),
             Self::EslintRegexp(rule_name) => format!("https://ota-meshi.github.io/eslint-plugin-regexp/rules/{rule_name}.html"),
             Self::DenoLint(rule_name) => format!("https://lint.deno.land/rules/{rule_name}"),
+            Self::EslintVitest(rule_name) => format!("https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rule/{rule_name}.md"),
         }
     }
 

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -2515,6 +2515,70 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
+        "vitest/max-nested-describe" => {
+            let group = rules.complexity.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_excessive_nested_test_suites
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "vitest/no-disabled-tests" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_skipped_tests
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "vitest/no-done-callback" => {
+            let group = rules.style.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_done_callback
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "vitest/no-duplicate-hooks" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_duplicate_test_hooks
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "vitest/no-focused-tests" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_focused_tests
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
+        "vitest/no-standalone-expect" => {
+            if !options.include_inspired {
+                results.has_inspired_rules = true;
+                return false;
+            }
+            let group = rules.suspicious.get_or_insert_with(Default::default);
+            let rule = group
+                .unwrap_group_as_mut()
+                .no_misplaced_assertion
+                .get_or_insert(Default::default());
+            rule.set_level(rule.level().max(rule_severity.into()));
+        }
         "yoda" => {
             let group = rules.style.get_or_insert_with(Default::default);
             let rule = group

--- a/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_excessive_nested_test_suites.rs
@@ -58,7 +58,7 @@ declare_lint_rule! {
         language: "js",
         recommended: true,
         severity: Severity::Error,
-        sources: &[RuleSource::EslintJest("max-nested-describe")],
+        sources: &[RuleSource::EslintJest("max-nested-describe"), RuleSource::EslintVitest("max-nested-describe")],
         source_kind: RuleSourceKind::SameLogic,
         domains: &[RuleDomain::Test],
     }

--- a/crates/biome_js_analyze/src/lint/style/no_done_callback.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_done_callback.rs
@@ -48,7 +48,7 @@ declare_lint_rule! {
         name: "noDoneCallback",
         language: "js",
         recommended: false,
-        sources: &[RuleSource::EslintJest("no-done-callback")],
+        sources: &[RuleSource::EslintJest("no-done-callback"), RuleSource::EslintVitest("no-done-callback")],
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
@@ -63,7 +63,7 @@ declare_lint_rule! {
         language: "js",
         recommended: true,
         severity: Severity::Error,
-        sources: &[RuleSource::EslintJest("no-duplicate-hooks")],
+        sources: &[RuleSource::EslintJest("no-duplicate-hooks"), RuleSource::EslintVitest("no-duplicate-hooks")],
         source_kind: RuleSourceKind::Inspired,
         domains: &[RuleDomain::Test],
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_focused_tests.rs
@@ -46,7 +46,7 @@ declare_lint_rule! {
         language: "js",
         recommended: true,
         severity: Severity::Error,
-        sources: &[RuleSource::EslintJest("no-focused-tests")],
+        sources: &[RuleSource::EslintJest("no-focused-tests"), RuleSource::EslintVitest("no-focused-tests")],
         source_kind: RuleSourceKind::Inspired,
         fix_kind: FixKind::Unsafe,
         domains: &[RuleDomain::Test],

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misplaced_assertion.rs
@@ -107,7 +107,7 @@ declare_lint_rule! {
         name: "noMisplacedAssertion",
         language: "js",
         recommended: false,
-        sources: &[RuleSource::EslintJest("no-standalone-expect")],
+        sources: &[RuleSource::EslintJest("no-standalone-expect"), RuleSource::EslintVitest("no-standalone-expect")],
         source_kind: RuleSourceKind::Inspired,
     }
 }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_skipped_tests.rs
@@ -38,7 +38,7 @@ declare_lint_rule! {
         name: "noSkippedTests",
         language: "js",
         recommended: false,
-        sources: &[RuleSource::EslintJest("no-disabled-tests")],
+        sources: &[RuleSource::EslintJest("no-disabled-tests"), RuleSource::EslintVitest("no-disabled-tests")],
         source_kind: RuleSourceKind::Inspired,
         fix_kind: FixKind::Unsafe,
     }


### PR DESCRIPTION
## Summary

Part of https://github.com/biomejs/biome/discussions/5862. Adds `@vitest/eslint-plugin` alongside `eslint-plugin-jest` as a rule source.

## Test Plan

- Docs-only change
- [x] Lint/tests pass
