### PR TITLE
perf(core): reusable scoped resolver

### DIFF
--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -8,7 +8,7 @@ use biome_rowan::Text;
 
 use crate::{
     Class, GenericTypeParameter, MethodTypeMember, PropertyTypeMember, Resolvable, ResolvedTypeId,
-    TypeData, TypeId, TypeMember, TypeReference, TypeReferenceQualifier, TypeResolver,
+    ScopeId, TypeData, TypeId, TypeMember, TypeReference, TypeReferenceQualifier, TypeResolver,
     TypeResolverLevel,
 };
 
@@ -217,7 +217,7 @@ impl TypeResolver for GlobalsResolver {
         }
     }
 
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId> {
+    fn resolve_type_of(&self, identifier: &Text, _scope_id: ScopeId) -> Option<ResolvedTypeId> {
         match identifier.text() {
             "globalThis" | "window" => Some(GLOBAL_GLOBAL_ID),
             _ => None,

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -220,6 +220,7 @@ impl TypeData {
         Self::instance_of(TypeReference::Qualifier(TypeReferenceQualifier {
             path: [Text::Static("Array")].into(),
             type_parameters: [ty].into(),
+            scope_id: None,
         }))
     }
 
@@ -951,6 +952,7 @@ impl TypeData {
         Self::instance_of(TypeReference::Qualifier(TypeReferenceQualifier {
             path: Box::new([Text::Static("Promise")]),
             type_parameters: Box::new([ty]),
+            scope_id: None,
         }))
     }
 
@@ -1455,6 +1457,7 @@ impl TypeMember {
                             TypeofValue {
                                 identifier: name,
                                 ty: TypeReference::Unknown,
+                                scope_id: None,
                             },
                         ))),
                         is_optional: false,
@@ -1600,6 +1603,7 @@ impl TypeReferenceQualifier {
                 Some(Self {
                     path: identifiers.into(),
                     type_parameters: [].into(),
+                    scope_id: None,
                 })
             }
         }
@@ -1609,6 +1613,7 @@ impl TypeReferenceQualifier {
         Self {
             path: Box::new([name]),
             type_parameters: [].into(),
+            scope_id: None,
         }
     }
 

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -3,9 +3,10 @@ use std::fmt::Debug;
 use biome_rowan::Text;
 
 use crate::{
-    Class, DestructureField, Function, GenericTypeParameter, TypeData, TypeId, TypeImportQualifier,
-    TypeInstance, TypeMember, TypeReference, TypeReferenceQualifier, TypeofDestructureExpression,
-    TypeofExpression, TypeofValue, Union, globals::GLOBAL_UNDEFINED_ID,
+    Class, DestructureField, Function, GenericTypeParameter, ScopeId, TypeData, TypeId,
+    TypeImportQualifier, TypeInstance, TypeMember, TypeReference, TypeReferenceQualifier,
+    TypeofDestructureExpression, TypeofExpression, TypeofValue, Union,
+    globals::GLOBAL_UNDEFINED_ID,
 };
 
 const NUM_MODULE_ID_BITS: i32 = 30;
