### PR TITLE
fix(core): track resolver data

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicBar.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicBar.ts
@@ -1,0 +1,6 @@
+import type {Foo} from './panicFoo';
+
+let instance: Foo;
+
+// This call expression makes the `noFloatingPromises` rule work.
+instance.doSomething();

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicBar.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicBar.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: panicBar.ts
+---
+# Input
+```ts
+import type {Foo} from './panicFoo';
+
+let instance: Foo;
+
+// This call expression makes the `noFloatingPromises` rule work.
+instance.doSomething();
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicFoo.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicFoo.ts
@@ -1,0 +1,10 @@
+// Removing this fixes the problem.
+import type elliptic from 'elliptic';
+
+export class Foo {
+  // Removing this also fixes the problem.
+  prop: string;
+
+  // Turning this into a method declaration also fixes the problem.
+  doSomething = (): void => {};
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicFoo.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/panicFoo.ts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: panicFoo.ts
+---
+# Input
+```ts
+// Removing this fixes the problem.
+import type elliptic from 'elliptic';
+
+export class Foo {
+  // Removing this also fixes the problem.
+  prop: string;
+
+  // Turning this into a method declaration also fixes the problem.
+  doSomething = (): void => {};
+}
+
+```

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -7,9 +7,9 @@ use std::sync::LazyLock;
 use biome_rowan::Text;
 
 use crate::{
-    Class, GenericTypeParameter, MethodTypeMember, PropertyTypeMember, Resolvable, ResolvedTypeId,
-    ScopeId, TypeData, TypeId, TypeMember, TypeReference, TypeReferenceQualifier, TypeResolver,
-    TypeResolverLevel,
+    Class, GenericTypeParameter, MethodTypeMember, PropertyTypeMember, Resolvable,
+    ResolvedTypeData, ResolvedTypeId, ScopeId, TypeData, TypeId, TypeMember, TypeReference,
+    TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 
 const GLOBAL_LEVEL: TypeResolverLevel = TypeResolverLevel::Global;
@@ -179,8 +179,8 @@ impl TypeResolver for GlobalsResolver {
         &self.types[id.index()]
     }
 
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
-        (id.level() == GLOBAL_LEVEL).then(|| self.get_by_id(id.id()))
+    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
+        (id.level() == GLOBAL_LEVEL).then(|| (id, self.get_by_id(id.id())).into())
     }
 
     fn register_type(&mut self, type_data: TypeData) -> TypeId {

--- a/crates/biome_js_type_info/src/helpers.rs
+++ b/crates/biome_js_type_info/src/helpers.rs
@@ -1,0 +1,301 @@
+use std::borrow::Cow;
+
+use biome_rowan::Text;
+
+use crate::{
+    Class, GenericTypeParameter, Object, ResolvedTypeData, ResolvedTypeId, ResolvedTypeMember,
+    ResolverId, TypeData, TypeInstance, TypeReference, TypeResolver,
+    globals::{GLOBAL_ARRAY_ID, GLOBAL_PROMISE_ID, GLOBAL_TYPE_MEMBERS},
+};
+
+impl<'a> ResolvedTypeData<'a> {
+    /// Iterates all member fields, including those belonging to extended
+    /// classes or prototype objects.
+    ///
+    /// Note that members which are inherited and overridden may appear multiple
+    /// times, but the member that is closest to the current type is guaranteed
+    /// to come first.
+    pub fn all_members(
+        self,
+        resolver: &'a dyn TypeResolver,
+    ) -> impl Iterator<Item = ResolvedTypeMember<'a>> {
+        TypeMemberIterator {
+            resolver,
+            resolver_id: self.resolver_id(),
+            owner: TypeMemberOwner::from_type_data(self.as_raw_data()),
+            seen_types: Vec::new(),
+            index: 0,
+        }
+    }
+
+    /// Returns the type of an array's elements, if this object is an instance of `Array`.
+    pub fn find_array_element_type(self, resolver: &'a dyn TypeResolver) -> Option<Self> {
+        if self.is_instance_of(resolver, GLOBAL_ARRAY_ID) {
+            self.find_type_parameter(resolver, "T")
+                .and_then(|reference| resolver.resolve_and_get(&reference))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the promised type, if this object is an instance of `Promise`.
+    pub fn find_promise_type(self, resolver: &'a dyn TypeResolver) -> Option<Self> {
+        if self.is_instance_of(resolver, GLOBAL_PROMISE_ID) {
+            self.find_type_parameter(resolver, "T")
+                .and_then(|reference| resolver.resolve_and_get(&reference))
+        } else {
+            None
+        }
+    }
+
+    pub fn find_type_parameter(
+        self,
+        resolver: &'a dyn TypeResolver,
+        parameter_name: &str,
+    ) -> Option<Cow<'a, TypeReference>> {
+        let mut seen_types = Vec::new();
+        let mut current_object = Some(self);
+        while let Some(current) = current_object {
+            if let Some(argument) = current
+                .as_raw_data()
+                .type_parameters()
+                .iter()
+                .flat_map(|params| params.iter())
+                .find(|param| param.name == parameter_name && param.ty.is_known())
+            {
+                return Some(current.apply_module_id_to_reference(&argument.ty));
+            }
+
+            let Some(next_object) = current
+                .prototype(resolver)
+                .and_then(|prototype| resolver.resolve_reference(&prototype))
+            else {
+                break;
+            };
+
+            if seen_types.contains(&next_object) {
+                break;
+            }
+
+            seen_types.push(next_object);
+            current_object = resolver.get_by_resolved_id(next_object);
+        }
+
+        None
+    }
+
+    /// Returns whether this object is an instance of the type with the given ID.
+    pub fn is_instance_of(self, resolver: &dyn TypeResolver, id: ResolvedTypeId) -> bool {
+        let mut seen_types = Vec::new();
+        let mut current_object = Some(self);
+        while let Some(current) = current_object {
+            let Some(prototype) = current.prototype(resolver) else {
+                break;
+            };
+
+            let Some(next_id) = resolver.resolve_reference(&prototype) else {
+                break;
+            };
+
+            if next_id == id {
+                return true;
+            }
+
+            if seen_types.contains(&next_id) {
+                break;
+            }
+
+            seen_types.push(next_id);
+            current_object = resolver.get_by_resolved_id(next_id);
+        }
+
+        false
+    }
+
+    /// Returns whether this type is an instance of a `Promise`.
+    pub fn is_promise_instance(self, resolver: &dyn TypeResolver) -> bool {
+        self.is_instance_of(resolver, GLOBAL_PROMISE_ID)
+    }
+
+    /// Returns a reference to the type's prototype, if any.
+    pub fn prototype(self, resolver: &'a dyn TypeResolver) -> Option<Cow<'a, TypeReference>> {
+        match self.as_raw_data() {
+            TypeData::InstanceOf(instance_of) => {
+                Some(self.apply_module_id_to_reference(&instance_of.ty))
+            }
+            TypeData::Object(object) => object
+                .prototype
+                .as_ref()
+                .map(|reference| self.apply_module_id_to_reference(reference)),
+            TypeData::Reference(reference) => resolver
+                .resolve_and_get(&self.apply_module_id_to_reference(reference))
+                .and_then(|ty| ty.prototype(resolver)),
+            _ => None,
+        }
+    }
+}
+
+impl TypeData {
+    /// Returns the type of an element at a given index, if this object is an
+    /// array or a tuple.
+    pub fn find_element_type_at_index<'a>(
+        &'a self,
+        resolver_id: ResolverId,
+        resolver: &'a mut dyn TypeResolver,
+        index: usize,
+    ) -> Option<ResolvedTypeData<'a>> {
+        match self {
+            Self::Tuple(tuple) => Some(tuple.get_ty(resolver, index)),
+            _ => {
+                let resolved = ResolvedTypeData::from((resolver_id, self));
+                if resolved.is_instance_of(resolver, GLOBAL_ARRAY_ID) {
+                    resolved
+                        .find_type_parameter(resolver, "T")
+                        .map(|reference| reference.into_owned())
+                        .map(|reference| resolver.optional(reference))
+                        .map(|id| {
+                            ResolvedTypeData::from((
+                                ResolvedTypeId::new(resolver.level(), id),
+                                resolver.get_by_id(id),
+                            ))
+                        })
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// Returns the type of elements from a given index, if this object is an
+    /// array or a tuple.
+    pub fn find_type_of_elements_from_index<'a>(
+        &'a self,
+        resolver_id: ResolverId,
+        resolver: &'a mut dyn TypeResolver,
+        index: usize,
+    ) -> Option<ResolvedTypeData<'a>> {
+        let data = match self {
+            Self::Tuple(tuple) => Some(Self::Tuple(Box::new(tuple.slice_from(index)))),
+            _ => {
+                let resolved = ResolvedTypeData::from((resolver_id, self));
+                if resolved.is_instance_of(resolver, GLOBAL_ARRAY_ID) {
+                    match resolved.find_type_parameter(resolver, "T") {
+                        Some(elem_ty) => Some(Self::InstanceOf(Box::new(TypeInstance {
+                            ty: GLOBAL_ARRAY_ID.into(),
+                            type_parameters: Box::new([GenericTypeParameter {
+                                name: Text::Static("T"),
+                                ty: elem_ty.into_owned(),
+                            }]),
+                        }))),
+                        None => return resolver.get_by_resolved_id(GLOBAL_ARRAY_ID),
+                    }
+                } else {
+                    None
+                }
+            }
+        }?;
+
+        let id = resolver.register_and_resolve(data);
+        resolver.get_by_resolved_id(id)
+    }
+}
+
+struct TypeMemberIterator<'a> {
+    resolver: &'a dyn TypeResolver,
+    resolver_id: ResolverId,
+    owner: Option<TypeMemberOwner<'a>>,
+    seen_types: Vec<ResolvedTypeId>,
+    index: usize,
+}
+
+impl<'a> Iterator for TypeMemberIterator<'a> {
+    type Item = ResolvedTypeMember<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next_reference = match &self.owner {
+            Some(TypeMemberOwner::Class(class)) => {
+                match (class.members.get(self.index), class.extends.as_ref()) {
+                    (Some(member), _) => {
+                        self.index += 1;
+                        return Some((self.resolver_id, member).into());
+                    }
+                    (None, Some(extends)) => extends,
+                    (None, None) => {
+                        self.owner = None;
+                        return None;
+                    }
+                }
+            }
+            Some(TypeMemberOwner::Global) => {
+                if let Some(member) = GLOBAL_TYPE_MEMBERS.get(self.index) {
+                    self.index += 1;
+                    return Some((self.resolver_id, member).into());
+                } else {
+                    self.owner = None;
+                    return None;
+                }
+            }
+            Some(TypeMemberOwner::InstanceOf(instance_of)) => &instance_of.ty,
+            Some(TypeMemberOwner::Object(object)) => {
+                match (object.members.get(self.index), object.prototype.as_ref()) {
+                    (Some(member), _) => {
+                        self.index += 1;
+                        return Some((self.resolver_id, member).into());
+                    }
+                    (None, Some(prototype)) => prototype,
+                    (None, None) => {
+                        self.owner = None;
+                        return None;
+                    }
+                }
+            }
+            None => return None,
+        };
+
+        let Some(next_resolved_id) = self.resolver.resolve_reference(
+            &self
+                .resolver_id
+                .apply_module_id_to_reference(next_reference),
+        ) else {
+            self.owner = None;
+            return None;
+        };
+
+        if self.seen_types.contains(&next_resolved_id) {
+            self.owner = None;
+            return None;
+        }
+
+        self.seen_types.push(next_resolved_id);
+
+        let data = self.resolver.get_by_resolved_id(next_resolved_id);
+        if let Some(data) = &data {
+            self.owner = TypeMemberOwner::from_type_data(data.as_raw_data());
+            self.resolver_id = data.resolver_id();
+        } else {
+            self.owner = None;
+        }
+
+        self.index = 0;
+        self.next()
+    }
+}
+
+enum TypeMemberOwner<'a> {
+    Class(&'a Class),
+    Global,
+    InstanceOf(&'a TypeInstance),
+    Object(&'a Object),
+}
+
+impl<'a> TypeMemberOwner<'a> {
+    fn from_type_data(type_data: &'a TypeData) -> Option<Self> {
+        match type_data {
+            TypeData::Class(class) => Some(Self::Class(class)),
+            TypeData::Global => Some(Self::Global),
+            TypeData::InstanceOf(type_instance) => Some(Self::InstanceOf(type_instance)),
+            TypeData::Object(object) => Some(Self::Object(object)),
+            _ => None,
+        }
+    }
+}

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -3,6 +3,7 @@
 mod flattening;
 mod format_type_info;
 mod globals;
+mod helpers;
 mod local_inference;
 mod resolver;
 mod type_info;

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -176,8 +176,7 @@ impl TypeData {
                         Box::new([(
                             name,
                             resolver
-                                .destructuring_of(reference, DestructureField::Name(member_name))
-                                .clone(),
+                                .destructuring_of(reference, DestructureField::Name(member_name)),
                         )])
                     }),
                     AnyJsBindingPattern::JsArrayBindingPattern(pattern) => Some({

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -18,11 +18,9 @@ use biome_js_type_info_macros::Resolvable;
 use biome_rowan::Text;
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::globals::{
-    GLOBAL_ARRAY_ID, GLOBAL_PROMISE_ID, GLOBAL_TYPE_MEMBERS, GLOBAL_UNKNOWN_ID, PROMISE_ID,
-};
+use crate::globals::{GLOBAL_PROMISE_ID, GLOBAL_UNKNOWN_ID, PROMISE_ID};
 use crate::type_info::literal::{BooleanLiteral, NumberLiteral, StringLiteral};
-use crate::{GLOBAL_RESOLVER, Resolvable, ResolvedTypeId, TypeResolver};
+use crate::{GLOBAL_RESOLVER, Resolvable, ResolvedTypeData, ResolvedTypeId, TypeResolver};
 
 const UNKNOWN: TypeData = TypeData::Unknown;
 
@@ -70,9 +68,8 @@ impl Deref for Type {
     type Target = TypeData;
 
     fn deref(&self) -> &Self::Target {
-        self.resolver
-            .get_by_resolved_id(self.id)
-            .unwrap_or(&UNKNOWN)
+        self.resolved_data()
+            .map_or(&UNKNOWN, |resolved| resolved.as_raw_data())
     }
 }
 
@@ -104,8 +101,8 @@ impl Type {
 
     /// Returns whether this type is an instance of a `Promise`.
     pub fn is_promise_instance(&self) -> bool {
-        self.deref()
-            .is_instance_of(self.resolver.as_ref(), GLOBAL_PROMISE_ID)
+        self.resolved_data()
+            .is_some_and(|ty| ty.is_instance_of(self.resolver.as_ref(), GLOBAL_PROMISE_ID))
     }
 
     /// Returns whether the given type is known to reference a function that
@@ -123,8 +120,13 @@ impl Type {
 
     fn resolve(&self, ty: &TypeReference) -> Option<Self> {
         self.resolver
-            .resolve_reference(ty)
+            .resolve_reference(&self.id.apply_module_id_to_reference(ty))
             .map(|resolved_id| self.with_resolved_id(resolved_id))
+    }
+
+    #[inline]
+    fn resolved_data(&self) -> Option<ResolvedTypeData> {
+        self.resolver.get_by_resolved_id(self.id)
     }
 
     fn with_resolved_id(&self, id: ResolvedTypeId) -> Self {
@@ -224,24 +226,6 @@ pub enum TypeData {
 }
 
 impl TypeData {
-    /// Iterates all member fields, including those belonging to extended
-    /// classes or prototype objects.
-    ///
-    /// Note that members which are inherited and overridden may appear multiple
-    /// times, but the member that is closest to the current type is guaranteed
-    /// to come first.
-    pub fn all_members<'a>(
-        &'a self,
-        resolver: &'a dyn TypeResolver,
-    ) -> impl Iterator<Item = &'a TypeMember> {
-        TypeMemberIterator {
-            resolver,
-            seen_types: Vec::new(),
-            owner: TypeMemberOwner::from_type_data(self),
-            index: 0,
-        }
-    }
-
     pub fn as_class(&self) -> Option<&Class> {
         match self {
             Self::Class(class) => Some(class.as_ref()),
@@ -260,144 +244,10 @@ impl TypeData {
         Self::Boolean
     }
 
-    /// Returns the type of an array's elements, if this object is an instance of `Array`.
-    pub fn find_array_element_type<'a>(
-        &'a self,
-        resolver: &'a dyn TypeResolver,
-    ) -> Option<&'a Self> {
-        if self.is_instance_of(resolver, GLOBAL_ARRAY_ID) {
-            self.find_type_parameter(resolver, "T")
-                .and_then(|reference| resolver.resolve_and_get(reference))
-        } else {
-            None
-        }
-    }
-
-    /// Returns the type of an element at a given index, if this object is an
-    /// array or a tuple.
-    pub fn find_element_type_at_index<'a>(
-        &'a self,
-        resolver: &'a mut dyn TypeResolver,
-        index: usize,
-    ) -> Option<&'a Self> {
-        match self {
-            Self::Tuple(tuple) => Some(tuple.get_ty(resolver, index)),
-            _ if self.is_instance_of(resolver, GLOBAL_ARRAY_ID) => self
-                .find_type_parameter(resolver, "T")
-                .cloned()
-                .map(|reference| resolver.optional(reference))
-                .map(|id| resolver.get_by_id(id)),
-            _ => None,
-        }
-    }
-
-    /// Returns the promised type, if this object is an instance of `Promise`.
-    pub fn find_promise_type<'a>(&'a self, resolver: &'a dyn TypeResolver) -> Option<&'a Self> {
-        if self.is_instance_of(resolver, GLOBAL_PROMISE_ID) {
-            self.find_type_parameter(resolver, "T")
-                .and_then(|reference| resolver.resolve_and_get(reference))
-        } else {
-            None
-        }
-    }
-
-    /// Returns the type of elements from a given index, if this object is an
-    /// array or a tuple.
-    pub fn find_type_of_elements_from_index(
-        &self,
-        resolver: &mut dyn TypeResolver,
-        index: usize,
-    ) -> Option<Self> {
-        match self {
-            Self::Tuple(tuple) => Some(Self::Tuple(Box::new(tuple.slice_from(index)))),
-            _ if self.is_instance_of(resolver, GLOBAL_ARRAY_ID) => {
-                match self.find_type_parameter(resolver, "T") {
-                    Some(elem_ty) => Some(Self::InstanceOf(Box::new(TypeInstance {
-                        ty: GLOBAL_ARRAY_ID.into(),
-                        type_parameters: Box::new([GenericTypeParameter {
-                            name: Text::Static("T"),
-                            ty: elem_ty.clone(),
-                        }]),
-                    }))),
-                    None => resolver.get_by_resolved_id(GLOBAL_ARRAY_ID).cloned(),
-                }
-            }
-            _ => None,
-        }
-    }
-
-    pub fn find_type_parameter<'a>(
-        &'a self,
-        resolver: &'a dyn TypeResolver,
-        parameter_name: &str,
-    ) -> Option<&'a TypeReference> {
-        let mut seen_types = Vec::new();
-        let mut current_object = Some(self);
-        while let Some(current) = current_object {
-            if let Some(argument) = current
-                .type_parameters()
-                .iter()
-                .flat_map(|params| params.iter())
-                .find(|param| param.name == parameter_name && param.ty.is_known())
-            {
-                return Some(&argument.ty);
-            }
-
-            let Some(next_object) = current
-                .prototype(resolver)
-                .and_then(|prototype| resolver.resolve_reference(prototype))
-            else {
-                break;
-            };
-
-            if seen_types.contains(&next_object) {
-                break;
-            }
-
-            seen_types.push(next_object);
-            current_object = resolver.get_by_resolved_id(next_object);
-        }
-
-        None
-    }
-
     /// Returns the type with inference up to the level supported by the given `resolver`.
     #[inline]
     pub fn inferred(&self, resolver: &mut dyn TypeResolver) -> Self {
         self.resolved(resolver).flattened(resolver)
-    }
-
-    /// Returns whether this object is an instance of the type with the given ID.
-    pub fn is_instance_of(&self, resolver: &dyn TypeResolver, id: ResolvedTypeId) -> bool {
-        let mut seen_types = Vec::new();
-        let mut current_object = Some(self);
-        while let Some(current) = current_object {
-            let Some(prototype) = current.prototype(resolver) else {
-                break;
-            };
-
-            let Some(next_id) = resolver.resolve_reference(prototype) else {
-                break;
-            };
-
-            if next_id == id {
-                return true;
-            }
-
-            if seen_types.contains(&next_id) {
-                break;
-            }
-
-            seen_types.push(next_id);
-            current_object = resolver.get_by_resolved_id(next_id);
-        }
-
-        false
-    }
-
-    /// Returns whether this type is an instance of a `Promise`.
-    pub fn is_promise_instance(&self, resolver: &dyn TypeResolver) -> bool {
-        self.is_instance_of(resolver, GLOBAL_PROMISE_ID)
     }
 
     /// Returns whether the given type has been inferred.
@@ -406,18 +256,6 @@ impl TypeData {
     /// including an unexplicit `unknown` keyword.
     pub fn is_inferred(&self) -> bool {
         !matches!(self, Self::Unknown)
-    }
-
-    /// Returns a reference to the type's prototype, if any.
-    pub fn prototype<'a>(&'a self, resolver: &'a dyn TypeResolver) -> Option<&'a TypeReference> {
-        match self {
-            Self::InstanceOf(instance_of) => Some(&instance_of.ty),
-            Self::Object(object) => object.prototype.as_ref(),
-            Self::Reference(reference) => resolver
-                .resolve_and_get(reference)
-                .and_then(|ty| ty.prototype(resolver)),
-            _ => None,
-        }
     }
 
     pub fn reference(reference: impl Into<TypeReference>) -> Self {
@@ -639,7 +477,11 @@ impl Tuple {
     }
 
     /// Returns the type at the given index.
-    pub fn get_ty<'a>(&'a self, resolver: &'a mut dyn TypeResolver, index: usize) -> &'a TypeData {
+    pub fn get_ty<'a>(
+        &'a self,
+        resolver: &'a mut dyn TypeResolver,
+        index: usize,
+    ) -> ResolvedTypeData<'a> {
         let resolved_id = if let Some(elem_type) = self.0.get(index) {
             let ty = elem_type.ty.clone();
             let id = if elem_type.is_optional {
@@ -816,96 +658,6 @@ impl PropertyTypeMember {
     pub fn with_type(mut self, ty: TypeReference) -> Self {
         self.ty = ty;
         self
-    }
-}
-
-struct TypeMemberIterator<'a> {
-    resolver: &'a dyn TypeResolver,
-    seen_types: Vec<ResolvedTypeId>,
-    owner: Option<TypeMemberOwner<'a>>,
-    index: usize,
-}
-
-impl<'a> Iterator for TypeMemberIterator<'a> {
-    type Item = &'a TypeMember;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let next_reference = match &self.owner {
-            Some(TypeMemberOwner::Class(class)) => {
-                match (class.members.get(self.index), class.extends.as_ref()) {
-                    (Some(member), _) => {
-                        self.index += 1;
-                        return Some(member);
-                    }
-                    (None, Some(extends)) => extends,
-                    (None, None) => {
-                        self.owner = None;
-                        return None;
-                    }
-                }
-            }
-            Some(TypeMemberOwner::Global) => {
-                if let Some(member) = GLOBAL_TYPE_MEMBERS.get(self.index) {
-                    self.index += 1;
-                    return Some(member);
-                } else {
-                    self.owner = None;
-                    return None;
-                }
-            }
-            Some(TypeMemberOwner::InstanceOf(instance_of)) => &instance_of.ty,
-            Some(TypeMemberOwner::Object(object)) => {
-                match (object.members.get(self.index), object.prototype.as_ref()) {
-                    (Some(member), _) => {
-                        self.index += 1;
-                        return Some(member);
-                    }
-                    (None, Some(prototype)) => prototype,
-                    (None, None) => {
-                        self.owner = None;
-                        return None;
-                    }
-                }
-            }
-            None => return None,
-        };
-
-        let Some(next_resolved_id) = self.resolver.resolve_reference(next_reference) else {
-            self.owner = None;
-            return None;
-        };
-
-        if self.seen_types.contains(&next_resolved_id) {
-            self.owner = None;
-            return None;
-        }
-
-        self.seen_types.push(next_resolved_id);
-        self.owner = self
-            .resolver
-            .get_by_resolved_id(next_resolved_id)
-            .and_then(TypeMemberOwner::from_type_data);
-        self.index = 0;
-        self.next()
-    }
-}
-
-enum TypeMemberOwner<'a> {
-    Class(&'a Class),
-    Global,
-    InstanceOf(&'a TypeInstance),
-    Object(&'a Object),
-}
-
-impl<'a> TypeMemberOwner<'a> {
-    fn from_type_data(type_data: &'a TypeData) -> Option<Self> {
-        match type_data {
-            TypeData::Class(class) => Some(Self::Class(class)),
-            TypeData::Global => Some(Self::Global),
-            TypeData::InstanceOf(type_instance) => Some(Self::InstanceOf(type_instance)),
-            TypeData::Object(object) => Some(Self::Object(object)),
-            _ => None,
-        }
     }
 }
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
@@ -18,7 +18,13 @@ instanceof Promise
 ## Registered types
 
 ```
