### PR TITLE
fix(reporter): summary with diagnostics

### DIFF
--- a/.changeset/chubby-dancers-design.md
+++ b/.changeset/chubby-dancers-design.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The `summary` reporter doesn't take `--max-diagnostics` into account anymore.

--- a/.changeset/twelve-streets-drop.md
+++ b/.changeset/twelve-streets-drop.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The `summary` reporter now prints the files processed and the files fixed when passing the `--verbose` flag.

--- a/crates/biome_cli/src/cli_options.rs
+++ b/crates/biome_cli/src/cli_options.rs
@@ -120,7 +120,7 @@ impl FromStr for ColorsArg {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum CliReporter {
     /// The default reporter
     #[default]

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -644,6 +644,8 @@ pub fn execute_mode(
                     diagnostics_payload,
                     execution: execution.clone(),
                     verbose: cli_options.verbose,
+                    working_directory: fs.working_directory().clone(),
+                    evaluated_paths,
                 };
                 reporter.write(&mut SummaryReporterVisitor(console))?;
             } else {

--- a/crates/biome_cli/src/reporter/mod.rs
+++ b/crates/biome_cli/src/reporter/mod.rs
@@ -7,7 +7,8 @@ pub(crate) mod terminal;
 
 use crate::cli_options::MaxDiagnostics;
 use crate::execute::Execution;
-use biome_diagnostics::{Error, Severity};
+use biome_diagnostics::advice::ListAdvice;
+use biome_diagnostics::{Diagnostic, Error, Severity};
 use biome_fs::BiomePath;
 use camino::Utf8PathBuf;
 use serde::Serialize;
@@ -73,4 +74,26 @@ pub trait ReporterVisitor {
         _payload: DiagnosticsPayload,
         _verbose: bool,
     ) -> io::Result<()>;
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    tags(VERBOSE),
+    severity = Information,
+    message = "Files fixed:"
+)]
+pub(crate) struct FixedPathsDiagnostic {
+    #[advice]
+    advice: ListAdvice<String>,
+}
+
+#[derive(Debug, Diagnostic)]
+#[diagnostic(
+    tags(VERBOSE),
+    severity = Information,
+    message = "Files processed:"
+)]
+pub(crate) struct EvaluatedPathsDiagnostic {
+    #[advice]
+    advice: ListAdvice<String>,
 }

--- a/crates/biome_cli/src/reporter/summary.rs
+++ b/crates/biome_cli/src/reporter/summary.rs
@@ -1,11 +1,15 @@
 use crate::reporter::terminal::ConsoleTraversalSummary;
+use crate::reporter::{EvaluatedPathsDiagnostic, FixedPathsDiagnostic};
 use crate::{DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary};
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{Console, ConsoleExt, markup};
+use biome_diagnostics::advice::ListAdvice;
 use biome_diagnostics::{
     Advices, Category, Diagnostic, MessageAndDescription, PrintDiagnostic, Resource, Severity,
     Visit, category,
 };
