### PR TITLE
feat(yaml): parse plain node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,11 +1476,14 @@ dependencies = [
  "biome_diagnostics",
  "biome_parser",
  "biome_rowan",
+ "biome_test_utils",
  "biome_unicode_table",
  "biome_yaml_factory",
  "biome_yaml_syntax",
+ "insta",
  "quickcheck",
  "quickcheck_macros",
+ "tests_macros",
  "tracing",
 ]
 

--- a/crates/biome_yaml_parser/Cargo.toml
+++ b/crates/biome_yaml_parser/Cargo.toml
@@ -25,5 +25,8 @@ tracing             = { workspace = true }
 
 
 [dev-dependencies]
+biome_test_utils  = { workspace = true }
+insta             = { workspace = true }
 quickcheck        = { workspace = true }
 quickcheck_macros = { workspace = true }
+tests_macros      = { workspace = true }

--- a/crates/biome_yaml_parser/src/parser/block.rs
+++ b/crates/biome_yaml_parser/src/parser/block.rs
@@ -3,6 +3,7 @@ use biome_yaml_syntax::YamlSyntaxKind::*;
 
 use super::YamlParser;
 
+#[expect(dead_code)]
 pub(crate) fn parse_any_block(p: &mut YamlParser) -> CompletedMarker {
     parse_literal_scalar(p)
 }

--- a/crates/biome_yaml_parser/src/parser/document.rs
+++ b/crates/biome_yaml_parser/src/parser/document.rs
@@ -1,11 +1,18 @@
 use biome_parser::{
     CompletedMarker, Parser,
     parse_lists::ParseNodeList,
+    parse_recovery::{ParseRecoveryTokenSet, RecoveryResult},
     prelude::ParsedSyntax::{self, *},
+    token_set,
 };
-use biome_yaml_syntax::YamlSyntaxKind::{self, *};
+use biome_yaml_syntax::{
+    T,
+    YamlSyntaxKind::{self, *},
+};
 
-use super::{YamlParser, block::parse_any_block};
+use crate::lexer::YamlLexContext;
+
+use super::{YamlParser, flow::parse_any_flow_node, parse_error::expected_directive};
 
 #[derive(Default)]
 pub(crate) struct DocumentList;
@@ -28,16 +35,56 @@ impl ParseNodeList for DocumentList {
         &mut self,
         _p: &mut Self::Parser<'_>,
         parsed_element: ParsedSyntax,
-    ) -> biome_parser::parse_recovery::RecoveryResult {
+    ) -> RecoveryResult {
         Ok(parsed_element.expect("A document can not be absent"))
     }
 }
 
 fn parse_document(p: &mut YamlParser) -> CompletedMarker {
+    let m = p.start();
     p.eat(UNICODE_BOM);
-    parse_any_node(p)
+    DirectiveList.parse_list(p);
+    parse_any_flow_node(p, YamlLexContext::FlowOut);
+    m.complete(p, YAML_DOCUMENT)
 }
 
