### PR TITLE
fix(watcher): fix failing watcher tests on macOS

### DIFF
--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3206,6 +3206,10 @@ export function bar() {
         "This import is part of a cycle."
     );
 
+    // On macOS, wait until the fsevents watcher sets up before receiving the first event.
+    #[cfg(target_os = "macos")]
+    std::thread::sleep(Duration::from_secs(1));
+
     clear_notifications!(factory.service_data_rx);
 
     // ARRANGE: Remove `bar.ts`.
@@ -3419,7 +3423,9 @@ export function bar() {
         "This import is part of a cycle."
     );
 
-    #[cfg(target_os = "windows")]
+    // On Windows, wait until the event has been delivered.
+    // On macOS, wait until the fsevents watcher sets up before receiving the first event.
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     std::thread::sleep(Duration::from_secs(1));
 
     clear_notifications!(factory.service_data_rx);
@@ -3459,6 +3465,7 @@ export function bar() {
     //         longer there.
     assert_eq!(result.diagnostics.len(), 0);
 
+    // On Windows, wait until the event has been delivered.
     #[cfg(target_os = "windows")]
     std::thread::sleep(Duration::from_secs(1));
 

--- a/crates/biome_service/src/workspace_watcher.rs
+++ b/crates/biome_service/src/workspace_watcher.rs
@@ -139,11 +139,6 @@ impl WorkspaceWatcher {
                                 _ => workspace.open_paths_through_watcher(event.paths),
                             },
                             EventKind::Modify(modify_kind) => match modify_kind {
-                                // `ModifyKind::Any` needs to be included as a catch-all.
-                                // Without it, we'll miss events on Windows.
-                                ModifyKind::Data(_) | ModifyKind::Any => {
-                                    workspace.open_paths_through_watcher(event.paths)
-                                },
                                 ModifyKind::Name(RenameMode::From) => {
                                     workspace.close_paths_through_watcher(event.paths)
                                 }
@@ -155,6 +150,11 @@ impl WorkspaceWatcher {
                                         &event.paths[0],
                                         &event.paths[1]
                                     )
+                                },
+                                // `RenameMode::Any` and `ModifyKind::Any` need to be included as a catch-all.
+                                // Without it, we'll miss events on Windows or macOS.
+                                ModifyKind::Data(_) | ModifyKind::Name(RenameMode::Any) | ModifyKind::Any => {
+                                    workspace.open_paths_through_watcher(event.paths)
                                 },
                                 _ => Ok(()),
                             },


### PR DESCRIPTION
## Summary

Fixed failing watcher tests on macOS, broken since f535ccfde5da7d64cec28612cb2a2fc1dd2ceb7d.

## Test Plan

macOS CI should back to green.

Test Run: https://github.com/siketyan/biome/actions/runs/14854226578/job/41703612260
