### PR TITLE
perf(js_analyze): use Box<str> in more places to reduce memory

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -199,7 +199,7 @@ pub struct NoPrivateImportsState {
     range: TextRange,
 
     /// The path where the visibility of the imported symbol is defined.
-    path: String,
+    path: Box<str>,
 
     /// The visibility of the offending symbol.
     visibility: Visibility,
@@ -315,7 +315,7 @@ fn get_restricted_imports_from_module_source(
     node: &JsModuleSource,
     options: &GetRestrictedImportOptions,
 ) -> SyntaxResult<Vec<NoPrivateImportsState>> {
-    let path = options.target_path.to_string();
+    let path: Box<str> = options.target_path.as_str().into();
 
     let results = match node.syntax().parent().and_then(AnyJsImportClause::cast) {
         Some(AnyJsImportClause::JsImportCombinedClause(node)) => {

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -195,7 +195,7 @@ pub struct NoUndeclaredDependenciesOptions {
 }
 
 pub struct RuleState {
-    package_name: String,
+    package_name: Box<str>,
     is_dev_dependency_available: bool,
     is_peer_dependency_available: bool,
     is_optional_dependency_available: bool,
@@ -255,7 +255,7 @@ impl Rule for NoUndeclaredDependencies {
         }
 
         Some(RuleState {
-            package_name: package_name.to_string(),
+            package_name: package_name.into(),
             is_dev_dependency_available,
             is_peer_dependency_available,
             is_optional_dependency_available,

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_variables.rs
@@ -106,7 +106,7 @@ impl Rule for NoUndeclaredVariables {
                 }
 
                 let span = token.text_trimmed_range();
-                let text = text.to_string().into_boxed_str();
+                let text = text.into();
                 Some((span, text))
             })
             .collect::<Vec<_>>()

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_types.rs
@@ -139,7 +139,7 @@ pub struct NoRestrictedTypesOptions {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct CustomRestrictedTypeOptions {
-    message: String,
+    message: Box<str>,
     #[serde(rename = "use")]
     use_instead: Option<String>,
 }
@@ -148,7 +148,7 @@ pub struct CustomRestrictedTypeOptions {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum CustomRestrictedType {
-    Plain(String),
+    Plain(Box<str>),
     WithOptions(CustomRestrictedTypeOptions),
 }
 

--- a/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
@@ -63,13 +63,13 @@ declare_lint_rule! {
 pub enum NoUnresolvedImportsState {
     UnresolvedPath {
         range: TextRange,
-        specifier: String,
-        resolve_error: String,
+        specifier: Box<str>,
+        resolve_error: Box<str>,
     },
     UnresolvedSymbol {
         range: TextRange,
-        specifier: String,
-        export_name: String,
+        specifier: Box<str>,
+        export_name: Box<str>,
     },
 }
 
@@ -121,8 +121,8 @@ impl Rule for NoUnresolvedImports {
 
                 return vec![NoUnresolvedImportsState::UnresolvedPath {
                     range: node.syntax().text_trimmed_range(),
-                    specifier: specifier.to_string(),
-                    resolve_error: resolve_error.clone(),
+                    specifier: specifier.as_ref().into(),
+                    resolve_error: resolve_error.as_str().into(),
                 }];
             }
         };
@@ -190,7 +190,7 @@ impl Rule for NoUnresolvedImports {
                 })
             }
             NoUnresolvedImportsState::UnresolvedSymbol { export_name, .. }
-                if export_name == "default" =>
+                if export_name.as_ref() == "default" =>
             {
                 let specifier_kind = if specifier.starts_with('.') {
                     "path"
@@ -252,8 +252,8 @@ fn get_unresolved_imports_from_module_source(
             (!has_exported_symbol(&Text::Static("default"), options))
                 .then(|| NoUnresolvedImportsState::UnresolvedSymbol {
                     range,
-                    specifier: options.specifier.to_string(),
-                    export_name: "default".to_string(),
+                    specifier: options.specifier.as_ref().into(),
+                    export_name: "default".into(),
                 })
                 .into_iter()
                 .chain(
@@ -272,8 +272,8 @@ fn get_unresolved_imports_from_module_source(
                             .then(|| {
                                 NoUnresolvedImportsState::UnresolvedSymbol {
                                     range: name.text_trimmed_range(),
-                                    specifier: options.specifier.to_string(),
-                                    export_name: name.text_trimmed().to_string(),
+                                    specifier: options.specifier.as_ref().into(),
+                                    export_name: name.text_trimmed().into(),
                                 }
                             })
                         }),
@@ -285,8 +285,8 @@ fn get_unresolved_imports_from_module_source(
             (!has_exported_symbol(&Text::Static("default"), options))
                 .then(|| NoUnresolvedImportsState::UnresolvedSymbol {
                     range,
-                    specifier: options.specifier.to_string(),
-                    export_name: "default".to_string(),
+                    specifier: options.specifier.as_ref().into(),
+                    export_name: "default".into(),
                 })
                 .into_iter()
                 .collect()
@@ -301,8 +301,8 @@ fn get_unresolved_imports_from_module_source(
                     (!has_exported_symbol(&Text::Borrowed(name.token_text_trimmed()), options))
                         .then(|| NoUnresolvedImportsState::UnresolvedSymbol {
                             range: name.text_trimmed_range(),
-                            specifier: options.specifier.to_string(),
-                            export_name: name.text_trimmed().to_string(),
+                            specifier: options.specifier.as_ref().into(),
+                            export_name: name.text_trimmed().into(),
                         })
                 })
                 .collect()

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -168,7 +168,7 @@ static SORT_CONFIG: LazyLock<SortConfig> =
 
 impl Rule for UseSortedClasses {
     type Query = Ast<AnyClassStringLike>;
-    type State = String;
+    type State = Box<str>;
     type Signals = Option<Self::State>;
     type Options = Box<UtilityClassSortingOptions>;
 
@@ -187,7 +187,7 @@ impl Rule for UseSortedClasses {
                     return None;
                 }
                 if value.text() != sorted_value {
-                    return Some(sorted_value);
+                    return Some(sorted_value.into());
                 }
             }
         }

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/class_info.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/class_info.rs
@@ -123,7 +123,7 @@ fn get_utility_info(
         });
     }
 
-    let utility_text = utility_data.text.as_str();
+    let utility_text = utility_data.text.as_ref();
     let mut layer: Option<&str> = None;
     let mut match_index: usize = 0;
     let mut last_size: usize = 0;
@@ -178,7 +178,7 @@ mod get_utility_info_tests {
             classes: &["px-2$"],
         }];
         let utility_data = ClassSegmentStructure {
-            text: "px-2".to_string(),
+            text: "px-2".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -189,7 +189,7 @@ mod get_utility_info_tests {
             })
         );
         let utility_data = ClassSegmentStructure {
-            text: "px-4".to_string(),
+            text: "px-4".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -205,7 +205,7 @@ mod get_utility_info_tests {
             classes: &["px-"],
         }];
         let utility_data = ClassSegmentStructure {
-            text: "px-2".to_string(),
+            text: "px-2".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -216,7 +216,7 @@ mod get_utility_info_tests {
             })
         );
         let utility_data = ClassSegmentStructure {
-            text: "not-px-2".to_string(),
+            text: "not-px-2".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -232,7 +232,7 @@ mod get_utility_info_tests {
             classes: &["border-", "border-t-"],
         }];
         let utility_data = ClassSegmentStructure {
-            text: "border-t-2".to_string(),
+            text: "border-t-2".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -251,7 +251,7 @@ mod get_utility_info_tests {
             classes: &["border-t-", "border-"],
         }];
         let utility_data = ClassSegmentStructure {
-            text: "border-t-2".to_string(),
+            text: "border-t-2".into(),
             arbitrary: false,
         };
         assert_eq!(
@@ -270,7 +270,7 @@ mod get_utility_info_tests {
             classes: &["border-t-", "border-"],
         }];
         let utility_data = ClassSegmentStructure {
-            text: "[arbitrary:css]".to_string(),
+            text: "[arbitrary:css]".into(),
             arbitrary: true,
         };
         assert_eq!(
@@ -484,7 +484,7 @@ pub fn compute_variants_weight(
 #[derive(Debug, Eq, PartialEq)]
 pub struct ClassInfo {
     /// The full text of the class itself.
-    pub text: String,
+    pub text: Box<str>,
     /// The total variants weight that results from the combination of all the variants.
     pub variant_weight: Option<BitVec<u8, Lsb0>>,
     /// The layer the utility belongs to.
@@ -492,7 +492,7 @@ pub struct ClassInfo {
     /// The index of the utility within the layer.
     pub utility_index: usize,
     /// Arbitrary variants
-    pub arbitrary_variants: Option<Vec<String>>,
+    pub arbitrary_variants: Option<Box<[Box<str>]>>,
 }
 
 /// Computes sort-related information about a CSS class. If the class is not recognized as a utility,
@@ -507,14 +507,14 @@ pub fn get_class_info(class_name: &str, sort_config: &SortConfig) -> Option<Clas
         Vec<&ClassSegmentStructure>,
     ) = utility_data.variants.iter().partition(|el| el.arbitrary);
 
-    let arbitrary_variants: Vec<String> = arbitrary_variants
+    let arbitrary_variants: Box<[Box<str>]> = arbitrary_variants
         .iter()
         .map(|&variant| variant.text.clone())
         .collect();
 
     if let Some(utility_info) = utility_info {
         return Some(ClassInfo {
-            text: class_name.to_string(),
+            text: class_name.into(),
             variant_weight: compute_variants_weight(sort_config.variants, &current_variants),
             layer_index: *sort_config.layer_index_map.get(&utility_info.layer)?,
             utility_index: utility_info.index,
@@ -560,7 +560,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("px-2", &sort_config),
             Some(ClassInfo {
-                text: "px-2".to_string(),
+                text: "px-2".into(),
                 variant_weight: None,
                 layer_index: 0,
                 utility_index: 0,
@@ -570,7 +570,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("py-2", &sort_config),
             Some(ClassInfo {
-                text: "py-2".to_string(),
+                text: "py-2".into(),
                 variant_weight: None,
                 layer_index: 0,
                 utility_index: 1,
@@ -580,7 +580,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("block", &sort_config),
             Some(ClassInfo {
-                text: "block".to_string(),
+                text: "block".into(),
                 variant_weight: None,
                 layer_index: 0,
                 utility_index: 2,
@@ -590,7 +590,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("mx-2", &sort_config),
             Some(ClassInfo {
-                text: "mx-2".to_string(),
+                text: "mx-2".into(),
                 variant_weight: None,
                 layer_index: 1,
                 utility_index: 0,
@@ -600,7 +600,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("my-2", &sort_config),
             Some(ClassInfo {
-                text: "my-2".to_string(),
+                text: "my-2".into(),
                 variant_weight: None,
                 layer_index: 1,
                 utility_index: 1,
@@ -610,7 +610,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("inline", &sort_config),
             Some(ClassInfo {
-                text: "inline".to_string(),
+                text: "inline".into(),
                 variant_weight: None,
                 layer_index: 1,
                 utility_index: 2,
@@ -620,7 +620,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("[arbitrary:css]", &sort_config),
             Some(ClassInfo {
-                text: "[arbitrary:css]".to_string(),
+                text: "[arbitrary:css]".into(),
                 variant_weight: None,
                 layer_index: 2,
                 utility_index: 0,
@@ -630,7 +630,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("hover:bg-red-500", &sort_config),
             Some(ClassInfo {
-                text: "hover:bg-red-500".to_string(),
+                text: "hover:bg-red-500".into(),
                 variant_weight: Some(bitvec![u8, Lsb0; 1]),
                 layer_index: 0,
                 utility_index: 3,
@@ -640,7 +640,7 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("hover:focus:bg-yellow-600", &sort_config),
             Some(ClassInfo {
-                text: "hover:focus:bg-yellow-600".to_string(),
+                text: "hover:focus:bg-yellow-600".into(),
                 variant_weight: Some(bitvec![u8, Lsb0; 1, 1]),
                 layer_index: 0,
                 utility_index: 3,
@@ -650,21 +650,21 @@ mod get_class_info_tests {
         assert_eq!(
             get_class_info("[&nth-child(2)]:bg-yellow-300", &sort_config),
             Some(ClassInfo {
-                text: "[&nth-child(2)]:bg-yellow-300".to_string(),
+                text: "[&nth-child(2)]:bg-yellow-300".into(),
                 variant_weight: None,
                 layer_index: 0,
                 utility_index: 3,
-                arbitrary_variants: Some(vec!["[&nth-child(2)]".to_string()])
+                arbitrary_variants: Some(Box::new([Box::<str>::from("[&nth-child(2)]")]))
             })
         );
         assert_eq!(
             get_class_info("[&nth-child(1)]:focus:bg-yellow-300", &sort_config),
             Some(ClassInfo {
-                text: "[&nth-child(1)]:focus:bg-yellow-300".to_string(),
+                text: "[&nth-child(1)]:focus:bg-yellow-300".into(),
                 variant_weight: Some(bitvec![u8, Lsb0; 0, 1]),
                 layer_index: 0,
                 utility_index: 3,
-                arbitrary_variants: Some(vec!["[&nth-child(1)]".to_string()])
+                arbitrary_variants: Some(Box::new([Box::<str>::from("[&nth-child(1)]")]))
             })
         );
         assert_eq!(get_class_info("unknown", &sort_config), None);

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/class_lexer.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/class_lexer.rs
@@ -84,7 +84,7 @@ enum CharKind {
 #[derive(Debug, Eq, PartialEq)]
 pub struct ClassSegmentStructure {
     pub arbitrary: bool,
-    pub text: String,
+    pub text: Box<str>,
 }
 
 /// Information about the structure of a CSS class.
@@ -175,7 +175,7 @@ pub fn tokenize_class(class_name: &str) -> Option<ClassStructure> {
         .iter()
         .map(|&s| ClassSegmentStructure {
             arbitrary: s.starts_with('['),
-            text: s.to_string(),
+            text: s.into(),
         })
         .collect();
     let utility = variants.pop()?;
@@ -195,7 +195,7 @@ mod tests_tokenize_class {
                 variants: Vec::new(),
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "px-2".to_string(),
+                    text: "px-2".into(),
                 },
             })
         );
@@ -204,11 +204,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "hover".to_string(),
+                    text: "hover".into(),
                 }],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "px-2".to_string(),
+                    text: "px-2".into(),
                 },
             })
         );
@@ -218,16 +218,16 @@ mod tests_tokenize_class {
                 variants: vec![
                     ClassSegmentStructure {
                         arbitrary: false,
-                        text: "sm".to_string(),
+                        text: "sm".into(),
                     },
                     ClassSegmentStructure {
                         arbitrary: false,
-                        text: "hover".to_string(),
+                        text: "hover".into(),
                     },
                 ],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "px-2".to_string(),
+                    text: "px-2".into(),
                 },
             })
         );
@@ -236,11 +236,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "hover".to_string(),
+                    text: "hover".into(),
                 }],
                 utility: ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[mask:circle]".to_string(),
+                    text: "[mask:circle]".into(),
                 },
             })
         );
@@ -249,11 +249,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[&:nth-child(3)]".to_string(),
+                    text: "[&:nth-child(3)]".into(),
                 }],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "px-2".to_string(),
+                    text: "px-2".into(),
                 },
             })
         );
@@ -262,11 +262,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "hover".to_string(),
+                    text: "hover".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[mask:circle]".to_string(),
+                    text: "[mask:circle]".into(),
                 },
             })
         );
