### PR TITLE
fix(lint/noUselessEscapeInString): avoid false positive for `\${` escape in template literals

### DIFF
--- a/.changeset/rotten-birds-greet.md
+++ b/.changeset/rotten-birds-greet.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6039](https://github.com/biomejs/biome/issues/6039): [`noUselessEscapeInString`](https://next.biomejs.dev/linter/rules/no-useless-escape-in-string/) no longer reports `\${` escape in template literals.

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -174,6 +174,10 @@ fn next_useless_escape(str: &str, quote: u8) -> Option<usize> {
                         }
                     }
                     _ => {
+                        // In template literals, \${ is a valid escape for producing a literal ${
+                        if quote == b'`' && c == b'$' && (matches!(it.next(), Some((_, b'{')))) {
+                            return None;
+                        }
                         // The quote can be escaped
                         if c != quote {
                             return Some(i);

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
@@ -3,5 +3,7 @@ var s = {
     '\"': "\'",
     "abc\defg": ` test ${1} \a` /*after*/,
     // A test with unicode characters that take more than one byte
-    key: "😀\😀"
+    key: "😀\😀",
+    // https://github.com/biomejs/biome/issues/6039
+    templateLiterals: `\$x`
 };

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: invalid.js
+snapshot_kind: text
 ---
 # Input
 ```js
@@ -9,7 +10,9 @@ var s = {
     '\"': "\'",
     "abc\defg": ` test ${1} \a` /*after*/,
     // A test with unicode characters that take more than one byte
-    key: "😀\😀"
+    key: "😀\😀",
+    // https://github.com/biomejs/biome/issues/6039
+    templateLiterals: `\$x`
 };
 
 ```
@@ -107,18 +110,18 @@ invalid.js:4:10 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   > 4 │     "abc\defg": ` test ${1} \a` /*after*/,
       │          ^
     5 │     // A test with unicode characters that take more than one byte
-    6 │     key: "😀\😀"
+    6 │     key: "😀\😀",
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
   i Safe fix: Unescape the character.
   
-    2 2 │       '\a': /*before*/ "\a" /*after*/,
-    3 3 │       '\"': "\'",
-    4   │ - ····"abc\defg":·`·test·${1}·\a`·/*after*/,
-      4 │ + ····"abcdefg":·`·test·${1}·\a`·/*after*/,
-    5 5 │       // A test with unicode characters that take more than one byte
-    6 6 │       key: "😀\😀"
+     2  2 │       '\a': /*before*/ "\a" /*after*/,
+     3  3 │       '\"': "\'",
+     4    │ - ····"abc\defg":·`·test·${1}·\a`·/*after*/,
+        4 │ + ····"abcdefg":·`·test·${1}·\a`·/*after*/,
+     5  5 │       // A test with unicode characters that take more than one byte
+     6  6 │       key: "😀\😀",
   
 
 ```
@@ -133,7 +136,7 @@ invalid.js:4:30 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   > 4 │     "abc\defg": ` test ${1} \a` /*after*/,
       │                              ^
     5 │     // A test with unicode characters that take more than one byte
-    6 │     key: "😀\😀"
+    6 │     key: "😀\😀",
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
@@ -151,16 +154,37 @@ invalid.js:6:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   
     4 │     "abc\defg": ` test ${1} \a` /*after*/,
     5 │     // A test with unicode characters that take more than one byte
-  > 6 │     key: "😀\😀"
+  > 6 │     key: "😀\😀",
       │              ^^
-    7 │ };
-    8 │ 
+    7 │     // https://github.com/biomejs/biome/issues/6039
+    8 │     templateLiterals: `\$x`
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
   i Safe fix: Unescape the character.
   
-    6 │ ····key:·"😀\😀"
-      │             -   
+    6 │ ····key:·"😀\😀",
+      │             -    
+
+```
+
+```
+invalid.js:8:25 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The character doesn't need to be escaped.
+  
+     6 │     key: "😀\😀",
+     7 │     // https://github.com/biomejs/biome/issues/6039
+   > 8 │     templateLiterals: `\$x`
+       │                         ^
+     9 │ };
+    10 │ 
+  
+  i Only quotes that enclose the string and special characters need to be escaped.
+  
+  i Safe fix: Unescape the character.
+  
+    8 │ ····templateLiterals:·`\$x`
+      │                        -   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js
@@ -2,5 +2,6 @@
 var s = {
     '\0\'': "\n\"",
     "abc\u42efg": tagged` test ${1} \a`,
-    key: `\``
+    key: `\``,
+    escapeTemplateLiteralInterpolation: `\${`
 };

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
+snapshot_kind: text
 ---
 # Input
 ```js
@@ -8,6 +9,8 @@ expression: valid.js
 var s = {
     '\0\'': "\n\"",
     "abc\u42efg": tagged` test ${1} \a`,
-    key: `\``
+    key: `\``,
+    escapeTemplateLiteralInterpolation: `\${`
 };
+
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Fixes https://github.com/biomejs/biome/issues/6039, which incorrectly flagged `\${` escape in template literals.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- Added a valid test case for `\${`, and an invalid case for `\$x`.
- Existing tests pass.
