### PR TITLE
refactor(lint/useConst): recommend the rule

### DIFF
--- a/.changeset/rule-promotion.md
+++ b/.changeset/rule-promotion.md
@@ -90,6 +90,5 @@ And the following style rules are no longer recommended:
 - [style/noUnusedTemplateLiteral](https://biomejs.dev/linter/rules/no-unused-template-literal)
 - [style/useEnumInitializers](https://biomejs.dev/linter/rules/use-enum-initializers)
 - [style/noUselessElse](https://biomejs.dev/linter/rules/no-useless-else)
-- [style/useConst](https://biomejs.dev/linter/rules/use-const)
 - [style/useSelfClosingElements](https://biomejs.dev/linter/rules/use-self-closing-elements)
 - [style/useSingleVarDeclarator](https://biomejs.dev/linter/rules/use-single-var-declarator)

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -47,7 +47,7 @@ debugger;
 console.log(a);
 ";
 
-const APPLY_SUGGESTED_AFTER: &str = "let a = 4;\nconsole.log(a);\n";
+const APPLY_SUGGESTED_AFTER: &str = "const a = 4;\nconsole.log(a);\n";
 
 const NO_DEBUGGER_BEFORE: &str = "debugger;\n";
 const NO_DEBUGGER_AFTER: &str = "debugger;\n";
@@ -331,7 +331,7 @@ console.log(a);
 function _f() { arguments; }
 ";
 
-    let expected = "let a = 4;
+    let expected = "const a = 4;
 console.log(a);
 function _f() {\n\targuments;\n}
 ";
@@ -2633,7 +2633,7 @@ console.log(a);
 function _f() { arguments; }
 ";
 
-    let expected = "let a = 4;
+    let expected = "const a = 4;
 console.log(a);
 function _f() {\n\targuments;\n}
 ";
@@ -2778,7 +2778,7 @@ console.log(a);
 function _f() { arguments; }
 ";
 
-    let expected = "let a = 4;
+    let expected = "const a = 4;
 console.log(a);
 function _f() {\n\targuments;\n}
 ";

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -45,7 +45,7 @@ debugger;
 console.log(a);
 ";
 
-const APPLY_SUGGESTED_AFTER: &str = "let a = 4;\nconsole.log(a);\n";
+const APPLY_SUGGESTED_AFTER: &str = "const a = 4;\nconsole.log(a);\n";
 
 const NO_DEBUGGER_BEFORE: &str = "debugger;\n";
 const NO_DEBUGGER_AFTER: &str = "debugger;\n";
@@ -304,7 +304,7 @@ console.log(a);
 function _f() { arguments; }
 ";
 
-    let expected = "let a = 4;
+    let expected = "const a = 4;
 console.log(a);
 function _f() { arguments; }
 ";
@@ -3579,7 +3579,7 @@ console.log(a);
 function _f() { arguments; }
 ";
 
-    let expected = "let a = 4;
+    let expected = "const a = 4;
 console.log(a);
 function _f() { arguments; }
 ";

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_aws_config.snap
@@ -38,7 +38,6 @@ expression: redactor(content)
         "useDefaultParameterLast": "error",
         "useEnumInitializers": "error",
         "useSelfClosingElements": "error",
-        "useConst": "error",
         "useSingleVarDeclarator": "error",
         "noUnusedTemplateLiteral": "error",
         "useNumberNamespace": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_migrate_issue_5465.snap
@@ -38,7 +38,6 @@ expression: redactor(content)
         "useDefaultParameterLast": "error",
         "useEnumInitializers": "error",
         "useSelfClosingElements": "error",
-        "useConst": "error",
         "useSingleVarDeclarator": "error",
         "noUnusedTemplateLiteral": "error",
         "useNumberNamespace": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_ariakit.snap
@@ -64,7 +64,6 @@ expression: redactor(content)
         "useDefaultParameterLast": "error",
         "useEnumInitializers": "error",
         "useSelfClosingElements": "error",
-        "useConst": "error",
         "useSingleVarDeclarator": "error",
         "useNumberNamespace": "error",
         "noInferrableTypes": "error"

--- a/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_migrate_v2/should_successfully_migrate_knip.snap
@@ -37,7 +37,6 @@ expression: redactor(content)
         "useDefaultParameterLast": "error",
         "useEnumInitializers": "error",
         "useSelfClosingElements": "error",
-        "useConst": "error",
         "useSingleVarDeclarator": "error",
         "noUnusedTemplateLiteral": "error",
         "useNumberNamespace": "error",

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/misplaced_top_level_suppression.snap
@@ -83,6 +83,34 @@ file.js:3:1 suppressions/incorrect ━━━━━━━━━━━━━━━
 ```
 
 ```block
+file.js:2:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 2 │ let foo = 2;
+      │ ^^^
+    3 │ /**
+    4 │ * biome-ignore-all lint/style/useConst: reason
+  
+  i 'foo' is never reassigned.
+  
+  > 2 │ let foo = 2;
+      │     ^^^
+    3 │ /**
+    4 │ * biome-ignore-all lint/style/useConst: reason
+  
+  i Safe fix: Use const instead.
+  
+    1 1 │   
+    2   │ - let·foo·=·2;
+      2 │ + const·foo·=·2;
+    3 3 │   /**
+    4 4 │   * biome-ignore-all lint/style/useConst: reason
+  
+
+```
+
+```block
 file.js:2:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This variable is unused.
@@ -101,6 +129,33 @@ file.js:2:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━�
       2 │ + let·_foo·=·2;
     3 3 │   /**
     4 4 │   * biome-ignore-all lint/style/useConst: reason
+  
+
+```
+
+```block
+file.js:8:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+    6 │ */
+    7 │ debugger
+  > 8 │ let bar = 33;
+      │ ^^^
+  
+  i 'bar' is never reassigned.
+  
+    6 │ */
+    7 │ debugger
+  > 8 │ let bar = 33;
+      │     ^^^
+  
+  i Safe fix: Use const instead.
+  
+    6 6 │   */
+    7 7 │   debugger
+    8   │ - let·bar·=·33;
+      8 │ + const·bar·=·33;
   
 
 ```
@@ -155,5 +210,5 @@ file.js:7:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━�
 ```block
 Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
-Found 4 warnings.
+Found 6 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_suggested.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_suggested.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_suggested_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_suggested_error.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/apply_unsafe_with_error.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `test1.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -16,7 +16,7 @@ function _f() {
 ## `test2.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -31,7 +31,7 @@ test1.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^
@@ -47,7 +47,7 @@ test2.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fix_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fix_unsafe_with_error.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `test1.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -16,7 +16,7 @@ function _f() {
 ## `test2.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -31,7 +31,7 @@ test1.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^
@@ -47,7 +47,7 @@ test2.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_json.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_json_pretty.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_json_pretty.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/write_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/write_unsafe_with_error.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `test1.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -16,7 +16,7 @@ function _f() {
 ## `test2.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() {
 	arguments;
@@ -31,7 +31,7 @@ test1.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^
@@ -47,7 +47,7 @@ test2.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_runs_linter_not_formatter_issue_3495.snap
@@ -21,6 +21,27 @@ let a = !b || !c
 # Emitted Messages
 
 ```block
+file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ let a = !b || !c
+      │ ^^^
+  
+  i 'a' is never reassigned.
+  
+  > 1 │ let a = !b || !c
+      │     ^
+  
+  i Safe fix: Use const instead.
+  
+  - let·a·=·!b·||·!c
+  + const·a·=·!b·||·!c
+  
+
+```
+
+```block
 file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This variable is unused.
@@ -40,5 +61,5 @@ file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━�
 
 ```block
 Checked 1 file in <TIME>. No fixes applied.
-Found 1 warning.
+Found 2 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/correctly_handles_ignored_and_not_ignored_files.snap
@@ -50,6 +50,27 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+/formatter-ignored/test.js:1:19 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ statement(    ) ; let a = !b || !c;
+      │                   ^^^
+  
+  i 'a' is never reassigned.
+  
+  > 1 │ statement(    ) ; let a = !b || !c;
+      │                       ^
+  
+  i Safe fix: Use const instead.
+  
+  - statement(····)·;·let·a·=·!b·||·!c;
+  + statement(····)·;·const·a·=·!b·||·!c;
+  
+
+```
+
+```block
 /formatter-ignored/test.js:1:23 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This variable is unused.
@@ -82,5 +103,5 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ```block
 Checked 2 files in <TIME>. No fixes applied.
 Found 1 error.
-Found 1 warning.
+Found 2 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_suggested.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_suggested.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_suggested_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_suggested_error.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/apply_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/apply_unsafe_with_error.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `test1.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() { arguments; }
 
@@ -14,7 +14,7 @@ function _f() { arguments; }
 ## `test2.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() { arguments; }
 
@@ -27,7 +27,7 @@ test1.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^
@@ -43,7 +43,7 @@ test2.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fix_suggested.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fix_suggested.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `fix.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fix_unsafe_with_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fix_unsafe_with_error.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `test1.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() { arguments; }
 
@@ -14,7 +14,7 @@ function _f() { arguments; }
 ## `test2.js`
 
 ```js
-let a = 4;
+const a = 4;
 console.log(a);
 function _f() { arguments; }
 
@@ -27,7 +27,7 @@ test1.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^
@@ -43,7 +43,7 @@ test2.js:3:17 lint/style/noArguments ━━━━━━━━━━━━━━�
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ let a = 4;
+    1 │ const a = 4;
     2 │ console.log(a);
   > 3 │ function _f() { arguments; }
       │                 ^^^^^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_file_in_subdir_in_symlinked_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/ignore_file_in_subdir_in_symlinked_dir.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 # Termination Message
 
@@ -15,6 +14,33 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 # Emitted Messages
+
+```block
+<TEMP_DIR>/ignore_file_in_subdir_in_symlinked_dir/symlinked/subdir/file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ let a = 4;
+      │ ^^^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i 'a' is never reassigned.
+  
+  > 1 │ let a = 4;
+      │     ^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i Safe fix: Use const instead.
+  
+    1   │ - let·a·=·4;
+      1 │ + const·a·=·4;
+    2 2 │   debugger;
+    3 3 │   console.log(a);
+  
+
+```
 
 ```block
 <TEMP_DIR>/ignore_file_in_subdir_in_symlinked_dir/symlinked/subdir/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
@@ -40,4 +66,5 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 ```block
 Checked 2 files in <TIME>. No fixes applied.
 Found 1 error.
+Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_subdir.snap
@@ -16,6 +16,33 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
+subdir/file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ let a = 4;
+      │ ^^^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i 'a' is never reassigned.
+  
+  > 1 │ let a = 4;
+      │     ^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i Safe fix: Use const instead.
+  
+    1   │ - let·a·=·4;
+      1 │ + const·a·=·4;
+    2 2 │   debugger;
+    3 3 │   console.log(a);
+  
+
+```
+
+```block
 subdir/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This is an unexpected use of the debugger statement.
@@ -39,4 +66,5 @@ subdir/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━
 ```block
 Checked 2 files in <TIME>. No fixes applied.
 Found 1 error.
+Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -16,6 +16,33 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
+symlinked/file.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ let a = 4;
+      │ ^^^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i 'a' is never reassigned.
+  
+  > 1 │ let a = 4;
+      │     ^
+    2 │ debugger;
+    3 │ console.log(a);
+  
+  i Safe fix: Use const instead.
+  
+    1   │ - let·a·=·4;
+      1 │ + const·a·=·4;
+    2 2 │   debugger;
+    3 3 │   console.log(a);
+  
+
+```
+
+```block
 symlinked/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × This is an unexpected use of the debugger statement.
@@ -39,4 +66,5 @@ symlinked/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━
 ```block
 Checked 2 files in <TIME>. No fixes applied.
 Found 1 error.
+Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_config_up_to_date.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_config_up_to_date.snap
@@ -24,15 +24,14 @@ biome.json migrate ━━━━━━━━━━━━━━━━━━━━�
        6 │ + ········"useDefaultParameterLast":·"error",
        7 │ + ········"useEnumInitializers":·"error",
        8 │ + ········"useSelfClosingElements":·"error",
-       9 │ + ········"useConst":·"error",
-      10 │ + ········"useSingleVarDeclarator":·"error",
-      11 │ + ········"noUnusedTemplateLiteral":·"error",
-      12 │ + ········"useNumberNamespace":·"error",
-      13 │ + ········"noInferrableTypes":·"error",
-      14 │ + ········"noUselessElse":·"error"
-      15 │ + ······}
-      16 │ + ····}
-      17 │ + ··}·}
+       9 │ + ········"useSingleVarDeclarator":·"error",
+      10 │ + ········"noUnusedTemplateLiteral":·"error",
+      11 │ + ········"useNumberNamespace":·"error",
+      12 │ + ········"noInferrableTypes":·"error",
+      13 │ + ········"noUselessElse":·"error"
+      14 │ + ······}
+      15 │ + ····}
+      16 │ + ··}·}
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/should_migrate_nested_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/should_migrate_nested_files.snap
@@ -51,16 +51,15 @@ expression: redactor(content)
        8 │ + ········"useDefaultParameterLast":·"error",
        9 │ + ········"useEnumInitializers":·"error",
       10 │ + ········"useSelfClosingElements":·"error",
-      11 │ + ········"useConst":·"error",
-      12 │ + ········"useSingleVarDeclarator":·"error",
-      13 │ + ········"noUnusedTemplateLiteral":·"error",
-      14 │ + ········"useNumberNamespace":·"error",
-      15 │ + ········"noInferrableTypes":·"error",
-      16 │ + ········"noUselessElse":·"error"
-      17 │ + ······}
-    4 18 │       }
-      19 │ + ··}
-    5 20 │   }
+      11 │ + ········"useSingleVarDeclarator":·"error",
+      12 │ + ········"noUnusedTemplateLiteral":·"error",
+      13 │ + ········"useNumberNamespace":·"error",
+      14 │ + ········"noInferrableTypes":·"error",
+      15 │ + ········"noUselessElse":·"error"
+      16 │ + ······}
+    4 17 │       }
+      18 │ + ··}
+    5 19 │   }
   
 
 ```
@@ -82,16 +81,15 @@ expression: redactor(content)
        8 │ + ········"useDefaultParameterLast":·"error",
        9 │ + ········"useEnumInitializers":·"error",
       10 │ + ········"useSelfClosingElements":·"error",
-      11 │ + ········"useConst":·"error",
-      12 │ + ········"useSingleVarDeclarator":·"error",
-      13 │ + ········"noUnusedTemplateLiteral":·"error",
-      14 │ + ········"useNumberNamespace":·"error",
-      15 │ + ········"noInferrableTypes":·"error",
-      16 │ + ········"noUselessElse":·"error"
-      17 │ + ······}
-    4 18 │       }
-      19 │ + ··}
-    5 20 │   }
+      11 │ + ········"useSingleVarDeclarator":·"error",
+      12 │ + ········"noUnusedTemplateLiteral":·"error",
+      13 │ + ········"useNumberNamespace":·"error",
+      14 │ + ········"noInferrableTypes":·"error",
+      15 │ + ········"noUselessElse":·"error"
+      16 │ + ······}
+    4 17 │       }
+      18 │ + ··}
+    5 19 │   }
   
 
 ```
@@ -113,16 +111,15 @@ expression: redactor(content)
        8 │ + ········"useDefaultParameterLast":·"error",
        9 │ + ········"useEnumInitializers":·"error",
       10 │ + ········"useSelfClosingElements":·"error",
-      11 │ + ········"useConst":·"error",
-      12 │ + ········"useSingleVarDeclarator":·"error",
-      13 │ + ········"noUnusedTemplateLiteral":·"error",
-      14 │ + ········"useNumberNamespace":·"error",
-      15 │ + ········"noInferrableTypes":·"error",
-      16 │ + ········"noUselessElse":·"error"
-      17 │ + ······}
-    4 18 │       }
-      19 │ + ··}
-    5 20 │   }
+      11 │ + ········"useSingleVarDeclarator":·"error",
+      12 │ + ········"noUnusedTemplateLiteral":·"error",
+      13 │ + ········"useNumberNamespace":·"error",
+      14 │ + ········"noInferrableTypes":·"error",
+      15 │ + ········"noUselessElse":·"error"
+      16 │ + ······}
+    4 17 │       }
+      18 │ + ··}
+    5 19 │   }
   
 
 ```