@@ -24,7 +25,7 @@ impl Debug for ResolvedTypeId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let id = self.1;
         match self.level() {
-            TypeResolverLevel::AdHoc => f.write_fmt(format_args!("AdHoc {id:?}")),
+            TypeResolverLevel::Scope => f.write_fmt(format_args!("AdHoc {id:?}")),
             TypeResolverLevel::Module => f.write_fmt(format_args!(
                 "Module({:?}) {id:?}",
                 self.module_id().index()
@@ -101,9 +102,9 @@ impl ModuleId {
 /// another resolver that may be able to handle the level.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TypeResolverLevel {
-    /// Used for ad-hoc inference that is not cached except in the ad-hoc
-    /// resolver itself (which is discarded after use).
-    AdHoc,
+    /// Used for ad-hoc inference that is not cached except in the scope
+    /// resolver (which is discarded after use).
+    Scope,
 
     /// Used for resolving types that exist within the same module as from which
     /// the resolution took place.
@@ -144,7 +145,7 @@ impl TypeResolverLevel {
     ///       constraint ;)
     pub const fn from_u2(bits: u32) -> Self {
         match bits {
-            0 => Self::AdHoc,
+            0 => Self::Scope,
             1 => Self::Module,
             2 => Self::Import,
             3 => Self::Global,
@@ -281,8 +282,8 @@ pub trait TypeResolver {
     /// Resolves a type by its reference `qualifier`.
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId>;
 
-    /// Resolves the type of a value by its `identifier`.
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId>;
+    /// Resolves the type of a value by its `identifier` in a specific scope.
+    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId>;
 
     // #region Utilities for test inspection
 
@@ -452,6 +453,12 @@ pub trait Resolvable: Sized {
     ///
     /// Does not perform any resolving in the process.
     fn with_module_id(self, module_id: ModuleId) -> Self;
+
+    /// Returns the instance with all scoped references augmented with the
+    /// given `scope_id`.
+    ///
+    /// Does not perform any resolving in the process.
+    fn with_scope_id(self, scope_id: ScopeId) -> Self;
 }
 
 impl Resolvable for TypeReference {
@@ -491,6 +498,7 @@ impl Resolvable for TypeReference {
                                 Self::Qualifier(TypeReferenceQualifier {
                                     path: qualifier.path.clone(),
                                     type_parameters: self.resolved_params(resolver),
+                                    scope_id: qualifier.scope_id,
                                 })
                             })
                     }
@@ -523,6 +531,13 @@ impl Resolvable for TypeReference {
             other => other,
         }
     }
+
+    fn with_scope_id(self, scope_id: ScopeId) -> Self {
+        match self {
+            Self::Qualifier(qualifier) => Self::Qualifier(qualifier.with_scope_id(scope_id)),
+            other => other,
+        }
+    }
 }
 
 impl Resolvable for TypeofValue {
@@ -530,13 +545,17 @@ impl Resolvable for TypeofValue {
         let identifier = self.identifier.clone();
         let ty = if self.ty == TypeReference::Unknown {
             resolver
-                .resolve_type_of(&identifier)
+                .resolve_type_of(&identifier, self.scope_id.unwrap_or(ScopeId::GLOBAL))
                 .map_or(TypeReference::Unknown, TypeReference::Resolved)
         } else {
             self.ty.resolved(resolver)
         };
 
-        Self { identifier, ty }
+        Self {
+            identifier,
+            ty,
+            scope_id: self.scope_id,
+        }
     }
 
     fn resolved_with_mapped_references(
@@ -544,18 +563,35 @@ impl Resolvable for TypeofValue {
         map: impl Copy + Fn(TypeReference, &mut dyn TypeResolver) -> TypeReference,
         resolver: &mut dyn TypeResolver,
     ) -> Self {
-        let Self { identifier, ty } = self.resolved(resolver);
+        let Self {
+            identifier,
+            ty,
+            scope_id,
+        } = self.resolved(resolver);
         Self {
             identifier,
             ty: map(ty, resolver),
+            scope_id,
         }
     }
 
     fn with_module_id(self, module_id: ModuleId) -> Self {
-        let Self { identifier, ty } = self;
+        let Self {
+            identifier,
+            ty,
+            scope_id,
+        } = self;
         Self {
             identifier,
             ty: ty.with_module_id(module_id),
+            scope_id,
+        }
+    }
+
+    fn with_scope_id(self, scope_id: ScopeId) -> Self {
+        Self {
+            scope_id: Some(scope_id),
+            ..self
         }
     }
 }
@@ -576,6 +612,10 @@ macro_rules! derive_primitive_resolved {
             }
 
             fn with_module_id(self, _module_id: ModuleId) -> Self {
+                self
+            }
+
+            fn with_scope_id(self, _scope_id: ScopeId) -> Self {
                 self
             }
         })+

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -8,7 +8,7 @@ use biome_js_syntax::{
     AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsFileSource, JsFunctionDeclaration,
 };
 use biome_js_type_info::{
-    GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeId, TypeData, TypeId,
+    GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeId, ScopeId, TypeData, TypeId,
     TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 use biome_rowan::{AstNode, Text};
@@ -147,7 +147,7 @@ impl TypeResolver for HardcodedSymbolResolver {
 
     fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
         match id.level() {
-            TypeResolverLevel::AdHoc => {
+            TypeResolverLevel::Scope => {
                 panic!("Ad-hoc references unsupported by resolver")
             }
             TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
@@ -188,8 +188,8 @@ impl TypeResolver for HardcodedSymbolResolver {
         }
     }
 
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId> {
-        self.globals.resolve_type_of(identifier)
+    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId> {
+        self.globals.resolve_type_of(identifier, scope_id)
     }
 
     fn fallback_resolver(&self) -> Option<&dyn TypeResolver> {

--- a/crates/biome_js_type_info_macros/src/resolvable_derive.rs
+++ b/crates/biome_js_type_info_macros/src/resolvable_derive.rs
@@ -131,6 +131,14 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
         None => quote! { Self::#ident => Self::#ident },
     });
 
+    let variants_with_scope_id = variants.iter().map(|VariantData { ident, ty }| match ty {
+        Some(ty) => {
+            let ty_with_scope_id = unit_type_with_scope_id(ty);
+            quote! { Self::#ident(ty) => Self::#ident(#ty_with_scope_id) }
+        }
+        None => quote! { Self::#ident => Self::#ident },
+    });
+
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
@@ -154,6 +162,12 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
                     #( #variants_with_module_id ),*
                 }
             }
+
+            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
+                match self {
+                    #( #variants_with_scope_id ),*
+                }
+            }
         }
     }
 }
@@ -172,6 +186,11 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
     let fields_with_module_id = fields.iter().map(|FieldData { ident, ty }| {
         let ty_with_module_id = type_with_module_id(IdentOrZero::Ident(ident), ty);
         quote! { #ident: #ty_with_module_id }
+    });
+
+    let fields_with_scope_id = fields.iter().map(|FieldData { ident, ty }| {
+        let ty_with_scope_id = type_with_scope_id(IdentOrZero::Ident(ident), ty);
+        quote! { #ident: #ty_with_scope_id }
     });
 
     quote! {
@@ -197,6 +216,12 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
                     #( #fields_with_module_id ),*
                 }
             }
+
+            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
+                Self {
+                    #( #fields_with_scope_id ),*
+                }
+            }
         }
     }
 }
@@ -208,6 +233,8 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
         resolved_type_with_mapped_references(IdentOrZero::Zero, &ty);
 
     let field_with_module_id = type_with_module_id(IdentOrZero::Zero, &ty);
+
+    let field_with_scope_id = type_with_scope_id(IdentOrZero::Zero, &ty);
 
     quote! {
         impl crate::Resolvable for #ident {
@@ -225,6 +252,10 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
 
             fn with_module_id(self, module_id: crate::ModuleId) -> Self {
                 Self(#field_with_module_id)
+            }
+
+            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
+                Self(#field_with_scope_id)
             }
         }
     }
@@ -609,6 +640,123 @@ fn unit_type_with_module_id(ty: &Type) -> TokenStream {
         },
         _ => {
             quote! { ty.with_module_id(module_id) }
+        }
+    }
+}
+
+fn type_with_scope_id(ident: IdentOrZero, ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { self.#ident }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => {
+                            quote! { self.#ident }
+                        }
+                        Type::Path(_) => quote! {
+                            self.#ident.into_iter().map(|elem| elem.with_scope_id(scope_id)).collect()
+                        },
+                        _ => abort!(slice, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident }
+                        } else {
+                            quote! {
+                                Box::new(self.#ident.with_scope_id(scope_id))
+                            }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { self.#ident }
+                        } else {
+                            quote! { self.#ident.map(|f| f.with_scope_id(scope_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { self.#ident.with_scope_id(scope_id) }
+        }
+    }
+}
+
+fn unit_type_with_scope_id(ty: &Type) -> TokenStream {
+    let Type::Path(path) = ty else {
+        abort!(ty, "Resolvable derive requires plain path types");
+    };
+
+    match path.path.segments.last() {
+        Some(segment) if segment.ident == "Text" => {
+            quote! { ty }
+        }
+        Some(segment) if segment.ident == "Box" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Box is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
+                        Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
+                        _ => abort!(args, "Unsupported arguments"),
+                    },
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty }
+                        } else {
+                            quote! { Box::new(ty.with_scope_id(scope_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        Some(segment) if segment.ident == "Option" => match &segment.arguments {
+            PathArguments::None => abort!(segment, "Option is missing argument"),
+            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                match args.args.iter().next().unwrap() {
+                    GenericArgument::Type(Type::Path(ty)) => {
+                        if ty.path.is_ident("Text") {
+                            quote! { ty }
+                        } else {
+                            quote! { ty.map(|f| f.with_scope_id(scope_id)) }
+                        }
+                    }
+                    _ => abort!(args, "Unsupported arguments"),
+                }
+            }
+            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
+                abort!(path, "Unsupported type arguments in path")
+            }
+        },
+        _ => {
+            quote! { ty.with_scope_id(scope_id) }
         }
     }
 }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -1,25 +1,24 @@
-mod ad_hoc_scope_resolver;
 mod binding;
 mod collector;
 mod scope;
+mod scoped_resolver;
 mod visitor;
 
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
-use biome_js_semantic::ScopeId;
-use biome_js_syntax::{AnyJsExpression, AnyJsImportLike};
+use biome_js_syntax::AnyJsImportLike;
 use biome_js_type_info::{
-    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ResolvedPath, ResolvedTypeId, Type, TypeData,
-    TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ResolvedPath, ResolvedTypeId, ScopeId,
+    TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
-use biome_rowan::{AstNode, Text, TextRange, TokenText};
+use biome_rowan::{Text, TextRange, TokenText};
 
 use crate::{ModuleGraph, jsdoc_comment::JsdocComment};
 
 use binding::{BindingId, JsBindingData};
 use scope::{JsScope, JsScopeData};
 
-pub use ad_hoc_scope_resolver::AdHocScopeResolver;
+pub use scoped_resolver::ScopedResolver;
 pub(crate) use visitor::JsModuleVisitor;
 
 /// Information restricted to a single module in the [ModuleGraph].
@@ -68,24 +67,15 @@ impl JsModuleInfo {
         }
     }
 
-    /// Returns the resolved type of the given expression within this module.
-    pub fn resolved_type_for_expression(
-        &self,
-        expr: &AnyJsExpression,
-        module_graph: Arc<ModuleGraph>,
-    ) -> Type {
-        let scope = self.scope_for_range(expr.range());
-        let mut resolver =
-            AdHocScopeResolver::from_scope_in_module(scope, self.clone(), module_graph);
-        let ty = TypeData::from_any_js_expression(&mut resolver, expr);
-        resolver.run_inference();
-
-        let ty = ty.inferred(&mut resolver);
-        Type::from_data(Box::new(resolver), ty)
-    }
-
     /// Returns the scope to be used for the given `range`.
     pub fn scope_for_range(&self, range: TextRange) -> JsScope {
+        JsScope {
+            info: self.0.clone(),
+            id: self.scope_id_for_range(range),
+        }
+    }
+
+    pub fn scope_id_for_range(&self, range: TextRange) -> ScopeId {
         let start = range.start().into();
         let end = range.end().into();
         self.0
@@ -93,13 +83,9 @@ impl JsModuleInfo {
             .find(start, end)
             .filter(|interval| !(start < interval.start || end > interval.stop))
             .max_by_key(|interval| interval.val)
-            .map_or_else(
-                || self.global_scope(),
-                |interval| JsScope {
-                    info: self.0.clone(),
-                    id: ScopeId::new(interval.val.index()),
-                },
-            )
+            .map_or(ScopeId::GLOBAL, |interval| {
+                ScopeId::new(interval.val.index())
+            })
     }
 }
 
@@ -232,7 +218,7 @@ impl TypeResolver for JsModuleInfoInner {
         match id.level() {
             TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
             TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
-            TypeResolverLevel::AdHoc | TypeResolverLevel::Import => None,
+            TypeResolverLevel::Scope | TypeResolverLevel::Import => None,
         }
     }
 
@@ -251,21 +237,24 @@ impl TypeResolver for JsModuleInfoInner {
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
         if qualifier.path.len() == 1 {
-            self.resolve_type_of(&qualifier.path[0])
-                .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
+            self.resolve_type_of(
+                &qualifier.path[0],
+                qualifier.scope_id.unwrap_or(ScopeId::GLOBAL),
+            )
+            .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
         } else {
             // TODO: Resolve nested qualifiers
             None
         }
     }
 
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId> {
+    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId> {
         if let Some(export) = self.exports.get(identifier) {
             export
                 .as_own_export()
                 .and_then(|own_export| self.resolve_reference(&own_export.ty))
         } else {
-            GLOBAL_RESOLVER.resolve_type_of(identifier)
+            GLOBAL_RESOLVER.resolve_type_of(identifier, scope_id)
         }
     }
 

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use biome_js_semantic::ScopeId;
 use biome_js_syntax::{AnyJsDeclaration, JsImport, JsSyntaxNode, JsVariableKind, TextRange};
-use biome_js_type_info::{TypeId, TypeReference};
+use biome_js_type_info::{ScopeId, TypeId, TypeReference};
 use biome_rowan::{AstNode, Text, TextSize};
 
 use crate::jsdoc_comment::JsdocComment;

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -3,15 +3,15 @@ use std::{
     sync::Arc,
 };
 
-use biome_js_semantic::{ScopeId, SemanticEvent, SemanticEventExtractor};
+use biome_js_semantic::{SemanticEvent, SemanticEventExtractor};
 use biome_js_syntax::{
     AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsExportDefaultDeclaration, AnyJsImportClause,
     JsFormalParameter, JsIdentifierBinding, JsSyntaxKind, JsSyntaxNode, JsSyntaxToken,
     TsIdentifierBinding, inner_string_text,
 };
 use biome_js_type_info::{
-    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeId, TypeData,
-    TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolver,
+    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeId, ScopeId,
+    TypeData, TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolver,
     TypeResolverLevel,
 };
 use biome_rowan::{AstNode, Text, TextSize, TokenText};
@@ -173,7 +173,7 @@ impl JsModuleInfoCollector {
 
                 self.scopes.push(JsScopeData {
                     range,
-                    parent: parent_scope_id,
+                    parent: parent_scope_id.map(|id| ScopeId::new(id.index())),
                     children: Vec::new(),
                     bindings: Vec::new(),
                     bindings_by_name: FxHashMap::default(),
@@ -440,7 +440,7 @@ impl TypeResolver for JsModuleInfoCollector {
         match id.level() {
             TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
             TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
-            TypeResolverLevel::AdHoc | TypeResolverLevel::Import => None,
+            TypeResolverLevel::Scope | TypeResolverLevel::Import => None,
         }
     }
 
@@ -468,15 +468,18 @@ impl TypeResolver for JsModuleInfoCollector {
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
         if qualifier.path.len() == 1 {
-            self.resolve_type_of(&qualifier.path[0])
-                .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
+            self.resolve_type_of(
+                &qualifier.path[0],
+                qualifier.scope_id.unwrap_or(ScopeId::GLOBAL),
+            )
+            .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
         } else {
             // TODO: Resolve nested qualifiers
             None
         }
     }
 
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId> {
+    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId> {
         // We only care about the global scope, since that's where all exported
         // symbols reside.
         if let Some(binding_id) = self.scopes[0].bindings_by_name.get(identifier.text()) {
@@ -491,7 +494,7 @@ impl TypeResolver for JsModuleInfoCollector {
             };
         }
 
-        GLOBAL_RESOLVER.resolve_type_of(identifier)
+        GLOBAL_RESOLVER.resolve_type_of(identifier, scope_id)
     }
 
     fn fallback_resolver(&self) -> Option<&dyn TypeResolver> {

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -1,7 +1,7 @@
 use std::{collections::VecDeque, iter::FusedIterator, sync::Arc};
 
-use biome_js_semantic::ScopeId;
 use biome_js_syntax::TextRange;
+use biome_js_type_info::ScopeId;
 use biome_rowan::TokenText;
 use rustc_hash::FxHashMap;
 
@@ -46,13 +46,13 @@ impl JsScope {
     }
 
     /// Returns all parents of this scope. Starting with the current
-    /// [Scope].
+    /// [JsScope].
     pub fn ancestors(&self) -> impl Iterator<Item = Self> + use<> {
         std::iter::successors(Some(self.clone()), |scope| scope.parent())
     }
 
-    /// Returns all descendents of this scope in breadth-first order. Starting with the current
-    /// [Scope].
+    /// Returns all descendents of this scope in breadth-first order. Starting
+    /// with the current [JsScope].
     pub fn descendents(&self) -> impl Iterator<Item = Self> + use<> {
         let mut q = VecDeque::new();
         q.push_back(self.id);
@@ -65,8 +65,6 @@ impl JsScope {
 
     /// Returns this scope parent.
     pub fn parent(&self) -> Option<Self> {
-        // id will always be a valid scope because
-        // it was created by [SemanticModel::scope] method.
         debug_assert!((self.id.index()) < self.info.scopes.len());
 
         let parent = self.info.scopes[self.id.index()].parent?;
@@ -76,8 +74,9 @@ impl JsScope {
         })
     }
 
-    /// Returns all bindings that were bound in this scope. It **does
-    /// not** returns bindings of parent scopes.
+    /// Returns all bindings that were bound in this scope.
+    ///
+    /// It **does not** return bindings of parent scopes.
     pub fn bindings(&self) -> ScopeBindingsIter {
         ScopeBindingsIter {
             info: self.info.clone(),
@@ -86,8 +85,9 @@ impl JsScope {
         }
     }
 
-    /// Returns a binding by its name, like it appears on code.  It **does
-    /// not** returns bindings of parent scopes.
+    /// Returns a binding by its name, like it appears on code.
+    ///
+    /// It **does not** return bindings of parent scopes.
     pub fn get_binding(&self, name: impl AsRef<str>) -> Option<JsBinding> {
         let data = &self.info.scopes[self.id.index()];
 
@@ -100,9 +100,10 @@ impl JsScope {
         })
     }
 
-    /// Checks if the current scope is one of the ancestor of "other". Given
-    /// that [Scope::ancestors] return "self" as the first scope,
-    /// this function returns true for:
+    /// Checks if the current scope is an ancestor of `other`.
+    ///
+    /// Given that [Self::ancestors()] returns `self` as the first scope,
+    /// the following snippet always returns `true`:
     ///
     /// ```rust,ignore
     /// assert!(scope.is_ancestor_of(scope));
@@ -116,7 +117,8 @@ impl JsScope {
     }
 }
 
-/// Iterate all descendents scopes of the specified scope in breadth-first order.
+/// Iterates all descendent scopes of the specified scope in breadth-first
+/// order.
 pub struct ScopeDescendentsIter {
     info: Arc<JsModuleInfoInner>,
     q: VecDeque<ScopeId>,
@@ -141,8 +143,9 @@ impl Iterator for ScopeDescendentsIter {
 
 impl FusedIterator for ScopeDescendentsIter {}
 
-/// Iterate all bindings that were bound in a given scope. It **does
-/// not** Returns bindings of parent scopes.
+/// Iterates all bindings that were bound in a given scope.
+///
+/// It **does not** return bindings of parent scopes.
 #[derive(Debug)]
 pub struct ScopeBindingsIter {
     info: Arc<JsModuleInfoInner>,
@@ -154,8 +157,6 @@ impl Iterator for ScopeBindingsIter {
     type Item = JsBinding;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // scope_id will always be a valid scope because
-        // it was created by [Scope::bindings] method.
         debug_assert!(self.scope_id.index() < self.info.scopes.len());
 
         let id = *self.info.scopes[self.scope_id.index()]
@@ -173,8 +174,6 @@ impl Iterator for ScopeBindingsIter {
 
 impl ExactSizeIterator for ScopeBindingsIter {
     fn len(&self) -> usize {
-        // scope_id will always be a valid scope because
-        // it was created by [Scope::bindings] method.
         debug_assert!(self.scope_id.index() < self.info.scopes.len());
 
         self.info.scopes[self.scope_id.index()].bindings.len()

--- a/crates/biome_module_graph/src/js_module_info/scoped_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/scoped_resolver.rs
@@ -4,45 +4,97 @@ use std::{
     sync::Arc,
 };
 
+use biome_js_syntax::{AnyJsExpression, JsSyntaxNode};
 use biome_js_type_info::{
     GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ModuleId, Resolvable, ResolvedPath,
-    ResolvedTypeId, TypeData, TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier,
-    TypeResolver, TypeResolverLevel,
+    ResolvedTypeId, ScopeId, Type, TypeData, TypeId, TypeImportQualifier, TypeReference,
+    TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
-use biome_rowan::Text;
+use biome_rowan::{AstNode, Text};
+use rustc_hash::FxHashMap;
 
 use crate::{JsExport, ModuleGraph};
 
-use super::{JsModuleInfo, scope::JsScope};
+use super::JsModuleInfo;
 
-/// Type resolver that is able to resolve types from an arbitrary scope on an
-/// ad-hoc basic.
+/// Type resolver that is able to resolve types from arbitrary scopes in a
+/// module.
 ///
-/// The ad-hoc scope resolver can register types in order to infer the type of
-/// expressions, but it cannot create bindings for such types. Any references to
-/// named bindings are assumed to come from the scope in the module the resolver
-/// applies to.
-pub struct AdHocScopeResolver {
-    scope: JsScope,
+/// The scoped resolver can register types in order to infer the type of
+/// expressions, but it cannot create bindings for such types. For this reason,
+/// whenever the type of an expression is inferred, a `ScopeId` needs to be
+/// provided explicitly.
+///
+/// The scoped resolver is also able to resolve imported symbols from other
+/// modules, but any expressions it evaluates must be from the module for
+/// which the resolver was created.
+#[derive(Clone, Debug)]
+pub struct ScopedResolver {
     module_graph: Arc<ModuleGraph>,
+
+    /// Modules from which this resolver is using types.
+    ///
+    /// Any scopes referenced by this resolver are always assumed to be part of
+    /// the first module in this vector. Other modules are those imported by
+    /// the first module, either directly or transitively.
     modules: Vec<JsModuleInfo>,
+
+    /// Map of module IDs keyed by their resolved paths.
+    ///
+    /// Module IDs are used to index the [`Self::modules`] vector.
     pub modules_by_path: BTreeMap<ResolvedPath, ModuleId>,
+
+    /// Types registered within this resolver.
     types: Vec<TypeData>,
+
+    /// Map for looking up types of expressions.
+    expressions: FxHashMap<JsSyntaxNode, ResolvedTypeId>,
+
+    /// Type index up to which inference has run thus far.
+    inference_index: usize,
 }
 
-impl AdHocScopeResolver {
-    pub fn from_scope_in_module(
-        scope: JsScope,
-        module_info: JsModuleInfo,
-        module_graph: Arc<ModuleGraph>,
-    ) -> Self {
+impl ScopedResolver {
+    pub fn from_global_scope(module_info: JsModuleInfo, module_graph: Arc<ModuleGraph>) -> Self {
         Self {
-            scope,
             module_graph,
             modules: vec![module_info],
             modules_by_path: Default::default(),
             types: Default::default(),
+            expressions: Default::default(),
+            inference_index: 0,
         }
+    }
+
+    /// Registers all the necessary types so the given expression becomes
+    /// resolvable.
+    ///
+    /// The given expression must be from the module for which the resolver was
+    /// created.
+    pub fn register_types_for_expression(&mut self, expr: &AnyJsExpression) {
+        let scope_id = self.modules[0].scope_id_for_range(expr.range());
+
+        let mut resolver = ScopeRestrictedRegistrationResolver::new(self, scope_id);
+        let ty = TypeData::from_any_js_expression(&mut resolver, expr);
+        resolver.run_inference();
+
+        let ty = ty.inferred(&mut resolver);
+        let id = resolver.register_and_resolve(ty);
+        self.expressions.insert(expr.syntax().clone(), id);
+    }
+
+    /// Returns the resolved type of the given expression within this module.
+    ///
+    /// Assumes that [`Self::register_types_for_expression()`] has already been
+    /// called for this expression and the resolver's inference has run.
+    pub fn resolved_type_for_expression(self: &Arc<Self>, expr: &AnyJsExpression) -> Type {
+        let type_id = self
+            .expressions
+            .get(expr.syntax())
+            .copied()
+            .unwrap_or(GLOBAL_UNKNOWN_ID);
+
+        Type::from_id(self.clone(), type_id)
     }
 
     fn find_module(&self, path: &ResolvedPath) -> Option<ModuleId> {
@@ -63,13 +115,23 @@ impl AdHocScopeResolver {
     }
 
     pub fn run_inference(&mut self) {
-        self.resolve_all_own_types();
-        self.resolve_imports_in_modules();
-        self.flatten_all();
+        let from_index = self.inference_index;
+
+        self.resolve_all_own_types(from_index);
+
+        // We only perform import resolution for the first inference run in the
+        // global scope.
+        if from_index == 0 {
+            self.resolve_imports_in_modules();
+        }
+
+        self.flatten_all(from_index);
+
+        self.inference_index = self.types.len();
     }
 
-    fn resolve_all_own_types(&mut self) {
-        let mut i = 0;
+    fn resolve_all_own_types(&mut self, from_index: usize) {
+        let mut i = from_index;
         while i < self.types.len() {
             // First take the type to satisfy the borrow checker:
             let ty = std::mem::take(&mut self.types[i]);
@@ -102,8 +164,8 @@ impl AdHocScopeResolver {
         }
     }
 
-    fn flatten_all(&mut self) {
-        let mut i = 0;
+    fn flatten_all(&mut self, from_index: usize) {
+        let mut i = from_index;
         while i < self.types.len() {
             // First take the type to satisfy the borrow checker:
             let ty = std::mem::take(&mut self.types[i]);
@@ -158,7 +220,7 @@ impl AdHocScopeResolver {
                     let data = module.get_by_resolved_id(*resolved_id)?;
                     let data = data.clone().with_module_id(module_id);
                     self.find_type(&data)
-                        .map(|type_id| ResolvedTypeId::new(TypeResolverLevel::AdHoc, type_id))
+                        .map(|type_id| ResolvedTypeId::new(TypeResolverLevel::Scope, type_id))
                 }
                 TypeReference::Import(import) => {
                     qualifier = Cow::Borrowed(import);
@@ -172,9 +234,9 @@ impl AdHocScopeResolver {
     }
 }
 
-impl TypeResolver for AdHocScopeResolver {
+impl TypeResolver for ScopedResolver {
     fn level(&self) -> TypeResolverLevel {
-        TypeResolverLevel::AdHoc
+        TypeResolverLevel::Scope
     }
 
     fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
@@ -190,7 +252,7 @@ impl TypeResolver for AdHocScopeResolver {
 
     fn get_by_resolved_id(&self, resolved_id: ResolvedTypeId) -> Option<&TypeData> {
         match resolved_id.level() {
-            TypeResolverLevel::AdHoc => Some(self.get_by_id(resolved_id.id())),
+            TypeResolverLevel::Scope => Some(self.get_by_id(resolved_id.id())),
             TypeResolverLevel::Module => {
                 let module_id = resolved_id.module_id();
                 Some(&self.modules[module_id.index()].types[resolved_id.index()])
@@ -272,49 +334,45 @@ impl TypeResolver for AdHocScopeResolver {
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
         if qualifier.path.len() == 1 {
-            self.resolve_type_of(&qualifier.path[0])
-                .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
+            self.resolve_type_of(
+                &qualifier.path[0],
+                qualifier.scope_id.unwrap_or(ScopeId::GLOBAL),
+            )
+            .or_else(|| GLOBAL_RESOLVER.resolve_qualifier(qualifier))
         } else {
             // TODO: Resolve nested qualifiers
             None
         }
     }
 
-    fn resolve_type_of(&self, identifier: &Text) -> Option<ResolvedTypeId> {
-        let mut scope = self.scope.clone();
+    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId> {
+        let module = &self.modules[0];
+        let mut scope = &module.scopes[scope_id.index()];
         loop {
-            if let Some(binding) = scope.get_binding(identifier.text()) {
-                return if binding.is_imported() {
-                    match self.modules[0].exports.get(&binding.name()) {
-                        Some(JsExport::Own(export) | JsExport::OwnType(export)) => {
-                            self.resolve_reference(&export.ty)
-                        }
-                        Some(JsExport::Reexport(reexport) | JsExport::ReexportType(reexport)) => {
-                            self.resolve_reference(
-                                &TypeImportQualifier {
-                                    symbol: reexport.import.symbol.clone(),
-                                    resolved_path: reexport.import.resolved_path.clone(),
-                                }
-                                .into(),
-                            )
-                        }
-                        None => {
-                            // TODO: Follow blanket reexports.
-                            None
-                        }
-                    }
+            if let Some(binding) = scope
+                .bindings_by_name
+                .get(identifier.text())
+                .map(|id| &module.bindings[id.index()])
+            {
+                return if binding.declaration_kind.is_import_declaration() {
+                    module.static_imports.get(&binding.name).and_then(|import| {
+                        self.resolve_import_reference(&TypeImportQualifier {
+                            symbol: import.symbol.clone(),
+                            resolved_path: import.resolved_path.clone(),
+                        })
+                    })
                 } else {
-                    self.resolve_reference(binding.ty())
+                    self.resolve_reference(&binding.ty)
                 };
             }
 
-            match scope.parent() {
-                Some(parent) => scope = parent,
+            match &scope.parent {
+                Some(parent_id) => scope = &module.scopes[parent_id.index()],
                 None => break,
             }
         }
 
-        GLOBAL_RESOLVER.resolve_type_of(identifier)
+        GLOBAL_RESOLVER.resolve_type_of(identifier, scope_id)
     }
 
     fn fallback_resolver(&self) -> Option<&dyn TypeResolver> {
@@ -323,5 +381,66 @@ impl TypeResolver for AdHocScopeResolver {
 
     fn registered_types(&self) -> &[TypeData] {
         &self.types
+    }
+}
+
+struct ScopeRestrictedRegistrationResolver<'a> {
+    resolver: &'a mut ScopedResolver,
+    scope_id: ScopeId,
+}
+
+impl<'a> ScopeRestrictedRegistrationResolver<'a> {
+    fn new(resolver: &'a mut ScopedResolver, scope_id: ScopeId) -> Self {
+        Self { resolver, scope_id }
+    }
+
+    fn run_inference(&mut self) {
+        self.resolver.run_inference();
+    }
+}
+
+impl TypeResolver for ScopeRestrictedRegistrationResolver<'_> {
+    fn level(&self) -> TypeResolverLevel {
+        TypeResolverLevel::Scope
+    }
+
+    fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
+        self.resolver
+            .find_type(&type_data.clone().with_scope_id(self.scope_id))
+    }
+
+    fn get_by_id(&self, id: TypeId) -> &TypeData {
+        self.resolver.get_by_id(id)
+    }
+
+    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
+        self.resolver.get_by_resolved_id(id)
+    }
+
+    fn register_type(&mut self, type_data: TypeData) -> TypeId {
+        self.resolver
+            .register_type(type_data.with_scope_id(self.scope_id))
+    }
+
+    fn resolve_reference(&self, ty: &TypeReference) -> Option<ResolvedTypeId> {
+        match ty {
+            TypeReference::Qualifier(qualifier) => self.resolve_qualifier(qualifier),
+            TypeReference::Resolved(id) => Some(*id),
+            TypeReference::Import(import) => self.resolver.resolve_import_reference(import),
+            TypeReference::Unknown => Some(GLOBAL_UNKNOWN_ID),
+        }
+    }
+
+    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
+        self.resolver
+            .resolve_qualifier(&qualifier.clone().with_scope_id(self.scope_id))
+    }
+
+    fn resolve_type_of(&self, _identifier: &Text, _scope_id: ScopeId) -> Option<ResolvedTypeId> {
+        panic!("ScopeRestrictedRegistrationResolver is only used for registering types")
+    }
+
+    fn registered_types(&self) -> &[TypeData] {
+        panic!("ScopeRestrictedRegistrationResolver is only used for registering types")
     }
 }

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -9,7 +9,7 @@ mod resolver_cache;
 pub use biome_js_type_info::{ImportSymbol, ResolvedPath};
 
 pub use js_module_info::{
-    AdHocScopeResolver, JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport,
+    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, ScopedResolver,
 };
 pub use jsdoc_comment::JsdocComment;
 pub use module_graph::{ModuleGraph, SUPPORTED_EXTENSIONS};

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -4,7 +4,7 @@ use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::JsFileSource;
 use biome_js_type_info::ResolvedPath;
-use biome_module_graph::{AdHocScopeResolver, ModuleGraph};
+use biome_module_graph::{ScopedResolver, ModuleGraph};
 use biome_rowan::AstNode;
 use biome_test_utils::dump_registered_types;
 use camino::Utf8PathBuf;
@@ -12,7 +12,7 @@ use camino::Utf8PathBuf;
 pub struct ModuleGraphSnapshot<'a> {
     module_graph: &'a ModuleGraph,
     fs: &'a MemoryFileSystem,
-    resolver: Option<&'a AdHocScopeResolver>,
+    resolver: Option<&'a ScopedResolver>,
 }
 
 impl<'a> ModuleGraphSnapshot<'a> {
@@ -24,7 +24,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
         }
     }
 
-    pub fn with_resolver(self, resolver: &'a AdHocScopeResolver) -> Self {
+    pub fn with_resolver(self, resolver: &'a ScopedResolver) -> Self {
         Self {
             resolver: Some(resolver),
             ..self

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -135,7 +135,7 @@ Module TypeId(2) => sync Function "returnPromiseResult" {
 ## Registered types
 
 ```
-AdHoc TypeId(0) => sync Function "returnPromiseResult" {
+Scope TypeId(0) => sync Function "returnPromiseResult" {
   accepts: {
     params: []
     type_args: []
@@ -143,5 +143,5 @@ AdHoc TypeId(0) => sync Function "returnPromiseResult" {
   returns: Module(1) TypeId(1)
 }
 
-AdHoc TypeId(1) => instanceof Promise<T = Module(2) TypeId(3)>
+Scope TypeId(1) => instanceof Promise<T = Module(2) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -155,7 +155,7 @@ Module TypeId(2) => sync Function "returnPromiseResult" {
 ## Registered types
 
 ```
-AdHoc TypeId(0) => sync Function "returnPromiseResult" {
+Scope TypeId(0) => sync Function "returnPromiseResult" {
   accepts: {
     params: []
     type_args: []


### PR DESCRIPTION
## Summary

As it turned out our original ad-hoc scope resolver was somewhat of a performance liability, I've revised this part:

* The resolver is no longer constructed ad-hoc, instead it's created in a builder visitor created by the `Typed` service.
* Because we create a single resolver for the visitor, it needs to be able to handle all scopes within a module, so scope handling has been improved to handle this.
* The resolver has now been named `ScopedResolver` to better reflect the new situation.

While architecturally this seems a clear improvement, I did some benchmarking and unfortunately the performance hasn't changed at all :( I'll start doing some profiling to figure out the next steps.

## Test Plan

CI should remain green.