-fn parse_any_node(p: &mut YamlParser) -> CompletedMarker {
-    parse_any_block(p)
+#[derive(Default)]
+pub(crate) struct DirectiveList;
+
+impl ParseNodeList for DirectiveList {
+    type Kind = YamlSyntaxKind;
+    type Parser<'source> = YamlParser<'source>;
+
+    const LIST_KIND: Self::Kind = YAML_DIRECTIVE_LIST;
+
+    fn parse_element(&mut self, p: &mut Self::Parser<'_>) -> ParsedSyntax {
+        parse_directive(p)
+    }
+
+    fn is_at_list_end(&self, p: &mut Self::Parser<'_>) -> bool {
+        p.at(T![...])
+            // Consecutive directives are rare, so it's better to just fail fast here
+            || !p.at(DIRECTIVE_LITERAL)
+    }
+
+    fn recover(
+        &mut self,
+        p: &mut Self::Parser<'_>,
+        parsed_element: ParsedSyntax,
+    ) -> RecoveryResult {
+        parsed_element.or_recover_with_token_set(
+            p,
+            &ParseRecoveryTokenSet::new(YAML_BOGUS, token_set![DIRECTIVE_LITERAL]),
+            expected_directive,
+        )
+    }
+}
+
+fn parse_directive(p: &mut YamlParser) -> ParsedSyntax {
+    if !p.at(DIRECTIVE_LITERAL) {
+        return Absent;
+    }
+    let m = p.start();
+    p.bump(DIRECTIVE_LITERAL);
+    Present(m.complete(p, YAML_DIRECTIVE))
 }

--- a/crates/biome_yaml_parser/src/parser/flow.rs
+++ b/crates/biome_yaml_parser/src/parser/flow.rs
@@ -1,0 +1,39 @@
+use biome_parser::{CompletedMarker, Parser};
+use biome_yaml_syntax::YamlSyntaxKind::*;
+
+use crate::lexer::YamlLexContext;
+
+use super::YamlParser;
+
+pub(crate) fn parse_any_flow_node(p: &mut YamlParser, context: YamlLexContext) -> CompletedMarker {
+    parse_flow_yaml_node(p, context)
+}
+
+// TODO: parse node properties
+pub(crate) fn parse_flow_yaml_node(p: &mut YamlParser, context: YamlLexContext) -> CompletedMarker {
+    let m = p.start();
+    parse_plain_scalar(p, context);
+    m.complete(p, YAML_FLOW_YAML_NODE)
+}
+
+fn parse_plain_scalar(p: &mut YamlParser, context: YamlLexContext) -> CompletedMarker {
+    // The current plain token was lexed during the last `bump` or `bump_with_context` call, which
+    // might have used a different context than the current one
+    p.re_lex(context);
+    let m = p.start();
+    p.bump(PLAIN_LITERAL);
+    m.complete(p, YAML_PLAIN_SCALAR)
+}
+
+#[expect(dead_code)]
+pub(crate) fn is_at_any_flow_node(p: &YamlParser) -> bool {
+    is_at_flow_yaml_node(p)
+}
+
+pub(crate) fn is_at_flow_yaml_node(p: &YamlParser) -> bool {
+    is_at_plain_scalar(p)
+}
+
+fn is_at_plain_scalar(p: &YamlParser) -> bool {
+    p.at(PLAIN_LITERAL)
+}

--- a/crates/biome_yaml_parser/src/parser/mod.rs
+++ b/crates/biome_yaml_parser/src/parser/mod.rs
@@ -15,6 +15,8 @@ use crate::{
 
 mod block;
 mod document;
+mod flow;
+mod parse_error;
 
 pub(crate) struct YamlParser<'source> {
     context: ParserContext<YamlSyntaxKind>,
@@ -31,7 +33,6 @@ impl<'source> YamlParser<'source> {
 
     /// Re-lexes the current token in the specified context. Returns the kind
     /// of the re-lexed token
-    #[expect(dead_code)]
     pub fn re_lex(&mut self, context: YamlLexContext) -> YamlSyntaxKind {
         self.source_mut().re_lex(context)
     }

--- a/crates/biome_yaml_parser/src/parser/parse_error.rs
+++ b/crates/biome_yaml_parser/src/parser/parse_error.rs
@@ -1,0 +1,7 @@
+use crate::parser::YamlParser;
+use biome_parser::diagnostic::{ParseDiagnostic, expected_node};
+use biome_rowan::TextRange;
+
+pub(crate) fn expected_directive(p: &YamlParser, range: TextRange) -> ParseDiagnostic {
+    expected_node("directive", range, p)
+}

--- a/crates/biome_yaml_parser/tests/spec_test.rs
+++ b/crates/biome_yaml_parser/tests/spec_test.rs
@@ -1,0 +1,124 @@
+use biome_console::fmt::{Formatter, Termcolor};
+use biome_console::markup;
+use biome_diagnostics::DiagnosticExt;
+use biome_diagnostics::display::PrintDiagnostic;
+use biome_diagnostics::termcolor;
+use biome_rowan::SyntaxKind;
+use biome_test_utils::validate_eof_token;
+use biome_yaml_parser::parse_yaml;
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+
+#[derive(Copy, Clone)]
+pub enum ExpectedOutcome {
+    Pass,
+    Fail,
+}
+
+pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_str: &str) {
+    let outcome = match outcome_str {
+        "ok" => ExpectedOutcome::Pass,
+        "error" => ExpectedOutcome::Fail,
+        _ => panic!("Invalid expected outcome {outcome_str}"),
+    };
+
+    let test_case_path = Path::new(test_case);
+
+    let file_name = test_case_path
+        .file_name()
+        .expect("Expected test to have a file name")
+        .to_str()
+        .expect("File name to be valid UTF8");
+
+    let content = fs::read_to_string(test_case_path)
+        .expect("Expected test path to be a readable file in UTF8 encoding");
+
+    let parsed = parse_yaml(&content);
+    validate_eof_token(parsed.syntax());
+    println!("Raw tree {:#?}", parsed.syntax());
+
+    let formatted_ast = format!("{:#?}", parsed.tree());
+
+    let mut snapshot = String::new();
+    writeln!(snapshot, "## Input\n```yaml\n{content}\n```\n").unwrap();
+
+    writeln!(
+        snapshot,
+        r#"## AST
+
+```
+{formatted_ast}
+```
+
+## CST
+
+```
+{:#?}
+```
+"#,
+        parsed.syntax()
+    )
+    .unwrap();
+
+    let diagnostics = parsed.diagnostics();
+    if !diagnostics.is_empty() {
+        let mut diagnostics_buffer = termcolor::Buffer::no_color();
+
+        let termcolor = &mut Termcolor(&mut diagnostics_buffer);
+        let mut formatter = Formatter::new(termcolor);
+
+        for diagnostic in diagnostics {
+            let error = diagnostic
+                .clone()
+                .with_file_path(file_name)
+                .with_file_source_code(&content);
+
+            formatter
+                .write_markup(markup! { { PrintDiagnostic::verbose(&error) } })
+                .expect("failed to emit diagnostic");
+        }
+
+        let formatted_diagnostics =
+            std::str::from_utf8(diagnostics_buffer.as_slice()).expect("non utf8 in error buffer");
+
+        if matches!(outcome, ExpectedOutcome::Pass) {
+            panic!(
+                "Expected no errors to be present in a test case that is expected to pass but the following diagnostics are present:\n{formatted_diagnostics}"
+            )
+        }
+
+        writeln!(snapshot, "## Diagnostics\n\n```").unwrap();
+        snapshot.write_str(formatted_diagnostics).unwrap();
+
+        writeln!(snapshot, "```\n").unwrap();
+    }
+
+    match outcome {
+        ExpectedOutcome::Pass => {
+            let missing_required = formatted_ast.contains("missing (required)");
+            if missing_required
+                || parsed
+                    .syntax()
+                    .descendants()
+                    .any(|node| node.kind().is_bogus())
+            {
+                panic!(
+                    "Parsed tree of a 'OK' test case should not contain any missing required children or bogus nodes:\n{formatted_ast}"
+                );
+            }
+        }
+        ExpectedOutcome::Fail => {
+            if parsed.diagnostics().is_empty() {
+                panic!("Failing test must have diagnostics");
+            }
+        }
+    }
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        snapshot_path => &test_directory,
+    }, {
+        insta::assert_snapshot!(file_name, snapshot);
+    });
+}

