### PR TITLE
fix(lsp): compare only the formatted range on range formatting

### DIFF
--- a/.changeset/eleven-feet-heal.md
+++ b/.changeset/eleven-feet-heal.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#2260](https://github.com/biomejs/biome/2260): The LSP server now returns correct text edits for the specified range in `textDocument/rangeFormatting` and `textDocument/onTypeFormatting` requests.

--- a/crates/biome_lsp/src/handlers/formatting.rs
+++ b/crates/biome_lsp/src/handlers/formatting.rs
@@ -4,7 +4,7 @@ use crate::utils::text_edit;
 use anyhow::Context;
 use biome_fs::BiomePath;
 use biome_lsp_converters::from_proto;
-use biome_rowan::{TextRange, TextSize};
+use biome_rowan::{TextLen, TextRange, TextSize};
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::workspace::{
     CheckFileSizeParams, FeaturesBuilder, FileFeaturesResult, FormatFileParams, FormatOnTypeParams,
@@ -149,14 +149,19 @@ pub(crate) fn format_range(
             range: format_range,
         })?;
 
-        let indels =
-            biome_text_edit::TextEdit::from_unicode_words(content.as_str(), formatted.as_code());
+        let formatted_range = formatted
+            .range()
+            .unwrap_or_else(|| TextRange::up_to(content.text_len()));
+        let indels = biome_text_edit::TextEdit::from_unicode_words(
+            &content.as_str()[formatted_range],
+            formatted.as_code(),
+        );
         let position_encoding = session.position_encoding();
         let edits = text_edit(
             &doc.line_index,
             indels,
             position_encoding,
-            Some(format_range.start().into()),
+            Some(formatted_range.start().into()),
         )?;
 
         Ok(Some(edits))
@@ -217,13 +222,18 @@ pub(crate) fn format_on_type(
             path: path.clone(),
         })?;
 
-        let indels =
-            biome_text_edit::TextEdit::from_unicode_words(content.as_str(), formatted.as_code());
+        let formatted_range = formatted
+            .range()
+            .unwrap_or_else(|| TextRange::up_to(content.text_len()));
+        let indels = biome_text_edit::TextEdit::from_unicode_words(
+            &content.as_str()[formatted_range],
+            formatted.as_code(),
+        );
         let edits = text_edit(
             &doc.line_index,
             indels,
             position_encoding,
-            Some(offset.into()),
+            Some(formatted_range.start().into()),
         )?;
         Ok(Some(edits))
     } else {


### PR DESCRIPTION
## Summary

Fixes #2260 

The LSP implementation of `textDocument/rangeFormatting` and `textDocument/onTypeFormatting` compares entire code of the source and the formatted snippet returned by `Workspace::format_range`. Return value of `format_range` only contains code within the range, so the compared diff deletes most of the code incorrectly.

This pull request fixes the behaviour by limiting the source to the formatted range specified in `Printed::range`, before comparing it.

## Test Plan

Added a test to `server.tests.rs`.