+use biome_fs::BiomePath;
+use camino::Utf8PathBuf;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Debug;
@@ -15,12 +19,17 @@ pub(crate) struct SummaryReporter {
     pub(crate) summary: TraversalSummary,
     pub(crate) diagnostics_payload: DiagnosticsPayload,
     pub(crate) execution: Execution,
+    pub(crate) evaluated_paths: BTreeSet<BiomePath>,
+    pub(crate) working_directory: Option<Utf8PathBuf>,
     pub(crate) verbose: bool,
 }
 
 impl Reporter for SummaryReporter {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> io::Result<()> {
         visitor.report_diagnostics(&self.execution, self.diagnostics_payload, self.verbose)?;
+        if self.verbose {
+            visitor.report_handled_paths(self.evaluated_paths, self.working_directory)?;
+        }
         visitor.report_summary(&self.execution, self.summary, self.verbose)?;
         Ok(())
     }
@@ -64,12 +73,8 @@ impl ReporterVisitor for SummaryReporterVisitor<'_> {
     ) -> io::Result<()> {
         let mut files_to_diagnostics = FileToDiagnostics::default();
 
-        let iter = diagnostics_payload.diagnostics.iter().rev().enumerate();
-        for (index, diagnostic) in iter {
-            if diagnostics_payload.max_diagnostics.exceeded(index + 1) {
-                break;
-            }
-
+        let iter = diagnostics_payload.diagnostics.iter().rev();
+        for diagnostic in iter {
             let location = diagnostic.location().resource.and_then(|r| match r {
                 Resource::File(p) => Some(p),
                 _ => None,
@@ -124,6 +129,49 @@ impl ReporterVisitor for SummaryReporterVisitor<'_> {
         }
 
         self.0.log(markup! {{files_to_diagnostics}});
+
+        Ok(())
+    }
+
+    fn report_handled_paths(
+        &mut self,
+        evaluated_paths: BTreeSet<BiomePath>,
+        working_directory: Option<Utf8PathBuf>,
+    ) -> io::Result<()> {
+        let evaluated_paths_diagnostic = EvaluatedPathsDiagnostic {
+            advice: ListAdvice {
+                list: evaluated_paths
+                    .iter()
+                    .map(|p| {
+                        working_directory
+                            .as_ref()
+                            .and_then(|wd| {
+                                p.strip_prefix(wd.as_str())
+                                    .map(|path| path.to_string())
+                                    .ok()
+                            })
+                            .unwrap_or(p.to_string())
+                    })
+                    .collect(),
+            },
+        };
+
+        let fixed_paths_diagnostic = FixedPathsDiagnostic {
+            advice: ListAdvice {
+                list: evaluated_paths
+                    .iter()
+                    .filter(|p| p.was_written())
+                    .map(|p| p.to_string())
+                    .collect(),
+            },
+        };
+
+        self.0.log(markup! {
+            {PrintDiagnostic::verbose(&evaluated_paths_diagnostic)}
+        });
+        self.0.log(markup! {
+            {PrintDiagnostic::verbose(&fixed_paths_diagnostic)}
+        });
 
         Ok(())
     }

--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -1,10 +1,13 @@
 use crate::Reporter;
 use crate::execute::{Execution, TraversalMode};
-use crate::reporter::{DiagnosticsPayload, ReporterVisitor, TraversalSummary};
+use crate::reporter::{
+    DiagnosticsPayload, EvaluatedPathsDiagnostic, FixedPathsDiagnostic, ReporterVisitor,
+    TraversalSummary,
+};
 use biome_console::fmt::Formatter;
 use biome_console::{Console, ConsoleExt, fmt, markup};
+use biome_diagnostics::PrintDiagnostic;
 use biome_diagnostics::advice::ListAdvice;
-use biome_diagnostics::{Diagnostic, PrintDiagnostic};
 use biome_fs::BiomePath;
 use camino::Utf8PathBuf;
 use std::collections::BTreeSet;
@@ -29,28 +32,6 @@ impl Reporter for ConsoleReporter {
         }
         Ok(())
     }
-}
-
-#[derive(Debug, Diagnostic)]
-#[diagnostic(
-    tags(VERBOSE),
-    severity = Information,
-    message = "Files processed:"
-)]
-struct EvaluatedPathsDiagnostic {
-    #[advice]
-    advice: ListAdvice<String>,
-}
-
-#[derive(Debug, Diagnostic)]
-#[diagnostic(
-    tags(VERBOSE),
-    severity = Information,
-    message = "Files fixed:"
-)]
-struct FixedPathsDiagnostic {
-    #[advice]
-    advice: ListAdvice<String>,
 }
 
 pub(crate) struct ConsoleReporterVisitor<'a>(pub(crate) &'a mut dyn Console);