-Global TypeId(7) => Global TypeId(9)
+Global TypeId(7) => sync Function "resolve" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: instanceof Promise
+}
 
 Global TypeId(8) => value: value
 

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -8,8 +8,8 @@ use biome_js_syntax::{
     AnyJsModuleItem, AnyJsRoot, AnyJsStatement, JsFileSource, JsFunctionDeclaration,
 };
 use biome_js_type_info::{
-    GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeId, ScopeId, TypeData, TypeId,
-    TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    GlobalsResolver, NUM_PREDEFINED_TYPES, Resolvable, ResolvedTypeData, ResolvedTypeId, ScopeId,
+    TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 use biome_rowan::{AstNode, Text};
 use biome_test_utils::dump_registered_types;
@@ -145,16 +145,16 @@ impl TypeResolver for HardcodedSymbolResolver {
         &self.types[id.index()]
     }
 
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
+    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
         match id.level() {
             TypeResolverLevel::Scope => {
                 panic!("Ad-hoc references unsupported by resolver")
             }
-            TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
+            TypeResolverLevel::Module => Some((id, self.get_by_id(id.id())).into()),
             TypeResolverLevel::Import => {
                 panic!("Import references unsupported by resolver")
             }
-            TypeResolverLevel::Global => Some(self.globals.get_by_id(id.id())),
+            TypeResolverLevel::Global => Some((id, self.globals.get_by_id(id.id())).into()),
         }
     }
 

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -8,8 +8,9 @@ use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use biome_js_syntax::AnyJsImportLike;
 use biome_js_type_info::{
-    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ResolvedPath, ResolvedTypeId, ScopeId,
-    TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ResolvedPath, ResolvedTypeData,
+    ResolvedTypeId, ScopeId, TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver,
+    TypeResolverLevel,
 };
 use biome_rowan::{Text, TextRange, TokenText};
 
