### PR TITLE
fix(reporter): fixed paths are relative

### DIFF
--- a/crates/biome_cli/src/reporter/summary.rs
+++ b/crates/biome_cli/src/reporter/summary.rs
@@ -161,7 +161,16 @@ impl ReporterVisitor for SummaryReporterVisitor<'_> {
                 list: evaluated_paths
                     .iter()
                     .filter(|p| p.was_written())
-                    .map(|p| p.to_string())
+                    .map(|p| {
+                        working_directory
+                            .as_ref()
+                            .and_then(|wd| {
+                                p.strip_prefix(wd.as_str())
+                                    .map(|path| path.to_string())
+                                    .ok()
+                            })
+                            .unwrap_or(p.to_string())
+                    })
                     .collect(),
             },
         };

--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -92,7 +92,16 @@ impl ReporterVisitor for ConsoleReporterVisitor<'_> {
                 list: evaluated_paths
                     .iter()
                     .filter(|p| p.was_written())
-                    .map(|p| p.to_string())
+                    .map(|p| {
+                        working_directory
+                            .as_ref()
+                            .and_then(|wd| {
+                                p.strip_prefix(wd.as_str())
+                                    .map(|path| path.to_string())
+                                    .ok()
+                            })
+                            .unwrap_or(p.to_string())
+                    })
                     .collect(),
             },
         };

