### PR TITLE
fix(organizeImports): merge default and named imports

### DIFF
--- a/.changeset/rotten-llamas-hang.md
+++ b/.changeset/rotten-llamas-hang.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#5985](https://github.com/biomejs/biome/issues/5985), which caused the import organizer to fail the merging of a default import with a named import.
+The following code is now correctly organized:
+
+```diff
+- import moment from 'moment';
+- import { Moment } from 'moment';
++ import moment, { Moment } from 'moment';
+```

--- a/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports/import_key.rs
@@ -64,7 +64,7 @@ impl ImportStatementKind {
             Self::Namespace => kinds.contains(Self::Default),
             Self::Default => kinds.intersects(Self::Namespace | Self::Named),
             Self::DefaultNamed => kinds.contains(Self::Named),
-            Self::Named => kinds.intersects(Self::DefaultNamed | Self::Named),
+            Self::Named => kinds.intersects(Self::DefaultNamed | Self::Named | Self::Default),
             Self::NamedType => kinds.contains(Self::NamedType),
             _ => false,
         }

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js
@@ -1,0 +1,2 @@
+import moment from 'moment';
+import { Moment } from 'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue5985.js.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue5985.js
+---
+# Input
+```js
+import moment from 'moment';
+import { Moment } from 'moment';
+```
+
+# Diagnostics
+```
+issue5985.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 1 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ import { Moment } from 'moment';
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1   │ - import·moment·from·'moment';
+    2   │ - import·{·Moment·}·from·'moment';
+      1 │ + import·moment,·{·Moment·}·from·'moment';
+  
+
+```


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/5985

I forget to handle the case of default and named imports merging.

- [x] changeset

## Test Plan

I added a non regression test.
