### PR TITLE
feat(migrate): migrate nested configuration files

### DIFF
--- a/.changeset/whole-clouds-lead.md
+++ b/.changeset/whole-clouds-lead.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+The command `migrate` is now able to migrate nested configuration files.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -777,8 +777,16 @@ pub(crate) trait CommandRunner: Sized {
             execution,
             paths,
             duration,
+            configuration_files,
         } = self.configure_workspace(fs, console, workspace, cli_options)?;
-        execute_mode(execution, session, cli_options, paths, duration)
+        execute_mode(
+            execution,
+            session,
+            cli_options,
+            paths,
+            duration,
+            configuration_files,
+        )
     }
 
     /// This function prepares the workspace with the following:
@@ -864,6 +872,7 @@ pub(crate) trait CommandRunner: Sized {
             execution,
             paths,
             duration: Some(result.duration),
+            configuration_files: result.configuration_files,
         })
     }
 
@@ -944,6 +953,8 @@ pub(crate) struct ConfiguredWorkspace {
     pub paths: Vec<OsString>,
     /// The duration of the scanning
     pub duration: Option<Duration>,
+    /// Configuration files found inside the project
+    pub configuration_files: Vec<BiomePath>,
 }
 
 pub trait LoadEditorConfig: CommandRunner {

--- a/crates/biome_cli/src/commands/scan_kind.rs
+++ b/crates/biome_cli/src/commands/scan_kind.rs
@@ -14,13 +14,18 @@ use rustc_hash::FxHashSet;
 ///
 /// Rules:
 /// - CLI via `stdin` return [ScanKind::None]
+/// - `biome migrate` return [ScanKind:KnownFiles], so it can migrate all nested configuration files
 /// - `biome format` return [ScanKind::KnownFiles] if VCS is enabled, otherwise [ScanKind::None]
 /// - `biome lint`, `biome check` and `biome ci` may vary. It depends on whether the user has enabled rules that require the `RuleDomain::Project`.
 ///   If not, returns [ScanKind::KnownFiles] if VCS is enabled, otherwise [ScanKind::None]
 pub(crate) fn compute_scan_kind(execution: &Execution, configuration: &Configuration) -> ScanKind {
-    if execution.is_stdin() || execution.is_migrate() {
+    if execution.is_stdin() {
         return ScanKind::None;
     };
+
+    if execution.is_migrate() {
+        return ScanKind::KnownFiles;
+    }
 
     if execution.is_format() {
         // There's no need to scan further known files if the VCS isn't enabled

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -562,6 +562,7 @@ pub fn execute_mode(
     cli_options: &CliOptions,
     paths: Vec<OsString>,
     scanner_duration: Option<Duration>,
+    nested_configuration_files: Vec<BiomePath>,
 ) -> Result<(), CliDiagnostic> {
     // If a custom reporter was provided, let's lift the limit so users can see all of them
     execution.max_diagnostics = if cli_options.reporter.is_default() {
@@ -587,8 +588,8 @@ pub fn execute_mode(
             project_key,
             write,
             configuration_file_path,
-            verbose: cli_options.verbose,
             sub_command,
+            nested_configuration_files,
         };
         return migrate::run(payload);
     }

--- a/crates/biome_cli/tests/snap_test.rs
+++ b/crates/biome_cli/tests/snap_test.rs
@@ -33,7 +33,7 @@ pub(crate) struct CliSnapshot {
     /// the configuration, if set
     /// First string is the content
     /// Second string is the name
-    pub configuration: Option<(String, &'static str)>,
+    pub configuration_list: Vec<(String, String)>,
     /// file name -> content
     pub files: BTreeMap<String, String>,
     /// messages written in console
@@ -46,7 +46,7 @@ impl CliSnapshot {
     pub fn from_result(result: Result<(), CliDiagnostic>) -> Self {
         Self {
             in_messages: InMessages::default(),
-            configuration: None,
+            configuration_list: vec![],
             files: BTreeMap::default(),
             messages: Vec::new(),
             termination: result.err().map(Error::from),
@@ -58,7 +58,7 @@ impl CliSnapshot {
     pub fn emit_content_snapshot(&self) -> String {
         let mut content = String::new();
 
-        if let Some((configuration, file_name)) = &self.configuration {
+        for (configuration, file_name) in &self.configuration_list {
             let redacted = redact_snapshot(configuration).unwrap_or(String::new().into());
 
             let parsed = parse_json(
@@ -332,28 +332,23 @@ impl From<SnapshotPayload<'_>> for CliSnapshot {
             module_path: _,
         } = payload;
         let mut cli_snapshot = Self::from_result(result);
+        for (file, entry) in fs.files.read().iter() {
+            let content = entry.lock();
+            let content = std::str::from_utf8(content.as_slice()).unwrap();
 
-        for file_name in ConfigName::file_names() {
-            let config_path = Utf8PathBuf::from(file_name);
-            let configuration = fs.open(&config_path).ok();
-            if let Some(mut configuration) = configuration {
-                let mut buffer = String::new();
-                if configuration.read_to_string(&mut buffer).is_ok() {
-                    cli_snapshot.configuration = Some((buffer, file_name));
-                }
+            if file
+                .file_name()
+                .is_some_and(|file_name| ConfigName::file_names().contains(&file_name))
+            {
+                cli_snapshot
+                    .configuration_list
+                    .push((content.to_string(), file.to_string()));
+            } else {
+                cli_snapshot
+                    .files
+                    .insert(file.as_str().to_string(), String::from(content));
             }
         }
-
-        cli_snapshot.files = fs
-            .files
-            .read()
-            .iter()
-            .map(|(file, entry)| {
-                let content = entry.lock();
-                let content = std::str::from_utf8(content.as_slice()).unwrap();
-                (file.as_str().to_string(), String::from(content))
-            })
-            .collect();
 
         let in_buffer = &console.in_buffer;
         for (index, message) in in_buffer.iter().enumerate() {

--- a/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_path/set_config_path_to_directory.snap
@@ -1,11 +1,10 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `config/biome.jsonc`
 
-```jsonc
+```json
 {
   "assist": {
     "enabled": true
@@ -14,11 +13,11 @@ snapshot_kind: text
     "enabled": false
   },
   "formatter": {
-    "enabled": true,
+    "enabled": true
   },
   "javascript": {
     "formatter": {
-      "quoteStyle": "single", // comment
+      "quoteStyle": "single" // comment
     }
   }
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_not_use_higher_editorconfig_when_find_biome_conf.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_editorconfig/should_not_use_higher_editorconfig_when_find_biome_conf.snap
@@ -1,8 +1,17 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
+## `foo/biome.json`
+
+```json
+{
+  "formatter": {
+    "lineWidth": 60
+  }
+}
+```
+
 ## `.editorconfig`
 
 ```editorconfig
@@ -10,18 +19,6 @@ snapshot_kind: text
 [*]
 indent_style = space
 indent_size = 2
-
-```
-
-## `foo/biome.json`
-
-```json
-
-{
-    "formatter": {
-        "lineWidth": 60
-    }
-}
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
@@ -62,5 +62,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-The configuration biome.json has been successfully migrated.
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
@@ -65,5 +65,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-The configuration biome.json has been successfully migrated.
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
@@ -77,5 +77,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-The configuration biome.json has been successfully migrated.
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
@@ -141,5 +141,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-The configuration biome.json has been successfully migrated.
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_sentry.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_sentry.snap
@@ -199,5 +199,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-The configuration biome.json has been successfully migrated.
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/custom_config_file_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/custom_config_file_path.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `/test/biome.json`
 
@@ -13,7 +13,6 @@ expression: content
     "indentWidth": 6
   }
 }
-
 ```
 
 ## `file.js`

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/should_migrate_nested_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/should_migrate_nested_files.snap
@@ -1,0 +1,163 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  }
+}
+```
+
+## `lorem/biome.json`
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  }
+}
+```
+
+## `ipsum/biome.json`
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  }
+}
+```
+
+# Emitted Messages
+
+```block
+<TEMP_DIR>/missing_configuration_file/biome.json migrate ━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1  1 │   {
+    2    │ - ····"organizeImports":·{
+    3    │ - ········"enabled":·true
+       2 │ + ····"assist":·{·"actions":·{·"source":·{·"organizeImports":·"on"·}·}·},
+       3 │ + ··"linter":·{
+       4 │ + ····"rules":·{
+       5 │ + ······"style":·{
+       6 │ + ········"noParameterAssign":·"error",
+       7 │ + ········"useAsConstAssertion":·"error",
+       8 │ + ········"useDefaultParameterLast":·"error",
+       9 │ + ········"useEnumInitializers":·"error",
+      10 │ + ········"useSelfClosingElements":·"error",
+      11 │ + ········"useConst":·"error",
+      12 │ + ········"useSingleVarDeclarator":·"error",
+      13 │ + ········"noUnusedTemplateLiteral":·"error",
+      14 │ + ········"useNumberNamespace":·"error",
+      15 │ + ········"noInferrableTypes":·"error",
+      16 │ + ········"noUselessElse":·"error"
+      17 │ + ······}
+    4 18 │       }
+      19 │ + ··}
+    5 20 │   }
+  
+
+```
+
+```block
+<TEMP_DIR>/missing_configuration_file/biome.json migrate ━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1  1 │   {
+    2    │ - ····"organizeImports":·{
+    3    │ - ········"enabled":·true
+       2 │ + ····"assist":·{·"actions":·{·"source":·{·"organizeImports":·"on"·}·}·},
+       3 │ + ··"linter":·{
+       4 │ + ····"rules":·{
+       5 │ + ······"style":·{
+       6 │ + ········"noParameterAssign":·"error",
+       7 │ + ········"useAsConstAssertion":·"error",
+       8 │ + ········"useDefaultParameterLast":·"error",
+       9 │ + ········"useEnumInitializers":·"error",
+      10 │ + ········"useSelfClosingElements":·"error",
+      11 │ + ········"useConst":·"error",
+      12 │ + ········"useSingleVarDeclarator":·"error",
+      13 │ + ········"noUnusedTemplateLiteral":·"error",
+      14 │ + ········"useNumberNamespace":·"error",
+      15 │ + ········"noInferrableTypes":·"error",
+      16 │ + ········"noUselessElse":·"error"
+      17 │ + ······}
+    4 18 │       }
+      19 │ + ··}
+    5 20 │   }
+  
+
+```
+
+```block
+<TEMP_DIR>/missing_configuration_file/ipsum/biome.json migrate ━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1  1 │   {
+    2    │ - ····"organizeImports":·{
+    3    │ - ········"enabled":·true
+       2 │ + ····"assist":·{·"actions":·{·"source":·{·"organizeImports":·"on"·}·}·},
+       3 │ + ··"linter":·{
+       4 │ + ····"rules":·{
+       5 │ + ······"style":·{
+       6 │ + ········"noParameterAssign":·"error",
+       7 │ + ········"useAsConstAssertion":·"error",
+       8 │ + ········"useDefaultParameterLast":·"error",
+       9 │ + ········"useEnumInitializers":·"error",
+      10 │ + ········"useSelfClosingElements":·"error",
+      11 │ + ········"useConst":·"error",
+      12 │ + ········"useSingleVarDeclarator":·"error",
+      13 │ + ········"noUnusedTemplateLiteral":·"error",
+      14 │ + ········"useNumberNamespace":·"error",
+      15 │ + ········"noInferrableTypes":·"error",
+      16 │ + ········"noUselessElse":·"error"
+      17 │ + ······}
+    4 18 │       }
+      19 │ + ··}
+    5 20 │   }
+  
+
+```
+
+```block
+<TEMP_DIR>/missing_configuration_file/lorem/biome.json migrate ━━━━━━━━━━━━━━━━━━━━
+
+  i Configuration file can be updated.
+  
+    1  1 │   {
+    2    │ - ····"organizeImports":·{
+    3    │ - ········"enabled":·true
+       2 │ + ····"assist":·{·"actions":·{·"source":·{·"organizeImports":·"on"·}·}·},
+       3 │ + ··"linter":·{
+       4 │ + ····"rules":·{
+       5 │ + ······"style":·{
+       6 │ + ········"noParameterAssign":·"error",
+       7 │ + ········"useAsConstAssertion":·"error",
+       8 │ + ········"useDefaultParameterLast":·"error",
+       9 │ + ········"useEnumInitializers":·"error",
+      10 │ + ········"useSelfClosingElements":·"error",
+      11 │ + ········"useConst":·"error",
+      12 │ + ········"useSingleVarDeclarator":·"error",
+      13 │ + ········"noUnusedTemplateLiteral":·"error",
+      14 │ + ········"useNumberNamespace":·"error",
+      15 │ + ········"noInferrableTypes":·"error",
+      16 │ + ········"noUselessElse":·"error"
+      17 │ + ······}
+    4 18 │       }
+      19 │ + ··}
+    5 20 │   }
+  
+
+```
+
+```block
+Run the command with the option --write to apply the changes.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_exclude_inspired.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_exclude_inspired.snap
@@ -29,9 +29,9 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Run the command with the option --write to apply the changes.
+Run the command with the option --include-inspired to also migrate inspired rules.
 ```
 
 ```block
-Run the command with the option --include-inspired to also migrate inspired rules.
+Run the command with the option --write to apply the changes.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_fix.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -65,4 +64,8 @@ snapshot_kind: text
 
 ```block
 .eslintrc.json has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_eslint/migrate_eslintrcjson_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -65,4 +64,8 @@ snapshot_kind: text
 
 ```block
 .eslintrc.json has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_fix.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -48,4 +47,8 @@ snapshot_kind: text
 
 ```block
 .prettierrc has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -48,4 +47,8 @@ snapshot_kind: text
 
 ```block
 .prettierrc has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_biome_jsonc.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.jsonc`
 
@@ -48,4 +47,8 @@ snapshot_kind: text
 
 ```block
 .prettierrc has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_packagejson.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -52,4 +51,8 @@ snapshot_kind: text
 
 ```block
 package.json has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettier_migrate_write_with_ignore_file.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -66,4 +65,8 @@ generated/*.spec.js
 
 ```block
 .prettierrc has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate_prettier/prettierjson_migrate_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -48,4 +47,8 @@ snapshot_kind: text
 
 ```block
 .prettierrc.json has been successfully migrated.
+```
+
+```block
+Your configuration file(s) have been successfully migrated.
 ```

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -892,6 +892,9 @@ pub struct ScanProjectFolderResult {
 
     /// Duration of the scan.
     pub duration: Duration,
+
+    /// A list of child configuration files found inside the project
+    pub configuration_files: Vec<BiomePath>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -32,6 +32,9 @@ pub(crate) struct ScanResult {
 
     /// Duration of the full scan.
     pub duration: Duration,
+
+    /// List of additional configuration files found inside the project (it doesn't contain the current one)
+    pub configuration_files: Vec<BiomePath>,
 }
 
 impl WorkspaceServer {
@@ -49,7 +52,7 @@ impl WorkspaceServer {
 
         let collector = DiagnosticsCollector::new();
 
-        let (duration, diagnostics) = thread::scope(|scope| {
+        let (duration, diagnostics, configuration_files) = thread::scope(|scope| {
             let handler = thread::Builder::new()
                 .name("biome::scanner".to_string())
                 .spawn_scoped(scope, || collector.run(diagnostics_receiver))
@@ -57,7 +60,7 @@ impl WorkspaceServer {
 
             // The traversal context is scoped to ensure all the channels it
             // contains are properly closed once scanning finishes.
-            let duration = scan_folder(
+            let (duration, configuration_files) = scan_folder(
                 folder,
                 ScanContext {
                     workspace: self,
@@ -72,12 +75,13 @@ impl WorkspaceServer {
             // Wait for the collector thread to finish.
             let diagnostics = handler.join().unwrap();
 
-            (duration, diagnostics)
+            (duration, diagnostics, configuration_files)
         });
 
         Ok(ScanResult {
             diagnostics,
             duration,
+            configuration_files,
         })
     }
 }
@@ -86,7 +90,7 @@ impl WorkspaceServer {
 ///
 /// Returns the duration of the process and the evaluated paths.
 #[instrument(level = "debug", skip(ctx))]
-fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> Duration {
+fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>) {
     let start = Instant::now();
     let fs = ctx.workspace.fs();
     let ctx_ref = &ctx;
@@ -137,7 +141,7 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> Duration {
         }
     }));
 
-    start.elapsed()
+    (start.elapsed(), configs)
 }
 
 struct DiagnosticsCollector {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -826,6 +826,7 @@ impl Workspace for WorkspaceServer {
             return Ok(ScanProjectFolderResult {
                 diagnostics: Vec::new(),
                 duration: Duration::from_millis(0),
+                configuration_files: vec![],
             });
         }
 
@@ -840,6 +841,7 @@ impl Workspace for WorkspaceServer {
             return Ok(ScanProjectFolderResult {
                 diagnostics: Vec::new(),
                 duration: Duration::from_millis(0),
+                configuration_files: vec![],
             });
         }
 
@@ -856,6 +858,7 @@ impl Workspace for WorkspaceServer {
         Ok(ScanProjectFolderResult {
             diagnostics: result.diagnostics,
             duration: result.duration,
+            configuration_files: result.configuration_files,
         })
     }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Part of #2228 

This PR adds a new feature to the `migrate` command. With this PR, the command is now able to migrate nested configuration files. 

We take advantage of the light scanner to return the path to he configuration files. This will fix some repositories in the ecosystem CI, where they have nested `biome.json` inside their repositories, but the command fails because it sees old configuration files. 

This is also part of the monorepo support.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test

<!-- What demonstrates that your implementation is correct? -->