@@ -214,10 +215,10 @@ impl TypeResolver for JsModuleInfoInner {
         &self.types[id.index()]
     }
 
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
+    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
         match id.level() {
-            TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
-            TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
+            TypeResolverLevel::Module => Some((id, self.get_by_id(id.id())).into()),
+            TypeResolverLevel::Global => Some((id, GLOBAL_RESOLVER.get_by_id(id.id())).into()),
             TypeResolverLevel::Scope | TypeResolverLevel::Import => None,
         }
     }

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -10,9 +10,9 @@ use biome_js_syntax::{
     TsIdentifierBinding, inner_string_text,
 };
 use biome_js_type_info::{
-    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeId, ScopeId,
-    TypeData, TypeId, TypeImportQualifier, TypeReference, TypeReferenceQualifier, TypeResolver,
-    TypeResolverLevel,
+    FunctionParameter, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, Resolvable, ResolvedTypeData,
+    ResolvedTypeId, ScopeId, TypeData, TypeId, TypeImportQualifier, TypeReference,
+    TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 use biome_rowan::{AstNode, Text, TextSize, TokenText};
 use rust_lapper::{Interval, Lapper};
@@ -436,10 +436,10 @@ impl TypeResolver for JsModuleInfoCollector {
         &self.types[id.index()]
     }
 
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<&TypeData> {
+    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
         match id.level() {
-            TypeResolverLevel::Module => Some(self.get_by_id(id.id())),
-            TypeResolverLevel::Global => Some(GLOBAL_RESOLVER.get_by_id(id.id())),
+            TypeResolverLevel::Module => Some((id, self.get_by_id(id.id())).into()),
+            TypeResolverLevel::Global => Some((id, GLOBAL_RESOLVER.get_by_id(id.id())).into()),
             TypeResolverLevel::Scope | TypeResolverLevel::Import => None,
         }
     }

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -95,7 +95,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
         }
 
         if let Some(resolver) = self.resolver {
-            content.push_str("\n# Ad-Hoc Type Resolver\n\n");
+            content.push_str("\n# Scoped Type Resolver\n\n");
             dump_registered_types(&mut content, resolver);
         }
 

