### PR TITLE
Rewrite useExplicitType top-level variables checking

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts
@@ -139,3 +139,13 @@ declare module "foo" {
 
 const x = { prop: () => {} }
 const x = { bar: { prop: () => {} } }
+
+const x = { dynamic: someFunc() }
+
+let x;
+let x = null;
+let x = undefined;
+
+const wrapped = {
+	foo: () => "untyped",
+};

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalid.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -147,6 +146,16 @@ declare module "foo" {
 const x = { prop: () => {} }
 const x = { bar: { prop: () => {} } }
 
+const x = { dynamic: someFunc() }
+
+let x;
+let x = null;
+let x = undefined;
+
+const wrapped = {
+	foo: () => "untyped",
+};
+
 ```
 
 # Diagnostics
@@ -187,25 +196,6 @@ invalid.ts:5:1 lint/nursery/useExplicitType ━━━━━━━━━━━━
 ```
 
 ```
-invalid.ts:9:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-     7 │ }
-     8 │ 
-   > 9 │ const fn = function () {
-       │       ^^
-    10 │ 	return 1;
-    11 │ };
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:9:12 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -223,25 +213,6 @@ invalid.ts:9:12 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:13:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    11 │ };
-    12 │ 
-  > 13 │ const arrowFn = () => "test";
-       │       ^^^^^^^
-    14 │ 
-    15 │ class Test {
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -351,25 +322,6 @@ invalid.ts:25:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:30:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    28 │ }
-    29 │ 
-  > 30 │ const obj = {
-       │       ^^^
-    31 │ 	method() {
-    32 │ 		return "test";
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:31:2 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on member.
@@ -386,25 +338,6 @@ invalid.ts:31:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the member.
-  
-
-```
-
-```
-invalid.ts:36:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    34 │ };
-    35 │ 
-  > 36 │ const obj = {
-       │       ^^^
-    37 │ 	get method() {
-    38 │ 		return "test";
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -431,25 +364,6 @@ invalid.ts:37:2 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:42:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    40 │ };
-    41 │ 
-  > 42 │ const func = (value: number) => ({ type: "X", value }) as any;
-       │       ^^^^
-    43 │ const func = (value: number) => ({ type: "X", value }) as Action;
-    44 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:42:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -464,24 +378,6 @@ invalid.ts:42:14 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:43:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    42 │ const func = (value: number) => ({ type: "X", value }) as any;
-  > 43 │ const func = (value: number) => ({ type: "X", value }) as Action;
-       │       ^^^^
-    44 │ 
-    45 │ export default () => {};
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -542,24 +438,6 @@ invalid.ts:46:16 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:49:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    48 │ // check higher order functions
-  > 49 │ const arrowFn = () => () => {};
-       │       ^^^^^^^
-    50 │ const arrowFn = () => function () {};
-    51 │ const arrowFn = () => {
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:49:23 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -573,25 +451,6 @@ invalid.ts:49:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:50:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    48 │ // check higher order functions
-    49 │ const arrowFn = () => () => {};
-  > 50 │ const arrowFn = () => function () {};
-       │       ^^^^^^^
-    51 │ const arrowFn = () => {
-    52 │ 	return () => {};
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -616,25 +475,6 @@ invalid.ts:50:23 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:51:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    49 │ const arrowFn = () => () => {};
-    50 │ const arrowFn = () => function () {};
-  > 51 │ const arrowFn = () => {
-       │       ^^^^^^^
-    52 │ 	return () => {};
-    53 │ };
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:52:9 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -649,25 +489,6 @@ invalid.ts:52:9 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:57:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    55 │ // does not support detecting a return of a function inside other statements like if, switch, etc.
-    56 │ // we check only the first statment
-  > 57 │ const arrowFn = (a: number) => {
-       │       ^^^^^^^
-    58 │ 	if (a === 1) {
-    59 │ 		return (): void => {};
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -692,25 +513,6 @@ invalid.ts:57:17 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:66:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    64 │ 	}
-    65 │ };
-  > 66 │ const arrowFn = (a: number) => {
-       │       ^^^^^^^
-    67 │ 	switch (a) {
-    68 │ 		case 1: {
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -778,25 +580,6 @@ invalid.ts:87:1 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:94:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    92 │ }
-    93 │ 
-  > 94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
-       │       ^
-    95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
-    96 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:94:29 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -830,23 +613,6 @@ invalid.ts:94:69 lint/nursery/useExplicitType ━━━━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Add a return type to the function.
-  
-
-```
-
-```
-invalid.ts:95:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    94 │ const x = { namedFunctions: function alpha () {}, unNamedFunctions: function () {} };
-  > 95 │ const x = { bar: { namedFunctions: function alpha () {}, unNamedFunctions: function () {} } };
-       │       ^
-    96 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
   
 
 ```
@@ -1015,25 +781,6 @@ invalid.ts:137:17 lint/nursery/useExplicitType ━━━━━━━━━━━
 ```
 
 ```
-invalid.ts:140:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    138 │ }
-    139 │ 
-  > 140 │ const x = { prop: () => {} }
-        │       ^
-    141 │ const x = { bar: { prop: () => {} } }
-    142 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
 invalid.ts:140:19 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
@@ -1053,14 +800,34 @@ invalid.ts:140:19 lint/nursery/useExplicitType ━━━━━━━━━━━
 ```
 
 ```
-invalid.ts:141:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:141:26 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × The variable doesn't have a type defined.
+  × Missing return type on function.
   
     140 │ const x = { prop: () => {} }
   > 141 │ const x = { bar: { prop: () => {} } }
-        │       ^
+        │                          ^^^^^^^^
     142 │ 
+    143 │ const x = { dynamic: someFunc() }
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a return type to the function.
+  
+
+```
+
+```
+invalid.ts:143:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+    141 │ const x = { bar: { prop: () => {} } }
+    142 │ 
+  > 143 │ const x = { dynamic: someFunc() }
+        │       ^
+    144 │ 
+    145 │ let x;
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
@@ -1070,14 +837,71 @@ invalid.ts:141:7 lint/nursery/useExplicitType ━━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:141:26 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:145:5 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+    143 │ const x = { dynamic: someFunc() }
+    144 │ 
+  > 145 │ let x;
+        │     ^
+    146 │ let x = null;
+    147 │ let x = undefined;
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the variable.
+  
+
+```
+
+```
+invalid.ts:146:5 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+    145 │ let x;
+  > 146 │ let x = null;
+        │     ^
+    147 │ let x = undefined;
+    148 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the variable.
+  
+
+```
+
+```
+invalid.ts:147:5 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+    145 │ let x;
+    146 │ let x = null;
+  > 147 │ let x = undefined;
+        │     ^
+    148 │ 
+    149 │ const wrapped = {
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the variable.
+  
+
+```
+
+```
+invalid.ts:150:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Missing return type on function.
   
-    140 │ const x = { prop: () => {} }
-  > 141 │ const x = { bar: { prop: () => {} } }
-        │                          ^^^^^^^^
-    142 │ 
+    149 │ const wrapped = {
+  > 150 │ 	foo: () => "untyped",
+        │ 	     ^^^^^^^^^^^^^^^
+    151 │ };
+    152 │ 
   
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidArguments.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalidArguments.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -73,6 +72,25 @@ invalidArguments.ts:5:28 lint/nursery/useExplicitType ━━━━━━━━�
   i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
   
   i Replace any with unknown or a more specific type.
+  
+
+```
+
+```
+invalidArguments.ts:7:5 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The variable doesn't have a type defined.
+  
+    5 │ export var arrowFn = (arg: any): string => `test ${arg}`;
+    6 │ 
+  > 7 │ var foo = arr.map((i) => i * i);
+      │     ^^^
+    8 │ new Promise((resolve) => resolve(1));
+    9 │ 
+  
+  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
+  
+  i Add a type to the variable.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/invalidDeclarationStatements.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalidDeclarationStatements.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -13,39 +12,5 @@ const bar = {};
 export {
 	bar
 }
-
-```
-
-# Diagnostics
-```
-invalidDeclarationStatements.ts:1:14 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-  > 1 │ export const foo = {};
-      │              ^^^
-    2 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
-
-```
-
-```
-invalidDeclarationStatements.ts:4:7 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-  > 4 │ const bar = {};
-      │       ^^^
-    5 │ 
-    6 │ export {
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/namespace.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/namespace.ts.snap
@@ -1,31 +1,11 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: namespace.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
 namespace Ns {
 	export const X = {};
 }
-
-```
-
-# Diagnostics
-```
-namespace.ts:2:15 lint/nursery/useExplicitType ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × The variable doesn't have a type defined.
-  
-    1 │ namespace Ns {
-  > 2 │ 	export const X = {};
-      │ 	             ^
-    3 │ }
-    4 │ 
-  
-  i Declaring the type makes the code self-documented and can speed up TypeScript type checking.
-  
-  i Add a type to the variable.
-  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts
@@ -153,3 +153,40 @@ declare module "foo" {
 
 var X: Type = { prop: () => {} };
 f({ prop: () => {} })
+
+
+const x: string | null = someFunc();
+let x: string | null;
+var x: string | null;
+
+const x = "";
+const x = 1;
+const x = null;
+const x = undefined;
+
+let x = "";
+let x = 1;
+
+var x = "";
+var x = 1;
+
+const fn = (x: number): void => {};
+
+var obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+let obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+const obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+
+const obj = { dynamic: someFunc() as string }
+const obj = { dynamic: <string>(someFunc()) }

--- a/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExplicitType/valid.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -161,4 +160,40 @@ declare module "foo" {
 var X: Type = { prop: () => {} };
 f({ prop: () => {} })
 
+
+const x: string | null = someFunc();
+let x: string | null;
+var x: string | null;
+
+const x = "";
+const x = 1;
+const x = null;
+const x = undefined;
+
+let x = "";
+let x = 1;
+
+var x = "";
+var x = 1;
+
+const fn = (x: number): void => {};
+
+var obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+let obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+const obj = {
+	x: 1,
+	func: (x: number): void => {},
+	meth(x: number): string {},
+}
+
+const obj = { dynamic: someFunc() as string }
+const obj = { dynamic: <string>(someFunc()) }
 ```


### PR DESCRIPTION
## Summary

This PR significantly changes handling of top-level `const`, `let` and `var` variables by `useExplicitType` nursery rule.

Fixes #5932.

I went with the following heuristics:

* Any literal value and primitive is trivial, except for `let` and `var` bindings with literal `null` or `undefined` RHS as those don't usually have real `null` or `undefined` type but are later reassigned to something more useful.
* Any cast of the shape `x as SomeType` and legacy-style `<SomeType>x` is also trivial.
* Trivial object literals are also fine. An object literal is trivial if all its non-method properties are trivial. This does not include methods and getters: they are checked separately and will be flagged anyway. 
* Any `var`, `let` or `const` declaration of a variable without an explicit type annotation is flagged by this rule unless the RHS is trivial.

The rules outlined above solve one of the existing pain points. The following code has one missing type, and yet current biome version reports two errors on it (for the variable and for the method).

```ts
const x = {
    fn(arg): void {
        console.log("this is untyped")
    }
}
```

## Test Plan

I added several simple testcases and will expand that list as the PR grows. 