### PR TITLE
fix(core): only trigger on ServiceDataNotification per scan

### DIFF
--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -12,7 +12,7 @@ use super::server::WorkspaceServer;
 use super::{FeatureName, IsPathIgnoredParams};
 use crate::diagnostics::Panic;
 use crate::projects::ProjectKey;
-use crate::workspace::{DocumentFileSource, FileContent, OpenFileParams};
+use crate::workspace::DocumentFileSource;
 use crate::{Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
 use biome_diagnostics::{Diagnostic as _, Error, Severity};
@@ -320,13 +320,8 @@ impl TraversalContext for ScanContext<'_> {
 /// so panics are caught, and diagnostics are submitted in case of panic too.
 fn open_file(ctx: &ScanContext, path: &BiomePath) {
     match catch_unwind(move || {
-        ctx.workspace.open_file_by_scanner(OpenFileParams {
-            project_key: ctx.project_key,
-            path: path.clone(),
-            content: FileContent::FromServer,
-            document_file_source: None,
-            persist_node_cache: false,
-        })
+        ctx.workspace
+            .open_file_during_initial_scan(ctx.project_key, path.clone())
     }) {
         Ok(Ok(())) => {}
         Ok(Err(err)) => {

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -15,11 +15,14 @@ use biome_fs::{FileSystemDiagnostic, PathKind};
 use camino::Utf8Path;
 use papaya::{Compute, Operation};
 
-use crate::{IGNORE_ENTRIES, WorkspaceError, workspace_watcher::WatcherSignalKind};
+use crate::{
+    IGNORE_ENTRIES, WorkspaceError,
+    workspace_watcher::{OpenFileReason, WatcherSignalKind},
+};
 
 use super::{
-    FileContent, OpenFileParams, ScanKind, ScanProjectFolderParams, ServiceDataNotification,
-    Workspace, WorkspaceServer, document::Document,
+    ScanKind, ScanProjectFolderParams, ServiceDataNotification, Workspace, WorkspaceServer,
+    document::Document,
 };
 
 impl WorkspaceServer {
@@ -72,15 +75,12 @@ impl WorkspaceServer {
             return Ok(()); // file events outside our projects can be safely ignored.
         };
 
-        self.open_file_by_scanner(OpenFileParams {
-            project_key,
-            path: path.into(),
-            content: FileContent::FromServer,
-            document_file_source: None,
-            persist_node_cache: false,
-        })?;
+        self.open_file_by_watcher(project_key, path)?;
 
-        self.update_service_data(WatcherSignalKind::AddedOrChanged, path)
+        self.update_service_data(
+            WatcherSignalKind::AddedOrChanged(OpenFileReason::WatcherUpdate),
+            path,
+        )
     }
 
     /// Used indirectly by the watcher to open an individual folder.

--- a/crates/biome_service/src/workspace/watcher.tests.rs
+++ b/crates/biome_service/src/workspace/watcher.tests.rs
@@ -6,8 +6,8 @@ use tokio::sync::watch;
 use crate::{
     WatcherInstruction,
     workspace::{
-        ChangeFileParams, CloseFileParams, GetFileContentParams, OpenProjectParams,
-        ServiceDataNotification,
+        ChangeFileParams, CloseFileParams, FileContent, GetFileContentParams, OpenFileParams,
+        OpenProjectParams, ServiceDataNotification,
     },
 };
 
@@ -31,13 +31,7 @@ fn close_file_through_watcher_before_client() {
         .expect("can open project");
 
     workspace
-        .open_file_by_scanner(OpenFileParams {
-            project_key,
-            path: BiomePath::new("/project/a.js"),
-            content: FileContent::FromServer,
-            document_file_source: None,
-            persist_node_cache: false,
-        })
+        .open_file_during_initial_scan(project_key, BiomePath::new("/project/a.js"))
         .expect("can open file");
 
     workspace
@@ -114,13 +108,7 @@ fn close_file_from_client_before_watcher() {
         .expect("can also open from client");
 
     workspace
-        .open_file_by_scanner(OpenFileParams {
-            project_key,
-            path: BiomePath::new("/project/a.js"),
-            content: FileContent::FromServer,
-            document_file_source: None,
-            persist_node_cache: false,
-        })
+        .open_file_during_initial_scan(project_key, BiomePath::new("/project/a.js"))
         .expect("can open file");
 
     workspace
@@ -185,13 +173,7 @@ fn close_modified_file_from_client_before_watcher() {
         .expect("can also open from client");
 
     workspace
-        .open_file_by_scanner(OpenFileParams {
-            project_key,
-            path: BiomePath::new("/project/a.js"),
-            content: FileContent::FromServer,
-            document_file_source: None,
-            persist_node_cache: false,
-        })
+        .open_file_during_initial_scan(project_key, BiomePath::new("/project/a.js"))
         .expect("can open file");
 
     workspace

--- a/crates/biome_service/src/workspace_watcher.rs
+++ b/crates/biome_service/src/workspace_watcher.rs
@@ -19,7 +19,7 @@ pub enum WatcherInstruction {
     /// Resyncs a file after a file was closed by a client.
     ///
     /// This is done through an instruction instead of calling
-    /// `WorkspaceServer::open_file_by_scanner()` directly to ensure it is only
+    /// `WorkspaceServer::open_file_by_watcher()` directly to ensure it is only
     /// done if the watcher is active.
     ResyncFile(Utf8PathBuf),
 
@@ -46,8 +46,27 @@ impl Drop for WatcherInstructionChannel {
 /// Kind of change being reported.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WatcherSignalKind {
-    AddedOrChanged,
+    AddedOrChanged(OpenFileReason),
     Removed,
+}
+
+/// Reports the reason why a file is being opened/indexed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OpenFileReason {
+    /// A workspace client has explicitly requested the file to be opened.
+    ClientRequest,
+
+    /// The file is being opened as part of an initial scanner run.
+    InitialScan,
+
+    /// The file is being opened or updated as part of a watcher update.
+    WatcherUpdate,
+}
+
+impl OpenFileReason {
+    pub const fn is_opened_by_scanner(self) -> bool {
+        matches!(self, Self::InitialScan | Self::WatcherUpdate)
+    }
 }
 
 /// Watcher to keep the [WorkspaceServer] in sync with the filesystem state.


### PR DESCRIPTION
## Summary

This prevents a huge CPU spike we sometimes see when starting the LSP.

I do suspect a follow-up may be necessary trying to further optimise `session.update_all_diagnostics()` itself.

## Test Plan

Manually tested.
