### PR TITLE
refactor(core): pull manifest on demand

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -76,9 +76,6 @@
       },
       "suspicious": {
         "noVar": "on"
-      },
-      "nursery": {
-        "noImportCycles": "error"
       }
     }
   },

--- a/crates/biome_package/src/lib.rs
+++ b/crates/biome_package/src/lib.rs
@@ -5,18 +5,17 @@ mod license;
 mod node_js_package;
 
 pub use crate::diagnostics::{ProjectAnalyzeDiagnostic, ProjectDiagnostic};
+use biome_deserialize::{DeserializationDiagnostic, Deserialized};
+use biome_diagnostics::serde::Diagnostic;
+use biome_parser::AnyParse;
+use biome_parser::diagnostic::ParseDiagnostic;
+use biome_rowan::Language;
 pub use license::generated::*;
 pub use node_js_package::{
     Dependencies, NodeJsPackage, PackageJson, PackageType, TsConfigJson, Version,
 };
-
 use std::any::TypeId;
 use std::fmt::Debug;
-
-use biome_deserialize::{DeserializationDiagnostic, Deserialized};
-use biome_diagnostics::serde::Diagnostic;
-use biome_parser::diagnostic::ParseDiagnostic;
-use biome_rowan::Language;
 
 pub(crate) type LanguageRoot<L> = <L as Language>::Root;
 
@@ -36,6 +35,9 @@ pub trait Package {
 
     /// Inserts a manifest into the package, taking care of deserialization.
     fn insert_serialized_manifest(&mut self, root: &PackageRoot<Self>);
+
+    /// Inserts the raw (parse) manifest
+    fn insert_raw_manifest(&mut self, root: &AnyParse);
 
     fn manifest(&self) -> Option<&Self::Manifest> {
         None

--- a/crates/biome_project_layout/src/project_layout.rs
+++ b/crates/biome_project_layout/src/project_layout.rs
@@ -66,25 +66,25 @@ impl ProjectLayout {
         // Contrary to what I expected however, the below implementation
         // appeared significantly faster (tested on the `unleash` repository).
 
-        let mut result: Option<(&Utf8PathBuf, &PackageJson)> = None;
+        let mut result: Option<(Utf8PathBuf, PackageJson)> = None;
 
         let packages = self.0.pin();
         for (package_path, data) in packages.iter() {
             let Some(node_manifest) = data
                 .node_package
                 .as_ref()
-                .and_then(|node_package| node_package.manifest.as_ref())
+                .and_then(|node_package| node_package.to_deserialized_manifest())
             else {
                 continue;
             };
 
             let is_closest_match = path.strip_prefix(package_path).is_ok()
-                && result.is_none_or(|(matched_package_path, _)| {
+                && result.as_ref().is_none_or(|(matched_package_path, _)| {
                     package_path.as_str().len() > matched_package_path.as_str().len()
                 });
 
             if is_closest_match {
-                result = Some((package_path, node_manifest));
+                result = Some((package_path.clone(), node_manifest));
             }
         }
 
@@ -102,13 +102,13 @@ impl ProjectLayout {
             path,
             |data| {
                 let mut node_js_package = NodeJsPackage {
-                    manifest: Default::default(),
                     diagnostics: Default::default(),
                     tsconfig: data
                         .node_package
                         .as_ref()
                         .map(|package| package.tsconfig.clone())
                         .unwrap_or_default(),
+                    ..Default::default()
                 };
                 node_js_package.manifest = Some(manifest.clone());
 
@@ -132,21 +132,22 @@ impl ProjectLayout {
     /// Inserts a `package.json` manifest for the package at the given `path`,
     /// parsing the manifest on demand.
     ///
+    /// This method doesn't deserialize the manifest.
+    ///
     /// See also [Self::insert_node_manifest()].
-    pub fn insert_serialized_node_manifest(&self, path: Utf8PathBuf, manifest: AnyParse) {
+    pub fn insert_raw_node_manifest(&self, path: Utf8PathBuf, manifest: AnyParse) {
         self.0.pin().update_or_insert_with(
             path,
             |data| {
                 let mut node_js_package = NodeJsPackage {
-                    manifest: Default::default(),
-                    diagnostics: Default::default(),
                     tsconfig: data
                         .node_package
                         .as_ref()
                         .map(|package| package.tsconfig.clone())
                         .unwrap_or_default(),
+                    ..Default::default()
                 };
-                node_js_package.insert_serialized_manifest(&manifest.tree());
+                node_js_package.insert_raw_manifest(&manifest);
 
                 PackageData {
                     node_package: Some(node_js_package),
@@ -154,7 +155,7 @@ impl ProjectLayout {
             },
             || {
                 let mut node_js_package = NodeJsPackage::default();
-                node_js_package.insert_serialized_manifest(&manifest.tree());
+                node_js_package.insert_raw_manifest(&manifest);
 
                 PackageData {
                     node_package: Some(node_js_package),

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -612,7 +612,7 @@ impl WorkspaceServer {
                 WatcherSignalKind::AddedOrChanged => {
                     let parsed = self.get_parse(path)?;
                     self.project_layout
-                        .insert_serialized_node_manifest(package_path, parsed);
+                        .insert_raw_node_manifest(package_path, parsed);
                 }
                 WatcherSignalKind::Removed => {
                     self.project_layout.remove_package(&package_path);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR changes the way we pull the manifest. Before, the manifest was **always** deserialised every time we read a `package.json` file. Deserialisation is slow, and not always needed. Now, we deserialise the manifest only when needed. We copy some information during the operation, but we save a bit in performance.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

CI should pass.

<!-- What demonstrates that your implementation is correct? -->
