### PR TITLE
fix(lsp): scope `workspace/configuration` request to workspace folder

### DIFF
--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -732,7 +732,10 @@ impl Session {
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn load_extension_settings(&self) {
         let item = lsp_types::ConfigurationItem {
-            scope_uri: None,
+            scope_uri: match self.initialize_params.get() {
+                Some(params) => params.root_uri.clone(),
+                None => None,
+            },
             section: Some(String::from(CONFIGURATION_SECTION)),
         };
 


### PR DESCRIPTION
## Summary

This pull request scopes the `workspace/configuration` LSP request to the `root_uri` (root of the workspace folder).

If we don't scope the request, VS Code will return the global configuration and ignore any potential workspace folder configuration overrides (`.vscode/settings.json`).

## Test Plan

- [x] Opening VS Code in single-file mode means there isn't a `root_uri`, so `scopeUri` should not be set.

```
2025-05-17 10:09:57.397 [info] [Trace - 10:09:57 AM] Sending request 'initialize - (0)'.
2025-05-17 10:09:57.397 [info] Params: {
    "processId": 23983,
    "clientInfo": {
        "name": "Visual Studio Code",
        "version": "1.100.2"
    },
    "locale": "en",
    "rootPath": null,
    "rootUri": null,
    ...
```

  ```
  2025-05-17 10:10:07.361 [info] [Trace - 10:10:07 AM] Received request 'workspace/configuration - (0)'.
  2025-05-17 10:10:07.361 [info] Params: {
      "items": [
          {
              "section": "biome"
          }
      ]
  }
  ```

- [x] Opening VS Code in workspace mode means the `root_uri` is specified, and the workspace/configuration request is scoped to it.

```
2025-05-17 10:12:32.703 [info] [Trace - 10:12:32 AM] Sending request 'initialize - (0)'.
2025-05-17 10:12:32.703 [info] Params: {
    "processId": 24703,
    "clientInfo": {
        "name": "Visual Studio Code",
        "version": "1.100.2"
    },
    "locale": "en",
    "rootPath": "/Users/nicolas/Code/biome-vscode-next/test/fixtures/single-root-workspace",
    "rootUri": "file:///Users/nicolas/Code/biome-vscode-next/test/fixtures/single-root-workspace",
    ...
```

```
2025-05-17 10:12:42.678 [info] [Trace - 10:12:42 AM] Received request 'workspace/configuration - (0)'.
2025-05-17 10:12:42.678 [info] Params: {
    "items": [
        {
            "scopeUri": "file:///Users/nicolas/Code/biome-vscode-next/test/fixtures/single-root-workspace",
            "section": "biome"
        }
    ]
}
```

Should return the configuration, with the appropriate overrides, in this case:

```json
{
    "biome.lsp.bin": "/Users/nicolas/code/biome/target/debug/biome",
    "biome.configurationPath": "biome.custom.json"
}

```