--- a/crates/biome_module_graph/tests/snapshots/test_module_id_handling.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_module_id_handling.snap
@@ -1,0 +1,110 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/bar.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+import type { Foo } from "./foo";
+
+let instance: Foo;
+
+// This call expression makes the `noFloatingPromises` rule work.
+instance.doSomething();
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "Foo" => {
+    Specifier: "./foo"
+    Resolved path: "/src/foo.ts"
+    Import Symbol: Foo
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => unknown
+
+Module TypeId(1) => instanceof Import Symbol: Foo from "/src/foo.ts"
+```
+
+# `/src/foo.ts` (Module 1)
+
+## Source
+
+```ts
+// Removing this fixes the problem.
+import type elliptic from "elliptic";
+
+export class Foo {
+	// Removing this also fixes the problem.
+	prop: string;
+
+	// Turning this into a method declaration also fixes the problem.
+	doSomething = (): void => {};
+}
+```
+
+## Module Info
+
+```
+Exports {
+  "Foo" => {
+    ExportOwnExport => JsOwnExport(
+      Module(0) TypeId(4)
+      Local name: Foo
+    )
+  }
+}
+Imports {
+  "elliptic" => {
+    Specifier: "elliptic"
+    Resolved path:
+    Import Symbol: Default
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => unknown
+
+Module TypeId(1) => string
+
+Module TypeId(2) => void
+
+Module TypeId(3) => sync Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(2)
+}
+
+Module TypeId(4) => class "Foo" {
+  extends: none
+  type_args: []
+}
+```
+
+# Ad-Hoc Type Resolver
+
+## Registered types
+
+```
+Scope TypeId(0) => class "Foo" {
+  extends: none
+  type_args: []
+}
+```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -130,18 +130,4 @@ Module TypeId(2) => sync Function "returnPromiseResult" {
 }
 ```
 
-# Ad-Hoc Type Resolver
-
-## Registered types
-
-```
-Scope TypeId(0) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(1)
-}
-
-Scope TypeId(1) => instanceof Promise<T = Module(2) TypeId(3)>
-```
+# Scoped Type Resolver

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -150,16 +150,4 @@ Module TypeId(2) => sync Function "returnPromiseResult" {
 }
 ```
 
-# Ad-Hoc Type Resolver
-
-## Registered types
-
-```
-Scope TypeId(0) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(1)
-}
-```
+# Scoped Type Resolver

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -592,7 +592,7 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     let ty = resolver
         .get_by_resolved_id(resolved_id)
         .expect("cannot find type data")
-        .clone();
+        .to_data();
     let _ty_string = format!("{ty:?}"); // for debugging
     let ty = ty.inferred(&mut resolver);
     let _ty_string = format!("{ty:?}"); // for debugging
@@ -658,7 +658,7 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     let ty = resolver
         .get_by_resolved_id(resolved_id)
         .expect("cannot find type data")
-        .clone();
+        .to_data();
     let _ty_string = format!("{ty:?}"); // for debugging
     let ty = ty.inferred(&mut resolver);
     let _ty_string = format!("{ty:?}"); // for debugging


### PR DESCRIPTION
## Summary

Since I introduced full type inference, there's been instances of panics because types would be looked up in the wrong module. I tracked it to an oversight with how we look up references: Whenever we retrieve a type from a resolver, we would get a `TypeData` reference. If that type contained nested `TypeReference` instances, we would attempt to look up those as well, but at that point we'd lost the information from which module the resolver had retrieved the initial `TypeData`.

I had already introduced the module IDs on `ResolvedTypeId`, so that such information can be tracked, but whenever we'd get a plain `&TypeData`, we'd lose track of it.

To fix this, I've introduced `ResolvedTypeData`, which can track the same information when dealing with `TypeData` references as well.

This did become another large change, since `TypeData` was used directly in quite a few places, especially in `flattening.rs`.

## Test Plan

Tests added and snapshots updated.