@@ -275,11 +275,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "has-[:checked]".to_string(),
+                    text: "has-[:checked]".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "bg-red-500".to_string(),
+                    text: "bg-red-500".into(),
                 },
             })
         );
@@ -288,11 +288,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[&:nth-child(3)]".to_string(),
+                    text: "[&:nth-child(3)]".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[mask:circle]".to_string(),
+                    text: "[mask:circle]".into(),
                 },
             })
         );
@@ -301,11 +301,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "font-[Roboto]".to_string(),
+                    text: "font-[Roboto]".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[mask:circle]".to_string(),
+                    text: "[mask:circle]".into(),
                 },
             })
         );
@@ -314,11 +314,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "font-['Roboto']".to_string(),
+                    text: "font-['Roboto']".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: true,
-                    text: "[mask:circle]".to_string(),
+                    text: "[mask:circle]".into(),
                 },
             })
         );
@@ -327,11 +327,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "quotes-['Ro'b\"`oto']".to_string(),
+                    text: "quotes-['Ro'b\"`oto']".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "block".to_string(),
+                    text: "block".into(),
                 },
             })
         );
@@ -340,11 +340,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "quotes-[']']".to_string(),
+                    text: "quotes-[']']".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "block".to_string(),
+                    text: "block".into(),
                 },
             })
         );
