### PR TITLE
fix(core): handle named reexports

### DIFF
--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -7,14 +7,20 @@ expression: content
 ## Source
 
 ```ts
-export * from "./promisedResult.ts";
+export { PromisedResult } from "./promisedResult.ts";
 ```
 
 ## Module Info
 
 ```
 Exports {
-  No exports
+  "PromisedResult" => {
+    ExportReexport => Reexport(
+      Specifier: "./promisedResult.ts"
+      Resolved path: "/src/promisedResult.ts"
+      Import Symbol: PromisedResult
+    )
+  }
 }
 Imports {
   No imports
@@ -57,7 +63,7 @@ Module TypeId(1) => Call Import Symbol: returnPromiseResult from "/src/returnPro
 )
 ```
 
-# `/src/promisedResult.ts` (Not imported by resolver)
+# `/src/promisedResult.ts` (Module 3)
 
 ## Source
 

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -610,7 +610,7 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     );
     fs.insert(
         "/src/reexport.ts".into(),
-        "export * from \"./promisedResult.ts\";\n",
+        "export { PromisedResult } from \"./promisedResult.ts\";\n",
     );
     fs.insert(
         "/src/returnPromiseResult.ts".into(),
@@ -663,7 +663,6 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     let _ty_string = format!("{ty:?}"); // for debugging
     let ty = ty.inferred(&mut resolver);
     let _ty_string = format!("{ty:?}"); // for debugging
-    let _ty = Type::from_data(Box::new(resolver), ty);
-    // FIXME: This assertion should hold, but one step at a time...
-    //assert!(ty.is_promise_instance());
+    let ty = Type::from_data(Box::new(resolver), ty);
+    assert!(ty.is_promise_instance());
 }


### PR DESCRIPTION
## Summary

Small fix so our type inference can follow named reexports. Blanket reexports are still not followed.

## Test Plan

Test updated.
