### PR TITLE
perf: faster manifest handling

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -76,6 +76,9 @@
       },
       "suspicious": {
         "noVar": "on"
+      },
+      "nursery": {
+        "noImportCycles": "error"
       }
     }
   },

--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -152,7 +152,7 @@ where
     services.insert_service(options.file_path.clone());
     services.insert_service(
         project_layout
-            .get_node_manifest_for_path(options.file_path.as_ref())
+            .find_node_manifest_for_path(options.file_path.as_ref())
             .map(|(path, manifest)| (path, Arc::new(manifest))),
     );
     services.insert_service(project_layout);

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -8,7 +8,7 @@ use biome_deserialize::{
 use biome_deserialize_macros::Deserializable;
 use biome_js_syntax::{AnyJsImportClause, AnyJsImportLike};
 use biome_rowan::AstNode;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{globals::is_node_builtin_module, services::manifest::Manifest};
 
@@ -280,7 +280,13 @@ impl Rule for NoUndeclaredDependencies {
             ));
         };
 
-        let manifest_path = package_path.clone();
+        let cwd = Utf8PathBuf::from(
+            std::env::current_dir()
+                .map(|cwd| cwd.to_string_lossy().to_string())
+                .unwrap_or_default(),
+        );
+
+        let manifest_path = package_path.strip_prefix(&cwd).unwrap_or(&package_path);
 
         let diag = RuleDiagnostic::new(
             rule_category!(),

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -286,7 +286,7 @@ impl Rule for NoUndeclaredDependencies {
                 .unwrap_or_default(),
         );
 
-        let manifest_path = package_path.strip_prefix(&cwd).unwrap_or(&package_path);
+        let manifest_path = package_path.strip_prefix(&cwd).unwrap_or(package_path);
 
         let diag = RuleDiagnostic::new(
             rule_category!(),

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -179,7 +179,7 @@ pub(crate) fn analyze_and_snap(
     let mut code_fixes = Vec::new();
     let project_layout = project_layout_with_node_manifest(input_file, &mut diagnostics);
 
-    if let Some((_, manifest)) = project_layout.get_node_manifest_for_path(input_file) {
+    if let Some((_, manifest)) = project_layout.find_node_manifest_for_path(input_file) {
         if manifest.r#type == Some(PackageType::CommonJs) &&
             // At the moment we treat JS and JSX at the same way
             (source_type.file_extension() == "js" || source_type.file_extension() == "jsx" )

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/invalid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -19,7 +18,7 @@ require("@testing-library/react");
 ```
 invalid.js:1:8 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
   > 1 │ import "notInstalled";
       │        ^^^^^^^^^^^^^^
@@ -36,7 +35,7 @@ invalid.js:1:8 lint/correctness/noUndeclaredDependencies ━━━━━━━�
 ```
 invalid.js:2:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     1 │ import "notInstalled";
   > 2 │ import("notInstalled");
@@ -54,7 +53,7 @@ invalid.js:2:1 lint/correctness/noUndeclaredDependencies ━━━━━━━�
 ```
 invalid.js:3:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     1 │ import "notInstalled";
     2 │ import("notInstalled");
@@ -73,7 +72,7 @@ invalid.js:3:1 lint/correctness/noUndeclaredDependencies ━━━━━━━�
 ```
 invalid.js:5:8 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     3 │ require("notInstalled")
     4 │ 
@@ -92,7 +91,7 @@ invalid.js:5:8 lint/correctness/noUndeclaredDependencies ━━━━━━━�
 ```
 invalid.js:6:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     5 │ import "@testing-library/react";
   > 6 │ import("@testing-library/react");
@@ -110,7 +109,7 @@ invalid.js:6:1 lint/correctness/noUndeclaredDependencies ━━━━━━━�
 ```
 invalid.js:7:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     5 │ import "@testing-library/react";
     6 │ import("@testing-library/react");

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/invalid.test.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/invalid.test.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.test.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -19,7 +18,7 @@ require("@testing-library/react");
 ```
 invalid.test.js:1:8 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
   > 1 │ import "notInstalled";
       │        ^^^^^^^^^^^^^^
@@ -36,7 +35,7 @@ invalid.test.js:1:8 lint/correctness/noUndeclaredDependencies ━━━━━━
 ```
 invalid.test.js:2:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     1 │ import "notInstalled";
   > 2 │ import("notInstalled");
@@ -54,7 +53,7 @@ invalid.test.js:2:1 lint/correctness/noUndeclaredDependencies ━━━━━━
 ```
 invalid.test.js:3:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency notInstalled isn't specified in package.json.
+  i Dependency notInstalled isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     1 │ import "notInstalled";
     2 │ import("notInstalled");
@@ -73,7 +72,7 @@ invalid.test.js:3:1 lint/correctness/noUndeclaredDependencies ━━━━━━
 ```
 invalid.test.js:5:8 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     3 │ require("notInstalled")
     4 │ 
@@ -92,7 +91,7 @@ invalid.test.js:5:8 lint/correctness/noUndeclaredDependencies ━━━━━━
 ```
 invalid.test.js:6:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     5 │ import "@testing-library/react";
   > 6 │ import("@testing-library/react");
@@ -110,7 +109,7 @@ invalid.test.js:6:1 lint/correctness/noUndeclaredDependencies ━━━━━━
 ```
 invalid.test.js:7:1 lint/correctness/noUndeclaredDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Dependency @testing-library/react isn't specified in package.json.
+  i Dependency @testing-library/react isn't specified in tests/specs/correctness/noUndeclaredDependencies/package.json.
   
     5 │ import "@testing-library/react";
     6 │ import("@testing-library/react");

--- a/crates/biome_module_graph/src/resolver_cache.rs
+++ b/crates/biome_module_graph/src/resolver_cache.rs
@@ -127,8 +127,7 @@ impl<'a> ResolverCache<'a> {
                                 self,
                             );
 
-                            let utf8_path = Utf8PathBuf::try_from(path.path().to_path_buf())
-                                .map_err(FromPathBufError::into_io_error)?;
+                            let utf8_path = path.to_utf8_path_buf();
                             if self.fs.path_is_symlink(&utf8_path) {
                                 let link = self.fs.read_link(&normalized.path)?;
                                 if link.is_absolute() {
@@ -383,6 +382,10 @@ impl CachedPathImpl {
 
     pub fn kind(&self) -> Option<PathKind> {
         self.kind
+    }
+
+    fn to_utf8_path_buf(&self) -> Utf8PathBuf {
+        self.path.to_path_buf()
     }
 }
 

--- a/crates/biome_module_graph/tests/spec_test.rs
+++ b/crates/biome_module_graph/tests/spec_test.rs
@@ -13,7 +13,7 @@ use biome_module_graph::JsExport;
 use biome_module_graph::{
     ImportSymbol, JsImport, JsReexport, ModuleGraph, ResolvedPath, ScopedResolver,
 };
-use biome_package::{Dependencies, PackageJson, Version};
+use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
 use biome_rowan::Text;
 use biome_test_utils::get_added_paths;
@@ -57,10 +57,10 @@ fn create_test_project_layout() -> (MemoryFileSystem, ProjectLayout) {
         "/".into(),
         PackageJson::new("frontend")
             .with_path("/package.json")
-            .with_version(Version::Literal("0.0.0".into()))
+            .with_version("0.0.0".into())
             .with_dependencies(Dependencies::from([(
                 "shared".into(),
-                Version::Literal("link:./node_modules/shared".into()),
+                "link:./node_modules/shared".into(),
             )])),
     );
 
@@ -69,7 +69,7 @@ fn create_test_project_layout() -> (MemoryFileSystem, ProjectLayout) {
         PackageJson::new("shared")
             .with_path("/node_modules/shared/package.json")
             .with_exports(JsonString::from("./dist/index.js"))
-            .with_version(Version::Literal("0.0.1".into())),
+            .with_version("0.0.1".into()),
     );
 
     (fs, project_layout)
@@ -352,7 +352,7 @@ fn test_resolve_exports() {
         "/".into(),
         PackageJson::new("frontend")
             .with_path("/package.json")
-            .with_version(Version::Literal("0.0.0".into())),
+            .with_version("0.0.0".into()),
     );
 
     let added_paths = [

--- a/crates/biome_package/src/lib.rs
+++ b/crates/biome_package/src/lib.rs
@@ -5,17 +5,18 @@ mod license;
 mod node_js_package;
 
 pub use crate::diagnostics::{ProjectAnalyzeDiagnostic, ProjectDiagnostic};
-use biome_deserialize::{DeserializationDiagnostic, Deserialized};
-use biome_diagnostics::serde::Diagnostic;
-use biome_parser::AnyParse;
-use biome_parser::diagnostic::ParseDiagnostic;
-use biome_rowan::Language;
 pub use license::generated::*;
 pub use node_js_package::{
     Dependencies, NodeJsPackage, PackageJson, PackageType, TsConfigJson, Version,
 };
+
 use std::any::TypeId;
 use std::fmt::Debug;
+
+use biome_deserialize::{DeserializationDiagnostic, Deserialized};
+use biome_diagnostics::serde::Diagnostic;
+use biome_parser::diagnostic::ParseDiagnostic;
+use biome_rowan::Language;
 
 pub(crate) type LanguageRoot<L> = <L as Language>::Root;
 
@@ -35,9 +36,6 @@ pub trait Package {
 
     /// Inserts a manifest into the package, taking care of deserialization.
     fn insert_serialized_manifest(&mut self, root: &PackageRoot<Self>);
-
-    /// Inserts the raw (parse) manifest
-    fn insert_raw_manifest(&mut self, root: &AnyParse);
 
     fn manifest(&self) -> Option<&Self::Manifest> {
         None

--- a/crates/biome_package/src/node_js_package/mod.rs
+++ b/crates/biome_package/src/node_js_package/mod.rs
@@ -1,45 +1,33 @@
 mod package_json;
 mod tsconfig_json;
-use crate::{LICENSE_LIST, Manifest, Package, PackageAnalyzeResult, ProjectAnalyzeDiagnostic};
-use biome_parser::AnyParse;
-use biome_rowan::Language;
+
 pub use package_json::{Dependencies, PackageJson, PackageType, Version};
 pub use tsconfig_json::TsConfigJson;
+
+use biome_rowan::Language;
+
+use crate::{LICENSE_LIST, Manifest, Package, PackageAnalyzeResult, ProjectAnalyzeDiagnostic};
 
 #[derive(Default, Debug, Clone)]
 /// A Node.js project.
 pub struct NodeJsPackage {
     /// The `package.json` manifest
     pub manifest: Option<PackageJson>,
-    /// The raw manifest
-    pub raw_manifest: Option<AnyParse>,
     /// Diagnostics emitted during the operations
     pub diagnostics: Vec<biome_diagnostics::serde::Diagnostic>,
     /// The `tsconfig.json` manifest
-    pub tsconfig: Option<TsConfigJson>,
+    pub tsconfig: TsConfigJson,
 }
 
 impl NodeJsPackage {
     pub fn deserialize_tsconfig(&mut self, content: &ProjectLanguageRoot<TsConfigJson>) {
         let tsconfig = TsConfigJson::deserialize_manifest(content);
         let (tsconfig, deserialize_diagnostics) = tsconfig.consume();
-        self.tsconfig = tsconfig;
+        self.tsconfig = tsconfig.unwrap_or_default();
         self.diagnostics = deserialize_diagnostics
             .into_iter()
             .map(biome_diagnostics::serde::Diagnostic::new)
             .collect();
-    }
-
-    pub fn to_deserialized_manifest(&self) -> Option<PackageJson> {
-        self.raw_manifest
-            .as_ref()
-            .and_then(|root| {
-                let node = root.tree();
-                let deserialized = <Self as Package>::Manifest::deserialize_manifest(&node);
-                let (manifest, _) = deserialized.consume();
-                manifest
-            })
-            .or_else(|| self.manifest.clone())
     }
 }
 
@@ -56,10 +44,6 @@ impl Package for NodeJsPackage {
             .into_iter()
             .map(biome_diagnostics::serde::Diagnostic::new)
             .collect();
-    }
-
-    fn insert_raw_manifest(&mut self, json_root: &AnyParse) {
-        self.raw_manifest = Some(json_root.clone());
     }
 
     fn manifest(&self) -> Option<&Self::Manifest> {

--- a/crates/biome_package/tests/tsconfig/valid/tsconfig.valid.baseUrl.json.snap
+++ b/crates/biome_package/tests/tsconfig/valid/tsconfig.valid.baseUrl.json.snap
@@ -13,18 +13,16 @@ expression: tsconfig.valid.baseUrl.json
 
 ## Data structure
 
-Some(
-    TsConfigJson {
-        root: false,
-        path: "",
-        extends: None,
-        compiler_options: CompilerOptions {
-            base_url: Some(
-                "src",
-            ),
-            paths: None,
-            paths_base: "",
-        },
-        references: [],
+TsConfigJson {
+    root: false,
+    path: "",
+    extends: None,
+    compiler_options: CompilerOptions {
+        base_url: Some(
+            "src",
+        ),
+        paths: None,
+        paths_base: "",
     },
-)
+    references: [],
+}

--- a/crates/biome_package/tests/tsconfig/valid/tsconfig.valid.paths.json.snap
+++ b/crates/biome_package/tests/tsconfig/valid/tsconfig.valid.paths.json.snap
@@ -19,25 +19,23 @@ expression: tsconfig.valid.paths.json
 
 ## Data structure
 
-Some(
-    TsConfigJson {
-        root: false,
-        path: "",
-        extends: None,
-        compiler_options: CompilerOptions {
-            base_url: Some(
-                "src",
-            ),
-            paths: Some(
-                {
-                    "@/services": [
-                        "services",
-                        "vendor/services",
-                    ],
-                },
-            ),
-            paths_base: "",
-        },
-        references: [],
+TsConfigJson {
+    root: false,
+    path: "",
+    extends: None,
+    compiler_options: CompilerOptions {
+        base_url: Some(
+            "src",
+        ),
+        paths: Some(
+            {
+                "@/services": [
+                    "services",
+                    "vendor/services",
+                ],
+            },
+        ),
+        paths_base: "",
     },
-)
+    references: [],
+}

--- a/crates/biome_project_layout/src/project_layout.rs
+++ b/crates/biome_project_layout/src/project_layout.rs
@@ -66,25 +66,25 @@ impl ProjectLayout {
         // Contrary to what I expected however, the below implementation
         // appeared significantly faster (tested on the `unleash` repository).
 
-        let mut result: Option<(Utf8PathBuf, PackageJson)> = None;
+        let mut result: Option<(&Utf8PathBuf, &PackageJson)> = None;
 
         let packages = self.0.pin();
         for (package_path, data) in packages.iter() {
             let Some(node_manifest) = data
                 .node_package
                 .as_ref()
-                .and_then(|node_package| node_package.to_deserialized_manifest())
+                .and_then(|node_package| node_package.manifest.as_ref())
             else {
                 continue;
             };
 
             let is_closest_match = path.strip_prefix(package_path).is_ok()
-                && result.as_ref().is_none_or(|(matched_package_path, _)| {
+                && result.is_none_or(|(matched_package_path, _)| {
                     package_path.as_str().len() > matched_package_path.as_str().len()
                 });
 
             if is_closest_match {
-                result = Some((package_path.clone(), node_manifest));
+                result = Some((package_path, node_manifest));
             }
         }
 
@@ -102,13 +102,13 @@ impl ProjectLayout {
             path,
             |data| {
                 let mut node_js_package = NodeJsPackage {
+                    manifest: Default::default(),
                     diagnostics: Default::default(),
                     tsconfig: data
                         .node_package
                         .as_ref()
                         .map(|package| package.tsconfig.clone())
                         .unwrap_or_default(),
-                    ..Default::default()
                 };
                 node_js_package.manifest = Some(manifest.clone());
 
@@ -132,22 +132,21 @@ impl ProjectLayout {
     /// Inserts a `package.json` manifest for the package at the given `path`,
     /// parsing the manifest on demand.
     ///
-    /// This method doesn't deserialize the manifest.
-    ///
     /// See also [Self::insert_node_manifest()].
-    pub fn insert_raw_node_manifest(&self, path: Utf8PathBuf, manifest: AnyParse) {
+    pub fn insert_serialized_node_manifest(&self, path: Utf8PathBuf, manifest: AnyParse) {
         self.0.pin().update_or_insert_with(
             path,
             |data| {
                 let mut node_js_package = NodeJsPackage {
+                    manifest: Default::default(),
+                    diagnostics: Default::default(),
                     tsconfig: data
                         .node_package
                         .as_ref()
                         .map(|package| package.tsconfig.clone())
                         .unwrap_or_default(),
-                    ..Default::default()
                 };
-                node_js_package.insert_raw_manifest(&manifest);
+                node_js_package.insert_serialized_manifest(&manifest.tree());
 
                 PackageData {
                     node_package: Some(node_js_package),
@@ -155,7 +154,7 @@ impl ProjectLayout {
             },
             || {
                 let mut node_js_package = NodeJsPackage::default();
-                node_js_package.insert_raw_manifest(&manifest);
+                node_js_package.insert_serialized_manifest(&manifest.tree());
 
                 PackageData {
                     node_package: Some(node_js_package),

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1458,7 +1458,7 @@ impl<'b> AnalyzerVisitorBuilder<'b> {
 
         let package_json = self
             .path
-            .and_then(|path| self.project_layout.get_node_manifest_for_path(path))
+            .and_then(|path| self.project_layout.find_node_manifest_for_path(path))
             .map(|(_, manifest)| manifest);
 
         let mut lint = LintVisitor::new(

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -270,7 +270,7 @@ impl TraversalContext for ScanContext<'_> {
         if self.scan_kind.is_known_files() {
             (path.is_ignore() || path.is_config() || path.is_manifest()) && !path.is_dependency()
         } else if path.is_dependency() {
-            path.is_type_declaration()
+            path.is_manifest() || path.is_type_declaration()
         } else {
             DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
         }

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -310,7 +310,7 @@ impl WorkspaceServer {
 
         if let DocumentFileSource::Js(js) = &mut source {
             if path.extension().is_some_and(|extension| extension == "js") {
-                let manifest = self.project_layout.get_node_manifest_for_path(&path);
+                let manifest = self.project_layout.find_node_manifest_for_path(&path);
                 if let Some((_, manifest)) = manifest {
                     if manifest.r#type == Some(PackageType::CommonJs) {
                         js.set_module_kind(ModuleKind::Script);

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -612,7 +612,7 @@ impl WorkspaceServer {
                 WatcherSignalKind::AddedOrChanged => {
                     let parsed = self.get_parse(path)?;
                     self.project_layout
-                        .insert_raw_node_manifest(package_path, parsed);
+                        .insert_serialized_node_manifest(package_path, parsed);
                 }
                 WatcherSignalKind::Removed => {
                     self.project_layout.remove_package(&package_path);

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -257,7 +257,10 @@ pub fn project_layout_with_node_manifest(
         } else {
             let project_layout = ProjectLayout::default();
             project_layout.insert_node_manifest(
-                Utf8PathBuf::new(),
+                input_file
+                    .parent()
+                    .map(|dir_path| dir_path.to_path_buf())
+                    .unwrap_or_default(),
                 deserialized.into_deserialized().unwrap_or_default(),
             );
             return Arc::new(project_layout);


### PR DESCRIPTION
## Summary

Includes performance improvements **and one functional change**:

* Reverts #5910 due to a performance regression.
* Because parsing versions in `package.json` has proved problematic, they're now deserialised as `String` and only parsed into a semantic version on demand. I haven't noticed much performance impact of this, but at least it should solve issues with panics on incorrect semantic versions that plagued us before.
* Some tiny optimisations in our resolver cache.
* **Functional change:** `package.json` files inside `node_modules` are scanned again. I witnessed that indeed this used to cause a performance regression, but I've managed to mitigate this impact as you can see in https://github.com/biomejs/biome/commit/74266e62222f273c7f2c33647c14d15dca7d1115.

Performance is now back to where it was before #5910 was merged, even though we're now able to scan `package.json` files inside `node_modules`.

## Test Plan

Everything should remain green.