### PR TITLE
chore(tests): add test utils for asserting valid snapshots did not generate diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "biome_project_layout",
  "biome_rowan",
  "biome_service",
+ "biome_string_case",
  "camino",
  "countme",
  "json_comments",

--- a/crates/biome_css_analyze/tests/spec_tests.rs
+++ b/crates/biome_css_analyze/tests/spec_tests.rs
@@ -8,9 +8,10 @@ use biome_fs::OsFileSystem;
 use biome_plugin_loader::AnalyzerGritPlugin;
 use biome_rowan::AstNode;
 use biome_test_utils::{
-    CheckActionType, assert_errors_are_absent, code_fix_to_string, create_analyzer_options,
-    diagnostic_to_string, has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker,
-    scripts_from_json, write_analyzer_snapshot,
+    CheckActionType, assert_errors_are_absent, assert_valid_snapshot_did_not_generate_diagnostics,
+    code_fix_to_string, create_analyzer_options, diagnostic_to_string,
+    has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker, scripts_from_json,
+    write_analyzer_snapshot,
 };
 use camino::Utf8Path;
 use std::ops::Deref;
@@ -62,7 +63,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
 
     let input_code = read_to_string(input_file)
         .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
-    let quantity_diagnostics = if let Some(scripts) = scripts_from_json(extension, &input_code) {
+
+    // FIXME: Enable this assertion once all valid snapshots contain no diagnostic comment
+    // assert_valid_snapshot_contains_no_diagnostic_comment(input_file, &input_code);
+
+    let diagnostics_quantity = if let Some(scripts) = scripts_from_json(extension, &input_code) {
         for script in scripts {
             analyze_and_snap(
                 &mut snapshot,
@@ -102,9 +107,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });
 
-    if input_code.contains("/* should not generate diagnostics */") && quantity_diagnostics > 0 {
-        panic!("This test should not generate diagnostics");
-    }
+    assert_valid_snapshot_did_not_generate_diagnostics(
+        input_file,
+        &input_code,
+        diagnostics_quantity,
+    );
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/biome_css_analyze/tests/spec_tests.rs
+++ b/crates/biome_css_analyze/tests/spec_tests.rs
@@ -8,10 +8,9 @@ use biome_fs::OsFileSystem;
 use biome_plugin_loader::AnalyzerGritPlugin;
 use biome_rowan::AstNode;
 use biome_test_utils::{
-    CheckActionType, assert_errors_are_absent, assert_valid_snapshot_did_not_generate_diagnostics,
-    code_fix_to_string, create_analyzer_options, diagnostic_to_string,
-    has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker, scripts_from_json,
-    write_analyzer_snapshot,
+    CheckActionType, assert_errors_are_absent, code_fix_to_string, create_analyzer_options,
+    diagnostic_to_string, has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker,
+    scripts_from_json, write_analyzer_snapshot,
 };
 use camino::Utf8Path;
 use std::ops::Deref;
@@ -64,10 +63,7 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     let input_code = read_to_string(input_file)
         .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
 
-    // FIXME: Enable this assertion once all valid snapshots contain no diagnostic comment
-    // assert_valid_snapshot_contains_no_diagnostic_comment(input_file, &input_code);
-
-    let diagnostics_quantity = if let Some(scripts) = scripts_from_json(extension, &input_code) {
+    let quantity_diagnostics = if let Some(scripts) = scripts_from_json(extension, &input_code) {
         for script in scripts {
             analyze_and_snap(
                 &mut snapshot,
@@ -107,11 +103,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });
 
-    assert_valid_snapshot_did_not_generate_diagnostics(
-        input_file,
-        &input_code,
-        diagnostics_quantity,
-    );
+    // FIXME: Use `assert_valid_snapshot_did_not_generate_diagnostics` once all valid snapshots contain
+    // the `/* should not generate diagnostics */` comment.
+    if input_code.contains("/* should not generate diagnostics */") && quantity_diagnostics > 0 {
+        panic!("This test should not generate diagnostics");
+    }
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/biome_graphql_analyze/tests/spec_tests.rs
+++ b/crates/biome_graphql_analyze/tests/spec_tests.rs
@@ -4,9 +4,10 @@ use biome_graphql_parser::parse_graphql;
 use biome_graphql_syntax::{GraphqlFileSource, GraphqlLanguage};
 use biome_rowan::AstNode;
 use biome_test_utils::{
-    CheckActionType, assert_errors_are_absent, code_fix_to_string, create_analyzer_options,
-    diagnostic_to_string, has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker,
-    scripts_from_json, write_analyzer_snapshot,
+    CheckActionType, assert_errors_are_absent, assert_valid_snapshot_did_not_generate_diagnostics,
+    code_fix_to_string, create_analyzer_options, diagnostic_to_string,
+    has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker, scripts_from_json,
+    write_analyzer_snapshot,
 };
 use camino::Utf8Path;
 use std::ops::Deref;
@@ -47,7 +48,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
 
     let input_code = read_to_string(input_file)
         .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
-    let quantity_diagnostics = if let Some(scripts) = scripts_from_json(extension, &input_code) {
+
+    // FIXME: Enable this assertion once all valid snapshots contain no diagnostic comment
+    // assert_valid_snapshot_contains_no_diagnostic_comment(input_file, &input_code);
+
+    let diagnostics_quantity = if let Some(scripts) = scripts_from_json(extension, &input_code) {
         for script in scripts {
             analyze_and_snap(
                 &mut snapshot,
@@ -83,9 +88,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });
 
-    if input_code.contains("/* should not generate diagnostics */") && quantity_diagnostics > 0 {
-        panic!("This test should not generate diagnostics");
-    }
+    assert_valid_snapshot_did_not_generate_diagnostics(
+        input_file,
+        &input_code,
+        diagnostics_quantity,
+    );
 }
 
 pub(crate) fn analyze_and_snap(

--- a/crates/biome_graphql_analyze/tests/specs/nursery/useNamedOperation/valid.graphql
+++ b/crates/biome_graphql_analyze/tests/specs/nursery/useNamedOperation/valid.graphql
@@ -1,2 +1,2 @@
-/* should not generate diagnostics */
+# should not generate diagnostics
 // var a = 1;

--- a/crates/biome_graphql_analyze/tests/specs/nursery/useNamedOperation/valid.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/specs/nursery/useNamedOperation/valid.graphql.snap
@@ -4,6 +4,6 @@ expression: valid.graphql
 ---
 # Input
 ```graphql
-/* should not generate diagnostics */
+# should not generate diagnostics
 // var a = 1;
 ```

--- a/crates/biome_graphql_analyze/tests/specs/nursery/useNamingConvention/valid.graphql
+++ b/crates/biome_graphql_analyze/tests/specs/nursery/useNamingConvention/valid.graphql
@@ -1,3 +1,4 @@
+# should not generate diagnostics
 enum Status {
 	ACTIVE
 	INACTIVE

--- a/crates/biome_graphql_analyze/tests/specs/nursery/useNamingConvention/valid.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/specs/nursery/useNamingConvention/valid.graphql.snap
@@ -4,6 +4,7 @@ expression: valid.graphql
 ---
 # Input
 ```graphql
+# should not generate diagnostics
 enum Status {
 	ACTIVE
 	INACTIVE

--- a/crates/biome_graphql_analyze/tests/specs/style/useDeprecatedReason/valid.graphql
+++ b/crates/biome_graphql_analyze/tests/specs/style/useDeprecatedReason/valid.graphql
@@ -1,4 +1,4 @@
-/* should not generate diagnostics */
+# should not generate diagnostics
 query {
   member @deprecated(reason: "Use `members` instead") {
 		id

--- a/crates/biome_graphql_analyze/tests/specs/style/useDeprecatedReason/valid.graphql.snap
+++ b/crates/biome_graphql_analyze/tests/specs/style/useDeprecatedReason/valid.graphql.snap
@@ -4,7 +4,7 @@ expression: valid.graphql
 ---
 # Input
 ```graphql
-/* should not generate diagnostics */
+# should not generate diagnostics
 query {
   member @deprecated(reason: "Use `members` instead") {
 		id

--- a/crates/biome_js_analyze/tests/suppression/source/useSortedAttributes/valid.jsx
+++ b/crates/biome_js_analyze/tests/suppression/source/useSortedAttributes/valid.jsx
@@ -1,3 +1,4 @@
+/** should not generate diagnostics */
 <>
 	{/* biome-ignore assist/source/useSortedAttributes: test */}
 	<Hello

--- a/crates/biome_js_analyze/tests/suppression/source/useSortedAttributes/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/source/useSortedAttributes/valid.jsx.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
+/** should not generate diagnostics */
 <>
 	{/* biome-ignore assist/source/useSortedAttributes: test */}
 	<Hello

--- a/crates/biome_json_analyze/tests/spec_tests.rs
+++ b/crates/biome_json_analyze/tests/spec_tests.rs
@@ -4,9 +4,11 @@ use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_syntax::{JsonFileSource, JsonLanguage};
 use biome_rowan::AstNode;
 use biome_test_utils::{
-    CheckActionType, assert_errors_are_absent, code_fix_to_string, create_analyzer_options,
-    diagnostic_to_string, has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker,
-    write_analyzer_snapshot,
+    CheckActionType, assert_errors_are_absent,
+    assert_valid_snapshot_contains_no_diagnostic_comment,
+    assert_valid_snapshot_did_not_generate_diagnostics, code_fix_to_string,
+    create_analyzer_options, diagnostic_to_string, has_bogus_nodes_or_empty_slots, parse_test_path,
+    register_leak_checker, write_analyzer_snapshot,
 };
 use camino::Utf8Path;
 use std::ops::Deref;
@@ -59,11 +61,13 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
     let input_code = read_to_string(input_file)
         .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
 
+    assert_valid_snapshot_contains_no_diagnostic_comment(input_file, &input_code);
+
     let Ok(file_source) = input_file.try_into() else {
         return;
     };
 
-    let quantity_diagnostics = analyze_and_snap(
+    let diagnostics_quantity = analyze_and_snap(
         &mut snapshot,
         &input_code,
         file_source,
@@ -81,9 +85,11 @@ fn run_test(input: &'static str, _: &str, _: &str, _: &str) {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });
 
-    if input_code.contains("/* should not generate diagnostics */") && quantity_diagnostics > 0 {
-        panic!("This test should not generate diagnostics");
-    }
+    assert_valid_snapshot_did_not_generate_diagnostics(
+        input_file,
+        &input_code,
+        diagnostics_quantity,
+    );
 }
 
 fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &str) {

--- a/crates/biome_migrate/tests/spec_tests.rs
+++ b/crates/biome_migrate/tests/spec_tests.rs
@@ -5,7 +5,8 @@ use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_syntax::JsonLanguage;
 use biome_rowan::AstNode;
 use biome_test_utils::{
-    assert_errors_are_absent, code_fix_to_string, diagnostic_to_string,
+    assert_errors_are_absent, assert_valid_snapshot_contains_no_diagnostic_comment,
+    assert_valid_snapshot_did_not_generate_diagnostics, code_fix_to_string, diagnostic_to_string,
     has_bogus_nodes_or_empty_slots, parse_test_path, register_leak_checker,
     write_analyzer_snapshot,
 };
@@ -35,7 +36,9 @@ fn run_test(input: &'static str, _: &str, directory_path: &str, _: &str) {
     let input_code = read_to_string(input_file)
         .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
 
-    let quantity_diagnostics = analyze_and_snap(
+    assert_valid_snapshot_contains_no_diagnostic_comment(input_file, &input_code);
+
+    let diagnostics_quantity = analyze_and_snap(
         &mut snapshot,
         &input_code,
         file_name,
@@ -50,9 +53,11 @@ fn run_test(input: &'static str, _: &str, directory_path: &str, _: &str) {
         insta::assert_snapshot!(file_name, snapshot, file_name);
     });
 
-    if input_code.contains("/* should not generate diagnostics */") && quantity_diagnostics > 0 {
-        panic!("This test should not generate diagnostics");
-    }
+    assert_valid_snapshot_did_not_generate_diagnostics(
+        input_file,
+        &input_code,
+        diagnostics_quantity,
+    );
 }
 
 pub(crate) fn analyze_and_snap(

--- a/crates/biome_test_utils/Cargo.toml
+++ b/crates/biome_test_utils/Cargo.toml
@@ -29,6 +29,7 @@ biome_package        = { workspace = true }
 biome_project_layout = { workspace = true }
 biome_rowan          = { workspace = true }
 biome_service        = { workspace = true }
+biome_string_case    = { workspace = true }
 camino               = { workspace = true }
 countme              = { workspace = true, features = ["enable"] }
 json_comments        = "0.2.2"


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Follow up to https://github.com/biomejs/biome/pull/5883

- Add new `assert_diagnostics_expectation_comment` test helper which validates if diagnostics were genereted or not based on `should not generate diagnostics` / `should generate diagnostics` comments.
  - It also checks that valid test files contain former comment.
- Update grapqhl snapshots with the right comment.  

## Test Plan

Existing tests pass