@@ -144,16 +141,15 @@ expression: redactor(content)
        8 │ + ········"useDefaultParameterLast":·"error",
        9 │ + ········"useEnumInitializers":·"error",
       10 │ + ········"useSelfClosingElements":·"error",
-      11 │ + ········"useConst":·"error",
-      12 │ + ········"useSingleVarDeclarator":·"error",
-      13 │ + ········"noUnusedTemplateLiteral":·"error",
-      14 │ + ········"useNumberNamespace":·"error",
-      15 │ + ········"noInferrableTypes":·"error",
-      16 │ + ········"noUselessElse":·"error"
-      17 │ + ······}
-    4 18 │       }
-      19 │ + ··}
-    5 20 │   }
+      11 │ + ········"useSingleVarDeclarator":·"error",
+      12 │ + ········"noUnusedTemplateLiteral":·"error",
+      13 │ + ········"useNumberNamespace":·"error",
+      14 │ + ········"noInferrableTypes":·"error",
+      15 │ + ········"noUselessElse":·"error"
+      16 │ + ······}
+    4 17 │       }
+      18 │ + ··}
+    5 19 │   }
   
 
 ```

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -6147,6 +6147,7 @@ impl Style {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]),

--- a/crates/biome_js_analyze/src/lint/style/use_const.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_const.rs
@@ -78,7 +78,7 @@ declare_lint_rule! {
         name: "useConst",
         language: "js",
         sources: &[RuleSource::Eslint("prefer-const")],
-        recommended: false,
+        recommended: true,
         severity: Severity::Warning,
         fix_kind: FixKind::Safe,
     }

--- a/crates/biome_migrate/src/analyzers/style_rules.rs
+++ b/crates/biome_migrate/src/analyzers/style_rules.rs
@@ -20,7 +20,7 @@ declare_migration! {
     }
 }
 
-const STYLE_RULES_THAT_WERE_ERROR: [&str; 11] = [
+const STYLE_RULES_THAT_WERE_ERROR: [&str; 10] = [
     "useNumberNamespace",
     "useAsConstAssertion",
     "noParameterAssign",
@@ -29,7 +29,6 @@ const STYLE_RULES_THAT_WERE_ERROR: [&str; 11] = [
     "noUnusedTemplateLiteral",
     "useEnumInitializers",
     "noUselessElse",
-    "useConst",
     "useSelfClosingElements",
     "useSingleVarDeclarator",
 ];

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/empty.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/empty.json.snap
@@ -78,7 +78,7 @@ empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
 ```
 empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
   > 1 │ {
       │ ^
@@ -98,7 +98,7 @@ empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
        4 │ + ··"linter":·{
        5 │ + ····"rules":·{
        6 │ + ······"style":·{
-       7 │ + ········"useSingleVarDeclarator":·"error"
+       7 │ + ········"noUnusedTemplateLiteral":·"error"
        8 │ + ······}
        9 │ + ····}
       10 │ + ··}
@@ -174,6 +174,38 @@ empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
 ```
 empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+  > 1 │ {
+      │ ^
+  > 2 │   "formatter": {},
+  > 3 │   "javascript": {}
+  > 4 │ }
+      │ ^
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+    1  1 │   {
+    2  2 │     "formatter": {},
+    3    │ - ··"javascript":·{}
+       3 │ + ··"javascript":·{},
+       4 │ + ··"linter":·{
+       5 │ + ····"rules":·{
+       6 │ + ······"style":·{
+       7 │ + ········"useSingleVarDeclarator":·"error"
+       8 │ + ······}
+       9 │ + ····}
+      10 │ + ··}
+    4 11 │   }
+  
+
+```
+
+```
+empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
   > 1 │ {
@@ -195,70 +227,6 @@ empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
        5 │ + ····"rules":·{
        6 │ + ······"style":·{
        7 │ + ········"useNumberNamespace":·"error"
-       8 │ + ······}
-       9 │ + ····}
-      10 │ + ··}
-    4 11 │   }
-  
-
-```
-
-```
-empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "formatter": {},
-  > 3 │   "javascript": {}
-  > 4 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    1  1 │   {
-    2  2 │     "formatter": {},
-    3    │ - ··"javascript":·{}
-       3 │ + ··"javascript":·{},
-       4 │ + ··"linter":·{
-       5 │ + ····"rules":·{
-       6 │ + ······"style":·{
-       7 │ + ········"useConst":·"error"
-       8 │ + ······}
-       9 │ + ····}
-      10 │ + ··}
-    4 11 │   }
-  
-
-```
-
-```
-empty.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "formatter": {},
-  > 3 │   "javascript": {}
-  > 4 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    1  1 │   {
-    2  2 │     "formatter": {},
-    3    │ - ··"javascript":·{}
-       3 │ + ··"javascript":·{},
-       4 │ + ··"linter":·{
-       5 │ + ····"rules":·{
-       6 │ + ······"style":·{
-       7 │ + ········"noUnusedTemplateLiteral":·"error"
        8 │ + ······}
        9 │ + ····}
       10 │ + ··}

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/realCase.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/realCase.json.snap
@@ -93,7 +93,7 @@ realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━�
 ```
 realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
    > 1 │ {
        │ ^
@@ -115,7 +115,7 @@ realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━�
     10 10 │           "noNonNullAssertion": "off",
     11    │ - ········"useNodejsImportProtocol":·"error"
        11 │ + ········"useNodejsImportProtocol":·"error",
-       12 │ + ········"useSingleVarDeclarator":·"error"
+       12 │ + ········"noUnusedTemplateLiteral":·"error"
     12 13 │         },
     13 14 │         "suspicious": {
   
@@ -189,6 +189,38 @@ realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━�
 ```
 realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+   > 1 │ {
+       │ ^
+   > 2 │   "linter": {
+   > 3 │     "enabled": true,
+   > 4 │     "rules": {
+        ...
+  > 16 │     }
+  > 17 │   }
+  > 18 │ }
+       │ ^
+    19 │ 
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+     9  9 │         "style": {
+    10 10 │           "noNonNullAssertion": "off",
+    11    │ - ········"useNodejsImportProtocol":·"error"
+       11 │ + ········"useNodejsImportProtocol":·"error",
+       12 │ + ········"useSingleVarDeclarator":·"error"
+    12 13 │         },
+    13 14 │         "suspicious": {
+  
+
+```
+
+```
+realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
    > 1 │ {
@@ -212,70 +244,6 @@ realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━�
     11    │ - ········"useNodejsImportProtocol":·"error"
        11 │ + ········"useNodejsImportProtocol":·"error",
        12 │ + ········"useNumberNamespace":·"error"
-    12 13 │         },
-    13 14 │         "suspicious": {
-  
-
-```
-
-```
-realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "linter": {
-   > 3 │     "enabled": true,
-   > 4 │     "rules": {
-        ...
-  > 16 │     }
-  > 17 │   }
-  > 18 │ }
-       │ ^
-    19 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-     9  9 │         "style": {
-    10 10 │           "noNonNullAssertion": "off",
-    11    │ - ········"useNodejsImportProtocol":·"error"
-       11 │ + ········"useNodejsImportProtocol":·"error",
-       12 │ + ········"useConst":·"error"
-    12 13 │         },
-    13 14 │         "suspicious": {
-  
-
-```
-
-```
-realCase.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "linter": {
-   > 3 │     "enabled": true,
-   > 4 │     "rules": {
-        ...
-  > 16 │     }
-  > 17 │   }
-  > 18 │ }
-       │ ^
-    19 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-     9  9 │         "style": {
-    10 10 │           "noNonNullAssertion": "off",
-    11    │ - ········"useNodejsImportProtocol":·"error"
-       11 │ + ········"useNodejsImportProtocol":·"error",
-       12 │ + ········"noUnusedTemplateLiteral":·"error"
     12 13 │         },
     13 14 │         "suspicious": {
   

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/valid.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/valid.json.snap
@@ -103,7 +103,7 @@ valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
 ```
 valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
    > 1 │ {
        │ ^
@@ -128,7 +128,7 @@ valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
        16 │ + ··"linter":·{
        17 │ + ····"rules":·{
        18 │ + ······"style":·{
-       19 │ + ········"useSingleVarDeclarator":·"error"
+       19 │ + ········"noUnusedTemplateLiteral":·"error"
        20 │ + ······}
        21 │ + ····}
        22 │ + ··}
@@ -217,6 +217,44 @@ valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
 ```
 valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+   > 1 │ {
+       │ ^
+   > 2 │   "files": {
+   > 3 │     "ignore": ["./src/**/*.graphql.ts"]
+   > 4 │   },
+        ...
+  > 14 │     "jsxRuntime": "reactClassic"
+  > 15 │   }
+  > 16 │ }
+       │ ^
+    17 │ 
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+    13 13 │       },
+    14 14 │       "jsxRuntime": "reactClassic"
+    15    │ - ··}
+       15 │ + ··},
+       16 │ + ··"linter":·{
+       17 │ + ····"rules":·{
+       18 │ + ······"style":·{
+       19 │ + ········"useSingleVarDeclarator":·"error"
+       20 │ + ······}
+       21 │ + ····}
+       22 │ + ··}
+    16 23 │   }
+    17 24 │   
+  
+
+```
+
+```
+valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
    > 1 │ {
@@ -243,82 +281,6 @@ valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━�
        17 │ + ····"rules":·{
        18 │ + ······"style":·{
        19 │ + ········"useNumberNamespace":·"error"
-       20 │ + ······}
-       21 │ + ····}
-       22 │ + ··}
-    16 23 │   }
-    17 24 │   
-  
-
-```
-
-```
-valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "files": {
-   > 3 │     "ignore": ["./src/**/*.graphql.ts"]
-   > 4 │   },
-        ...
-  > 14 │     "jsxRuntime": "reactClassic"
-  > 15 │   }
-  > 16 │ }
-       │ ^
-    17 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    13 13 │       },
-    14 14 │       "jsxRuntime": "reactClassic"
-    15    │ - ··}
-       15 │ + ··},
-       16 │ + ··"linter":·{
-       17 │ + ····"rules":·{
-       18 │ + ······"style":·{
-       19 │ + ········"useConst":·"error"
-       20 │ + ······}
-       21 │ + ····}
-       22 │ + ··}
-    16 23 │   }
-    17 24 │   
-  
-
-```
-
-```
-valid.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "files": {
-   > 3 │     "ignore": ["./src/**/*.graphql.ts"]
-   > 4 │   },
-        ...
-  > 14 │     "jsxRuntime": "reactClassic"
-  > 15 │   }
-  > 16 │ }
-       │ ^
-    17 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    13 13 │       },
-    14 14 │       "jsxRuntime": "reactClassic"
-    15    │ - ··}
-       15 │ + ··},
-       16 │ + ··"linter":·{
-       17 │ + ····"rules":·{
-       18 │ + ······"style":·{
-       19 │ + ········"noUnusedTemplateLiteral":·"error"
        20 │ + ······}
        21 │ + ····}
        22 │ + ··}

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_linter.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_linter.json.snap
@@ -71,7 +71,7 @@ with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
 ```
 with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
   > 1 │ {
       │ ^
@@ -88,7 +88,7 @@ with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
       2 │ + ··"linter":·{
       3 │ + ····"rules":·{
       4 │ + ······"style":·{
-      5 │ + ········"useSingleVarDeclarator":·"error"
+      5 │ + ········"noUnusedTemplateLiteral":·"error"
       6 │ + ······}
       7 │ + ····}
       8 │ + ··}
@@ -158,6 +158,35 @@ with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
 ```
 with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+  > 1 │ {
+      │ ^
+  > 2 │   "linter": {}
+  > 3 │ }
+      │ ^
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+    1 1 │   {
+    2   │ - ··"linter":·{}
+      2 │ + ··"linter":·{
+      3 │ + ····"rules":·{
+      4 │ + ······"style":·{
+      5 │ + ········"useSingleVarDeclarator":·"error"
+      6 │ + ······}
+      7 │ + ····}
+      8 │ + ··}
+    3 9 │   }
+  
+
+```
+
+```
+with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
   > 1 │ {
@@ -176,64 +205,6 @@ with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
       3 │ + ····"rules":·{
       4 │ + ······"style":·{
       5 │ + ········"useNumberNamespace":·"error"
-      6 │ + ······}
-      7 │ + ····}
-      8 │ + ··}
-    3 9 │   }
-  
-
-```
-
-```
-with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {}
-  > 3 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    1 1 │   {
-    2   │ - ··"linter":·{}
-      2 │ + ··"linter":·{
-      3 │ + ····"rules":·{
-      4 │ + ······"style":·{
-      5 │ + ········"useConst":·"error"
-      6 │ + ······}
-      7 │ + ····}
-      8 │ + ··}
-    3 9 │   }
-  
-
-```
-
-```
-with_existing_linter.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {}
-  > 3 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    1 1 │   {
-    2   │ - ··"linter":·{}
-      2 │ + ··"linter":·{
-      3 │ + ····"rules":·{
-      4 │ + ······"style":·{
-      5 │ + ········"noUnusedTemplateLiteral":·"error"
       6 │ + ······}
       7 │ + ····}
       8 │ + ··}

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_rules.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_rules.json.snap
@@ -81,7 +81,7 @@ with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━
 ```
 with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
   > 1 │ {
       │ ^
@@ -102,7 +102,7 @@ with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━
     4    │ - ······"recommended":·true
        4 │ + ······"recommended":·true,
        5 │ + ······"style":·{
-       6 │ + ········"useSingleVarDeclarator":·"error"
+       6 │ + ········"noUnusedTemplateLiteral":·"error"
        7 │ + ······}
     5  8 │       }
     6  9 │     }
@@ -177,6 +177,38 @@ with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━
 ```
 with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+  > 1 │ {
+      │ ^
+  > 2 │   "linter": {
+  > 3 │     "rules": {
+  > 4 │       "recommended": true
+  > 5 │     }
+  > 6 │   }
+  > 7 │ }
+      │ ^
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+    2  2 │     "linter": {
+    3  3 │       "rules": {
+    4    │ - ······"recommended":·true
+       4 │ + ······"recommended":·true,
+       5 │ + ······"style":·{
+       6 │ + ········"useSingleVarDeclarator":·"error"
+       7 │ + ······}
+    5  8 │       }
+    6  9 │     }
+  
+
+```
+
+```
+with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
   > 1 │ {
@@ -199,70 +231,6 @@ with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━
        4 │ + ······"recommended":·true,
        5 │ + ······"style":·{
        6 │ + ········"useNumberNamespace":·"error"
-       7 │ + ······}
-    5  8 │       }
-    6  9 │     }
-  
-
-```
-
-```
-with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {
-  > 3 │     "rules": {
-  > 4 │       "recommended": true
-  > 5 │     }
-  > 6 │   }
-  > 7 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    2  2 │     "linter": {
-    3  3 │       "rules": {
-    4    │ - ······"recommended":·true
-       4 │ + ······"recommended":·true,
-       5 │ + ······"style":·{
-       6 │ + ········"useConst":·"error"
-       7 │ + ······}
-    5  8 │       }
-    6  9 │     }
-  
-
-```
-
-```
-with_existing_rules.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {
-  > 3 │     "rules": {
-  > 4 │       "recommended": true
-  > 5 │     }
-  > 6 │   }
-  > 7 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    2  2 │     "linter": {
-    3  3 │       "rules": {
-    4    │ - ······"recommended":·true
-       4 │ + ······"recommended":·true,
-       5 │ + ······"style":·{
-       6 │ + ········"noUnusedTemplateLiteral":·"error"
        7 │ + ······}
     5  8 │       }
     6  9 │     }

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_style_rule.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_style_rule.json.snap
@@ -90,6 +90,38 @@ with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━�
 ```
 with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule noInferrableTypes isn't recommended anymore.
+  
+   > 1 │ {
+       │ ^
+   > 2 │   "linter": {
+   > 3 │     "rules": {
+   > 4 │       "recommended": true,
+        ...
+  > 13 │     }
+  > 14 │   }
+  > 15 │ }
+       │ ^
+    16 │ 
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+     9  9 │           "useShorthandFunctionType": "warn",
+    10 10 │           "useExportType":  "warn",
+    11    │ - ········"useDefaultParameterLast":·"warn"
+       11 │ + ········"useDefaultParameterLast":·"warn",
+       12 │ + ········"noInferrableTypes":·"error"
+    12 13 │         }
+    13 14 │       }
+  
+
+```
+
+```
+with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
    > 1 │ {
@@ -186,70 +218,6 @@ with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━�
 ```
 with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule noInferrableTypes isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "linter": {
-   > 3 │     "rules": {
-   > 4 │       "recommended": true,
-        ...
-  > 13 │     }
-  > 14 │   }
-  > 15 │ }
-       │ ^
-    16 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-     9  9 │           "useShorthandFunctionType": "warn",
-    10 10 │           "useExportType":  "warn",
-    11    │ - ········"useDefaultParameterLast":·"warn"
-       11 │ + ········"useDefaultParameterLast":·"warn",
-       12 │ + ········"noInferrableTypes":·"error"
-    12 13 │         }
-    13 14 │       }
-  
-
-```
-
-```
-with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
-  
-   > 1 │ {
-       │ ^
-   > 2 │   "linter": {
-   > 3 │     "rules": {
-   > 4 │       "recommended": true,
-        ...
-  > 13 │     }
-  > 14 │   }
-  > 15 │ }
-       │ ^
-    16 │ 
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-     9  9 │           "useShorthandFunctionType": "warn",
-    10 10 │           "useExportType":  "warn",
-    11    │ - ········"useDefaultParameterLast":·"warn"
-       11 │ + ········"useDefaultParameterLast":·"warn",
-       12 │ + ········"useSingleVarDeclarator":·"error"
-    12 13 │         }
-    13 14 │       }
-  
-
-```
-
-```
-with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
   ! Biome style rule useEnumInitializers isn't recommended anymore.
   
    > 1 │ {
@@ -282,7 +250,7 @@ with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━�
 ```
 with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useConst isn't recommended anymore.
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
   
    > 1 │ {
        │ ^
@@ -304,7 +272,7 @@ with_existing_style_rule.json:1:1 migrate  FIXABLE  ━━━━━━━━━�
     10 10 │           "useExportType":  "warn",
     11    │ - ········"useDefaultParameterLast":·"warn"
        11 │ + ········"useDefaultParameterLast":·"warn",
-       12 │ + ········"useConst":·"error"
+       12 │ + ········"useSingleVarDeclarator":·"error"
     12 13 │         }
     13 14 │       }
   

--- a/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_styles.json.snap
+++ b/crates/biome_migrate/tests/specs/migrations/styleRules/with_existing_styles.json.snap
@@ -82,7 +82,7 @@ with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
 ```
 with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
   
   > 1 │ {
       │ ^
@@ -103,7 +103,7 @@ with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
     4  4 │         "recommended": true,
     5    │ - ······"style":·{}
        5 │ + ······"style":·{
-       6 │ + ········"useSingleVarDeclarator":·"error"
+       6 │ + ········"noUnusedTemplateLiteral":·"error"
        7 │ + ······}
     6  8 │       }
     7  9 │     }
@@ -178,6 +178,38 @@ with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
 ```
 with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  ! Biome style rule useSingleVarDeclarator isn't recommended anymore.
+  
+  > 1 │ {
+      │ ^
+  > 2 │   "linter": {
+  > 3 │     "rules": {
+  > 4 │       "recommended": true,
+  > 5 │       "style": {}
+  > 6 │     }
+  > 7 │   }
+  > 8 │ }
+      │ ^
+  
+  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
+  
+  i Safe fix: Update the configuration to enable these rules.
+  
+    3  3 │       "rules": {
+    4  4 │         "recommended": true,
+    5    │ - ······"style":·{}
+       5 │ + ······"style":·{
+       6 │ + ········"useSingleVarDeclarator":·"error"
+       7 │ + ······}
+    6  8 │       }
+    7  9 │     }
+  
+
+```
+
+```
+with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
   ! Biome style rule useNumberNamespace isn't recommended anymore.
   
   > 1 │ {
@@ -200,70 +232,6 @@ with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━�
     5    │ - ······"style":·{}
        5 │ + ······"style":·{
        6 │ + ········"useNumberNamespace":·"error"
-       7 │ + ······}
-    6  8 │       }
-    7  9 │     }
-  
-
-```
-
-```
-with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule useConst isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {
-  > 3 │     "rules": {
-  > 4 │       "recommended": true,
-  > 5 │       "style": {}
-  > 6 │     }
-  > 7 │   }
-  > 8 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    3  3 │       "rules": {
-    4  4 │         "recommended": true,
-    5    │ - ······"style":·{}
-       5 │ + ······"style":·{
-       6 │ + ········"useConst":·"error"
-       7 │ + ······}
-    6  8 │       }
-    7  9 │     }
-  
-
-```
-
-```
-with_existing_styles.json:1:1 migrate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! Biome style rule noUnusedTemplateLiteral isn't recommended anymore.
-  
-  > 1 │ {
-      │ ^
-  > 2 │   "linter": {
-  > 3 │     "rules": {
-  > 4 │       "recommended": true,
-  > 5 │       "style": {}
-  > 6 │     }
-  > 7 │   }
-  > 8 │ }
-      │ ^
-  
-  i To avoid regressions with your code base, Biome will update the configuration file to maintain the compatibility with your current setup.
-  
-  i Safe fix: Update the configuration to enable these rules.
-  
-    3  3 │       "rules": {
-    4  4 │         "recommended": true,
-    5    │ - ······"style":·{}
-       5 │ + ······"style":·{
-       6 │ + ········"noUnusedTemplateLiteral":·"error"
        7 │ + ······}
     6  8 │       }
     7  9 │     }


### PR DESCRIPTION
## Summary

Recommend `useConst`.
Note that we don't have to document this change because `useCOnst` is recommended in v1.94.
Its removal of the recommended rule set was part of an initial change in Biome v2 to make Biome less opinionated.
All recommended rules from the `style` group was then unremmended.
Since we recommended some of them again.
I think `useConst` should also be recommended because it is generally assumed that it is a good practice of using `useCOnst`. Moreover, it can detect some situation where a `let` variable is unchanged while it was intended to.

## Test Plan

I updated the snapshots