### PR TITLE
perf(analyzer): reduce use of owned strings

### DIFF
--- a/crates/biome_analyze/src/signals.rs
+++ b/crates/biome_analyze/src/signals.rs
@@ -143,7 +143,7 @@ impl<L: Language> Default for AnalyzerActionIter<L> {
 
 impl<L: Language> From<AnalyzerAction<L>> for CodeSuggestionAdvice<MarkupBuf> {
     fn from(action: AnalyzerAction<L>) -> Self {
-        let (_, suggestion) = action.mutation.as_text_range_and_edit().unwrap_or_default();
+        let (_, suggestion) = action.mutation.to_text_range_and_edit().unwrap_or_default();
         Self {
             applicability: action.applicability,
             msg: action.message,
@@ -154,7 +154,7 @@ impl<L: Language> From<AnalyzerAction<L>> for CodeSuggestionAdvice<MarkupBuf> {
 
 impl<L: Language> From<AnalyzerAction<L>> for CodeSuggestionItem {
     fn from(action: AnalyzerAction<L>) -> Self {
-        let (range, suggestion) = action.mutation.as_text_range_and_edit().unwrap_or_default();
+        let (range, suggestion) = action.mutation.to_text_range_and_edit().unwrap_or_default();
 
         Self {
             rule_name: action.rule_name,

--- a/crates/biome_analyze/src/suppression_action.rs
+++ b/crates/biome_analyze/src/suppression_action.rs
@@ -16,7 +16,7 @@ pub trait SuppressionAction {
             suppression_reason,
         } = payload;
 
-        // retrieve the most suited, most left token where the diagnostics was emitted
+        // retrieve the most suited, leftest token where the diagnostics was emitted
         let original_token = self.get_token_from_offset(token_offset, diagnostic_text_range);
 
         // considering that our suppression system works via lines, we need to look for the first newline,

--- a/crates/biome_css_analyze/src/utils.rs
+++ b/crates/biome_css_analyze/src/utils.rs
@@ -48,8 +48,8 @@ pub fn is_css_variable(value: &str) -> bool {
 pub fn find_font_family(value: CssGenericComponentValueList) -> Vec<AnyCssValue> {
     let mut font_families: Vec<AnyCssValue> = Vec::new();
     for v in value {
-        let value = v.to_trimmed_string();
-        let lower_case_value = value.to_ascii_lowercase_cow();
+        let value = v.to_trimmed_text();
+        let lower_case_value = value.text().to_ascii_lowercase_cow();
 
         // Ignore CSS variables
         if is_css_variable(&lower_case_value) {

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_catch.rs
@@ -108,9 +108,9 @@ impl Rule for NoUselessCatch {
             .argument()
             .ok()?
             .as_js_identifier_expression()?
-            .to_trimmed_string();
+            .to_trimmed_text();
 
-        if throw_ident.eq(catch_err_name) {
+        if throw_ident.text().eq(catch_err_name) {
             Some(js_throw_statement.syntax().text_trimmed_range())
         } else {
             None

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -217,8 +217,8 @@ impl Rule for NoUselessFragments {
                             JsSyntaxKind::JSX_TEXT => {
                                 // We need to whitespaces and newlines from the original string.
                                 // Since in the JSX newlines aren't trivia, we require to allocate a string to trim from those characters.
-                                let original_text = child.to_trimmed_string();
-                                let child_text = original_text.trim();
+                                let original_text = child.to_trimmed_text();
+                                let child_text = original_text.text().trim();
 
                                 if (in_jsx_expr || in_js_logical_expr)
                                     && contains_html_character_references(child_text)

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_undefined_initialization.rs
@@ -96,10 +96,10 @@ impl Rule for NoUselessUndefinedInitialization {
 
             if keyword.is_undefined() {
                 let decl_range = initializer.range();
-                let Some(binding_name) = decl.id().ok().map(|id| id.to_trimmed_string()) else {
+                let Some(binding_name) = decl.id().ok().map(|id| id.to_trimmed_text()) else {
                     continue;
                 };
-                signals.push((binding_name.into(), decl_range));
+                signals.push((binding_name.text().into(), decl_range));
             }
         }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_constant_math_min_max_clamp.rs
@@ -96,7 +96,7 @@ impl Rule for NoConstantMathMinMaxClamp {
             ).detail(
                 state.0.range(),
                 markup! {
-                    "It always evaluates to "<Emphasis>{state.0.to_trimmed_string()}</Emphasis>"."
+                    "It always evaluates to "<Emphasis>{state.0.to_trimmed_text().text()}</Emphasis>"."
                 }
             )
         )
@@ -111,7 +111,7 @@ impl Rule for NoConstantMathMinMaxClamp {
         Some(JsRuleAction::new(
             ctx.metadata().action_category(ctx.category(), ctx.group()),
             ctx.metadata().applicability(),
-            markup! {"Swap "<Emphasis>{state.0.to_trimmed_string()}</Emphasis>" with "<Emphasis>{state.1.to_trimmed_string()}</Emphasis>"."}
+            markup! {"Swap "<Emphasis>{state.0.to_trimmed_text().text()}</Emphasis>" with "<Emphasis>{state.1.to_trimmed_text().text()}</Emphasis>"."}
             .to_owned(),
             mutation,
         ))

--- a/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_hook_at_top_level.rs
@@ -91,22 +91,22 @@ impl AnyJsFunctionOrMethod {
         false
     }
 
-    fn name(&self) -> Option<String> {
+    fn name(&self) -> Option<Text> {
         match self {
             Self::AnyJsFunction(function) => function
                 .binding()
                 .as_ref()
-                .map(AnyJsBinding::to_trimmed_string),
+                .map(AnyJsBinding::to_trimmed_text),
             Self::JsMethodClassMember(method) => method
                 .name()
                 .ok()
                 .as_ref()
-                .map(AnyJsClassMemberName::to_trimmed_string),
+                .map(AnyJsClassMemberName::to_trimmed_text),
             Self::JsMethodObjectMember(method) => method
                 .name()
                 .ok()
                 .as_ref()
-                .map(AnyJsObjectMemberName::to_trimmed_string),
+                .map(AnyJsObjectMemberName::to_trimmed_text),
         }
     }
 }

--- a/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_is_nan.rs
@@ -237,7 +237,10 @@ fn create_is_nan_expression(nan: AnyJsExpression) -> Option<AnyJsExpression> {
                 .object()
                 .ok()?
                 .as_js_static_member_expression()
-                .is_some_and(|y| y.member().is_ok_and(|z| z.to_trimmed_string() == "Number"));
+                .is_some_and(|y| {
+                    y.member()
+                        .is_ok_and(|z| z.to_trimmed_text().text() == "Number")
+                });
 
             if !reference.is_global_this() && !reference.has_name("window")
                 || number_identifier_exists

--- a/crates/biome_js_analyze/src/lint/nursery/use_explicit_type.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_explicit_type.rs
@@ -572,7 +572,7 @@ fn is_direct_const_assertion_in_arrow_functions(func: &AnyJsFunction) -> bool {
         return false;
     };
 
-    ts_ref.to_trimmed_string() == "const"
+    ts_ref.to_trimmed_text().text() == "const"
 }
 
 /// Checks if a function is allowed within specific expression contexts.

--- a/crates/biome_js_analyze/src/lint/performance/no_delete.rs
+++ b/crates/biome_js_analyze/src/lint/performance/no_delete.rs
@@ -94,7 +94,7 @@ impl Rule for NoDelete {
                 {
                     let name = static_expression.member().ok()?;
                     let name = name.as_js_name()?;
-                    if name.to_trimmed_string() == "dataset" {
+                    if name.to_trimmed_text().text() == "dataset" {
                         return None;
                     }
                 }

--- a/crates/biome_js_analyze/src/lint/style/use_component_export_only_modules.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_component_export_only_modules.rs
@@ -210,7 +210,7 @@ impl Rule for UseComponentExportOnlyModules {
         }
 
         let local_component_ids = local_declaration_ids.iter().filter_map(|id| {
-            if Case::identify(&id.to_trimmed_string(), false) == Case::Pascal {
+            if Case::identify(&id.to_trimmed_text().text(), false) == Case::Pascal {
                 Some(id.range())
             } else {
                 None
@@ -294,7 +294,7 @@ fn is_exported_react_component(any_exported_item: &ExportedItem) -> bool {
         any_exported_item.exported.clone()
     {
         if let Ok(AnyJsExpression::JsIdentifierExpression(fn_name)) = f.callee() {
-            if !REACT_HOOKS.contains(&fn_name.to_trimmed_string().as_str()) {
+            if !REACT_HOOKS.contains(&fn_name.to_trimmed_text().text()) {
                 return false;
             }
             let Ok(args) = f.arguments() else {
@@ -316,13 +316,13 @@ fn is_exported_react_component(any_exported_item: &ExportedItem) -> bool {
             let Ok(arg_name) = arg.name() else {
                 return false;
             };
-            return Case::identify(&arg_name.to_trimmed_string(), false) == Case::Pascal;
+            return Case::identify(&arg_name.to_trimmed_text().text(), false) == Case::Pascal;
         }
     }
     let Some(exported_item_id) = any_exported_item.identifier.clone() else {
         return false;
     };
-    Case::identify(&exported_item_id.to_trimmed_string(), false) == Case::Pascal
+    Case::identify(&exported_item_id.to_trimmed_text().text(), false) == Case::Pascal
         && match any_exported_item.exported.clone() {
             Some(exported) => !matches!(exported, AnyJsExported::TsEnumDeclaration(_)),
             None => true,

--- a/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_number_namespace.rs
@@ -168,12 +168,12 @@ impl Rule for UseNumberNamespace {
                 )
             }
             AnyJsExpression::JsStaticMemberExpression(expression) => {
-                let name = expression.member().ok()?.to_trimmed_string();
+                let name = expression.member().ok()?.to_trimmed_text();
 
-                if !GLOBAL_NUMBER_PROPERTIES.contains(&name.as_str()) {
+                if !GLOBAL_NUMBER_PROPERTIES.contains(&name.text()) {
                     return None;
                 }
-                let (old_node, replacement) = match name.as_str() {
+                let (old_node, replacement) = match name.text() {
                     "Infinity" => {
                         if let Some(parent) = node.parent::<JsUnaryExpression>() {
                             match parent.operator().ok()? {
@@ -191,7 +191,7 @@ impl Rule for UseNumberNamespace {
                             (node.clone(), "POSITIVE_INFINITY")
                         }
                     }
-                    _ => (node.clone(), name.as_str()),
+                    _ => (node.clone(), name.text()),
                 };
                 (
                     old_node,

--- a/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_shorthand_assign.rs
@@ -82,11 +82,9 @@ impl Rule for UseShorthandAssign {
         let right = node.right().ok()?;
 
         let left_var_name = match left.as_any_js_assignment()? {
-            AnyJsAssignment::JsComputedMemberAssignment(assignment) => {
-                assignment.to_trimmed_string()
-            }
-            AnyJsAssignment::JsIdentifierAssignment(assignment) => assignment.to_trimmed_string(),
-            AnyJsAssignment::JsStaticMemberAssignment(assignment) => assignment.to_trimmed_string(),
+            AnyJsAssignment::JsComputedMemberAssignment(assignment) => assignment.to_trimmed_text(),
+            AnyJsAssignment::JsIdentifierAssignment(assignment) => assignment.to_trimmed_text(),
+            AnyJsAssignment::JsStaticMemberAssignment(assignment) => assignment.to_trimmed_text(),
             _ => return None,
         };
 

--- a/crates/biome_js_analyze/src/lint/suspicious/no_document_cookie.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_document_cookie.rs
@@ -101,7 +101,7 @@ fn is_cookie(assignment: &AnyJsAssignment) -> Option<()> {
         AnyJsAssignment::JsStaticMemberAssignment(static_assignment) => {
             let property = static_assignment.member().ok()?;
 
-            if property.to_trimmed_string() != COOKIE {
+            if property.to_trimmed_text().text() != COOKIE {
                 return None;
             };
         }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_duplicate_test_hooks.rs
@@ -130,7 +130,7 @@ impl Visitor for DuplicateHooksVisitor {
                     else if let AnyJsExpression::JsCallExpression(call_expression) = callee {
                         if let Ok(callee) = call_expression.callee() {
                             if matches!(
-                                callee.to_trimmed_string().as_str(),
+                                callee.to_trimmed_text().text(),
                                 "describe.each" | "describe.only.each" | "fdescribe.each"
                             ) {
                                 self.stack.push(HooksContext::default());

--- a/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_exports_in_test.rs
@@ -67,25 +67,25 @@ impl MaybeExport {
                                 AnyJsMemberAssignment::JsComputedMemberAssignment(_) => false,
                                 AnyJsMemberAssignment::JsStaticMemberAssignment(static_member) => {
                                     // module.exports = {}
-                                    let indent_text = ident.to_trimmed_string();
+                                    let indent_text = ident.to_trimmed_text();
                                     let member_text = static_member
                                         .member()
-                                        .map(|member| member.to_trimmed_string());
-                                    indent_text == "module"
-                                        && member_text
-                                            .is_ok_and(|member_text| member_text == "exports")
+                                        .map(|member| member.to_trimmed_text());
+                                    indent_text.text() == "module"
+                                        && member_text.is_ok_and(|member_text| {
+                                            member_text.text() == "exports"
+                                        })
                                 }
                             },
                             AnyJsExpression::JsStaticMemberExpression(member_expr) => {
                                 // modules.exports.foo = {}, module.exports[foo] = {}
-                                let object_text = member_expr
-                                    .object()
-                                    .map(|object| object.to_trimmed_string());
-                                let member_text = member_expr
-                                    .member()
-                                    .map(|member| member.to_trimmed_string());
-                                object_text.is_ok_and(|text| text == "module")
-                                    && member_text.is_ok_and(|member_text| member_text == "exports")
+                                let object_text =
+                                    member_expr.object().map(|object| object.to_trimmed_text());
+                                let member_text =
+                                    member_expr.member().map(|member| member.to_trimmed_text());
+                                object_text.is_ok_and(|text| text.text() == "module")
+                                    && member_text
+                                        .is_ok_and(|member_text| member_text.text() == "exports")
                             }
                             _ => false,
                         })

--- a/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_misrefactored_shorthand_assign.rs
@@ -96,7 +96,7 @@ impl Rule for NoMisrefactoredShorthandAssign {
 
         let left = node.left().ok()?;
         let left = left.as_any_js_assignment()?;
-        let left_text = left.to_trimmed_string();
+        let left_text = left.to_trimmed_text();
 
         let variable_position_in_expression =
             find_variable_position(&binary_expression, &left_text)?;

--- a/crates/biome_js_analyze/src/lint/suspicious/no_react_specific_props.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_react_specific_props.rs
@@ -60,9 +60,9 @@ impl Rule for NoReactSpecificProps {
         let attribute = ctx.query();
         let name = attribute.name().ok()?;
         let range = name.range();
-        let name = name.to_trimmed_string();
+        let name = name.to_trimmed_text();
 
-        if REACT_SPECIFIC_JSX_PROPS.contains(&name.as_str()) {
+        if REACT_SPECIFIC_JSX_PROPS.contains(&name.text()) {
             let replacement = get_replacement_for_react_prop(&name)?;
             Some((range, replacement))
         } else {

--- a/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_then_property.rs
@@ -267,8 +267,8 @@ fn process_js_assignment_expr(node: &JsAssignmentExpression) -> Option<RuleState
     match node.left().ok()? {
         AnyJsAssignmentPattern::AnyJsAssignment(assignment) => match assignment {
             AnyJsAssignment::JsComputedMemberAssignment(c) => {
-                if c.member().ok()?.to_trimmed_string() == "\"then\""
-                    || c.member().ok()?.to_trimmed_string() == "`then`"
+                if c.member().ok()?.to_trimmed_text().text() == "\"then\""
+                    || c.member().ok()?.to_trimmed_text().text() == "`then`"
                 {
                     return Some(RuleState {
                         range: node.left().ok()?.range(),
@@ -277,7 +277,7 @@ fn process_js_assignment_expr(node: &JsAssignmentExpression) -> Option<RuleState
                 }
             }
             AnyJsAssignment::JsStaticMemberAssignment(m) => {
-                if m.member().ok()?.to_trimmed_string() == "then" {
+                if m.member().ok()?.to_trimmed_text().text() == "then" {
                     return Some(RuleState {
                         range: node.left().ok()?.range(),
                         message: NoThenPropertyMessage::Object,
@@ -301,8 +301,8 @@ fn process_js_call_expr(node: &JsCallExpression) -> Option<RuleState> {
                 return None;
             }
 
-            let callee = m.object().ok()?.to_trimmed_string();
-            let member = m.member().ok()?.to_trimmed_string();
+            let callee = m.object().ok()?.to_trimmed_text();
+            let member = m.member().ok()?.to_trimmed_text();
 
             let args = node.arguments().ok()?.args();
             let first = args.iter().next()?.ok()?;
@@ -311,7 +311,7 @@ fn process_js_call_expr(node: &JsCallExpression) -> Option<RuleState> {
             // ex)
             //   Object.fromEntries([["then", 1]])
             //   Object.fromEntries([['foo', 'foo'], ['then', 32],['bar', 'bar']]);
-            if callee == "Object" && member == "fromEntries" {
+            if callee.text() == "Object" && member.text() == "fromEntries" {
                 if args.len() != 1 {
                     return None;
                 }
@@ -323,8 +323,8 @@ fn process_js_call_expr(node: &JsCallExpression) -> Option<RuleState> {
                             ) = arr.ok()?
                             {
                                 let key = arg.elements().first()?.ok()?;
-                                if key.to_trimmed_string() == "\"then\""
-                                    || key.to_trimmed_string() == "`then`"
+                                if key.to_trimmed_text().text() == "\"then\""
+                                    || key.to_trimmed_text().text() == "`then`"
                                 {
                                     return Some(RuleState {
                                         range: key.range(),
@@ -348,8 +348,8 @@ fn process_js_call_expr(node: &JsCallExpression) -> Option<RuleState> {
                     return None;
                 }
                 let second = args.iter().nth(1)?.ok()?;
-                if second.to_trimmed_string() == "\"then\""
-                    || second.to_trimmed_string() == "`then`"
+                if second.to_trimmed_text().text() == "\"then\""
+                    || second.to_trimmed_text().text() == "`then`"
                 {
                     return Some(RuleState {
                         range: second.range(),
@@ -378,7 +378,7 @@ fn process_js_export_named_clause(node: &JsExport) -> Option<RuleState> {
                         }
                     }
                     AnyJsExportNamedSpecifier::JsExportNamedSpecifier(name) => {
-                        if name.exported_name().ok()?.to_trimmed_string() == "then" {
+                        if name.exported_name().ok()?.syntax().text_trimmed() == "then" {
                             return Some(RuleState {
                                 range: name.exported_name().ok()?.range(),
                                 message: NoThenPropertyMessage::Export,
@@ -394,7 +394,7 @@ fn process_js_export_named_clause(node: &JsExport) -> Option<RuleState> {
             let decls = node.declaration().ok()?;
             for d in decls.declarators().iter() {
                 let id = d.ok()?.id().ok()?;
-                if id.to_trimmed_string() == "then" {
+                if id.syntax().text_trimmed() == "then" {
                     return Some(RuleState {
                         range: id.range(),
                         message: NoThenPropertyMessage::Object,

--- a/crates/biome_rowan/src/ast/batch.rs
+++ b/crates/biome_rowan/src/ast/batch.rs
@@ -313,7 +313,7 @@ where
     ///
     /// If the new tree is also required,
     /// please use `commit_with_text_range_and_edit`
-    pub fn as_text_range_and_edit(self) -> Option<(TextRange, TextEdit)> {
+    pub fn to_text_range_and_edit(self) -> Option<(TextRange, TextEdit)> {
         self.commit_with_text_range_and_edit(true).1
     }
 
@@ -360,7 +360,7 @@ where
         let Self { root, mut changes } = self;
 
         // Ordered text mutation list sorted by text range
-        let mut text_mutation_list: Vec<(TextRange, Option<String>)> =
+        let mut text_mutation_list: Vec<(TextRange, Option<SyntaxElement<L>>)> =
             // SAFETY: this is safe bacause changes from actions can only
             // overwrite each other, so the total number of the finalized
             // text mutations will only be less.
@@ -431,20 +431,17 @@ where
                             }
                             None => continue,
                         };
-                        let optional_inserted_text = new_node.as_ref().map(|n| n.to_string());
-
                         // We use binary search to keep the text mutations in order
                         match text_mutation_list
                             .binary_search_by(|(range, _)| range.ordering(deleted_text_range))
                         {
                             // Overwrite the text mutation with an overlapping text range
                             Ok(pos) => {
-                                text_mutation_list[pos] =
-                                    (deleted_text_range, optional_inserted_text)
+                                text_mutation_list[pos] = (deleted_text_range, new_node.clone())
                             }
                             // Insert the text mutation at the correct position
                             Err(pos) => text_mutation_list
-                                .insert(pos, (deleted_text_range, optional_inserted_text)),
+                                .insert(pos, (deleted_text_range, new_node.clone())),
                         }
                     }
                 }
@@ -453,7 +450,7 @@ where
                 // and push a pending change to its parent
                 let mut current_parent = curr_parent.detach();
                 let is_list = current_parent.kind().is_list();
-                for (new_node_slot, new_node, ..) in modifications {
+                for (new_node_slot, new_node, ..) in modifications.clone() {
                     current_parent = if is_list && new_node.is_none() {
                         current_parent.splice_slots(new_node_slot..=new_node_slot, empty())
                     } else {
@@ -484,11 +481,7 @@ where
                     if curr_is_from_action {
                         text_mutation_list = vec![(
                             document_root.text_range_with_trivia(),
-                            Some(
-                                curr_new_node
-                                    .as_ref()
-                                    .map_or(String::new(), |n| n.to_string()),
-                            ),
+                            curr_new_node.clone(),
                         )];
                     }
 
@@ -509,9 +502,22 @@ where
                             }
 
                             let old = &root_string[range_start..range_end];
-                            let new = &optional_inserted_text.map_or(String::new(), |t| t);
 
-                            text_edit_builder.with_unicode_words_diff(old, new);
+                            match optional_inserted_text {
+                                None => {
+                                    text_edit_builder.with_unicode_words_diff(old, "");
+                                }
+                                Some(element) => match element {
+                                    SyntaxElement::Node(node) => {
+                                        text_edit_builder
+                                            .with_unicode_words_diff(old, &node.to_string());
+                                    }
+                                    SyntaxElement::Token(token) => {
+                                        text_edit_builder
+                                            .with_unicode_words_diff(old, token.text());
+                                    }
+                                },
+                            }
 
                             pointer = range_end;
                         }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -1098,7 +1098,7 @@ fn rename(
                         new_name,
                     }))
                 } else {
-                    let (range, indels) = batch.as_text_range_and_edit().unwrap_or_default();
+                    let (range, indels) = batch.to_text_range_and_edit().unwrap_or_default();
                     Ok(RenameResult { range, indels })
                 }
             }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -337,7 +337,7 @@ pub fn register_leak_checker() {
 }
 
 pub fn code_fix_to_string<L: ServiceLanguage>(source: &str, action: AnalyzerAction<L>) -> String {
-    let (_, text_edit) = action.mutation.as_text_range_and_edit().unwrap_or_default();
+    let (_, text_edit) = action.mutation.to_text_range_and_edit().unwrap_or_default();
 
     let output = text_edit.new_string(source);
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Address https://github.com/biomejs/biome/issues/5990

I'm not sure this PR will fix ALL the performance bottlenecks of the batch mutations. Unfortunately, there is one point inside `batch.rs` where we're kinda forced to allocate a new strings because we need to print an entire node with its trivia, and that's also recursive. I will have to find a smart way to emit `&str` when printing a node. I will leave a comment to show the line.

I also reduced the use of `to_strimmed_string` around lint rules. What I find saddening is that we often try to print **nodes** instead of extracting the *token* we want to check. Maybe we should have some guide that explains how to do so.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Current tests should still pass

<!-- What demonstrates that your implementation is correct? -->
