### PR TITLE
fix(core): add guard for flattening depth

### DIFF
--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -50,106 +50,134 @@ impl TypeData {
     /// TypeData::Literal(Literal::Number(1)))
     /// ```
     pub fn flattened(self, resolver: &mut dyn TypeResolver) -> Self {
-        match &self {
-            Self::InstanceOf(instance_of) => match resolver.resolve_and_get(&instance_of.ty) {
+        flattened(self, resolver, 0)
+    }
+}
+
+fn flattened(mut ty: TypeData, resolver: &mut dyn TypeResolver, depth: usize) -> TypeData {
+    const MAX_FLATTEN_DEPTH: usize = 10; // Arbitrary depth, may require tweaking.
+
+    for depth in depth + 1..=MAX_FLATTEN_DEPTH {
+        match &ty {
+            TypeData::InstanceOf(instance_of) => match resolver.resolve_and_get(&instance_of.ty) {
                 Some(resolved) => match resolved.as_raw_data() {
-                    Self::InstanceOf(resolved_instance) => {
-                        resolved.apply_module_id_to_data(Self::instance_of(TypeInstance {
-                            ty: resolved_instance.ty.clone(),
-                            type_parameters: GenericTypeParameter::merge_parameters(
-                                &resolved_instance.type_parameters,
-                                &instance_of.type_parameters,
-                            ),
-                        }))
+                    TypeData::InstanceOf(resolved_instance) => {
+                        return resolved.apply_module_id_to_data(TypeData::instance_of(
+                            TypeInstance {
+                                ty: resolved_instance.ty.clone(),
+                                type_parameters: GenericTypeParameter::merge_parameters(
+                                    &resolved_instance.type_parameters,
+                                    &instance_of.type_parameters,
+                                ),
+                            },
+                        ));
                     }
-                    Self::Global | Self::Function(_) | Self::Literal(_) | Self::Object(_) => {
-                        resolved.to_data().flattened(resolver)
-                    }
-                    _ => self,
+                    TypeData::Global
+                    | TypeData::Function(_)
+                    | TypeData::Literal(_)
+                    | TypeData::Object(_) => ty = resolved.to_data(),
+                    _ => return ty,
                 },
-                None => self,
+                None => return ty,
             },
-            Self::Reference(reference) => match resolver.resolve_and_get(reference) {
-                Some(ty) => ty.to_data().flattened(resolver),
-                None => self,
+            TypeData::Reference(reference) => match resolver.resolve_and_get(reference) {
+                Some(reference) => ty = reference.to_data(),
+                None => return ty,
             },
-            Self::TypeofExpression(expr) => match expr.as_ref() {
+            TypeData::TypeofExpression(expr) => match expr.as_ref() {
                 TypeofExpression::Addition(_expr) => {
                     // TODO
-                    self
+                    return ty;
                 }
                 TypeofExpression::Await(expr) => match resolver.resolve_and_get(&expr.argument) {
-                    Some(resolved) => match resolved.as_raw_data() {
-                        Self::BigInt => Self::BigInt,
-                        Self::Boolean => Self::Boolean,
-                        Self::Class(class) => {
-                            resolved.apply_module_id_to_data(Self::Class(class.clone()))
-                        }
-                        Self::Function(function) => {
-                            resolved.apply_module_id_to_data(Self::Function(function.clone()))
-                        }
-                        Self::Literal(literal) => Self::Literal(literal.clone()),
-                        Self::Null => Self::Null,
-                        Self::Number => Self::Number,
-                        Self::Object(object) => {
-                            resolved.apply_module_id_to_data(Self::Object(object.clone()))
-                        }
-                        Self::String => Self::String,
-                        _ => match resolved.find_promise_type(resolver) {
-                            Some(ty) => ty.to_data().flattened(resolver),
-                            None => self,
-                        },
-                    },
-                    None => self,
+                    Some(resolved) => {
+                        return match resolved.as_raw_data() {
+                            TypeData::BigInt => TypeData::BigInt,
+                            TypeData::Boolean => TypeData::Boolean,
+                            TypeData::Class(class) => {
+                                resolved.apply_module_id_to_data(TypeData::Class(class.clone()))
+                            }
+                            TypeData::Function(function) => resolved
+                                .apply_module_id_to_data(TypeData::Function(function.clone())),
+                            TypeData::Literal(literal) => TypeData::Literal(literal.clone()),
+                            TypeData::Null => TypeData::Null,
+                            TypeData::Number => TypeData::Number,
+                            TypeData::Object(object) => {
+                                resolved.apply_module_id_to_data(TypeData::Object(object.clone()))
+                            }
+                            TypeData::String => TypeData::String,
+                            _ => match resolved.find_promise_type(resolver) {
+                                Some(promised_ty) => {
+                                    ty = promised_ty.to_data();
+                                    continue;
+                                }
+                                None => ty,
+                            },
+                        };
+                    }
+                    None => return ty,
                 },
                 TypeofExpression::Call(expr) => match resolver.resolve_and_get(&expr.callee) {
-                    Some(resolved) => match resolved.as_raw_data() {
-                        Self::Function(function) => match function.return_type.as_type() {
-                            Some(ty) => resolver
-                                .resolve_and_get(&resolved.apply_module_id_to_reference(ty))
-                                .map(ResolvedTypeData::to_data)
-                                .map(|data| data.flattened(resolver))
-                                .unwrap_or_default(),
-                            None => self,
-                        },
-                        Self::Object(_) => {
-                            let member = resolved
-                                .all_members(resolver)
-                                .find(|member| member.has_name("constructor"))
-                                .map(ResolvedTypeMember::to_member);
-                            match member {
-                                Some(member) => resolver
-                                    .type_from_member(resolved.to_data(), member)
-                                    .to_data()
-                                    .flattened(resolver),
-                                None => Self::unknown(),
+                    Some(resolved) => {
+                        return match resolved.as_raw_data() {
+                            TypeData::Function(function) => match function.return_type.as_type() {
+                                Some(return_ty) => resolver
+                                    .resolve_and_get(
+                                        &resolved.apply_module_id_to_reference(return_ty),
+                                    )
+                                    .map(ResolvedTypeData::to_data)
+                                    .map(|data| flattened(data, resolver, depth))
+                                    .unwrap_or_default(),
+                                None => ty,
+                            },
+                            TypeData::Object(_) => {
+                                let member = resolved
+                                    .all_members(resolver)
+                                    .find(|member| member.has_name("constructor"))
+                                    .map(ResolvedTypeMember::to_member);
+                                match member {
+                                    Some(member) => {
+                                        ty = resolver
+                                            .type_from_member(resolved.to_data(), member)
+                                            .to_data();
+                                        continue;
+                                    }
+                                    None => TypeData::unknown(),
+                                }
                             }
-                        }
-                        _ => self,
-                    },
-                    None => self,
+                            _ => ty,
+                        };
+                    }
+                    None => return ty,
                 },
                 TypeofExpression::Destructure(expr) => {
                     match resolver.resolve_and_get(&expr.ty) {
                         Some(resolved) => match (resolved.as_raw_data(), &expr.destructure_field) {
-                            (Self::Class(class), DestructureField::Name(name)) => match class
-                                .members
-                                .iter()
-                                .find(|own_member| {
+                            (TypeData::Class(class), DestructureField::Name(name)) => {
+                                match class.members.iter().find(|own_member| {
                                     own_member.is_static() && own_member.has_name(name.text())
                                 }) {
-                                Some(member) => resolver
-                                    .type_from_member(
-                                        resolved.to_data(),
-                                        ResolvedTypeMember::from((resolved.resolver_id(), member))
-                                            .to_member(),
-                                    )
-                                    .to_data()
-                                    .flattened(resolver),
-                                None => Self::unknown(),
-                            },
-                            (Self::Class(class), DestructureField::RestExcept(names)) => {
-                                Self::object_with_members(
+                                    Some(member) => {
+                                        ty = flattened(
+                                            resolver
+                                                .type_from_member(
+                                                    resolved.to_data(),
+                                                    ResolvedTypeMember::from((
+                                                        resolved.resolver_id(),
+                                                        member,
+                                                    ))
+                                                    .to_member(),
+                                                )
+                                                .to_data(),
+                                            resolver,
+                                            depth,
+                                        );
+                                    }
+                                    None => return TypeData::Unknown,
+                                }
+                            }
+                            (TypeData::Class(class), DestructureField::RestExcept(names)) => {
+                                return TypeData::object_with_members(
                                     class
                                         .members
                                         .iter()
@@ -167,36 +195,40 @@ impl TypeData {
                                             .to_member()
                                         })
                                         .collect(),
-                                )
+                                );
                             }
-                            (ty, DestructureField::Index(index)) => ty
-                                .clone()
-                                .find_element_type_at_index(
-                                    resolved.resolver_id(),
-                                    resolver,
-                                    *index,
-                                )
-                                .map(ResolvedTypeData::to_data)
-                                .unwrap_or_default(),
-                            (ty, DestructureField::RestFrom(index)) => ty
-                                .clone()
-                                .find_type_of_elements_from_index(
-                                    resolved.resolver_id(),
-                                    resolver,
-                                    *index,
-                                )
-                                .map(ResolvedTypeData::to_data)
-                                .unwrap_or_default(),
+                            (subject, DestructureField::Index(index)) => {
+                                return subject
+                                    .clone()
+                                    .find_element_type_at_index(
+                                        resolved.resolver_id(),
+                                        resolver,
+                                        *index,
+                                    )
+                                    .map(ResolvedTypeData::to_data)
+                                    .unwrap_or_default();
+                            }
+                            (subject, DestructureField::RestFrom(index)) => {
+                                return subject
+                                    .clone()
+                                    .find_type_of_elements_from_index(
+                                        resolved.resolver_id(),
+                                        resolver,
+                                        *index,
+                                    )
+                                    .map(ResolvedTypeData::to_data)
+                                    .unwrap_or_default();
+                            }
                             (_, DestructureField::Name(name)) => {
                                 let member = resolved.all_members(resolver).find(|member| {
                                     !member.is_static() && member.has_name(name.text())
                                 });
-                                match member {
+                                return match member {
                                     Some(member) => resolver
                                         .type_from_member(resolved.to_data(), member.to_member())
                                         .to_data(),
-                                    None => Self::unknown(),
-                                }
+                                    None => TypeData::Unknown,
+                                };
                             }
                             (_, DestructureField::RestExcept(names)) => {
                                 // We need to look up the prototype chain, which may
@@ -216,26 +248,26 @@ impl TypeData {
                                         }
                                         map
                                     });
-                                Self::object_with_members(
+                                return TypeData::object_with_members(
                                     members
                                         .into_values()
                                         .map(ResolvedTypeMember::to_member)
                                         .collect(),
-                                )
+                                );
                             }
                         },
-                        None => self,
+                        None => return ty,
                     }
                 }
                 TypeofExpression::New(expr) => {
                     match resolver
                         .resolve_and_get(&expr.callee)
                         .map(ResolvedTypeData::to_data)
-                        .map(|type_data| type_data.flattened(resolver))
+                        .map(|type_data| flattened(type_data, resolver, depth))
                     {
-                        Some(Self::Class(class)) => {
+                        Some(TypeData::Class(class)) => {
                             let num_args = expr.arguments.len();
-                            let ty = class
+                            let constructed_ty = class
                                 .members
                                 .iter()
                                 .find_map(|member| match member {
@@ -249,10 +281,10 @@ impl TypeData {
                                     _ => None,
                                 })
                                 .unwrap_or_else(|| expr.callee.clone());
-                            Self::instance_of(ty).flattened(resolver)
+                            ty = TypeData::instance_of(constructed_ty);
                         }
                         // TODO: Handle objects with call signatures.
-                        _ => self,
+                        _ => return ty,
                     }
                 }
                 TypeofExpression::StaticMember(expr) => {
@@ -260,28 +292,28 @@ impl TypeData {
                         // FIXME: Flattening intersections and unions for members should be done in
                         //        `TypeMemberIterator`.
 
-                        if let Self::InstanceOf(instance) = object.as_raw_data() {
+                        if let TypeData::InstanceOf(instance) = object.as_raw_data() {
                             let instance_ty = object.apply_module_id_to_reference(&instance.ty);
                             if resolver
                                 .resolve_and_get(&instance_ty)
                                 .is_some_and(|object| {
                                     matches!(
                                         object.as_raw_data(),
-                                        Self::Intersection(_) | Self::Union(_)
+                                        TypeData::Intersection(_) | TypeData::Union(_)
                                     )
                                 })
                             {
-                                return Self::TypeofExpression(Box::new(
+                                ty = TypeData::TypeofExpression(Box::new(
                                     TypeofExpression::StaticMember(TypeofStaticMemberExpression {
                                         object: instance_ty.into_owned(),
                                         member: expr.member.clone(),
                                     }),
-                                ))
-                                .flattened(resolver);
+                                ));
+                                continue;
                             }
                         };
 
-                        if let Self::Intersection(intersection) = object.as_raw_data() {
+                        if let TypeData::Intersection(intersection) = object.as_raw_data() {
                             let types: Vec<_> = intersection
                                 .types()
                                 .iter()
@@ -290,26 +322,29 @@ impl TypeData {
                                 .collect();
                             let types = types
                                 .into_iter()
-                                .map(|ty| {
+                                .map(|variant| {
                                     // Resolve and flatten the type member for each variant.
-                                    let ty = Self::TypeofExpression(Box::new(
-                                        TypeofExpression::StaticMember(
-                                            TypeofStaticMemberExpression {
-                                                object: ty,
-                                                member: expr.member.clone(),
-                                            },
-                                        ),
-                                    ))
-                                    .flattened(resolver);
+                                    let variant = flattened(
+                                        TypeData::TypeofExpression(Box::new(
+                                            TypeofExpression::StaticMember(
+                                                TypeofStaticMemberExpression {
+                                                    object: variant,
+                                                    member: expr.member.clone(),
+                                                },
+                                            ),
+                                        )),
+                                        resolver,
+                                        depth,
+                                    );
 
-                                    resolver.reference_to_registered_data(ty)
+                                    resolver.reference_to_registered_data(variant)
                                 })
                                 .collect();
 
-                            return Self::intersection_of(types);
+                            return TypeData::intersection_of(types);
                         }
 
-                        if let Self::Union(union) = object.as_raw_data() {
+                        if let TypeData::Union(union) = object.as_raw_data() {
                             let types: Vec<_> = union
                                 .types()
                                 .iter()
@@ -318,26 +353,29 @@ impl TypeData {
                                 .collect();
                             let types = types
                                 .into_iter()
-                                .map(|ty| {
+                                .map(|variant| {
                                     // Resolve and flatten the type member for each variant.
-                                    let ty = Self::TypeofExpression(Box::new(
-                                        TypeofExpression::StaticMember(
-                                            TypeofStaticMemberExpression {
-                                                object: ty,
-                                                member: expr.member.clone(),
-                                            },
-                                        ),
-                                    ))
-                                    .flattened(resolver);
+                                    let variant = flattened(
+                                        TypeData::TypeofExpression(Box::new(
+                                            TypeofExpression::StaticMember(
+                                                TypeofStaticMemberExpression {
+                                                    object: variant,
+                                                    member: expr.member.clone(),
+                                                },
+                                            ),
+                                        )),
+                                        resolver,
+                                        depth,
+                                    );
 
-                                    resolver.reference_to_registered_data(ty)
+                                    resolver.reference_to_registered_data(variant)
                                 })
                                 .collect();
 
-                            return Self::union_of(types);
+                            return TypeData::union_of(types);
                         }
 
-                        let is_class = matches!(object.as_raw_data(), Self::Class(_));
+                        let is_class = matches!(object.as_raw_data(), TypeData::Class(_));
                         let member = object.all_members(resolver).find(|member| {
                             member.has_name(&expr.member)
                                 && if is_class {
@@ -349,44 +387,47 @@ impl TypeData {
                         match member {
                             Some(member) => {
                                 let member = member.to_member();
-                                Self::reference(
+                                ty = TypeData::reference(
                                     resolver.register_type_from_member(object.to_data(), member),
-                                )
-                                .flattened(resolver)
+                                );
                             }
-                            None => Self::unknown(),
+                            None => return TypeData::Unknown,
                         }
                     } else {
-                        self
+                        return ty;
                     }
                 }
                 TypeofExpression::Super(expr) => match resolver.resolve_and_get(&expr.parent) {
                     Some(resolved) => match resolved.as_raw_data() {
-                        Self::Class(class) => match class.extends.as_ref() {
-                            Some(super_class) => Self::instance_of(
-                                resolved
-                                    .apply_module_id_to_reference(super_class)
-                                    .into_owned(),
-                            )
-                            .flattened(resolver),
-                            None => Self::unknown(),
+                        TypeData::Class(class) => match class.extends.as_ref() {
+                            Some(super_class) => {
+                                ty = TypeData::instance_of(
+                                    resolved
+                                        .apply_module_id_to_reference(super_class)
+                                        .into_owned(),
+                                );
+                            }
+                            None => return TypeData::Unknown,
                         },
-                        _ => Self::unknown(),
+                        _ => return TypeData::Unknown,
                     },
-                    None => self,
+                    None => return ty,
                 },
                 TypeofExpression::This(expr) => match resolver.resolve_reference(&expr.parent) {
                     Some(class_id) => {
-                        Self::instance_of(TypeReference::from(class_id)).flattened(resolver)
+                        ty = TypeData::instance_of(TypeReference::from(class_id));
                     }
-                    None => self,
+                    None => return ty,
                 },
             },
-            Self::TypeofValue(value) => match resolver.resolve_reference(&value.ty) {
-                Some(type_id) => Self::reference(type_id).flattened(resolver),
-                None => self,
+            TypeData::TypeofValue(value) => match resolver.resolve_reference(&value.ty) {
+                Some(type_id) => ty = TypeData::reference(type_id),
+                None => return ty,
             },
-            _ => self,
+            _ => return ty,
         }
     }
+
+    debug_assert!(false, "max flattening depth reached");
+    TypeData::Unknown
 }


### PR DESCRIPTION
## Summary

I've noticed it is easy to make mistakes that cause a stack overflow in flattening, given that the method calls itself recursively.

This PR reduces the recursiveness and adds a maximum depth guard.

## Test Plan

Manually tested.