--- a/crates/biome_yaml_parser/tests/spec_tests.rs
+++ b/crates/biome_yaml_parser/tests/spec_tests.rs
@@ -1,0 +1,11 @@
+mod spec_test;
+
+mod ok {
+    //! Tests that are valid YAML
+    tests_macros::gen_tests! {"tests/yaml_test_suite/ok/**/*.yaml", crate::spec_test::run, "ok"}
+}
+
+mod err {
+    //! Tests that must fail because they are not valid YAML
+    tests_macros::gen_tests! {"tests/yaml_test_suite/err/**/*.yaml", crate::spec_test::run, "error"}
+}

--- a/crates/biome_yaml_parser/tests/yaml_test_suite/ok/flow/simple_plain.yaml
+++ b/crates/biome_yaml_parser/tests/yaml_test_suite/ok/flow/simple_plain.yaml
@@ -1,0 +1,1 @@
+simple_plain

--- a/crates/biome_yaml_parser/tests/yaml_test_suite/ok/flow/simple_plain.yaml.snap
+++ b/crates/biome_yaml_parser/tests/yaml_test_suite/ok/flow/simple_plain.yaml.snap
@@ -1,0 +1,49 @@
+---
+source: crates/biome_yaml_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+```yaml
+simple_plain
+
+```
+
+## AST
+
+```
+YamlRoot {
+    documents: YamlDocumentList [
+        YamlDocument {
+            bom_token: missing (optional),
+            directives: YamlDirectiveList [],
+            dashdashdash_token: missing (optional),
+            node: YamlFlowYamlNode {
+                properties: missing (optional),
+                content: YamlPlainScalar {
+                    value_token: PLAIN_LITERAL@0..12 "simple_plain" [] [],
+                },
+            },
+            dotdotdot_token: missing (optional),
+        },
+    ],
+    eof_token: EOF@12..13 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: YAML_ROOT@0..13
+  0: YAML_DOCUMENT_LIST@0..12
+    0: YAML_DOCUMENT@0..12
+      0: (empty)
+      1: YAML_DIRECTIVE_LIST@0..0
+      2: (empty)
+      3: YAML_FLOW_YAML_NODE@0..12
+        0: (empty)
+        1: YAML_PLAIN_SCALAR@0..12
+          0: PLAIN_LITERAL@0..12 "simple_plain" [] []
+      4: (empty)
+  1: EOF@12..13 "" [Newline("\n")] []
+
+```


### PR DESCRIPTION
## Summary

Allows the parser to parse a document containing a single plain node

## Test Plan

Added a new test document with contains a single plain node