### PR TITLE
chore: update rust-toolchain.toml on Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,5 +56,16 @@
       "matchDepTypes": ["engines"],
       "enabled": false
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["(^|/)rust-toolchain\\.toml?$"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
+      ],
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-tags"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Added a [regex manager](https://docs.renovatebot.com/modules/manager/regex/) for updating the toolchain version in `rust-toolchain.toml` automatically.

ref: https://github.com/renovatebot/renovate/issues/11488
ref: https://github.com/Turbo87/renovate-config/blob/3efd54b2e6eb9ad396970a61dfb52024d45052a8/rust/updateToolchain.json

## Test Plan

I will check the dependency dashboard after merged this PR
