### PR TITLE
refactor(lsp): use `tower-lsp-server`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,28 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bc070afe45e3d9e628b82d77d61c90531dc6997b341d57715b82461af415669"
 
 [[package]]
-name = "async-trait"
-version = "0.1.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,8 +1083,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower",
- "tower-lsp",
+ "tower 0.5.2",
+ "tower-lsp-server",
  "tracing",
 ]
 
@@ -1117,8 +1095,8 @@ dependencies = [
  "anyhow",
  "biome_rowan",
  "rustc-hash 2.1.1",
- "tower",
- "tower-lsp",
+ "tower 0.4.13",
+ "tower-lsp-server",
 ]
 
 [[package]]
@@ -2150,6 +2128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,15 +2832,15 @@ checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lsp-types"
-version = "0.94.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -3149,26 +3136,6 @@ name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
-
-[[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -3954,6 +3921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,9 +4184,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
  "pin-project-lite",
  "tokio",
  "tower-layer",
@@ -4222,21 +4192,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
+name = "tower"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
-name = "tower-lsp"
-version = "0.20.0"
+name = "tower-layer"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp-server"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fade4c658b63d11b623ddfa80821901e943a2923a010ae4a038661de42bd377"
 dependencies = [
- "async-trait",
- "auto_impl",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap 6.1.0",
  "futures",
  "httparse",
  "lsp-types",
@@ -4245,27 +4228,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower",
- "tower-lsp-macros",
+ "tower 0.5.2",
  "tracing",
 ]
 
 [[package]]
-name = "tower-lsp-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4474,7 +4445,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-lsp-server",
  "tracing",
 ]
@@ -1095,7 +1095,7 @@ dependencies = [
  "anyhow",
  "biome_rowan",
  "rustc-hash 2.1.1",
- "tower 0.4.13",
+ "tower",
  "tower-lsp-server",
 ]
 
@@ -4180,19 +4180,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -4228,7 +4215,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ syn                  = "1.0.109"
 termcolor            = "1.4.1"
 terminal_size        = "0.4.2"
 tokio                = "1.44.2"
+tower                = "0.5.2"
 tower-lsp-server     = "0.21.1"
 tracing              = { version = "0.1.41", default-features = false, features = ["std", "attributes"] }
 tracing-subscriber   = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ syn                  = "1.0.109"
 termcolor            = "1.4.1"
 terminal_size        = "0.4.2"
 tokio                = "1.44.2"
+tower-lsp-server     = "0.21.1"
 tracing              = { version = "0.1.41", default-features = false, features = ["std", "attributes"] }
 tracing-subscriber   = "0.3.19"
 unicode-bom          = "2.0.3"

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -7,12 +7,13 @@ use crate::ConfigName;
 use camino::{Utf8Path, Utf8PathBuf};
 use enumflags2::{BitFlags, bitflags};
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::fs::read_to_string;
 use std::hash::Hash;
 use std::ops::DerefMut;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{fs::File, io, io::Write, ops::Deref};
 
 /// The priority of the file
@@ -282,6 +283,14 @@ impl TryFrom<PathBuf> for BiomePath {
     type Error = PathBuf;
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
         let path = Utf8PathBuf::from_path_buf(value)?;
+        Ok(Self::new(path))
+    }
+}
+
+impl TryFrom<Cow<'_, Path>> for BiomePath {
+    type Error = PathBuf;
+    fn try_from(value: Cow<'_, Path>) -> Result<Self, Self::Error> {
+        let path = Utf8PathBuf::from_path_buf(value.as_ref().into())?;
         Ok(Self::new(path))
     }
 }

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -33,12 +33,12 @@ rustc-hash           = { workspace = true }
 serde                = { workspace = true, features = ["derive"] }
 serde_json           = { workspace = true }
 tokio                = { workspace = true, features = ["rt", "io-std"] }
-tower-lsp            = { version = "0.20.0" }
+tower-lsp-server     = { workspace = true }
 tracing              = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-tower = { version = "0.4.13", features = ["timeout"] }
+tower = { version = "0.5.2", features = ["timeout"] }
 
 [lints]
 workspace = true

--- a/crates/biome_lsp/Cargo.toml
+++ b/crates/biome_lsp/Cargo.toml
@@ -38,7 +38,7 @@ tracing              = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-tower = { version = "0.5.2", features = ["timeout"] }
+tower = { workspace = true, features = ["timeout"] }
 
 [lints]
 workspace = true

--- a/crates/biome_lsp/src/capabilities.rs
+++ b/crates/biome_lsp/src/capabilities.rs
@@ -1,6 +1,6 @@
 use biome_analyze::{SUPPRESSION_INLINE_ACTION_CATEGORY, SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY};
 use biome_lsp_converters::{PositionEncoding, WideEncoding, negotiated_encoding};
