### PR TITLE
refactor(migrate): don't unpromote useNamingConvention

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
@@ -27,6 +27,12 @@ expression: redactor(content)
         "noVar": "error"
       },
       "style": {
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": false
+          }
+        },
         "noDefaultExport": "error",
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",
@@ -48,14 +54,6 @@ expression: redactor(content)
         "noUnsafeFinally": "error",
         "noSwitchDeclarations": "off",
         "noSelfAssign": "off"
-      },
-      "nursery": {
-        "useNamingConvention": {
-          "level": "error",
-          "options": {
-            "strictCase": false
-          }
-        }
       }
     }
   }

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -70,7 +70,9 @@ impl Rule for RuleMover {
                 };
                 let rule_name = rule_name.text();
                 if let Ok(new_rule) = RuleName::from_str(rule_name) {
-                    if new_rule.group() != current_group {
+                    // TODO: remove the `useNamingConvention` exception,
+                    // once we have promoted the GraphQL `useNamingConvention` rule
+                    if new_rule.group() != current_group && rule_name != "useNamingConvention" {
                         result.push(State {
                             rule_node,
                             new_rule,


### PR DESCRIPTION
## Summary

Currently, `useNamingConvention` is associated to two groups: `style` for the JS rule and `niursery` for the GraphQL rule.
This breaks the assumption that a rule is associated to a single group.
This leads the rule mover to unpromote `style/useNamingConvention` to `nursery/useNamingConvention`.

Unfortunately we can promote the GraphQL rule because the rule options are incompatible at the moment.

As a temporary fix of the rule mover, I added a hardcoded exception for `useNamingConvention`.

## Test Plan

I updated the snapshots