### PR TITLE
chore(renovate): ignore rust in the github-actions group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,9 @@
       "groupName": "github-actions",
       "matchManagers": [
         "github-actions"
+      ],
+      "matchDepNames": [
+        "!rust"
       ]
     },
     {


### PR DESCRIPTION
## Summary

The `rust` dependency is incorrectly included in the `github-actions` group as the Rust container image is referred in release workflows. However, we want to update `rust` as well as `rust-toolchain.toml` and `Dockerfile`. Added `rust` to the exclusion list of `depName` in the `github-actions` group to ensure the dependency is grouped individually.

## Test Plan

N/A
