### PR TITLE
fix(analyzer): fix plugin diagnostic suppression + resolve double diagnostics

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -199,7 +199,8 @@ where
 
         for plugin in plugins {
             let root: AnyParse = ctx.root.syntax().as_send().expect("not a root node").into();
-            for diagnostic in plugin.evaluate(root, ctx.options.file_path.clone()) {
+            let diagnostics = plugin.evaluate(root, ctx.options.file_path.clone());
+            for diagnostic in diagnostics {
                 let name = diagnostic
                     .subcategory
                     .clone()

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -6,6 +6,7 @@ use crate::configs::{
 use crate::snap_test::{SnapshotPayload, assert_file_contents, markup_to_string};
 use crate::{
     FORMATTED, LINT_ERROR, PARSE_ERROR, assert_cli_snapshot, run_cli, run_cli_with_dyn_fs,
+    run_cli_with_server_workspace,
 };
 use biome_console::{BufferConsole, LogLevel, MarkupBuf, markup};
 use biome_fs::{ErrorEntry, FileSystemExt, MemoryFileSystem, OsFileSystem};
@@ -2928,6 +2929,63 @@ fn check_skip_parse_errors() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "check_skip_parse_errors",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn check_plugin_suppressions() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    fs.insert(
+        Utf8PathBuf::from("biome.json"),
+        br#"{
+    "plugins": ["noManualZIndex.grit"],
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 4
+    }
+}
+"#,
+    );
+
+    fs.insert(
+        Utf8PathBuf::from("noManualZIndex.grit"),
+        br#"language css
+
+`z-index: $zIndexValue;` where {
+    not $zIndexValue <: r"^var\(--dt-z-index-\S+\)$",
+    register_diagnostic(span=$zIndexValue, message="company/plugin/noManualZIndex :: z-index values should be set using the design library.", severity="error")
+}
+"#,
+    );
+
+    let file_path = "style.css";
+    fs.insert(
+        file_path.into(),
+        br#".report-this-error {
+    z-index: 1;
+}
+
+.dont-report-this-error-please {
+    /* biome-ignore lint/plugin/noManualZIndex: Should not report */
+    z-index: 2;
+}
+"#,
+    );
+
+    let (fs, result) = run_cli_with_server_workspace(
+        fs,
+        &mut console,
+        Args::from(["check", file_path].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "check_plugin_suppressions",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_plugin_suppressions.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_plugin_suppressions.snap
@@ -1,0 +1,73 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "plugins": ["noManualZIndex.grit"],
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 4
+  }
+}
+```
+
+## `noManualZIndex.grit`
+
+```grit
+language css
+
+`z-index: $zIndexValue;` where {
+    not $zIndexValue <: r"^var\(--dt-z-index-\S+\)$",
+    register_diagnostic(span=$zIndexValue, message="company/plugin/noManualZIndex :: z-index values should be set using the design library.", severity="error")
+}
+
+```
+
+## `style.css`
+
+```css
+.report-this-error {
+    z-index: 1;
+}
+
+.dont-report-this-error-please {
+    /* biome-ignore lint/plugin/noManualZIndex: Should not report */
+    z-index: 2;
+}
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+style.css:2:14 plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × company/plugin/noManualZIndex :: z-index values should be set using the design library.
+  
+    1 │ .report-this-error {
+  > 2 │     z-index: 1;
+      │              ^
+    3 │ }
+    4 │ 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_can_use_custom_severity.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__plugins_can_use_custom_severity.snap
@@ -37,38 +37,4 @@ expression: result.diagnostics
         ),
         source: None,
     },
-    Diagnostic {
-        category: Some(
-            Category {
-                name: "plugin",
-                link: None,
-            },
-        ),
-        severity: Warning,
-        description: "Don't set explicit colors. Use `.color-*` classes instead.",
-        message: "Don't set explicit colors. Use `.color-*` classes instead.",
-        advices: Advices {
-            advices: [],
-        },
-        verbose_advices: Advices {
-            advices: [],
-        },
-        location: Location {
-            path: Some(
-                File(
-                    "/project/a.css",
-                ),
-            ),
-            span: Some(
-                4..14,
-            ),
-            source_code: None,
-        },
-        tags: DiagnosticTags(
-            BitFlags<DiagnosticTag> {
-                bits: 0b0,
-            },
-        ),
-        source: None,
-    },
 ]

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use append_only_vec::AppendOnlyVec;
-use biome_analyze::AnalyzerPluginVec;
+use biome_analyze::{AnalyzerPluginVec, RuleCategory};
 use biome_configuration::plugins::{PluginConfiguration, Plugins};
 use biome_configuration::{BiomeDiagnostic, Configuration};
 use biome_deserialize::Deserialized;
@@ -1195,7 +1195,11 @@ impl Workspace for WorkspaceServer {
                     suppression_reason: None,
                     enabled_rules,
                     pull_code_actions,
-                    plugins: self.get_analyzer_plugins_for_project(project_key),
+                    plugins: if categories.contains(RuleCategory::Lint) {
+                        self.get_analyzer_plugins_for_project(project_key)
+                    } else {
+                        Vec::new()
+                    },
                 });
 
                 (
@@ -1277,7 +1281,7 @@ impl Workspace for WorkspaceServer {
             skip,
             suppression_reason: None,
             enabled_rules,
-            plugins: self.get_analyzer_plugins_for_project(project_key),
+            plugins: Vec::new(),
         }))
     }
 
@@ -1419,7 +1423,11 @@ impl Workspace for WorkspaceServer {
             rule_categories,
             suppression_reason,
             enabled_rules,
-            plugins: self.get_analyzer_plugins_for_project(project_key),
+            plugins: if rule_categories.contains(RuleCategory::Lint) {
+                self.get_analyzer_plugins_for_project(project_key)
+            } else {
+                Vec::new()
+            },
         })
     }
 


### PR DESCRIPTION
## Summary

Fixes #6031: `biome check` calls the analyzer twice, once for formatting and once for linting. But it handed the linter plugins to both invocations, causing them to run twice. Worse, in the formatting invocation, the suppressions didn't work either.

Also fixes an issue that could cause certain Grit queries to report double diagnostics.

## Test Plan

Test added.
