### PR TITLE
refactor(migrate): handle already migrated rules

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
@@ -23,9 +23,9 @@ expression: redactor(content)
         "noForEach": "off"
       },
       "correctness": {
-        "noInvalidBuiltinInstantiation": "error",
         "noUndeclaredVariables": "error",
-        "noUnusedVariables": "error"
+        "noUnusedVariables": "error",
+        "noInvalidBuiltinInstantiation": "error"
       },
       "style": {
         "noNamespace": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
@@ -54,8 +54,8 @@ expression: redactor(content)
         }
       },
       "suspicious": {
-        "noConsole": { "level": "error", "options": { "allow": ["log"] } },
-        "noExplicitAny": "off"
+        "noExplicitAny": "off",
+        "noConsole": { "level": "error", "options": { "allow": ["log"] } }
       }
     }
   },

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -133,32 +133,21 @@ impl Rule for RuleMover {
         // If the rule is moved or renamed
         let rule_node = state.rule_node.clone();
         // Rename the rule
-        let rule_node = if let Some(old_rule_name) = state.old_rule_name {
+        let new_rule_node = if let Some(old_rule_name) = state.old_rule_name {
             let new_name =
                 make::json_member_name(make::json_string_literal(state.new_rule.as_str()));
-            let rule_node = rule_node.with_name(new_name);
-            if let Some(value) = rule_node
+            let new_rule_node = rule_node.with_name(new_name);
+            if let Some(value) = new_rule_node
                 .value()
                 .ok()
                 .and_then(|value| transform_value(value, old_rule_name))
             {
-                rule_node.with_value(value)
+                new_rule_node.with_value(value)
             } else {
-                rule_node
+                new_rule_node
             }
         } else {
             rule_node
-        };
-
-        // If the rule is not moved and just renamed, we return early.
-        if state.old_group.is_none() {
-            mutation.replace_node(state.rule_node.clone(), rule_node);
-            return Some(MigrationAction::new(
-                ctx.metadata().action_category(ctx.category(), ctx.group()),
-                ctx.metadata().applicability(),
-                markup! { "Rename the rule." }.to_owned(),
-                mutation,
-            ));
         };
 
         // Update or create the group where the rule is moved to
@@ -173,12 +162,34 @@ impl Rule for RuleMover {
             };
             let old_list = group_obj.json_member_list();
             let mut new_elements = Vec::with_capacity(old_list.len() + 1);
+            let new_rule_name = state.new_rule.as_str();
+            let mut last_has_separator = false;
+            let mut is_rule_migrated = false;
             for elt in old_list.elements() {
-                new_elements.push((elt.node.ok()?, elt.trailing_separator.ok()?));
+                let node = elt.node.ok()?;
+                if let Ok(name) = node.name().and_then(|name| name.inner_string_text()) {
+                    if name.text() == new_rule_name {
+                        // This happens when:
+                        // - the rule has already been manually migrated, but the old one was not removed
+                        // - several rules are renamed and merged into a same rule.
+                        is_rule_migrated = true;
+                    } else if state.old_rule_name == Some(name.text()) {
+                        // Remove the old rule.
+                        // This happens when the new and old rule are located in the same group.
+                        continue;
+                    }
+                }
+                let trailing_separator = elt.trailing_separator.ok()?;
+                last_has_separator = trailing_separator.is_some();
+                new_elements.push((node, trailing_separator));
             }
-            let last_has_separator = new_elements.last().is_some_and(|(_, sep)| sep.is_some());
-            // Add the new rule
-            new_elements.push((rule_node, None));
+            if !is_rule_migrated {
+                let new_rule_node = new_rule_node.with_leading_trivia_pieces(
+                    state.rule_node.syntax().first_leading_trivia()?.pieces(),
+                )?;
+                // Add the new rule
+                new_elements.push((new_rule_node, None));
+            }
             handle_trvia(
                 new_elements.iter_mut().map(|(a, b)| (a, b)),
                 last_has_separator,
@@ -225,12 +236,12 @@ impl Rule for RuleMover {
                     make::token(T!['{']).with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")]),
                     if last_has_separator {
                         make::json_member_list(
-                            [rule_node],
+                            [new_rule_node],
                             [make::token(T![,])
                                 .with_trailing_trivia([(TriviaPieceKind::Whitespace, " ")])],
                         )
                     } else {
-                        make::json_member_list([rule_node], [])
+                        make::json_member_list([new_rule_node], [])
                     },
                     make::token(T!['}']).with_leading_trivia([(TriviaPieceKind::Whitespace, " ")]),
                 )
@@ -240,12 +251,15 @@ impl Rule for RuleMover {
         };
 
         // Update `rules` by updating or adding `new_group_node`.
-        // It is also in charge of removing the old rule.
+        // It is also in charge of removing the old rule if it is not in the same group as the new one.
         let mut new_rules_elements = Vec::with_capacity(old_rules_list.len() + 1);
         let rule_group_node = state.rule_node.syntax().grand_parent()?.parent()?;
         for elt in old_rules_list.elements() {
             let node = elt.node.ok()?;
-            let node = if node.range() == rule_group_node.text_range() {
+            let node = if new_group_range.is_some_and(|range| range == node.range()) {
+                // Update the group
+                new_group_node.clone()
+            } else if node.range() == rule_group_node.text_range() {
                 // Remove the old rule
                 let old_list = state.rule_node.parent::<JsonMemberList>()?;
                 let mut new_elements = Vec::with_capacity(old_list.len() - 1);
@@ -273,9 +287,6 @@ impl Rule for RuleMover {
                 let obj = old_list.parent::<JsonObjectValue>()?;
                 let obj = obj.with_json_member_list(new_list);
                 node.with_value(obj.into())
-            } else if new_group_range.is_some_and(|range| range == node.range()) {
-                // Update the group
-                new_group_node.clone()
             } else {
                 node
             };
@@ -305,7 +316,13 @@ impl Rule for RuleMover {
         Some(MigrationAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-            markup! { "Move the rule." }.to_owned(),
+            if state.old_group.is_none() {
+                "Rename the rule."
+            } else if state.old_rule_name.is_none() {
+                "Move the rule."
+            } else {
+                "Move and rename the rule."
+            },
             mutation,
         ))
     }

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/duplicated.json
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/duplicated.json
@@ -1,0 +1,15 @@
+{
+  "linter": {
+    "rules": {
+      
+      "correctness": {
+        "noInvalidNewBuiltin": "on",
+        "noInvalidBuiltinInstantiation": "on",
+        "noUselessContinue": "on"
+      },
+      "complexity": {
+        "noUnnecessaryContinue": "on"
+      }
+    }
+  }
+}

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/duplicated.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/duplicated.json.snap
@@ -1,0 +1,71 @@
+---
+source: crates/biome_migrate/tests/spec_tests.rs
+expression: duplicated.json
+---
+# Input
+```json
+{
+  "linter": {
+    "rules": {
+      
+      "correctness": {
+        "noInvalidNewBuiltin": "on",
+        "noInvalidBuiltinInstantiation": "on",
+        "noUselessContinue": "on"
+      },
+      "complexity": {
+        "noUnnecessaryContinue": "on"
+      }
+    }
+  }
+}
+
+```
+
+# Diagnostics
+```
+duplicated.json:6:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This rule has been renamed to noInvalidBuiltinInstantiation.
+  
+    5 │       "correctness": {
+  > 6 │         "noInvalidNewBuiltin": "on",
+      │         ^^^^^^^^^^^^^^^^^^^^^
+    7 │         "noInvalidBuiltinInstantiation": "on",
+    8 │         "noUselessContinue": "on"
+  
+  i Safe fix: Rename the rule.
+  
+     4  4 │         
+     5  5 │         "correctness": {
+     6    │ - ········"noInvalidNewBuiltin":·"on",
+     7    │ - ········"noInvalidBuiltinInstantiation":·"on",
+        6 │ + ········"noInvalidBuiltinInstantiation":·"on",
+     8  7 │           "noUselessContinue": "on"
+     9  8 │         },
+  
+
+```
+
+```
+duplicated.json:11:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This rule has been moved to correctness/noUselessContinue.
+  
+     9 │       },
+    10 │       "complexity": {
+  > 11 │         "noUnnecessaryContinue": "on"
+       │         ^^^^^^^^^^^^^^^^^^^^^^^
+    12 │       }
+    13 │     }
+  
+  i Safe fix: Move and rename the rule.
+  
+     9  9 │         },
+    10 10 │         "complexity": {
+    11    │ - ········"noUnnecessaryContinue":·"on"
+    12 11 │         }
+    13 12 │       }
+  
+
+```

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/renaming.json
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/renaming.json
@@ -1,6 +1,7 @@
 {
   "linter": {
     "rules": {
+      
       "complexity": {
         "noMultipleSpacesInRegularExpressionLiterals": "on",
         "noUnnecessaryContinue": "on"

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/renaming.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/renaming.json.snap
@@ -7,6 +7,7 @@ expression: renaming.json
 {
   "linter": {
     "rules": {
+      
       "complexity": {
         "noMultipleSpacesInRegularExpressionLiterals": "on",
         "noUnnecessaryContinue": "on"
@@ -19,53 +20,54 @@ expression: renaming.json
 
 # Diagnostics
 ```
-renaming.json:5:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+renaming.json:6:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This rule has been renamed to noAdjacentSpacesInRegex.
   
-    3 │     "rules": {
-    4 │       "complexity": {
-  > 5 │         "noMultipleSpacesInRegularExpressionLiterals": "on",
+    5 │       "complexity": {
+  > 6 │         "noMultipleSpacesInRegularExpressionLiterals": "on",
       │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    6 │         "noUnnecessaryContinue": "on"
-    7 │       }
+    7 │         "noUnnecessaryContinue": "on"
+    8 │       }
   
   i Safe fix: Rename the rule.
   
-     3  3 │       "rules": {
-     4  4 │         "complexity": {
-     5    │ - ········"noMultipleSpacesInRegularExpressionLiterals":·"on",
-        5 │ + ········"noAdjacentSpacesInRegex":·"on",
-     6  6 │           "noUnnecessaryContinue": "on"
-     7  7 │         }
+     4  4 │         
+     5  5 │         "complexity": {
+     6    │ - ········"noMultipleSpacesInRegularExpressionLiterals":·"on",
+     7    │ - ········"noUnnecessaryContinue":·"on"
+        6 │ + ········"noUnnecessaryContinue":·"on",
+        7 │ + ········"noAdjacentSpacesInRegex":·"on"
+     8  8 │         }
+     9  9 │       }
   
 
 ```
 
 ```
-renaming.json:6:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+renaming.json:7:9 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This rule has been moved to correctness/noUselessContinue.
   
-    4 │       "complexity": {
-    5 │         "noMultipleSpacesInRegularExpressionLiterals": "on",
-  > 6 │         "noUnnecessaryContinue": "on"
+    5 │       "complexity": {
+    6 │         "noMultipleSpacesInRegularExpressionLiterals": "on",
+  > 7 │         "noUnnecessaryContinue": "on"
       │         ^^^^^^^^^^^^^^^^^^^^^^^
-    7 │       }
-    8 │     }
+    8 │       }
+    9 │     }
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
-     3  3 │       "rules": {
-     4  4 │         "complexity": {
-     5    │ - ········"noMultipleSpacesInRegularExpressionLiterals":·"on",
-     6    │ - ········"noUnnecessaryContinue":·"on"
-     7    │ - ······}
-        5 │ + ········"noMultipleSpacesInRegularExpressionLiterals":·"on"
-        6 │ + ······},
-        7 │ + ······"correctness":·{·"noUselessContinue":·"on"·}
-     8  8 │       }
-     9  9 │     }
+     4  4 │         
+     5  5 │         "complexity": {
+     6    │ - ········"noMultipleSpacesInRegularExpressionLiterals":·"on",
+     7    │ - ········"noUnnecessaryContinue":·"on"
+     8    │ - ······}
+        6 │ + ········"noMultipleSpacesInRegularExpressionLiterals":·"on"
+        7 │ + ······},
+        8 │ + ······"correctness":·{·"noUselessContinue":·"on"·}
+     9  9 │       }
+    10 10 │     }
   
 
 ```

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/transformed.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/transformed.json.snap
@@ -38,9 +38,17 @@ transformed.json:5:9 migrate  FIXABLE  ━━━━━━━━━━━━━�
      3  3 │       "rules": {
      4  4 │         "suspicious": {
      5    │ - ········"noConsoleLog":·"error",
-        5 │ + ········"noConsole":·{·"level":·"error",·"options":·{·"allow":·["log"]·}·},
-     6  6 │           "useSingleCaseStatement": "error",
-     7  7 │           "useShorthandArrayType": "error",
+     6    │ - ········"useSingleCaseStatement":·"error",
+     7    │ - ········"useShorthandArrayType":·"error",
+     8    │ - ········"noNewSymbol":·"error",
+     9    │ - ········"noInvalidNewBuiltin":·"error"
+        5 │ + ········"useSingleCaseStatement":·"error",
+        6 │ + ········"useShorthandArrayType":·"error",
+        7 │ + ········"noNewSymbol":·"error",
+        8 │ + ········"noInvalidNewBuiltin":·"error",
+        9 │ + ········"noConsole":·{·"level":·"error",·"options":·{·"allow":·["log"]·}·}
+    10 10 │         }
+    11 11 │       }
   
 
 ```
@@ -57,7 +65,7 @@ transformed.json:6:9 migrate  FIXABLE  ━━━━━━━━━━━━━�
     7 │         "useShorthandArrayType": "error",
     8 │         "noNewSymbol": "error",
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      4  4 │         "suspicious": {
      5  5 │           "noConsoleLog": "error",
@@ -89,7 +97,7 @@ transformed.json:7:9 migrate  FIXABLE  ━━━━━━━━━━━━━�
     8 │         "noNewSymbol": "error",
     9 │         "noInvalidNewBuiltin": "error"
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      5  5 │           "noConsoleLog": "error",
      6  6 │           "useSingleCaseStatement": "error",
@@ -119,7 +127,7 @@ transformed.json:8:9 migrate  FIXABLE  ━━━━━━━━━━━━━�
      9 │         "noInvalidNewBuiltin": "error"
     10 │       }
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      6  6 │           "useSingleCaseStatement": "error",
      7  7 │           "useShorthandArrayType": "error",
@@ -147,7 +155,7 @@ transformed.json:9:9 migrate  FIXABLE  ━━━━━━━━━━━━━�
     10 │       }
     11 │     }
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      6  6 │           "useSingleCaseStatement": "error",
      7  7 │           "useShorthandArrayType": "error",

--- a/crates/biome_migrate/tests/specs/migrations/ruleMover/transformed_with_level.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/ruleMover/transformed_with_level.json.snap
@@ -49,10 +49,27 @@ transformed_with_level.json:5:9 migrate  FIXABLE  ━━━━━━━━━━
      4  4 │         "suspicious": {
      5    │ - ········"noConsoleLog":·{
      6    │ - ··········"level":·"warn"
-     7    │ - ········},
-        5 │ + ········"noConsole":·{·"level":·"warn",·"options":·{·"allow":·["log"]·}·},
-     8  6 │           "useSingleCaseStatement": {
-     9  7 │             "level": "error"
+        5 │ + ········"useSingleCaseStatement":·{
+        6 │ + ··········"level":·"error"
+     7  7 │           },
+     8    │ - ········"useSingleCaseStatement":·{
+        8 │ + ········"useShorthandArrayType":·{
+     9  9 │             "level": "error"
+    10 10 │           },
+    11    │ - ········"useShorthandArrayType":·{
+       11 │ + ········"noNewSymbol":·{
+    12 12 │             "level": "error"
+    13 13 │           },
+    14    │ - ········"noNewSymbol":·{
+       14 │ + ········"noInvalidNewBuiltin":·{
+    15 15 │             "level": "error"
+    16 16 │           },
+    17    │ - ········"noInvalidNewBuiltin":·{
+    18    │ - ··········"level":·"error"
+    19    │ - ········}
+       17 │ + ········"noConsole":·{·"level":·"warn",·"options":·{·"allow":·["log"]·}·}
+    20 18 │         }
+    21 19 │       }
   
 
 ```
@@ -69,7 +86,7 @@ transformed_with_level.json:8:9 migrate  FIXABLE  ━━━━━━━━━━
      9 │           "level": "error"
     10 │         },
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      6  6 │             "level": "warn"
      7  7 │           },
@@ -111,7 +128,7 @@ transformed_with_level.json:11:9 migrate  FIXABLE  ━━━━━━━━━�
     12 │           "level": "error"
     13 │         },
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
      9  9 │             "level": "error"
     10 10 │           },
@@ -148,7 +165,7 @@ transformed_with_level.json:14:9 migrate  FIXABLE  ━━━━━━━━━�
     15 │           "level": "error"
     16 │         },
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
     12 12 │             "level": "error"
     13 13 │           },
@@ -182,7 +199,7 @@ transformed_with_level.json:17:9 migrate  FIXABLE  ━━━━━━━━━�
     18 │           "level": "error"
     19 │         }
   
-  i Safe fix: Move the rule.
+  i Safe fix: Move and rename the rule.
   
     14 14 │           "noNewSymbol": {
     15 15 │             "level": "error"


### PR DESCRIPTION
## Summary

Improve the rule mover migration by handling already migrated rules and migration of several rules with the same name.
Basically, if the rule was already migrated, we just remove the old one.

This should solve an issue we have with a repository in the ecosystem-ci.

## Test Plan

I added some tests.
