### PR TITLE
fix(core): scanner tweak: mostly respect ignored dirs

### DIFF
--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -597,8 +597,12 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         {
             return false;
         }
-        let path = biome_path.as_path();
-        if self.fs.path_is_dir(path) || self.fs.path_is_symlink(path) {
+
+        let path_kind = self.fs.symlink_path_kind(biome_path);
+        if path_kind
+            .as_ref()
+            .is_ok_and(|kind| kind.is_dir() || kind.is_symlink())
+        {
             // handle:
             // - directories
             // - symlinks
@@ -622,7 +626,7 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         }
 
         // bail on fifo and socket files
-        if !self.fs.path_is_file(path) {
+        if path_kind.is_err() {
             Span::current().record("can_handle", false);
             return false;
         }

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -598,11 +598,8 @@ impl TraversalContext for TraversalOptions<'_, '_> {
             return false;
         }
 
-        let path_kind = self.fs.symlink_path_kind(biome_path);
-        if path_kind
-            .as_ref()
-            .is_ok_and(|kind| kind.is_dir() || kind.is_symlink())
-        {
+        let path = biome_path.as_path();
+        if self.fs.path_is_dir(path) || self.fs.path_is_symlink(path) {
             // handle:
             // - directories
             // - symlinks
@@ -626,7 +623,7 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         }
 
         // bail on fifo and socket files
-        if path_kind.is_err() {
+        if !self.fs.path_is_file(path) {
             Span::current().record("can_handle", false);
             return false;
         }

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -91,7 +91,7 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// [Self::path_is_symlink()] and this method to return `true` for the same
     /// path.
     fn path_is_file(&self, path: &Utf8Path) -> bool {
-        Self::path_kind(self, path).is_ok_and(|kind| matches!(kind, PathKind::File { .. }))
+        Self::path_kind(self, path).is_ok_and(PathKind::is_file)
     }
 
     /// Checks if the given path is a directory
@@ -100,7 +100,7 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// [Self::path_is_symlink()] and this method to return `true` for the same
     /// path.
     fn path_is_dir(&self, path: &Utf8Path) -> bool {
-        Self::path_kind(self, path).is_ok_and(|kind| matches!(kind, PathKind::Directory { .. }))
+        Self::path_kind(self, path).is_ok_and(PathKind::is_dir)
     }
 
     /// Checks if the given path is a symlink
@@ -114,6 +114,8 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     fn path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
     /// Returns metadata about the path without following symlinks.
+    ///
+    /// In other words, it returns the kind of the symlink itself, if it is one.
     fn symlink_path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
     /// This method accepts a directory path (`search_dir`) and a file name `search_file`,

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -111,11 +111,18 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
     /// Returns metadata about the path.
     ///
     /// This method follows symlinks.
+    ///
+    /// Errors if the path doesn't exist (including broken symlinks), isn't
+    /// accessible, or if the path points to neither a file or directory.
     fn path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
     /// Returns metadata about the path without following symlinks.
     ///
     /// In other words, it returns the kind of the symlink itself, if it is one.
+    /// If the path is an ordinary file or directory, it still returns its kind.
+    ///
+    /// Errors if the path doesn't exist, isn't accessible, or if the path is
+    /// not a file, directory, or symlink.
     fn symlink_path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
     /// This method accepts a directory path (`search_dir`) and a file name `search_file`,

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -105,11 +105,16 @@ pub trait FileSystem: Send + Sync + RefUnwindSafe {
 
     /// Checks if the given path is a symlink
     fn path_is_symlink(&self, path: &Utf8Path) -> bool {
-        Self::path_kind(self, path).is_ok_and(PathKind::is_symlink)
+        Self::symlink_path_kind(self, path).is_ok_and(PathKind::is_symlink)
     }
 
     /// Returns metadata about the path.
+    ///
+    /// This method follows symlinks.
     fn path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
+
+    /// Returns metadata about the path without following symlinks.
+    fn symlink_path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic>;
 
     /// This method accepts a directory path (`search_dir`) and a file name `search_file`,
     ///
@@ -418,6 +423,10 @@ where
 
     fn path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic> {
         T::path_kind(self, path)
+    }
+
+    fn symlink_path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic> {
+        T::symlink_path_kind(self, path)
     }
 
     fn get_changed_files(&self, base: &str) -> io::Result<Vec<String>> {

--- a/crates/biome_fs/src/fs/memory.rs
+++ b/crates/biome_fs/src/fs/memory.rs
@@ -213,6 +213,10 @@ impl FileSystem for MemoryFileSystem {
         }
     }
 
+    fn symlink_path_kind(&self, path: &Utf8Path) -> Result<PathKind, FileSystemDiagnostic> {
+        self.path_kind(path)
+    }
+
     fn get_changed_files(&self, _base: &str) -> io::Result<Vec<String>> {
         let cb_arc = self.on_get_changed_files.as_ref().unwrap().clone();
 

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -485,6 +485,10 @@ impl FeatureName {
     pub fn insert(&mut self, kind: FeatureKind) {
         self.0.insert(kind);
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl From<SmallVec<[FeatureKind; 6]>> for FeatureName {

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -263,11 +263,9 @@ impl TraversalContext for ScanContext<'_> {
 
         match self.workspace.fs().symlink_path_kind(path) {
             Ok(path_kind) if path_kind.is_dir() => {
-                if self.scan_kind.is_project()
-                    && path.file_name().is_some_and(|name| name == "node_modules")
-                {
-                    // In project mode, the scanner always scans `node_modules`,
-                    // because it's a valuable source of type information.
+                if self.scan_kind.is_project() && path.is_dependency() {
+                    // In project mode, the scanner always scans dependencies,
+                    // because they're a valuable source of type information.
                     true
                 } else {
                     !self

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -9,6 +9,7 @@
 //! well as the watcher to allow continuous scanning.
 
 use super::server::WorkspaceServer;
+use super::{FeatureName, IsPathIgnoredParams};
 use crate::diagnostics::Panic;
 use crate::projects::ProjectKey;
 use crate::workspace::{DocumentFileSource, FileContent, OpenFileParams};
@@ -260,19 +261,41 @@ impl TraversalContext for ScanContext<'_> {
             return false;
         }
 
-        if path
-            .symlink_metadata()
-            .is_ok_and(|metadata| metadata.is_dir())
-        {
-            return true;
-        }
-
-        if self.scan_kind.is_known_files() {
-            (path.is_ignore() || path.is_config() || path.is_manifest()) && !path.is_dependency()
-        } else if path.is_dependency() {
-            path.is_manifest() || path.is_type_declaration()
-        } else {
-            DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
+        match self.workspace.fs().symlink_path_kind(path) {
+            Ok(path_kind) if path_kind.is_dir() => {
+                if self.scan_kind.is_project()
+                    && path.file_name().is_some_and(|name| name == "node_modules")
+                {
+                    // In project mode, the scanner always scans `node_modules`,
+                    // because it's a valuable source of type information.
+                    true
+                } else {
+                    !self
+                        .workspace
+                        .is_path_ignored(IsPathIgnoredParams {
+                            project_key: self.project_key,
+                            path: path.clone(),
+                            // The scanner only cares about the top-level
+                            // `files.includes`.
+                            features: FeatureName::empty(),
+                        })
+                        .unwrap_or_default()
+                }
+            }
+            Ok(path_kind) if path_kind.is_file() => {
+                if self.scan_kind.is_known_files() {
+                    (path.is_ignore() || path.is_config() || path.is_manifest())
+                        && !path.is_dependency()
+                } else if path.is_dependency() {
+                    path.is_manifest() || path.is_type_declaration()
+                } else {
+                    DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
+                }
+            }
+            _ => {
+                // bail on fifo and socket files
+                false
+            }
         }
     }
 

--- a/crates/biome_service/tests/spec_test.rs
+++ b/crates/biome_service/tests/spec_test.rs
@@ -50,18 +50,15 @@ fn test_scanner_only_loads_type_definitions_from_node_modules() {
         })
         .unwrap();
 
-    // FIXME: We should load manifests again in order to actually resolve
-    //        type definitions, but last time we tried we ran into performance
-    //        issues, and a reoccurrence of panics inside `node_semver` (#5829).
-    //let manifest_result = workspace.get_file_content(GetFileContentParams {
-    //    project_key,
-    //    path: BiomePath::new(format!("{fixtures_path}/node_modules/shared/package.json")),
-    //});
-    //
-    //assert!(
-    //    manifest_result.is_ok_and(|result| !result.is_empty()),
-    //    "package.json should be loaded"
-    //);
+    let manifest_result = workspace.get_file_content(GetFileContentParams {
+        project_key,
+        path: BiomePath::new(format!("{fixtures_path}/node_modules/shared/package.json")),
+    });
+
+    assert!(
+        manifest_result.is_ok_and(|result| !result.is_empty()),
+        "package.json should be loaded"
+    );
 
     let d_mts_result = workspace.get_file_content(GetFileContentParams {
         project_key,


### PR DESCRIPTION
## Summary

This changes the logic for what the scanner should scan: It now respects the top-level `files.includes` setting, with two exceptions:
* Supported files are always scanned, provided they are in directory that is not ignored.
* `node_modules` is always scanned when using `ScanKind::Project`.

The main advantage of this is that users gain the ability to configure the scanner, without exposing new configuration settings. There is some subtlety with use cases such as codegen however: Users usually want to exclude generated files, but some use cases we _should_ scan them. For these use cases, we should advise users to _include_ them in the top-level `files.includes`, and _exclude_ them using the tool-specific `includes` settings.

## Test Plan

Everything should remain green. Also manually tested.