-use tower_lsp::lsp_types::{
+use tower_lsp_server::lsp_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     DocumentOnTypeFormattingOptions, OneOf, PositionEncodingKind, ServerCapabilities,
     TextDocumentSyncCapability, TextDocumentSyncKind, WorkspaceFoldersServerCapabilities,
@@ -9,7 +9,7 @@ use tower_lsp::lsp_types::{
 
 /// The capabilities to send from server as part of [`InitializeResult`]
 ///
-/// [`InitializeResult`]: lspower::lsp::InitializeResult
+/// [`InitializeResult`]: tower_lsp_server::lsp::InitializeResult
 pub(crate) fn server_capabilities(capabilities: &ClientCapabilities) -> ServerCapabilities {
     let supports_formatter_dynamic_registration = capabilities
         .text_document

--- a/crates/biome_lsp/src/diagnostics.rs
+++ b/crates/biome_lsp/src/diagnostics.rs
@@ -3,7 +3,8 @@ use anyhow::Error;
 use biome_diagnostics::print_diagnostic_to_string;
 use biome_service::WorkspaceError;
 use std::fmt::{Display, Formatter};
-use tower_lsp::lsp_types::MessageType;
+use tower_lsp_server::lsp_types::MessageType;
+use tower_lsp_server::{Client, jsonrpc};
 
 #[derive(Debug)]
 pub enum LspError {
@@ -49,8 +50,8 @@ impl Display for LspError {
 /// It accepts a `Client`, so contextual messages are sent to the user.
 pub(crate) async fn handle_lsp_error<T>(
     err: LspError,
-    client: &tower_lsp::Client,
-) -> Result<Option<T>, tower_lsp::jsonrpc::Error> {
+    client: &Client,
+) -> Result<Option<T>, jsonrpc::Error> {
     match err {
         LspError::WorkspaceError(err) => match err {
             // diagnostics that shouldn't raise an hard error, but send a message to the user

--- a/crates/biome_lsp/src/handlers/formatting.rs
+++ b/crates/biome_lsp/src/handlers/formatting.rs
@@ -12,7 +12,7 @@ use biome_service::workspace::{
 };
 use biome_service::{WorkspaceError, extension_error};
 use std::ops::Sub;
-use tower_lsp::lsp_types::*;
+use tower_lsp_server::lsp_types::*;
 
 #[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn format(
@@ -115,8 +115,9 @@ pub(crate) fn format_range(
         let format_range = from_proto::text_range(&doc.line_index, params.range, position_encoding)
             .with_context(|| {
                 format!(
-                    "failed to convert range {:?} in document {url}",
-                    params.range.end
+                    "failed to convert range {:?} in document {}",
+                    params.range.end,
+                    url.as_str()
                 )
             })?;
         let content = session.workspace.get_file_content(GetFileContentParams {
@@ -198,7 +199,12 @@ pub(crate) fn format_on_type(
 
         let position_encoding = session.position_encoding();
         let offset = from_proto::offset(&doc.line_index, position, position_encoding)
-            .with_context(|| format!("failed to access position {position:?} in document {url}"))?;
+            .with_context(|| {
+                format!(
+                    "failed to access position {position:?} in document {}",
+                    url.as_str()
+                )
+            })?;
 
         let formatted = session.workspace.format_on_type(FormatOnTypeParams {
             project_key: doc.project_key,

--- a/crates/biome_lsp/src/handlers/rename.rs
+++ b/crates/biome_lsp/src/handlers/rename.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
-
+#![expect(clippy::mutable_key_type)]
 use crate::diagnostics::LspError;
 use crate::{session::Session, utils};
 use anyhow::{Context, Result};
 use biome_lsp_converters::from_proto;
-use tower_lsp::lsp_types::{RenameParams, WorkspaceEdit};
+use std::collections::HashMap;
+use tower_lsp_server::lsp_types::{RenameParams, WorkspaceEdit};
 
 #[tracing::instrument(level = "debug", skip(session), err)]
 pub(crate) fn rename(
@@ -23,8 +23,9 @@ pub(crate) fn rename(
     )
     .with_context(|| {
         format!(
-            "failed to access position {:?} in document {url}",
-            params.text_document_position.position
+            "failed to access position {:?} in document {}",
+            params.text_document_position.position,
+            url.as_str()
         )
     })?;
 

--- a/crates/biome_lsp/src/requests/syntax_tree.rs
+++ b/crates/biome_lsp/src/requests/syntax_tree.rs
@@ -1,7 +1,7 @@
 use crate::{diagnostics::LspError, session::Session};
 use biome_service::workspace::GetSyntaxTreeParams;
 use serde::{Deserialize, Serialize};
-use tower_lsp::lsp_types::{TextDocumentIdentifier, Url};
+use tower_lsp_server::lsp_types::{TextDocumentIdentifier, Uri};
 use tracing::info;
 
 pub const SYNTAX_TREE_REQUEST: &str = "biome_lsp/syntaxTree";
@@ -12,7 +12,7 @@ pub struct SyntaxTreePayload {
     pub text_document: TextDocumentIdentifier,
 }
 
-pub(crate) fn syntax_tree(session: &Session, url: &Url) -> Result<String, LspError> {
+pub(crate) fn syntax_tree(session: &Session, url: &Uri) -> Result<String, LspError> {
     info!("Showing syntax tree");
     let path = session.file_path(url)?;
     let doc = session.document(url)?;

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1,7 +1,9 @@
+#![expect(clippy::mutable_key_type)]
 use std::any::type_name;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::slice;
+use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context, Error, Result, bail};
@@ -24,14 +26,14 @@ use serde_json::{from_value, to_value};
 use tokio::time::sleep;
 use tower::timeout::Timeout;
 use tower::{Service, ServiceExt};
-use tower_lsp::LspService;
-use tower_lsp::jsonrpc::{self, Request, Response};
-use tower_lsp::lsp_types::{
+use tower_lsp_server::LspService;
+use tower_lsp_server::jsonrpc::{self, Request, Response};
+use tower_lsp_server::lsp_types::{
     self as lsp, ClientCapabilities, CodeDescription, DidChangeConfigurationParams,
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     DocumentFormattingParams, FormattingOptions, InitializeParams, InitializeResult,
     InitializedParams, Position, PublishDiagnosticsParams, Range, TextDocumentContentChangeEvent,
-    TextDocumentIdentifier, TextDocumentItem, TextEdit, Url, VersionedTextDocumentIdentifier,
+    TextDocumentIdentifier, TextDocumentItem, TextEdit, Uri, VersionedTextDocumentIdentifier,
     WorkDoneProgressParams, WorkspaceFolder,
 };
 
@@ -39,16 +41,16 @@ use crate::WorkspaceSettings;
 
 use super::*;
 
-/// Statically build an [Url] instance that points to the file at `$path`
+/// Statically build an [Uri] instance that points to the file at `$path`
 /// within the workspace. The filesystem path contained in the return URI is
 /// guaranteed to be a valid path for the underlying operating system, but
 /// doesn't have to refer to an existing file on the host machine.
-macro_rules! url {
+macro_rules! uri {
     ($path:literal) => {
         if cfg!(windows) {
-            lsp::Url::parse(concat!("file:///z%3A/workspace/", $path)).unwrap()
+            lsp::Uri::from_str(concat!("/z%3A/workspace/", $path)).unwrap()
         } else {
-            lsp::Url::parse(concat!("file:///workspace/", $path)).unwrap()
+            lsp::Uri::from_str(concat!("/workspace/", $path)).unwrap()
         }
     };
 }
@@ -64,8 +66,8 @@ macro_rules! clear_notifications {
     };
 }
 
-fn fixable_diagnostic(line: u32) -> Result<lsp::Diagnostic> {
-    Ok(lsp::Diagnostic {
+fn fixable_diagnostic(line: u32) -> Result<Diagnostic> {
+    Ok(Diagnostic {
         range: Range {
             start: Position { line, character: 3 },
             end: Position {
@@ -73,8 +75,8 @@ fn fixable_diagnostic(line: u32) -> Result<lsp::Diagnostic> {
                 character: 11,
             },
         },
-        severity: Some(lsp::DiagnosticSeverity::ERROR),
-        code: Some(lsp::NumberOrString::String(String::from(
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String(String::from(
             "lint/suspicious/noCompareNegZero",
         ))),
         code_description: None,
@@ -174,13 +176,14 @@ impl Server {
                 InitializeParams {
                     process_id: None,
                     root_path: None,
-                    root_uri: Some(url!("")),
+                    root_uri: Some(uri!("")),
                     initialization_options: None,
                     capabilities: ClientCapabilities::default(),
                     trace: None,
                     workspace_folders: None,
                     client_info: None,
                     locale: None,
+                    work_done_progress_params: Default::default(),
                 },
             )
             .await?
@@ -202,22 +205,23 @@ impl Server {
                 InitializeParams {
                     process_id: None,
                     root_path: None,
-                    root_uri: Some(url!("/")),
+                    root_uri: Some(uri!("/")),
                     initialization_options: None,
                     capabilities: ClientCapabilities::default(),
                     trace: None,
                     workspace_folders: Some(vec![
                         WorkspaceFolder {
                             name: "test_one".to_string(),
-                            uri: url!("test_one"),
+                            uri: uri!("test_one"),
                         },
                         WorkspaceFolder {
                             name: "test_two".to_string(),
-                            uri: url!("test_two"),
+                            uri: uri!("test_two"),
                         },
                     ]),
                     client_info: None,
                     locale: None,
+                    work_done_progress_params: Default::default(),
                 },
             )
             .await?
@@ -256,7 +260,7 @@ impl Server {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: text.to_string(),
@@ -271,7 +275,7 @@ impl Server {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: url!("untitled-1"),
+                    uri: uri!("untitled-1"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: text.to_string(),
@@ -285,7 +289,7 @@ impl Server {
     async fn open_named_document(
         &mut self,
         text: impl Display,
-        document_name: Url,
+        document_name: Uri,
         language: impl Display,
     ) -> Result<()> {
         self.notify(
@@ -307,7 +311,7 @@ impl Server {
         self.notify(
             "workspace/didChangeConfiguration",
             DidChangeConfigurationParams {
-                settings: to_value(()).unwrap(),
+                settings: to_value(())?,
             },
         )
         .await
@@ -322,7 +326,7 @@ impl Server {
             "textDocument/didChange",
             DidChangeTextDocumentParams {
                 text_document: VersionedTextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                     version,
                 },
                 content_changes,
@@ -336,7 +340,7 @@ impl Server {
             "textDocument/didClose",
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
             },
         )
@@ -371,7 +375,7 @@ impl ServerNotification {
 }
 
 async fn wait_for_notification(
-    receiver: &mut (impl futures::stream::Stream<Item = ServerNotification> + Unpin),
+    receiver: &mut (impl Stream<Item = ServerNotification> + Unpin),
     check: impl Fn(&ServerNotification) -> bool,
 ) -> Option<ServerNotification> {
     loop {
@@ -596,7 +600,7 @@ async fn document_lifecycle() -> Result<()> {
             "get_syntax_tree",
             GetSyntaxTreeParams {
                 project_key,
-                path: BiomePath::try_from(url!("document.js").to_file_path().unwrap()).unwrap(),
+                path: BiomePath::try_from(uri!("document.js").to_file_path().unwrap()).unwrap(),
             },
         )
         .await?
@@ -656,7 +660,7 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
                 "get_syntax_tree",
                 GetSyntaxTreeParams {
                     project_key,
-                    path: BiomePath::try_from(url!("document.js").to_file_path().unwrap()).unwrap(),
+                    path: BiomePath::try_from(uri!("document.js").to_file_path().unwrap()).unwrap(),
                 },
             )
             .await?
@@ -700,7 +704,7 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
                 "get_syntax_tree",
                 GetSyntaxTreeParams {
                     project_key,
-                    path: BiomePath::try_from(url!("document.js").to_file_path().unwrap()).unwrap(),
+                    path: BiomePath::try_from(uri!("document.js").to_file_path().unwrap()).unwrap(),
                 },
             )
             .await?
@@ -733,7 +737,7 @@ async fn document_no_extension() -> Result<()> {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: String::from("statement()"),
@@ -748,7 +752,7 @@ async fn document_no_extension() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -774,7 +778,7 @@ async fn document_no_extension() -> Result<()> {
             "textDocument/didClose",
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                 },
             },
         )
@@ -807,9 +811,9 @@ async fn pull_diagnostics() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("document.js"),
+                uri: uri!("document.js"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 0,
@@ -820,19 +824,18 @@ async fn pull_diagnostics() -> Result<()> {
                             character: 14,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from(
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
                         "lint/correctness/noConstAssign",
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-const-assign")
-                            .unwrap()
+                        href: Uri::from_str("https://biomejs.dev/linter/rules/no-const-assign")?
                     }),
                     source: Some(String::from("biome")),
                     message: String::from("Can't assign a because it's a constant.",),
-                    related_information: Some(vec![lsp::DiagnosticRelatedInformation {
-                        location: lsp::Location {
-                            uri: url!("document.js"),
+                    related_information: Some(vec![DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: uri!("document.js"),
                             range: Range {
                                 start: Position {
                                     line: 0,
@@ -882,9 +885,9 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("document.js"),
+                uri: uri!("document.js"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 0,
@@ -895,8 +898,8 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
                             character: 20,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from(
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
                         "syntax/correctness/noDuplicatePrivateClassMembers",
                     ))),
                     code_description: None,
@@ -939,9 +942,9 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("untitled-1"),
+                uri: uri!("untitled-1"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 0,
@@ -952,19 +955,18 @@ async fn pull_diagnostics_from_new_file() -> Result<()> {
                             character: 14,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from(
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
                         "lint/correctness/noConstAssign",
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-const-assign")
-                            .unwrap()
+                        href: Uri::from_str("https://biomejs.dev/linter/rules/no-const-assign")?
                     }),
                     source: Some(String::from("biome")),
                     message: String::from("Can't assign a because it's a constant.",),
-                    related_information: Some(vec![lsp::DiagnosticRelatedInformation {
-                        location: lsp::Location {
-                            uri: url!("untitled-1"),
+                    related_information: Some(vec![DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: uri!("untitled-1"),
                             range: Range {
                                 start: Position {
                                     line: 0,
@@ -1008,13 +1010,13 @@ async fn pull_quick_fixes() -> Result<()> {
 
     server.open_document("if(a === -0) {}").await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -1026,15 +1028,15 @@ async fn pull_quick_fixes() -> Result<()> {
                         character: 6,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![fixable_diagnostic(0)?],
-                    only: Some(vec![lsp::CodeActionKind::QUICKFIX]),
+                    only: Some(vec![CodeActionKind::QUICKFIX]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1044,7 +1046,7 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let mut changes = HashMap::default();
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1060,13 +1062,13 @@ async fn pull_quick_fixes() -> Result<()> {
         }],
     );
 
-    let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_code_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Replace -0 with 0"),
-        kind: Some(lsp::CodeActionKind::new(
+        kind: Some(CodeActionKind::new(
             "quickfix.biome.suspicious.noCompareNegZero",
         )),
         diagnostics: Some(vec![fixable_diagnostic(0)?]),
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -1079,7 +1081,7 @@ async fn pull_quick_fixes() -> Result<()> {
 
     let mut suppression_changes = HashMap::default();
     suppression_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1097,27 +1099,24 @@ async fn pull_quick_fixes() -> Result<()> {
         }],
     );
 
-    let expected_inline_suppression_action =
-        lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from("Suppress rule lint/suspicious/noCompareNegZero for this line."),
-            kind: Some(lsp::CodeActionKind::new(
-                "quickfix.suppressRule.inline.biome",
-            )),
-            diagnostics: Some(vec![fixable_diagnostic(0)?]),
-            edit: Some(lsp::WorkspaceEdit {
-                changes: Some(suppression_changes),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            command: None,
-            is_preferred: None,
-            disabled: None,
-            data: None,
-        });
+    let expected_inline_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress rule lint/suspicious/noCompareNegZero for this line."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.inline.biome")),
+        diagnostics: Some(vec![fixable_diagnostic(0)?]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(suppression_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
 
     let mut top_level_changes = HashMap::default();
     top_level_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1135,25 +1134,20 @@ async fn pull_quick_fixes() -> Result<()> {
         }],
     );
 
-    let expected_top_level_suppression_action =
-        lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from(
-                "Suppress rule lint/suspicious/noCompareNegZero for the whole file.",
-            ),
-            kind: Some(lsp::CodeActionKind::new(
-                "quickfix.suppressRule.topLevel.biome",
-            )),
-            diagnostics: Some(vec![fixable_diagnostic(0)?]),
-            edit: Some(lsp::WorkspaceEdit {
-                changes: Some(top_level_changes),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            command: None,
-            is_preferred: None,
-            disabled: None,
-            data: None,
-        });
+    let expected_top_level_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress rule lint/suspicious/noCompareNegZero for the whole file."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.topLevel.biome")),
+        diagnostics: Some(vec![fixable_diagnostic(0)?]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(top_level_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
 
     assert_eq!(
         res,
@@ -1179,7 +1173,7 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let unsafe_fixable = lsp::Diagnostic {
+    let unsafe_fixable = Diagnostic {
         range: Range {
             start: Position {
                 line: 0,
@@ -1190,8 +1184,8 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
                 character: 9,
             },
         },
-        severity: Some(lsp::DiagnosticSeverity::ERROR),
-        code: Some(lsp::NumberOrString::String(String::from(
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String(String::from(
             "lint/suspicious/noDoubleEquals",
         ))),
         code_description: None,
@@ -1210,13 +1204,13 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
 
     server.open_document("if(a == 0) {}").await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -1228,15 +1222,15 @@ async fn pull_biome_quick_fixes_ignore_unsafe() -> Result<()> {
                         character: 6,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![unsafe_fixable.clone()],
-                    only: Some(vec![lsp::CodeActionKind::new("quickfix.biome")]),
+                    only: Some(vec![CodeActionKind::new("quickfix.biome")]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1269,13 +1263,13 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 
     server.open_document("if(a === -0) {}").await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -1287,9 +1281,9 @@ async fn pull_biome_quick_fixes() -> Result<()> {
                         character: 10,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![fixable_diagnostic(0)?],
-                    only: Some(vec![lsp::CodeActionKind::new(
+                    only: Some(vec![CodeActionKind::new(
                         "quickfix.biome.suspicious.noCompareNegZero",
                     )]),
                     ..Default::default()
@@ -1297,7 +1291,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1307,7 +1301,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 
     let mut changes = HashMap::default();
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1323,13 +1317,13 @@ async fn pull_biome_quick_fixes() -> Result<()> {
         }],
     );
 
-    let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_code_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Replace -0 with 0"),
-        kind: Some(lsp::CodeActionKind::new(
+        kind: Some(CodeActionKind::new(
             "quickfix.biome.suspicious.noCompareNegZero",
         )),
         diagnostics: Some(vec![fixable_diagnostic(0)?]),
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -1357,7 +1351,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let unsafe_fixable = lsp::Diagnostic {
+    let unsafe_fixable = Diagnostic {
         range: Range {
             start: Position {
                 line: 0,
@@ -1368,8 +1362,8 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
                 character: 9,
             },
         },
-        severity: Some(lsp::DiagnosticSeverity::ERROR),
-        code: Some(lsp::NumberOrString::String(String::from(
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String(String::from(
             "lint/suspicious/noDoubleEquals",
         ))),
         code_description: None,
@@ -1388,13 +1382,13 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 
     server.open_document("if(a == 0) {}").await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -1406,7 +1400,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
                         character: 6,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![unsafe_fixable.clone()],
                     only: Some(vec![]),
                     ..Default::default()
@@ -1414,7 +1408,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1424,7 +1418,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 
     let mut changes = HashMap::default();
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1440,13 +1434,13 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
         }],
     );
 
-    let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_code_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Use === instead."),
-        kind: Some(lsp::CodeActionKind::new(
+        kind: Some(CodeActionKind::new(
             "quickfix.biome.suspicious.noDoubleEquals",
         )),
         diagnostics: Some(vec![unsafe_fixable.clone()]),
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -1459,7 +1453,7 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
 
     let mut suppression_changes = HashMap::default();
     suppression_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1477,27 +1471,24 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
         }],
     );
 
-    let expected_inline_suppression_action =
-        lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from("Suppress rule lint/suspicious/noDoubleEquals for this line."),
-            kind: Some(lsp::CodeActionKind::new(
-                "quickfix.suppressRule.inline.biome",
-            )),
-            diagnostics: Some(vec![unsafe_fixable.clone()]),
-            edit: Some(lsp::WorkspaceEdit {
-                changes: Some(suppression_changes),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            command: None,
-            is_preferred: None,
-            disabled: None,
-            data: None,
-        });
+    let expected_inline_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress rule lint/suspicious/noDoubleEquals for this line."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.inline.biome")),
+        diagnostics: Some(vec![unsafe_fixable.clone()]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(suppression_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
 
     let mut top_level_changes = HashMap::default();
     top_level_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -1515,23 +1506,20 @@ async fn pull_quick_fixes_include_unsafe() -> Result<()> {
         }],
     );
 
-    let expected_toplevel_suppression_action =
-        lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from("Suppress rule lint/suspicious/noDoubleEquals for the whole file."),
-            kind: Some(lsp::CodeActionKind::new(
-                "quickfix.suppressRule.topLevel.biome",
-            )),
-            diagnostics: Some(vec![unsafe_fixable]),
-            edit: Some(lsp::WorkspaceEdit {
-                changes: Some(top_level_changes),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            command: None,
-            is_preferred: None,
-            disabled: None,
-            data: None,
-        });
+    let expected_toplevel_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress rule lint/suspicious/noDoubleEquals for the whole file."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.topLevel.biome")),
+        diagnostics: Some(vec![unsafe_fixable]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(top_level_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
 
     assert_eq!(
         res,
@@ -1569,7 +1557,7 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
         }
     }"#;
     server
-        .open_named_document(incorrect_config, url!("biome.json"), "json")
+        .open_named_document(incorrect_config, uri!("biome.json"), "json")
         .await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
@@ -1578,9 +1566,9 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("biome.json"),
+                uri: uri!("biome.json"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 2,
@@ -1591,8 +1579,8 @@ async fn pull_diagnostics_for_rome_json() -> Result<()> {
                             character: 34,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from("deserialize",))),
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from("deserialize",))),
                     code_description: None,
                     source: Some(String::from("biome")),
                     message: String::from("Found an unknown value `magic`.",),
@@ -1627,12 +1615,9 @@ async fn plugin_load_error_show_message() -> Result<()> {
 
     const INVALID_PLUGIN_CONTENT: &[u8] = br#"foo"#;
 
+    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
     fs.insert(
-        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
-        config,
-    );
-    fs.insert(
-        Utf8PathBuf::from_path_buf(url!("plugin").to_file_path().unwrap()).unwrap(),
+        Utf8PathBuf::from_str(uri!("plugin").as_str())?,
         INVALID_PLUGIN_CONTENT,
     );
 
@@ -1652,7 +1637,7 @@ async fn plugin_load_error_show_message() -> Result<()> {
 
     let incorrect_config = r#"a {colr: blue;}"#;
     server
-        .open_named_document(incorrect_config, url!("document.css"), "css")
+        .open_named_document(incorrect_config, uri!("document.css"), "css")
         .await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_show_message()).await;
@@ -1682,10 +1667,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
         }
     }"#;
 
-    fs.insert(
-        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
-        config,
-    );
+    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -1703,7 +1685,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
 
     let incorrect_config = r#"a {colr: blue;}"#;
     server
-        .open_named_document(incorrect_config, url!("document.css"), "css")
+        .open_named_document(incorrect_config, uri!("document.css"), "css")
         .await?;
 
     let notification = wait_for_notification(&mut receiver, |n| n.is_publish_diagnostics()).await;
@@ -1712,9 +1694,9 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("document.css"),
+                uri: uri!("document.css"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 0,
@@ -1725,13 +1707,14 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
                             character: 7,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from(
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
                         "lint/correctness/noUnknownProperty"
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-unknown-property")
-                            .unwrap()
+                        href: Uri::from_str(
+                            "https://biomejs.dev/linter/rules/no-unknown-property"
+                        )?
                     }),
                     source: Some(String::from("biome")),
                     message: String::from("Unknown property is not allowed.",),
@@ -1770,7 +1753,7 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
     server
         .open_named_document(
             incorrect_config,
-            url!("./node_modules/preact/package.json"),
+            uri!("./node_modules/preact/package.json"),
             "json",
         )
         .await?;
@@ -1781,19 +1764,19 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("./node_modules/preact/package.json"),
+                uri: uri!("./node_modules/preact/package.json"),
                 version: Some(0),
                 diagnostics: vec![],
             }
         ))
     );
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("./node_modules/preact/package.json"),
+                    uri: uri!("./node_modules/preact/package.json"),
                 },
                 range: Range {
                     start: Position {
@@ -1805,14 +1788,14 @@ async fn no_code_actions_for_ignored_json_files() -> Result<()> {
                         character: 7,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![],
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1855,13 +1838,13 @@ if(a === -0) {}
         )
         .await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -1873,14 +1856,14 @@ if(a === -0) {}
                         character: 10,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![fixable_diagnostic(0)?],
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -1890,7 +1873,7 @@ if(a === -0) {}
 
     let mut changes = HashMap::default();
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![
             TextEdit {
                 range: Range {
@@ -1973,11 +1956,11 @@ if(a === -0) {}
         ],
     );
 
-    let expected_code_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_code_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Organize Imports (Biome)"),
-        kind: Some(lsp::CodeActionKind::new("source.organizeImports.biome")),
+        kind: Some(CodeActionKind::new("source.organizeImports.biome")),
         diagnostics: None,
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -1990,7 +1973,7 @@ if(a === -0) {}
 
     let mut top_level_changes = HashMap::default();
     top_level_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -2010,7 +1993,7 @@ if(a === -0) {}
 
     let mut inline_changes = HashMap::default();
     inline_changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -2028,33 +2011,26 @@ if(a === -0) {}
         }],
     );
 
-    let expected_toplevel_suppression_action =
-        lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-            title: String::from(
-                "Suppress action assist/source/organizeImports for the whole file.",
-            ),
-            kind: Some(lsp::CodeActionKind::new(
-                "quickfix.suppressRule.topLevel.biome",
-            )),
-            diagnostics: None,
-            edit: Some(lsp::WorkspaceEdit {
-                changes: Some(top_level_changes),
-                document_changes: None,
-                change_annotations: None,
-            }),
-            command: None,
-            is_preferred: None,
-            disabled: None,
-            data: None,
-        });
-
-    let expected_line_suppression_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
-        title: String::from("Suppress action assist/source/organizeImports for this line."),
-        kind: Some(lsp::CodeActionKind::new(
-            "quickfix.suppressRule.inline.biome",
-        )),
+    let expected_toplevel_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress action assist/source/organizeImports for the whole file."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.topLevel.biome")),
         diagnostics: None,
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
+            changes: Some(top_level_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
+
+    let expected_line_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Suppress action assist/source/organizeImports for this line."),
+        kind: Some(CodeActionKind::new("quickfix.suppressRule.inline.biome")),
+        diagnostics: None,
+        edit: Some(WorkspaceEdit {
             changes: Some(inline_changes),
             document_changes: None,
             change_annotations: None,
@@ -2111,10 +2087,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
     ]
 }"#;
 
-    fs.insert(
-        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
-        config,
-    );
+    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -2127,7 +2100,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
     server.initialize().await?;
     server.initialized().await?;
     server
-        .open_named_document(config, url!("biome.json"), "json")
+        .open_named_document(config, uri!("biome.json"), "json")
         .await?;
     server
         .open_named_document(
@@ -2136,20 +2109,20 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
 	B,
 	C,
 }"#,
-            url!("test.ts"),
+            uri!("test.ts"),
             "typescript",
         )
         .await?;
 
     server.load_configuration().await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("test.ts"),
+                    uri: uri!("test.ts"),
                 },
                 range: Range {
                     start: Position {
@@ -2161,9 +2134,9 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
                         character: 10,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![fixable_diagnostic(0)?],
-                    only: Some(vec![lsp::CodeActionKind::new(
+                    only: Some(vec![CodeActionKind::new(
                         "quickfix.biome.style.useEnumInitializers",
                     )]),
                     ..Default::default()
@@ -2171,7 +2144,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -2206,13 +2179,13 @@ async fn pull_refactors() -> Result<()> {
         .open_document("let variable = \"value\"; func(variable);")
         .await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -2224,15 +2197,15 @@ async fn pull_refactors() -> Result<()> {
                         character: 7,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![],
-                    only: Some(vec![lsp::CodeActionKind::REFACTOR]),
+                    only: Some(vec![CodeActionKind::REFACTOR]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -2243,7 +2216,7 @@ async fn pull_refactors() -> Result<()> {
     let mut changes = HashMap::default();
 
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![
             TextEdit {
                 range: Range {
@@ -2274,11 +2247,11 @@ async fn pull_refactors() -> Result<()> {
         ],
     );
 
-    let _expected_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let _expected_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Inline variable"),
-        kind: Some(lsp::CodeActionKind::new("refactor.inline.biome")),
+        kind: Some(CodeActionKind::new("refactor.inline.biome")),
         diagnostics: None,
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -2316,13 +2289,13 @@ async fn pull_fix_all() -> Result<()> {
         .open_document("if(a === -0) {}\nif(a === -0) {}\nif(a === -0) {}")
         .await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 range: Range {
                     start: Position {
@@ -2334,19 +2307,19 @@ async fn pull_fix_all() -> Result<()> {
                         character: 7,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![
                         fixable_diagnostic(0)?,
                         fixable_diagnostic(1)?,
                         fixable_diagnostic(2)?,
                     ],
-                    only: Some(vec![lsp::CodeActionKind::new("source.fixAll")]),
+                    only: Some(vec![CodeActionKind::new("source.fixAll")]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -2357,7 +2330,7 @@ async fn pull_fix_all() -> Result<()> {
     let mut changes = HashMap::default();
 
     changes.insert(
-        url!("document.js"),
+        uri!("document.js"),
         vec![TextEdit {
             range: Range {
                 start: Position {
@@ -2373,15 +2346,15 @@ async fn pull_fix_all() -> Result<()> {
         }],
     );
 
-    let expected_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Fix all auto-fixable issues"),
-        kind: Some(lsp::CodeActionKind::new("source.fixAll.biome")),
+        kind: Some(CodeActionKind::new("source.fixAll.biome")),
         diagnostics: Some(vec![
             fixable_diagnostic(0)?,
             fixable_diagnostic(1)?,
             fixable_diagnostic(2)?,
         ]),
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -2464,10 +2437,7 @@ isSpreadAssignment;
             "get_file_content",
             GetFileContentParams {
                 project_key,
-                path: BiomePath::new(
-                    Utf8PathBuf::from_path_buf(url!("document.js").to_file_path().unwrap())
-                        .unwrap(),
-                ),
+                path: BiomePath::try_from(uri!("document.js").to_file_path().unwrap()).unwrap(),
             },
         )
         .await?
@@ -2508,7 +2478,7 @@ async fn format_with_syntax_errors() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -2554,7 +2524,7 @@ async fn format_jsx_in_javascript_file() -> Result<()> {
             "textDocument/didOpen",
             DidOpenTextDocumentParams {
                 text_document: TextDocumentItem {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                     language_id: String::from("javascript"),
                     version: 0,
                     text: String::from("const f  =  () => <div/>;"),
@@ -2569,7 +2539,7 @@ async fn format_jsx_in_javascript_file() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                 },
                 options: FormattingOptions::default(),
                 work_done_progress_params: WorkDoneProgressParams {
@@ -2588,7 +2558,7 @@ async fn format_jsx_in_javascript_file() -> Result<()> {
             "textDocument/didClose",
             DidCloseTextDocumentParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document"),
+                    uri: uri!("document"),
                 },
             },
         )
@@ -2611,10 +2581,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
         }
     }"#;
 
-    fs.insert(
-        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
-        config,
-    );
+    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -2628,11 +2595,11 @@ async fn does_not_format_ignored_files() -> Result<()> {
     server.initialized().await?;
 
     server
-        .open_named_document(config, url!("biome.json"), "json")
+        .open_named_document(config, uri!("biome.json"), "json")
         .await?;
 
     server
-        .open_named_document("statement (   );", url!("document.js"), "javascript")
+        .open_named_document("statement (   );", uri!("document.js"), "javascript")
         .await?;
 
     server.load_configuration().await?;
@@ -2643,7 +2610,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("document.js"),
+                    uri: uri!("document.js"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -2694,14 +2661,14 @@ async fn pull_diagnostics_from_manifest() -> Result<()> {
         }
     }"#;
     server
-        .open_named_document(config, url!("biome.json"), "json")
+        .open_named_document(config, uri!("biome.json"), "json")
         .await?;
 
     let manifest = r#"{
         "dependencies": { "react": "latest" }
     }"#;
     server
-        .open_named_document(manifest, url!("package.json"), "json")
+        .open_named_document(manifest, uri!("package.json"), "json")
         .await?;
 
     server.load_configuration().await?;
@@ -2716,9 +2683,9 @@ async fn pull_diagnostics_from_manifest() -> Result<()> {
         notification,
         Some(ServerNotification::PublishDiagnostics(
             PublishDiagnosticsParams {
-                uri: url!("document.js"),
+                uri: uri!("document.js"),
                 version: Some(0),
-                diagnostics: vec![lsp::Diagnostic {
+                diagnostics: vec![Diagnostic {
                     range: Range {
                         start: Position {
                             line: 0,
@@ -2729,21 +2696,20 @@ async fn pull_diagnostics_from_manifest() -> Result<()> {
                             character: 7,
                         },
                     },
-                    severity: Some(lsp::DiagnosticSeverity::ERROR),
-                    code: Some(lsp::NumberOrString::String(String::from(
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    code: Some(NumberOrString::String(String::from(
                         "lint/suspicious/noDoubleEquals",
                     ))),
                     code_description: Some(CodeDescription {
-                        href: Url::parse("https://biomejs.dev/linter/rules/no-double-equals")
-                            .unwrap()
+                        href: Uri::from_str("https://biomejs.dev/linter/rules/no-double-equals")?
                     }),
                     source: Some(String::from("biome")),
                     message: String::from(
                         "Use === instead of ==.\n== is only allowed when comparing against `null`",
                     ),
-                    related_information: Some(vec![lsp::DiagnosticRelatedInformation {
-                        location: lsp::Location {
-                            uri: url!("untitled-1"),
+                    related_information: Some(vec![DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: uri!("untitled-1"),
                             range: Range {
                                 start: Position {
                                     line: 0,
@@ -2819,7 +2785,7 @@ async fn multiple_projects() -> Result<()> {
         }
     }"#;
     server
-        .open_named_document(config_only_formatter, url!("test_one/biome.json"), "json")
+        .open_named_document(config_only_formatter, uri!("test_one/biome.json"), "json")
         .await?;
 
     let config_only_linter = r#"{
@@ -2831,19 +2797,19 @@ async fn multiple_projects() -> Result<()> {
         }
     }"#;
     server
-        .open_named_document(config_only_linter, url!("test_two/biome.json"), "json")
+        .open_named_document(config_only_linter, uri!("test_two/biome.json"), "json")
         .await?;
 
     // it should add a `;` but no diagnostics
     let file_format_only = r#"debugger"#;
     server
-        .open_named_document(file_format_only, url!("test_one/file.js"), "javascript")
+        .open_named_document(file_format_only, uri!("test_one/file.js"), "javascript")
         .await?;
 
     // it should raise a diagnostic, but no formatting
     let file_lint_only = r#"debugger;\n"#;
     server
-        .open_named_document(file_lint_only, url!("test_two/file.js"), "javascript")
+        .open_named_document(file_lint_only, uri!("test_two/file.js"), "javascript")
         .await?;
 
     let res: Option<Vec<TextEdit>> = server
@@ -2852,7 +2818,7 @@ async fn multiple_projects() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("test_two/file.js"),
+                    uri: uri!("test_two/file.js"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -2881,7 +2847,7 @@ async fn multiple_projects() -> Result<()> {
             "formatting",
             DocumentFormattingParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("test_one/file.js"),
+                    uri: uri!("test_one/file.js"),
                 },
                 options: FormattingOptions {
                     tab_size: 4,
@@ -2930,17 +2896,14 @@ async fn pull_source_assist_action() -> Result<()> {
         }
     }"#;
 
-    fs.insert(
-        Utf8PathBuf::from_path_buf(url!("biome.json").to_file_path().unwrap()).unwrap(),
-        config,
-    );
+    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
     let mut server = Server::new(service);
 
-    let unsafe_fixable = lsp::Diagnostic {
+    let unsafe_fixable = Diagnostic {
         range: Range {
             start: Position {
                 line: 0,
@@ -2951,8 +2914,8 @@ async fn pull_source_assist_action() -> Result<()> {
                 character: 9,
             },
         },
-        severity: Some(lsp::DiagnosticSeverity::ERROR),
-        code: Some(lsp::NumberOrString::String(String::from(
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String(String::from(
             "lint/suspicious/noDoubleEquals",
         ))),
         code_description: None,
@@ -2972,18 +2935,18 @@ async fn pull_source_assist_action() -> Result<()> {
     server
         .open_named_document(
             r#"{"zod": true,"lorem": "ipsum","foo": "bar"}"#,
-            url!("file.json"),
+            uri!("file.json"),
             "json",
         )
         .await?;
 
-    let res: lsp::CodeActionResponse = server
+    let res: CodeActionResponse = server
         .request(
             "textDocument/codeAction",
             "pull_code_actions",
-            lsp::CodeActionParams {
+            CodeActionParams {
                 text_document: TextDocumentIdentifier {
-                    uri: url!("file.json"),
+                    uri: uri!("file.json"),
                 },
                 range: Range {
                     start: Position {
@@ -2995,15 +2958,15 @@ async fn pull_source_assist_action() -> Result<()> {
                         character: 15,
                     },
                 },
-                context: lsp::CodeActionContext {
+                context: CodeActionContext {
                     diagnostics: vec![unsafe_fixable.clone()],
-                    only: Some(vec![lsp::CodeActionKind::new("source.biome.useSortedKeys")]),
+                    only: Some(vec![CodeActionKind::new("source.biome.useSortedKeys")]),
                     ..Default::default()
                 },
                 work_done_progress_params: WorkDoneProgressParams {
                     work_done_token: None,
                 },
-                partial_result_params: lsp::PartialResultParams {
+                partial_result_params: PartialResultParams {
                     partial_result_token: None,
                 },
             },
@@ -3012,7 +2975,7 @@ async fn pull_source_assist_action() -> Result<()> {
         .context("codeAction returned None")?;
     let mut changes = HashMap::default();
     changes.insert(
-        url!("file.json"),
+        uri!("file.json"),
         vec![
             TextEdit {
                 range: Range {
@@ -3068,11 +3031,11 @@ async fn pull_source_assist_action() -> Result<()> {
             },
         ],
     );
-    let expected_action = lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+    let expected_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("They keys of the current object can be sorted."),
-        kind: Some(lsp::CodeActionKind::new("source.biome.useSortedKeys")),
+        kind: Some(CodeActionKind::new("source.biome.useSortedKeys")),
         diagnostics: None,
-        edit: Some(lsp::WorkspaceEdit {
+        edit: Some(WorkspaceEdit {
             changes: Some(changes),
             document_changes: None,
             change_annotations: None,
@@ -3139,7 +3102,7 @@ export function bar() {
     let mut factory = ServerFactory::new(true, instruction_channel.sender.clone());
 
     let workspace = factory.workspace();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking(move || {
         watcher.run(workspace.as_ref());
     });
 
@@ -3356,7 +3319,7 @@ export function bar() {
     let mut factory = ServerFactory::new(true, instruction_channel.sender.clone());
 
     let workspace = factory.workspace();
-    tokio::task::spawn_blocking(move || {
+    spawn_blocking(move || {
         watcher.run(workspace.as_ref());
     });
 

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -48,9 +48,9 @@ use super::*;
 macro_rules! uri {
     ($path:literal) => {
         if cfg!(windows) {
-            lsp::Uri::from_str(concat!("/z%3A/workspace/", $path)).unwrap()
+            lsp::Uri::from_str(concat!("file:///z%3A/workspace/", $path)).unwrap()
         } else {
-            lsp::Uri::from_str(concat!("/workspace/", $path)).unwrap()
+            lsp::Uri::from_str(concat!("file:///workspace/", $path)).unwrap()
         }
     };
 }
@@ -64,6 +64,10 @@ macro_rules! clear_notifications {
             let _ = $channel.changed().await;
         }
     };
+}
+
+fn to_utf8_file_path_buf(uri: Uri) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(uri.to_file_path().unwrap().to_path_buf()).unwrap()
 }
 
 fn fixable_diagnostic(line: u32) -> Result<Diagnostic> {
@@ -1615,9 +1619,9 @@ async fn plugin_load_error_show_message() -> Result<()> {
 
     const INVALID_PLUGIN_CONTENT: &[u8] = br#"foo"#;
 
-    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
     fs.insert(
-        Utf8PathBuf::from_str(uri!("plugin").as_str())?,
+        to_utf8_file_path_buf(uri!("plugin")),
         INVALID_PLUGIN_CONTENT,
     );
 
@@ -1667,7 +1671,7 @@ async fn pull_diagnostics_for_css_files() -> Result<()> {
         }
     }"#;
 
-    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -2087,7 +2091,7 @@ async fn does_not_pull_action_for_disabled_rule_in_override_issue_2782() -> Resu
     ]
 }"#;
 
-    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -2581,7 +2585,7 @@ async fn does_not_format_ignored_files() -> Result<()> {
         }
     }"#;
 
-    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();
@@ -2896,7 +2900,7 @@ async fn pull_source_assist_action() -> Result<()> {
         }
     }"#;
 
-    fs.insert(Utf8PathBuf::from_str(uri!("biome.json").as_str())?, config);
+    fs.insert(to_utf8_file_path_buf(uri!("biome.json")), config);
 
     let factory = ServerFactory::new_with_fs(Box::new(fs));
     let (service, client) = factory.create().into_inner();

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -39,10 +39,10 @@ use tokio::sync::Notify;
 use tokio::sync::OnceCell;
 use tokio::sync::watch;
 use tokio::task::spawn_blocking;
-use tower_lsp::lsp_types;
-use tower_lsp::lsp_types::{Diagnostic, Url};
-use tower_lsp::lsp_types::{MessageType, Registration};
-use tower_lsp::lsp_types::{Unregistration, WorkspaceFolder};
+use tower_lsp_server::lsp_types::{ClientCapabilities, Diagnostic, Uri};
+use tower_lsp_server::lsp_types::{MessageType, Registration};
+use tower_lsp_server::lsp_types::{Unregistration, WorkspaceFolder};
+use tower_lsp_server::{Client, UriExt, lsp_types};
 use tracing::{error, info, warn};
 
 pub(crate) struct ClientInformation {
@@ -63,7 +63,7 @@ pub(crate) struct Session {
     pub(crate) key: SessionKey,
 
     /// The LSP client for this session.
-    pub(crate) client: tower_lsp::Client,
+    pub(crate) client: Client,
 
     /// The parameters provided by the client in the "initialize" request
     initialize_params: OnceCell<InitializeParams>,
@@ -84,7 +84,7 @@ pub(crate) struct Session {
     projects: HashMap<BiomePath, ProjectKey>,
 
     /// Documents opened in this session.
-    documents: HashMap<lsp_types::Url, Document, FxBuildHasher>,
+    documents: HashMap<Uri, Document, FxBuildHasher>,
 
     pub(crate) cancellation: Arc<Notify>,
 
@@ -98,9 +98,9 @@ pub(crate) struct Session {
 /// The parameters provided by the client in the "initialize" request
 struct InitializeParams {
     /// The capabilities provided by the client as part of [`lsp_types::InitializeParams`]
-    client_capabilities: lsp_types::ClientCapabilities,
+    client_capabilities: ClientCapabilities,
     client_information: Option<ClientInformation>,
-    root_uri: Option<Url>,
+    root_uri: Option<Uri>,
     workspace_folders: Option<Vec<WorkspaceFolder>>,
 }
 
@@ -185,7 +185,7 @@ impl CapabilitySet {
 impl Session {
     pub(crate) fn new(
         key: SessionKey,
-        client: tower_lsp::Client,
+        client: Client,
         workspace: Arc<dyn Workspace>,
         cancellation: Arc<Notify>,
         service_data_rx: watch::Receiver<ServiceDataNotification>,
@@ -209,9 +209,9 @@ impl Session {
     /// Initialize this session instance with the incoming initialization parameters from the client
     pub(crate) fn initialize(
         self: &Arc<Self>,
-        client_capabilities: lsp_types::ClientCapabilities,
+        client_capabilities: ClientCapabilities,
         client_information: Option<ClientInformation>,
-        root_uri: Option<Url>,
+        root_uri: Option<Uri>,
         workspace_folders: Option<Vec<WorkspaceFolder>>,
     ) {
         let result = self.initialize_params.set(InitializeParams {
@@ -226,13 +226,13 @@ impl Session {
         }
 
         let session = self.clone();
-        tokio::task::spawn(async move {
+        spawn(async move {
             let mut service_data_rx = session.service_data_rx.clone();
             while let Ok(()) = service_data_rx.changed().await {
                 match *session.service_data_rx.borrow() {
                     ServiceDataNotification::Updated => {
                         let session = session.clone();
-                        tokio::task::spawn(async move {
+                        spawn(async move {
                             session.update_all_diagnostics().await;
                         });
                     }
@@ -315,13 +315,13 @@ impl Session {
 
         // Spawn the scan in the background, to avoid timing out the LSP request.
         let session = self.clone();
-        tokio::spawn(async move { session.scan_project_folder(project_key, path).await });
+        spawn(async move { session.scan_project_folder(project_key, path).await });
     }
 
-    /// Get a [`Document`] matching the provided [`lsp_types::Url`]
+    /// Get a [`Document`] matching the provided [`Uri`]
     ///
     /// If document does not exist, result is [WorkspaceError::NotFound]
-    pub(crate) fn document(&self, url: &lsp_types::Url) -> Result<Document, Error> {
+    pub(crate) fn document(&self, url: &Uri) -> Result<Document, Error> {
         self.documents
             .pin()
             .get(url)
@@ -329,26 +329,27 @@ impl Session {
             .ok_or_else(|| WorkspaceError::not_found().with_file_path(url.to_string()))
     }
 
-    /// Set the [`Document`] for the provided [`lsp_types::Url`]
+    /// Set the [`Document`] for the provided [`Uri`]
     ///
     /// Used by [`handlers::text_document] to synchronize documents with the client.
-    pub(crate) fn insert_document(&self, url: lsp_types::Url, document: Document) {
+    pub(crate) fn insert_document(&self, url: Uri, document: Document) {
         self.documents.pin().insert(url, document);
     }
 
-    /// Remove the [`Document`] matching the provided [`lsp_types::Url`]
-    pub(crate) fn remove_document(&self, url: &lsp_types::Url) -> Option<ProjectKey> {
+    /// Remove the [`Document`] matching the provided [`Uri`]
+    pub(crate) fn remove_document(&self, url: &Uri) -> Option<ProjectKey> {
         self.documents.pin().remove(url).map(|doc| doc.project_key)
     }
 
-    pub(crate) fn file_path(&self, url: &lsp_types::Url) -> Result<BiomePath> {
+    pub(crate) fn file_path(&self, url: &Uri) -> Result<BiomePath> {
         let path_to_file = match url.to_file_path() {
-            Err(_) => {
+            None => {
                 // If we can't create a path, it's probably because the file doesn't exist.
                 // It can be a newly created file that it's not on disk
-                Utf8PathBuf::from(url.path())
+                Utf8PathBuf::from(url.path().to_string())
             }
-            Ok(path) => Utf8PathBuf::from_path_buf(path).expect("To to have a UTF-8 path"),
+            Some(path) => Utf8PathBuf::from_path_buf(path.as_ref().to_path_buf())
+                .expect("To to have a UTF-8 path"),
         };
 
         Ok(BiomePath::new(path_to_file))
@@ -357,8 +358,8 @@ impl Session {
     /// Computes diagnostics for the file matching the provided url and publishes
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
-    #[tracing::instrument(level = "debug", skip_all, fields(url = display(&url), diagnostic_count), err)]
-    pub(crate) async fn update_diagnostics(&self, url: lsp_types::Url) -> Result<(), LspError> {
+    #[tracing::instrument(level = "debug", skip_all, fields(url = display(url.as_str()), diagnostic_count), err)]
+    pub(crate) async fn update_diagnostics(&self, url: Uri) -> Result<(), LspError> {
         let doc = self.document(&url)?;
         self.update_diagnostics_for_document(url, doc).await
     }
@@ -366,10 +367,10 @@ impl Session {
     /// Computes diagnostics for the file matching the provided url and publishes
     /// them to the client. Called from [`handlers::text_document`] when a file's
     /// contents changes.
-    #[tracing::instrument(level = "debug", skip_all, fields(url = display(&url), diagnostic_count), err)]
+    #[tracing::instrument(level = "debug", skip_all, fields(url = display(url.as_str()), diagnostic_count), err)]
     async fn update_diagnostics_for_document(
         &self,
-        url: lsp_types::Url,
+        url: Uri,
         doc: Document,
     ) -> Result<(), LspError> {
         let biome_path = self.file_path(&url)?;
@@ -505,10 +506,10 @@ impl Session {
 
         let root_uri = initialize_params.root_uri.as_ref()?;
         match root_uri.to_file_path() {
-            Ok(base_path) => {
-                Some(Utf8PathBuf::from_path_buf(base_path).expect("To have a UTF-8 path"))
-            }
-            Err(()) => {
+            Some(base_path) => Some(
+                Utf8PathBuf::from_path_buf(base_path.to_path_buf()).expect("To have a UTF-8 path"),
+            ),
+            None => {
                 error!(
                     "The Workspace root URI {root_uri:?} could not be parsed as a filesystem path"
                 );
@@ -545,12 +546,11 @@ impl Session {
             self.set_configuration_status(ConfigurationStatus::Loading);
             for folder in folders {
                 info!("Attempt to load the configuration file in {:?}", folder.uri);
-                let base_path = folder
-                    .uri
-                    .to_file_path()
-                    .map(|p| Utf8PathBuf::from_path_buf(p).expect("To have a valid UTF-8 path"));
+                let base_path = folder.uri.to_file_path().map(|p| {
+                    Utf8PathBuf::from_path_buf(p.to_path_buf()).expect("To have a valid UTF-8 path")
+                });
                 match base_path {
-                    Ok(base_path) => {
+                    Some(base_path) => {
                         let status = self
                             .load_biome_configuration_file(ConfigurationPathHint::FromWorkspace(
                                 base_path,
@@ -558,7 +558,7 @@ impl Session {
                             .await;
                         self.set_configuration_status(status);
                     }
-                    Err(_) => {
+                    None => {
                         error!(
                             "The Workspace root URI {:?} could not be parsed as a filesystem path",
                             folder.uri

--- a/crates/biome_lsp/src/utils.rs
+++ b/crates/biome_lsp/src/utils.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::mutable_key_type)]
 use anyhow::{Context, Result, ensure};
 use biome_analyze::ActionCategory;
 use biome_console::fmt::Termcolor;
@@ -18,10 +19,11 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::ops::{Add, Range};
+use std::str::FromStr;
 use std::{io, mem};
-use tower_lsp::jsonrpc::Error as LspError;
-use tower_lsp::lsp_types;
-use tower_lsp::lsp_types::{self as lsp, CodeDescription, Url};
+use tower_lsp_server::jsonrpc::Error as LspError;
+use tower_lsp_server::lsp_types;
+use tower_lsp_server::lsp_types::{self as lsp, CodeDescription, Uri};
 use tracing::error;
 
 pub(crate) fn text_edit(
@@ -93,7 +95,7 @@ pub(crate) fn text_edit(
 }
 
 pub(crate) fn code_fix_to_lsp(
-    url: &lsp::Url,
+    url: &Uri,
     line_index: &LineIndex,
     position_encoding: PositionEncoding,
     diagnostics: &[lsp::Diagnostic],
@@ -169,7 +171,7 @@ pub(crate) fn code_fix_to_lsp(
 /// expected by LSP.
 pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
     diagnostic: D,
-    url: &lsp::Url,
+    url: &lsp::Uri,
     line_index: &LineIndex,
     position_encoding: PositionEncoding,
     offset: Option<u32>,
@@ -203,7 +205,7 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
         .category()
         .and_then(|category| category.link())
         .and_then(|link| {
-            let href = Url::parse(link).ok()?;
+            let href = Uri::from_str(link).ok()?;
             Some(CodeDescription { href })
         });
 
@@ -255,7 +257,7 @@ pub(crate) fn diagnostic_to_lsp<D: Diagnostic>(
 }
 
 struct RelatedInformationVisitor<'a> {
-    url: &'a lsp::Url,
+    url: &'a lsp::Uri,
     line_index: &'a LineIndex,
     position_encoding: PositionEncoding,
     related_information: &'a mut Option<Vec<lsp::DiagnosticRelatedInformation>>,
@@ -415,8 +417,8 @@ mod tests {
     use biome_lsp_converters::line_index::LineIndex;
     use biome_lsp_converters::{PositionEncoding, WideEncoding};
     use biome_text_edit::TextEdit;
-    use tower_lsp::lsp_types as lsp;
-    use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent};
+    use tower_lsp_server::lsp_types as lsp;
+    use tower_lsp_server::lsp_types::{Position, Range, TextDocumentContentChangeEvent};
 
     #[test]
     fn test_diff_1() {

--- a/crates/biome_lsp_converters/Cargo.toml
+++ b/crates/biome_lsp_converters/Cargo.toml
@@ -19,7 +19,7 @@ rustc-hash       = { workspace = true }
 tower-lsp-server = { workspace = true }
 
 [dev-dependencies]
-tower = { version = "0.4.13", features = ["timeout"] }
+tower = { workspace = true, features = ["timeout"] }
 
 [lints]
 workspace = true

--- a/crates/biome_lsp_converters/Cargo.toml
+++ b/crates/biome_lsp_converters/Cargo.toml
@@ -13,10 +13,10 @@ version              = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow      = { workspace = true }
-biome_rowan = { workspace = true }
-rustc-hash  = { workspace = true }
-tower-lsp   = { version = "0.20.0" }
+anyhow           = { workspace = true }
+biome_rowan      = { workspace = true }
+rustc-hash       = { workspace = true }
+tower-lsp-server = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.4.13", features = ["timeout"] }

--- a/crates/biome_lsp_converters/src/from_proto.rs
+++ b/crates/biome_lsp_converters/src/from_proto.rs
@@ -2,12 +2,12 @@ use crate::line_index::LineIndex;
 use crate::{LineCol, PositionEncoding, WideLineCol};
 use anyhow::{Context, Result};
 use biome_rowan::{TextRange, TextSize};
-use tower_lsp::lsp_types;
+use tower_lsp_server::lsp_types::{Position, Range};
 
 /// The function is used to convert a LSP position to TextSize.
 pub fn offset(
     line_index: &LineIndex,
-    position: lsp_types::Position,
+    position: Position,
     position_encoding: PositionEncoding,
 ) -> Result<TextSize> {
     let line_col = match position_encoding {
@@ -32,7 +32,7 @@ pub fn offset(
 /// The function is used to convert a LSP range to TextRange.
 pub fn text_range(
     line_index: &LineIndex,
-    range: lsp_types::Range,
+    range: Range,
     position_encoding: PositionEncoding,
 ) -> Result<TextRange> {
     let start = offset(line_index, range.start, position_encoding)?;

--- a/crates/biome_lsp_converters/src/lib.rs
+++ b/crates/biome_lsp_converters/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::use_self)]
 
 use biome_rowan::TextSize;
-use tower_lsp::lsp_types::{ClientCapabilities, PositionEncodingKind};
+use tower_lsp_server::lsp_types::{ClientCapabilities, PositionEncodingKind};
 
 pub mod from_proto;
 pub mod line_index;
@@ -94,7 +94,7 @@ mod tests {
     use crate::to_proto::position;
     use crate::{LineCol, PositionEncoding, WideEncoding};
     use biome_rowan::TextSize;
-    use tower_lsp::lsp_types::Position;
+    use tower_lsp_server::lsp_types::Position;
 
     macro_rules! check_conversion {
         ($line_index:ident : $position:expr => $text_size:expr ) => {

--- a/crates/biome_lsp_converters/src/to_proto.rs
+++ b/crates/biome_lsp_converters/src/to_proto.rs
@@ -2,25 +2,25 @@ use crate::PositionEncoding;
 use crate::line_index::LineIndex;
 use anyhow::{Context, Result};
 use biome_rowan::{TextRange, TextSize};
-use tower_lsp::lsp_types;
+use tower_lsp_server::lsp_types::{Position, Range};
 
 /// The function is used to convert TextSize to a LSP position.
 pub fn position(
     line_index: &LineIndex,
     offset: TextSize,
     position_encoding: PositionEncoding,
-) -> Result<lsp_types::Position> {
+) -> Result<Position> {
     let line_col = line_index
         .line_col(offset)
         .with_context(|| format!("could not convert offset {offset:?} into a line-column index"))?;
 
     let position = match position_encoding {
-        PositionEncoding::Utf8 => lsp_types::Position::new(line_col.line, line_col.col),
+        PositionEncoding::Utf8 => Position::new(line_col.line, line_col.col),
         PositionEncoding::Wide(enc) => {
             let line_col = line_index
                 .to_wide(enc, line_col)
                 .with_context(|| format!("could not convert {line_col:?} into wide line column"))?;
-            lsp_types::Position::new(line_col.line, line_col.col)
+            Position::new(line_col.line, line_col.col)
         }
     };
 
@@ -32,8 +32,8 @@ pub fn range(
     line_index: &LineIndex,
     range: TextRange,
     position_encoding: PositionEncoding,
-) -> Result<lsp_types::Range> {
+) -> Result<Range> {
     let start = position(line_index, range.start(), position_encoding)?;
     let end = position(line_index, range.end(), position_encoding)?;
-    Ok(lsp_types::Range::new(start, end))
+    Ok(Range::new(start, end))
 }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -795,7 +795,6 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
             .with_enabled_rules(&rules)
             .with_project_layout(project_layout.clone())
             .finish();
-
     let filter = AnalysisFilter {
         categories: RuleCategoriesBuilder::default()
             .with_syntax()


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The crate `tower-lsp` isn't maintained anymore. The create https://github.com/tower-lsp-community/tower-lsp-server is a new community fork that is maintained.
- changed the code to confirm to the new crate
- the new create uses `Uri` instead of `Url` which behaves differently, so I updated the code accordingly
- `Uri` has some interior mutability, which triggers [`mutable_key_type`](https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type), so I turned it off in the files where it was triggered

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

The CI should still pass

<!-- What demonstrates that your implementation is correct? -->
