### PR TITLE
fix(lint/noUselessEscapeInString): flag useless escapes after skipping \${ in template literals

### DIFF
--- a/.changeset/petite-rats-sniff.md
+++ b/.changeset/petite-rats-sniff.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6042](https://github.com/biomejs/biome/pull/6042): [`noUselessEscapeInString`](https://next.biomejs.dev/linter/rules/no-useless-escape-in-string/) now reports useless escapes after skipping \${ in template literals.

--- a/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_useless_escape_in_string.rs
@@ -165,6 +165,13 @@ fn next_useless_escape(str: &str, quote: u8) -> Option<usize> {
                     | b'u'
                     | b'v'
                     | b'x' => {}
+                    // In template literals, \${ is a valid escape for producing a literal ${
+                    b'$' => {
+                        // Clone iterator to peek ahead without advancing, so other escapes like \${\a aren't missed
+                        if !(quote == b'`' && (matches!(it.clone().next(), Some((_, b'{'))))) {
+                            return Some(i);
+                        }
+                    }
                     // Preserve escaping of Unicode characters U+2028 and U+2029
                     0xE2 => {
                         if !(matches!(it.next(), Some((_, 0x80)))
@@ -174,10 +181,6 @@ fn next_useless_escape(str: &str, quote: u8) -> Option<usize> {
                         }
                     }
                     _ => {
-                        // In template literals, \${ is a valid escape for producing a literal ${
-                        if quote == b'`' && c == b'$' && (matches!(it.next(), Some((_, b'{')))) {
-                            return None;
-                        }
                         // The quote can be escaped
                         if c != quote {
                             return Some(i);

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js
@@ -5,5 +5,7 @@ var s = {
     // A test with unicode characters that take more than one byte
     key: "😀\😀",
     // https://github.com/biomejs/biome/issues/6039
-    templateLiterals: `\$x`
+    templateLiterals1: `\$x`,
+    templateLiterals2: `\${\a`,
+    templateLiterals3: `\${} \a`
 };

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/invalid.js.snap
@@ -12,7 +12,9 @@ var s = {
     // A test with unicode characters that take more than one byte
     key: "😀\😀",
     // https://github.com/biomejs/biome/issues/6039
-    templateLiterals: `\$x`
+    templateLiterals1: `\$x`,
+    templateLiterals2: `\${\a`,
+    templateLiterals3: `\${} \a`
 };
 
 ```
@@ -157,7 +159,7 @@ invalid.js:6:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
   > 6 │     key: "😀\😀",
       │              ^^
     7 │     // https://github.com/biomejs/biome/issues/6039
-    8 │     templateLiterals: `\$x`
+    8 │     templateLiterals1: `\$x`,
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
@@ -169,22 +171,64 @@ invalid.js:6:13 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━�
 ```
 
 ```
-invalid.js:8:25 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:8:26 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! The character doesn't need to be escaped.
   
      6 │     key: "😀\😀",
      7 │     // https://github.com/biomejs/biome/issues/6039
-   > 8 │     templateLiterals: `\$x`
-       │                         ^
-     9 │ };
-    10 │ 
+   > 8 │     templateLiterals1: `\$x`,
+       │                          ^
+     9 │     templateLiterals2: `\${\a`,
+    10 │     templateLiterals3: `\${} \a`
   
   i Only quotes that enclose the string and special characters need to be escaped.
   
   i Safe fix: Unescape the character.
   
-    8 │ ····templateLiterals:·`\$x`
-      │                        -   
+    8 │ ····templateLiterals1:·`\$x`,
+      │                         -    
+
+```
+
+```
+invalid.js:9:29 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The character doesn't need to be escaped.
+  
+     7 │     // https://github.com/biomejs/biome/issues/6039
+     8 │     templateLiterals1: `\$x`,
+   > 9 │     templateLiterals2: `\${\a`,
+       │                             ^
+    10 │     templateLiterals3: `\${} \a`
+    11 │ };
+  
+  i Only quotes that enclose the string and special characters need to be escaped.
+  
+  i Safe fix: Unescape the character.
+  
+    9 │ ····templateLiterals2:·`\${\a`,
+      │                            -   
+
+```
+
+```
+invalid.js:10:31 lint/nursery/noUselessEscapeInString  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The character doesn't need to be escaped.
+  
+     8 │     templateLiterals1: `\$x`,
+     9 │     templateLiterals2: `\${\a`,
+  > 10 │     templateLiterals3: `\${} \a`
+       │                               ^
+    11 │ };
+    12 │ 
+  
+  i Only quotes that enclose the string and special characters need to be escaped.
+  
+  i Safe fix: Unescape the character.
+  
+    10 │ ····templateLiterals3:·`\${}·\a`
+       │                              -  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js
@@ -3,5 +3,6 @@ var s = {
     '\0\'': "\n\"",
     "abc\u42efg": tagged` test ${1} \a`,
     key: `\``,
-    escapeTemplateLiteralInterpolation: `\${`
+    escapeTemplateLiteralInterpolation1: `\${`,
+    escapeTemplateLiteralInterpolation2: `\${}`
 };

--- a/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUselessEscapeInString/valid.js.snap
@@ -10,7 +10,8 @@ var s = {
     '\0\'': "\n\"",
     "abc\u42efg": tagged` test ${1} \a`,
     key: `\``,
-    escapeTemplateLiteralInterpolation: `\${`
+    escapeTemplateLiteralInterpolation1: `\${`,
+    escapeTemplateLiteralInterpolation2: `\${}`
 };
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

Fixed https://github.com/biomejs/biome/pull/6042. The rule now reports useless escapes after skipping `\${` in template literals.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

- Added more tests for template literals with `\${`.
- Existing tests pass.
