### PR TITLE
fix: resolve packages in /node_modules correctly on Windows

### DIFF
--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -373,7 +373,12 @@ fn resolve_dependency(
     let (package_name, subpath) = parse_package_specifier(specifier)?;
 
     for dir in base_dir.ancestors() {
-        let package_path = Utf8PathBuf::from(format!("{dir}/node_modules/{package_name}"));
+        let package_path = {
+            let mut p = dir.to_path_buf();
+            p.push("node_modules");
+            p.push(package_name);
+            p
+        };
         let package_path = match fs.path_info(&package_path) {
             Ok(PathInfo::Directory) => package_path,
             Ok(PathInfo::Symlink {


### PR DESCRIPTION
## Summary

This pull request fixes the failing test on Windows.

The culprit was a very niche case, where `node_modules` directory is at the root of the filesystem. In this case, `package_path` becomes `//node_modules/shared` after concated the paths as string. I don't know why, but `Utf8Path::new("//node_modules/shared") == Utf8Path::new("/node_modules/shared")` is `true` on Linux/macOS but Windows. Thus we couldn't resolve the path correctly from the cache in `ModuleGraphFsProxy` only on Windows.

## Test Plan

Windows CI should back green.