--- a/crates/biome_css_analyze/src/assist/source/use_sorted_properties.rs
+++ b/crates/biome_css_analyze/src/assist/source/use_sorted_properties.rs
@@ -85,7 +85,7 @@ declare_source_rule! {
     /// ```
     ///
     pub UseSortedProperties {
-        version: "next",
+        version: "2.0.0",
         name: "useSortedProperties",
         language: "css",
         recommended: false,

--- a/crates/biome_css_analyze/src/lint/nursery/no_important_styles.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_important_styles.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
     ///
     /// - [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/important)
     pub NoImportantStyles {
-        version: "next",
+        version: "2.0.0",
         name: "noImportantStyles",
         language: "css",
         recommended: true,

--- a/crates/biome_css_analyze/src/lint/nursery/no_unknown_at_rule.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_unknown_at_rule.rs
@@ -39,7 +39,7 @@ declare_lint_rule! {
     /// }
     /// ```
     pub NoUnknownAtRule {
-        version: "next",
+        version: "2.0.0",
         name: "noUnknownAtRule",
         language: "css",
         recommended: true,

--- a/crates/biome_css_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -43,7 +43,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoUselessEscapeInString {
-        version: "next",
+        version: "2.0.0",
         name: "noUselessEscapeInString",
         language: "css",
         recommended: true,

--- a/crates/biome_graphql_analyze/src/lint/nursery/use_named_operation.rs
+++ b/crates/biome_graphql_analyze/src/lint/nursery/use_named_operation.rs
@@ -33,7 +33,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseNamedOperation {
-        version: "next",
+        version: "2.0.0",
         name: "useNamedOperation",
         language: "graphql",
         sources: &[RuleSource::EslintGraphql("no-anonymous-operations")],

--- a/crates/biome_graphql_analyze/src/lint/nursery/use_naming_convention.rs
+++ b/crates/biome_graphql_analyze/src/lint/nursery/use_naming_convention.rs
@@ -29,7 +29,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseNamingConvention {
-        version: "next",
+        version: "2.0.0",
         name: "useNamingConvention",
         language: "graphql",
         recommended: false,

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
@@ -73,7 +73,7 @@ declare_source_rule! {
     /// }
     /// ```
     pub UseSortedKeys {
-        version: "next",
+        version: "2.0.0",
         name: "useSortedKeys",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -140,7 +140,7 @@ declare_lint_rule! {
     /// import { subPrivateVariable } from "../index.js";
     /// ```
     pub NoPrivateImports {
-        version: "next",
+        version: "2.0.0",
         name: "noPrivateImports",
         language: "js",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_await_in_loop.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_await_in_loop.rs
@@ -36,7 +36,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoAwaitInLoop {
-        version: "next",
+        version: "2.0.0",
         name: "noAwaitInLoop",
         language: "js",
         sources: &[RuleSource::Eslint("no-await-in-loop")],

--- a/crates/biome_js_analyze/src/lint/nursery/no_bitwise_operators.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_bitwise_operators.rs
@@ -57,7 +57,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoBitwiseOperators {
-        version: "next",
+        version: "2.0.0",
         name: "noBitwiseOperators",
         language: "js",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_constant_binary_expression.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_constant_binary_expression.rs
@@ -90,7 +90,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoConstantBinaryExpression {
-        version: "next",
+        version: "2.0.0",
         name: "noConstantBinaryExpression",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/no_destructured_props.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_destructured_props.rs
@@ -47,7 +47,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoDestructuredProps {
-        version: "next",
+        version: "2.0.0",
         name: "noDestructuredProps",
         language: "js",
         domains: &[RuleDomain::Solid],

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -157,7 +157,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoFloatingPromises {
-        version: "next",
+        version: "2.0.0",
         name: "noFloatingPromises",
         language: "ts",
         recommended: true,

--- a/crates/biome_js_analyze/src/lint/nursery/no_global_dirname_filename.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_global_dirname_filename.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoGlobalDirnameFilename {
-        version: "next",
+        version: "2.0.0",
         name: "noGlobalDirnameFilename",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -79,7 +79,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoImportCycles {
-        version: "next",
+        version: "2.0.0",
         name: "noImportCycles",
         language: "js",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_noninteractive_element_interactions.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_noninteractive_element_interactions.rs
@@ -71,7 +71,7 @@ declare_lint_rule! {
     /// - [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
     ///
     pub NoNoninteractiveElementInteractions {
-        version: "next",
+        version: "2.0.0",
         name: "noNoninteractiveElementInteractions",
         language: "jsx",
         sources: &[RuleSource::EslintJsxA11y("no-noninteractive-element-interactions")],

--- a/crates/biome_js_analyze/src/lint/nursery/no_process_global.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_process_global.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoProcessGlobal {
-        version: "next",
+        version: "2.0.0",
         name: "noProcessGlobal",
         language: "js",
         sources: &[RuleSource::DenoLint("no-process-global")],

--- a/crates/biome_js_analyze/src/lint/nursery/no_restricted_elements.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_restricted_elements.rs
@@ -71,7 +71,7 @@ declare_lint_rule! {
     /// <TextField />
     /// ```
     pub NoRestrictedElements {
-        version: "next",
+        version: "2.0.0",
         name: "noRestrictedElements",
         language: "jsx",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_shadow.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_shadow.rs
@@ -58,7 +58,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoShadow {
-        version: "next",
+        version: "2.0.0",
         name: "noShadow",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/no_ts_ignore.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_ts_ignore.rs
@@ -35,7 +35,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoTsIgnore {
-        version: "next",
+        version: "2.0.0",
         name: "noTsIgnore",
         language: "js",
         sources: &[RuleSource::EslintTypeScript("ban-ts-comment")],

--- a/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
     /// import { foo } from "./foo.js";
     /// ```
     pub NoUnresolvedImports {
-        version: "next",
+        version: "2.0.0",
         name: "noUnresolvedImports",
         language: "js",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_unwanted_polyfillio.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unwanted_polyfillio.rs
@@ -49,7 +49,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoUnwantedPolyfillio {
-        version: "next",
+        version: "2.0.0",
         name: "noUnwantedPolyfillio",
         language: "jsx",
         sources: &[RuleSource::EslintNext("no-unwanted-polyfillio")],

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_backref_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_backref_in_regex.rs
@@ -81,7 +81,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoUselessBackrefInRegex {
-        version: "next",
+        version: "2.0.0",
         name: "noUselessBackrefInRegex",
         language: "js",
         sources: &[

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -52,7 +52,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoUselessEscapeInString {
-        version: "next",
+        version: "2.0.0",
         name: "noUselessEscapeInString",
         language: "js",
         recommended: true,

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_undefined.rs
@@ -70,7 +70,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub NoUselessUndefined {
-        version: "next",
+        version: "2.0.0",
         name: "noUselessUndefined",
         language: "js",
         fix_kind: FixKind::Safe,

--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_object_definition.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_object_definition.rs
@@ -111,7 +111,7 @@ declare_lint_rule! {
     /// **Default:** `explicit`
     ///
     pub UseConsistentObjectDefinition {
-        version: "next",
+        version: "2.0.0",
         name: "useConsistentObjectDefinition",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -90,7 +90,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseExhaustiveSwitchCases {
-        version: "next",
+        version: "2.0.0",
         name: "useExhaustiveSwitchCases",
         language: "js",
         recommended: true,

--- a/crates/biome_js_analyze/src/lint/nursery/use_exports_last.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exports_last.rs
@@ -33,7 +33,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseExportsLast {
-        version: "next",
+        version: "2.0.0",
         name: "useExportsLast",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/use_for_component.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_for_component.rs
@@ -53,7 +53,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseForComponent {
-        version: "next",
+        version: "2.0.0",
         name: "useForComponent",
         language: "js",
         domains: &[RuleDomain::Solid],

--- a/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_google_font_preconnect.rs
@@ -46,7 +46,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseGoogleFontPreconnect {
-        version: "next",
+        version: "2.0.0",
         name: "useGoogleFontPreconnect",
         language: "jsx",
         sources: &[RuleSource::EslintNext("google-font-preconnect")],

--- a/crates/biome_js_analyze/src/lint/nursery/use_iterable_callback_return.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_iterable_callback_return.rs
@@ -76,7 +76,7 @@ declare_lint_rule! {
     /// });
     /// ```
     pub UseIterableCallbackReturn {
-        version: "next",
+        version: "2.0.0",
         name: "useIterableCallbackReturn",
         language: "js",
         sources: &[RuleSource::Eslint("array-callback-return")],

--- a/crates/biome_js_analyze/src/lint/nursery/use_numeric_separators.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_numeric_separators.rs
@@ -53,7 +53,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseNumericSeparators {
-        version: "next",
+        version: "2.0.0",
         name: "useNumericSeparators",
         language: "js",
         sources: &[RuleSource::EslintUnicorn("numeric-separators-style"), RuleSource::Clippy("unreadable_literal")],

--- a/crates/biome_js_analyze/src/lint/nursery/use_parse_int_radix.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_parse_int_radix.rs
@@ -50,7 +50,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseParseIntRadix {
-        version: "next",
+        version: "2.0.0",
         name: "useParseIntRadix",
         language: "js",
         recommended: true,

--- a/crates/biome_js_analyze/src/lint/nursery/use_single_js_doc_asterisk.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_single_js_doc_asterisk.rs
@@ -60,7 +60,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseSingleJsDocAsterisk {
-        version: "next",
+        version: "2.0.0",
         name: "useSingleJsDocAsterisk",
         language: "js",
         recommended: false,

--- a/crates/biome_js_analyze/src/lint/nursery/use_symbol_description.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_symbol_description.rs
@@ -32,7 +32,7 @@ declare_lint_rule! {
     /// ```
     ///
     pub UseSymbolDescription {
-        version: "next",
+        version: "2.0.0",
         name: "useSymbolDescription",
         language: "js",
         sources: &[


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes the paths printed using the `--verbose` flag. While testing the path, I discovered that they were still absolute. With this PR, they will be relative.

Also, we forgot to remove the `"next"` from our new rules. We're getting close!!

This means we shouldn't merge any new rules, and if we do, we need to tell users to use the `2.0.0` version.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I tested it locally. CI should pass.

<!-- What demonstrates that your implementation is correct? -->