@@ -354,7 +354,7 @@ mod tests_tokenize_class {
                 variants: Vec::new(),
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "quotes-[\"]\"]".to_string(),
+                    text: "quotes-[\"]\"]".into(),
                 },
             })
         );
@@ -364,7 +364,7 @@ mod tests_tokenize_class {
                 variants: Vec::new(),
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "quotes-[`]`]".to_string(),
+                    text: "quotes-[`]`]".into(),
                 },
             })
         );
@@ -375,7 +375,7 @@ mod tests_tokenize_class {
                 variants: Vec::new(),
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "escaped-quotes-[']\\']:block".to_string(),
+                    text: "escaped-quotes-[']\\']:block".into(),
                 },
             })
         );
@@ -384,11 +384,11 @@ mod tests_tokenize_class {
             Some(ClassStructure {
                 variants: vec![ClassSegmentStructure {
                     arbitrary: false,
-                    text: "double-escaped-quotes-[']\\\\']".to_string(),
+                    text: "double-escaped-quotes-[']\\\\']".into(),
                 },],
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "block".to_string(),
+                    text: "block".into(),
                 },
             })
         );
@@ -398,7 +398,7 @@ mod tests_tokenize_class {
                 variants: Vec::new(),
                 utility: ClassSegmentStructure {
                     arbitrary: false,
-                    text: "triple-escaped-quotes-[']\\\\\\']:block".to_string(),
+                    text: "triple-escaped-quotes-[']\\\\\\']:block".into(),
                 },
             })
         );

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort.rs
@@ -180,7 +180,7 @@ pub fn sort_class_name(
     sorted_classes.extend(
         classes_info
             .iter()
-            .map(|class_info| class_info.text.as_str()),
+            .map(|class_info| class_info.text.as_ref()),
     );
 
     // Add the first class back if it was ignored.

--- a/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_numeric_literals.rs
@@ -114,7 +114,7 @@ impl Rule for UseNumericLiterals {
 
 pub struct CallInfo {
     callee: &'static str,
-    text: String,
+    text: Box<str>,
     radix: Radix,
 }
 
@@ -132,7 +132,7 @@ impl CallInfo {
             .as_any_js_expression()?
             .as_static_value()?
             .as_string_constant()?
-            .to_string();
+            .into();
         let radix = radix
             .as_any_js_expression()?
             .as_any_js_literal_expression()?

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_class_members.rs
@@ -166,7 +166,7 @@ impl AnyClassMemberDefinition {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct MemberState {
-    name: String,
+    name: Box<str>,
     is_static: bool,
 }
 
@@ -186,7 +186,7 @@ impl Rule for NoDuplicateClassMembers {
                 let member = AnyClassMemberDefinition::cast(member.into_syntax())?;
                 let member_name_node = member.name()?;
                 let member_state = MemberState {
-                    name: get_member_name(&member_name_node)?.to_string(),
+                    name: get_member_name(&member_name_node)?.text().into(),
                     is_static: is_static_member(member.modifiers_list()),
                 };
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_prototype_builtins.rs
@@ -67,7 +67,7 @@ declare_lint_rule! {
 }
 
 pub struct RuleState {
-    prototype_builtins_method_name: String,
+    prototype_builtins_method_name: Box<str>,
     text_range: TextRange,
     has_call_fn: bool,
 }
@@ -87,7 +87,7 @@ impl Rule for NoPrototypeBuiltins {
 
         if is_prototype_builtins(member_name_text) {
             return Some(RuleState {
-                prototype_builtins_method_name: member_name_text.to_string(),
+                prototype_builtins_method_name: member_name_text.into(),
                 text_range: member_name.range(),
                 has_call_fn: false,
             });
@@ -104,7 +104,7 @@ impl Rule for NoPrototypeBuiltins {
                 && is_global_object(ctx.model())
             {
                 return Some(RuleState {
-                    prototype_builtins_method_name: obj_name_text.to_string(),
+                    prototype_builtins_method_name: obj_name_text.into(),
                     text_range: call_expr.range(),
                     has_call_fn: true,
                 });
@@ -123,7 +123,7 @@ impl Rule for NoPrototypeBuiltins {
             },
         );
 
-        if state.prototype_builtins_method_name == "hasOwnProperty" {
+        if state.prototype_builtins_method_name.as_ref() == "hasOwnProperty" {
             Some(
                 diag.note(markup! {
                     "It's recommended using "<Emphasis>"Object.hasOwn()"</Emphasis>" instead of using "<Emphasis>"Object.hasOwnProperty()"</Emphasis>"."
@@ -140,7 +140,7 @@ impl Rule for NoPrototypeBuiltins {
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let node = ctx.query();
 
-        if node.is_optional() || state.prototype_builtins_method_name != "hasOwnProperty" {
+        if node.is_optional() || state.prototype_builtins_method_name.as_ref() != "hasOwnProperty" {
             return None;
         }
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_shadow_restricted_names.rs
@@ -46,7 +46,7 @@ declare_lint_rule! {
 }
 
 pub struct State {
-    shadowed_name: String,
+    shadowed_name: Box<str>,
 }
 
 impl Rule for NoShadowRestrictedNames {
@@ -62,7 +62,7 @@ impl Rule for NoShadowRestrictedNames {
 
         if ES_BUILTIN.contains(&name) {
             Some(State {
-                shadowed_name: name.to_string(),
+                shadowed_name: name.into(),
             })
         } else {
             None

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -187,7 +187,7 @@ pub(crate) fn is_react_hook_call(call: &JsCallExpression) -> bool {
 /// of all function that are considered hooks. See [ReactHookConfiguration].
 pub(crate) fn react_hook_with_dependency(
     call: &JsCallExpression,
-    hooks: &FxHashMap<String, ReactHookConfiguration>,
+    hooks: &FxHashMap<Box<str>, ReactHookConfiguration>,
     model: &SemanticModel,
 ) -> Option<ReactCallWithDependencyResult> {
     let expression = call.callee().ok()?.omit_parentheses();
@@ -227,7 +227,7 @@ pub(crate) fn react_hook_with_dependency(
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StableReactHookConfiguration {
     /// Name of the React hook
-    pub(crate) hook_name: String,
+    pub(crate) hook_name: Box<str>,
 
     /// The kind of (stable) result returned by the hook.
     pub(crate) result: StableHookResult,
@@ -456,7 +456,7 @@ pub fn is_binding_react_stable(
     };
     let function_name = function_name.text_trimmed();
     stable_config.iter().any(|config| {
-        if !config.builtin && config.hook_name.as_str() != function_name {
+        if !config.builtin && config.hook_name.as_ref() != function_name {
             return false;
         }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Essentially follow up to https://github.com/biomejs/biome/pull/4211. I have limited understanding of memory in Rust so correct me if I am wrong:

- Replace usages of `String` with `Box<str>`, because its immutable, 24b vs 16b.
- Replace some usages of `to_string().into_boxed_str()` with `Box::from(str)` to avoid additional temporary allocation into heap.
- Replace some usages of `text_trimmed().to_string()` with `text_trimmed().into_text()` to prevent allocating new string when possible.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Existing tests should pass