### PR TITLE
fix(lint): ignore async and generator callbacks in useIterableCallbackReturn

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_iterable_callback_return.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_iterable_callback_return.rs
@@ -19,7 +19,11 @@ use std::sync::LazyLock;
 declare_lint_rule! {
     /// Enforce consistent return values in iterable callbacks.
     ///
-    /// This rule ensures that callbacks passed to certain iterable methods either always return a value or never return a value, depending on the method's requirements.
+    /// This rule ensures that callbacks passed to certain iterable methods either always return a
+    /// value or never return a value, depending on the method's requirements.
+    ///
+    /// Note that async and generator callbacks are ignored as they always return `Promise` or
+    /// `Generator` respectively.
     ///
     /// ## Methods and Their Requirements
     ///
@@ -40,7 +44,7 @@ declare_lint_rule! {
     /// - `toSorted`
     /// — `from` (when called on `Array`)
     ///
-    /// A return value is disallowed in the  method `forEach`.
+    /// A return value is disallowed in the method `forEach`.
     ///
     /// ## Examples
     ///
@@ -90,9 +94,17 @@ impl Rule for UseIterableCallbackReturn {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let cfg = ctx.query();
 
-        if !JsFunctionExpression::can_cast(cfg.node.kind())
-            && !JsArrowFunctionExpression::can_cast(cfg.node.kind())
-        {
+        if let Some(function) = JsFunctionExpression::cast_ref(&cfg.node) {
+            // Async and generator function callbacks are ignored.
+            if function.async_token().is_some() || function.star_token().is_some() {
+                return None;
+            }
+        } else if let Some(function) = JsArrowFunctionExpression::cast_ref(&cfg.node) {
+            // Async arrow callbacks are ignored.
+            if function.async_token().is_some() {
+                return None;
+            }
+        } else {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/useIterableCallbackReturn/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIterableCallbackReturn/valid.js
@@ -161,3 +161,9 @@ window.from([], () => {});
     }
 });
 [].toSorted((a, b) => a - b);
+
+// Async and generator callbacks
+[].map(async (a) => {});
+[].map(function* (a) {});
+[].map(async function (a) {});
+[].map(async function* (a) {});

--- a/crates/biome_js_analyze/tests/specs/nursery/useIterableCallbackReturn/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useIterableCallbackReturn/valid.js.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 104
 expression: valid.js
 ---
 # Input
@@ -168,5 +167,11 @@ window.from([], () => {});
     }
 });
 [].toSorted((a, b) => a - b);
+
+// Async and generator callbacks
+[].map(async (a) => {});
+[].map(function* (a) {});
+[].map(async function (a) {});
+[].map(async function* (a) {});
 
 ```


### PR DESCRIPTION
## Summary

Fixes #5939 

Async and generator callbacks should be ignored as they always return a `Promise` or a `Generator` object respectively.

cc @mdevils 

## Test Plan

Added snapshot tests.
