### PR TITLE
fix(cli): support nested `files` property in ESLint flat config

### DIFF
--- a/.changeset/heavy-heads-slide.md
+++ b/.changeset/heavy-heads-slide.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5900](https://github.com/biomejs/biome/issues/5900): `biome migrate eslint` now support a nested `files` property in ESLint flat configs.

--- a/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_to_biome.rs
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn flat_config_single_config_object() {
         let flat_config = FlatConfigData(vec![FlatConfigObject {
-            files: vec!["*.js".into()],
+            files: vec!["*.js".into()].into(),
             ignores: vec!["*.test.js".into()],
             language_options: None,
             rules: Some(Rules(
@@ -414,13 +414,13 @@ mod tests {
     fn flat_config_multiple_config_object() {
         let flat_config = FlatConfigData(vec![
             FlatConfigObject {
-                files: vec![],
+                files: vec![].into(),
                 ignores: vec!["*.test.js".into()],
                 language_options: None,
                 rules: None,
             },
             FlatConfigObject {
-                files: vec![],
+                files: vec![].into(),
                 ignores: vec![],
                 language_options: None,
                 rules: Some(Rules(
@@ -430,13 +430,13 @@ mod tests {
                 )),
             },
             FlatConfigObject {
-                files: vec![],
+                files: vec![].into(),
                 ignores: vec!["*.spec.js".into()],
                 language_options: None,
                 rules: None,
             },
             FlatConfigObject {
-                files: vec!["*.ts".into()],
+                files: vec!["*.ts".into()].into(),
                 ignores: vec![],
                 language_options: None,
                 rules: Some(Rules(


### PR DESCRIPTION
## Summary

Fixes #5900 

Added support for nested `files` property in ESLint flat configurations, such as:

```jsonc
{
  "files": [
    ["**/*.ts", "**/*.tsx"],
    ["**/*.js", "**/*.jsx"],
  ],
}
```

Note that the deserialized value is flattened.

## Test Plan

Existing tests should pass. Manually tested that the reproduction in #5900 no longer emit diagnostics.
