### PR TITLE
refactor(migrate): improve organizeImports migration

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
@@ -21,13 +21,7 @@ expression: redactor(content)
       "!**/*.css"
     ]
   },
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
     "indentStyle": "space"

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
@@ -17,13 +17,7 @@ expression: redactor(content)
       "!**/packages/docs/.astro"
     ]
   },
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -119,9 +113,7 @@ expression: redactor(content)
     },
     {
       "includes": ["**/packages/knip/fixtures/**"],
-      "organizeImports": {
-        "enabled": false
-      },
+      "assist": { "actions": { "source": { "organizeImports": "off" } } },
       "linter": {
         "rules": {
           "correctness": {

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_sentry.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_sentry.snap
@@ -13,13 +13,7 @@ expression: redactor(content)
     "useIgnoreFile": true,
     "defaultBranch": "master"
   },
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "off"
-      }
-    }
-  },
+  "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "linter": {
     "enabled": true,
     "rules": {

--- a/crates/biome_json_syntax/src/object_ext.rs
+++ b/crates/biome_json_syntax/src/object_ext.rs
@@ -1,11 +1,29 @@
-use crate::{JsonMemberList, JsonObjectValue};
-use biome_rowan::AstNode;
+use crate::{JsonMember, JsonMemberList, JsonObjectValue};
+use biome_rowan::{AstNode, AstSeparatedList};
 
 impl JsonObjectValue {
+    pub fn find_member(&self, name: &str) -> Option<JsonMember> {
+        self.json_member_list().find_member(name)
+    }
+
     pub fn with_json_member_list(self, list: JsonMemberList) -> Self {
         Self::unwrap_cast(
             self.into_syntax()
                 .splice_slots(1..=1, [Some(list.into_syntax().into())]),
         )
+    }
+}
+
+impl JsonMemberList {
+    pub fn find_member(&self, name: &str) -> Option<JsonMember> {
+        for member in self.iter().flatten() {
+            let Ok(member_name) = member.name().and_then(|n| n.inner_string_text()) else {
+                continue;
+            };
+            if member_name == name {
+                return Some(member);
+            }
+        }
+        None
     }
 }

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -165,7 +165,7 @@ impl Rule for RuleMover {
         // If the group exists, then `new_group_range` will be the range of the group
         let new_group_name = state.new_rule.group().as_str();
         let (new_group_range, new_group_node) = if let Some(new_group) =
-            find_member(rules, new_group_name)
+            rules.find_member(new_group_name)
         {
             // The group exists, so we update it.
             let AnyJsonValue::JsonObjectValue(group_obj) = new_group.value().ok()? else {
@@ -179,7 +179,6 @@ impl Rule for RuleMover {
             let last_has_separator = new_elements.last().is_some_and(|(_, sep)| sep.is_some());
             // Add the new rule
             new_elements.push((rule_node, None));
-            // Reconstruct the list
             handle_trvia(
                 new_elements.iter_mut().map(|(a, b)| (a, b)),
                 last_has_separator,
@@ -319,18 +318,6 @@ pub struct State {
     /// Set if the rule is renamed.
     old_rule_name: Option<&'static str>,
     new_rule: RuleName,
-}
-
-fn find_member(object: &JsonObjectValue, name: &str) -> Option<JsonMember> {
-    for member in object.json_member_list().into_iter().flatten() {
-        let Ok(member_name) = member.name().and_then(|n| n.inner_string_text()) else {
-            continue;
-        };
-        if member_name == name {
-            return Some(member);
-        }
-    }
-    None
 }
 
 fn transform_value(value: AnyJsonValue, old_rule_name: &'static str) -> Option<AnyJsonValue> {

--- a/crates/biome_migrate/src/analyzers/style_rules.rs
+++ b/crates/biome_migrate/src/analyzers/style_rules.rs
@@ -114,7 +114,7 @@ impl Rule for StyleRules {
         let root = ctx.root();
         let new_rule_member = json_member(
             json_member_name(
-                json_string_literal(rule_to_move.as_ref()).with_leading_trivia(vec![
+                json_string_literal(rule_to_move.as_ref()).with_leading_trivia([
                     (TriviaPieceKind::Newline, "\n"),
                     (TriviaPieceKind::Whitespace, " ".repeat(8).as_str()),
                 ]),
@@ -122,7 +122,7 @@ impl Rule for StyleRules {
             token(T![:]),
             AnyJsonValue::JsonStringValue(json_string_value(
                 json_string_literal("error")
-                    .with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]),
+                    .with_leading_trivia([(TriviaPieceKind::Whitespace, " ")]),
             )),
         );
         let linter_member = get_linter_field(ctx.root());
@@ -205,44 +205,14 @@ fn find_member_by_name(member: &JsonMember, field_name: &str) -> Option<JsonMemb
         .value()
         .ok()?
         .as_json_object_value()?
-        .json_member_list()
-        .iter()
-        .flatten()
-        .find_map(|member| {
-            if member
-                .name()
-                .ok()?
-                .inner_string_text()
-                .ok()
-                .is_some_and(|name| name.text() == field_name)
-            {
-                Some(member)
-            } else {
-                None
-            }
-        })
+        .find_member(field_name)
 }
 
 fn get_linter_field(root: JsonRoot) -> Option<JsonMember> {
     root.value()
         .ok()?
         .as_json_object_value()?
-        .json_member_list()
-        .iter()
-        .flatten()
-        .find_map(|member| {
-            if member
-                .name()
-                .ok()?
-                .inner_string_text()
-                .ok()
-                .is_some_and(|name| name.text() == "linter")
-            {
-                Some(member)
-            } else {
-                None
-            }
-        })
+        .find_member("linter")
 }
 
 fn create_member(text: &str, value: AnyJsonValue, level: usize) -> JsonMember {
@@ -258,9 +228,9 @@ fn create_member(text: &str, value: AnyJsonValue, level: usize) -> JsonMember {
 
 fn create_object(list: JsonMemberList, spaces: usize) -> JsonObjectValue {
     json_object_value(
-        token(T!['{']).with_leading_trivia(vec![(TriviaPieceKind::Whitespace, " ")]),
+        token(T!['{']).with_leading_trivia([(TriviaPieceKind::Whitespace, " ")]),
         list,
-        token(T!['}']).with_leading_trivia(vec![
+        token(T!['}']).with_leading_trivia([
             (TriviaPieceKind::Newline, "\n"),
             (TriviaPieceKind::Whitespace, " ".repeat(spaces).as_str()),
         ]),

--- a/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid.json.snap
@@ -20,28 +20,21 @@ invalid.json:2:3 migrate  FIXABLE  ━━━━━━━━━━━━━━━
   
     1 │ {
   > 2 │   "organizeImports": {
-      │   ^^^^^^^^^^^^^^^^^^^^
-  > 3 │     "enabled": false
-  > 4 │   }
-      │   ^
-    5 │ }
-    6 │ 
+      │   ^^^^^^^^^^^^^^^^^
+    3 │     "enabled": false
+    4 │   }
   
   i The import sorting was the first assist action, however Biome analyzer infrastructure wasn't mature enough, so it was exposed as a standalone tool. The infrastructure is now ready to welcome it as an assist action.
   
   i Safe fix: Remove the old configuration, and turn off the relative assist action.
   
-    1  1 │   {
-    2    │ - ··"organizeImports":·{
-    3    │ - ····"enabled":·false
-       2 │ + ··"assist":··{
-       3 │ + ····"actions":··{
-       4 │ + ······"source":··{
-       5 │ + ········"organizeImports":·"off"
-       6 │ + ······}
-       7 │ + ····}
-    4  8 │     }
-    5  9 │   }
+    1 1 │   {
+    2   │ - ··"organizeImports":·{
+    3   │ - ····"enabled":·false
+    4   │ - ··}
+      2 │ + ··"assist":·{·"actions":·{·"source":·{·"organizeImports":·"off"·}·}·}
+    5 3 │   }
+    6 4 │   
   
 
 ```

--- a/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid2.json
+++ b/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid2.json
@@ -1,5 +1,14 @@
 {
   "organizeImports": {
     "enabled": true
-  }
+  },
+  "linter": {},
+  "overrides": [
+    {
+      "includes": [],
+      "organizeImports": {
+        "enabled": false
+      }
+    }
+  ]
 }

--- a/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid2.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/organizeImports/invalid2.json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_migrate/tests/spec_tests.rs
-assertion_line: 50
 expression: invalid2.json
 ---
 # Input
@@ -8,7 +7,16 @@ expression: invalid2.json
 {
   "organizeImports": {
     "enabled": true
-  }
+  },
+  "linter": {},
+  "overrides": [
+    {
+      "includes": [],
+      "organizeImports": {
+        "enabled": false
+      }
+    }
+  ]
 }
 
 ```
@@ -21,28 +29,49 @@ invalid2.json:2:3 migrate  FIXABLE  ━━━━━━━━━━━━━━�
   
     1 │ {
   > 2 │   "organizeImports": {
-      │   ^^^^^^^^^^^^^^^^^^^^
-  > 3 │     "enabled": true
-  > 4 │   }
-      │   ^
-    5 │ }
-    6 │ 
+      │   ^^^^^^^^^^^^^^^^^
+    3 │     "enabled": true
+    4 │   },
   
   i The import sorting was the first assist action, however Biome analyzer infrastructure wasn't mature enough, so it was exposed as a standalone tool. The infrastructure is now ready to welcome it as an assist action.
   
   i Safe fix: Remove the old configuration, and turn off the relative assist action.
   
-    1  1 │   {
-    2    │ - ··"organizeImports":·{
-    3    │ - ····"enabled":·true
-       2 │ + ··"assist":··{
-       3 │ + ····"actions":··{
-       4 │ + ······"source":··{
-       5 │ + ········"organizeImports":·"on"
-       6 │ + ······}
-       7 │ + ····}
-    4  8 │     }
-    5  9 │   }
+     1  1 │   {
+     2    │ - ··"organizeImports":·{
+     3    │ - ····"enabled":·true
+     4    │ - ··},
+        2 │ + ··"assist":·{·"actions":·{·"source":·{·"organizeImports":·"on"·}·}·},
+     5  3 │     "linter": {},
+     6  4 │     "overrides": [
+  
+
+```
+
+```
+invalid2.json:9:7 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The organizeImports configuration has been moved.
+  
+     7 │     {
+     8 │       "includes": [],
+   > 9 │       "organizeImports": {
+       │       ^^^^^^^^^^^^^^^^^
+    10 │         "enabled": false
+    11 │       }
+  
+  i The import sorting was the first assist action, however Biome analyzer infrastructure wasn't mature enough, so it was exposed as a standalone tool. The infrastructure is now ready to welcome it as an assist action.
+  
+  i Safe fix: Remove the old configuration, and turn off the relative assist action.
+  
+     7  7 │       {
+     8  8 │         "includes": [],
+     9    │ - ······"organizeImports":·{
+    10    │ - ········"enabled":·false
+    11    │ - ······}
+        9 │ + ······"assist":·{·"actions":·{·"source":·{·"organizeImports":·"off"·}·}·}
+    12 10 │       }
+    13 11 │     ]
   
 
 ```

--- a/crates/biome_rowan/src/syntax/token.rs
+++ b/crates/biome_rowan/src/syntax/token.rs
@@ -435,7 +435,7 @@ impl<L: Language> SyntaxToken<L> {
     /// Return whitespace that juxtapose the token until the first non-whitespace item.
     pub fn indentation_trivia_pieces(
         &self,
-    ) -> impl ExactSizeIterator<Item = SyntaxTriviaPiece<L>> + use<L> {
+    ) -> impl ExactSizeIterator<Item = SyntaxTriviaPiece<L>> + Clone + use<L> {
         let leading_trivia = self.leading_trivia().pieces();
         let skip_count = leading_trivia.len()
             - leading_trivia


### PR DESCRIPTION
## Summary

This PR improves our `organizeImports` migration by supporting overrides.

## Test Plan

I added a new test.