--- a/crates/biome_cli/tests/cases/reporter_summary.rs
+++ b/crates/biome_cli/tests/cases/reporter_summary.rs
@@ -76,7 +76,6 @@ fn reports_diagnostics_summary_check_command() {
             [
                 "check",
                 "--reporter=summary",
-                "--max-diagnostics=200",
                 file_path1.as_str(),
                 file_path2.as_str(),
                 file_path3.as_str(),
@@ -117,7 +116,6 @@ fn reports_diagnostics_summary_ci_command() {
             [
                 "ci",
                 "--reporter=summary",
-                "--max-diagnostics=200",
                 file_path1.as_str(),
                 file_path2.as_str(),
                 file_path3.as_str(),
@@ -158,7 +156,6 @@ fn reports_diagnostics_summary_lint_command() {
             [
                 "lint",
                 "--reporter=summary",
-                "--max-diagnostics=200",
                 file_path1.as_str(),
                 file_path2.as_str(),
                 file_path3.as_str(),
@@ -199,7 +196,6 @@ fn reports_diagnostics_summary_format_command() {
             [
                 "format",
                 "--reporter=summary",
-                "--max-diagnostics=200",
                 file_path1.as_str(),
                 file_path2.as_str(),
                 file_path3.as_str(),
@@ -213,6 +209,47 @@ fn reports_diagnostics_summary_format_command() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "reports_diagnostics_summary_format_command",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn reports_diagnostics_summary_check_verbose_command() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path1 = Utf8Path::new("main.ts");
+    fs.insert(file_path1.into(), MAIN_1.as_bytes());
+
+    let file_path2 = Utf8Path::new("index.ts");
+    fs.insert(file_path2.into(), MAIN_2.as_bytes());
+
+    let file_path3 = Utf8Path::new("index.css");
+    fs.insert(file_path3.into(), MAIN_3.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "check",
+                "--reporter=summary",
+                "--verbose",
+                file_path1.as_str(),
+                file_path2.as_str(),
+                file_path3.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "reports_diagnostics_summary_check_verbose_command",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_verbose_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_verbose_command.snap
@@ -1,0 +1,137 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `index.css`
+
+```css
+
+
+.brokenStyle { color: f( }
+
+.style {
+                color:
+                fakeFunction()
+}
+
+```
+
+## `index.ts`
+
+```ts
+import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;
+```
+
+## `main.ts`
+
+```ts
+import { z} from "z"
+import { z, b , a} from "lodash"
+
+a ==b
+a ==b
+a ==b
+a ==b
+
+debugger
+debugger
+debugger
+debugger
+
+let f;
+let f;
+let f;
+		let f;
+		let f;
+		let f;
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+reporter/parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The following files have parsing errors.
+  
+  - index.css
+  
+reporter/format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The following files needs to be formatted.
+  
+  - index.css
+  - index.ts
+  - main.ts
+  
+reporter/violations ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Some lint rules or assist actions reported some violations.
+  
+  Rule Name                                        Diagnostics
+  
+  lint/correctness/noUnknownFunction               14 (2 error(s), 12 warning(s), 0 info(s))
+  lint/suspicious/noImplicitAnyLet                 16 (12 error(s), 4 warning(s), 0 info(s))
+  lint/suspicious/noDoubleEquals                   8 (8 error(s), 0 warning(s), 0 info(s))
+  assist/source/organizeImports                    2 (2 error(s), 0 warning(s), 0 info(s))
+  lint/suspicious/noRedeclare                      12 (12 error(s), 0 warning(s), 0 info(s))
+  lint/suspicious/noDebugger                       8 (8 error(s), 0 warning(s), 0 info(s))
+
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files processed:
+  
+  - index.css
+  - index.ts
+  - main.ts
+  
+
+```
+
+```block
+ VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Files fixed:
+  
+  ! The list is empty.
+  
+
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 3 files in <TIME>. No fixes applied.
+Found 49 errors.
+Found 16 warnings.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/4052

The `summary` reporter now doesn't take `--max-diagnostics` into account. I ended up **not** adding a warning message because by default, Biome sets 20 as the default limit. This means there's a limit by default. 

I also fixed a bug where `summary` didn't report the processed/fixed files. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added a new test case

<!-- What demonstrates that your implementation is correct? -->
