### PR TITLE
feat(cli): support rule without group in `--only` and `--skip`

### DIFF
--- a/.changeset/bright-teeth-like.md
+++ b/.changeset/bright-teeth-like.md
@@ -1,0 +1,8 @@
+---
+"@biomejs/biome": minor
+---
+
+The CLI options `--only` and `--skip` now accept rule and action names without prefixing the group name.
+
+Previously `--only=noDebugger` was rejected.
+You had to add the group name: `--only=suspicious/noDebugger`.

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -2803,7 +2803,7 @@ fn lint_only_missing_group() {
         Args::from(["lint", "--only=noDebugger", file_path.as_str()].as_slice()),
     );
 
-    assert!(result.is_err(), "run_cli returned {result:?}");
+    assert!(result.is_ok(), "run_cli returned {result:?}");
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_missing_group.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_missing_group.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `check.js`
 
@@ -9,17 +9,8 @@ for(;true;);
 
 ```
 
-# Termination Message
+# Emitted Messages
 
 ```block
-flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Failed to parse CLI arguments.
-    
-    Caused by:
-      couldn't parse `noDebugger`: This group doesn't exist. Use the syntax `<group>/<rule>` to specify a
-      rule.
-  
-
-
+Checked 1 file in <TIME>. No fixes applied.
 ```

--- a/crates/biome_migrate/src/analyzers/rule_mover.rs
+++ b/crates/biome_migrate/src/analyzers/rule_mover.rs
@@ -72,6 +72,8 @@ impl Rule for RuleMover {
                 if let Ok(new_rule) = RuleName::from_str(rule_name) {
                     // TODO: remove the `useNamingConvention` exception,
                     // once we have promoted the GraphQL `useNamingConvention` rule
+                    //
+                    // See https://github.com/biomejs/biome/issues/6018
                     if new_rule.group() != current_group && rule_name != "useNamingConvention" {
                         result.push(State {
                             rule_node,


### PR DESCRIPTION
## Summary

This Pr adds the capability of passing only the rule name in `--only` and `--skip` CLI options.

Previously `--only=<rule-name>` was rejected.
You had to add the group name: `--only=<group-name>/<rule-name>`.
`--only=<rule-name>` is now accepted.

I took the opportunity of improving the validation.
We now reject using the `lint/` prefix for an assist action/group and the `assist/` prefix for a lint rule/group.

- [x] changeset

## Test Plan

I updated the snapshots.
