### PR TITLE
fix(linter): noFloatingPromises detects "maybe" Promises

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -180,7 +180,9 @@ impl Rule for NoFloatingPromises {
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");
-        if !ty.is_promise_instance() {
+        let is_maybe_promise =
+            ty.is_promise_instance() || ty.has_variant(|ty| ty.is_promise_instance());
+        if !is_maybe_promise {
             return None;
         }
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -335,3 +335,13 @@ async function testDestructuringAndCallingReturnsPromiseFromRest({
 import("some-module").then(() => {});
 
 returnPromiseResult();
+
+function returnMaybePromise(): Promise<void> | undefined {
+	if (!false) {
+		return;
+	}
+
+	return Promise.resolve();
+}
+
+returnMaybePromise();

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -342,6 +342,16 @@ import("some-module").then(() => {});
 
 returnPromiseResult();
 
+function returnMaybePromise(): Promise<void> | undefined {
+	if (!false) {
+		return;
+	}
+
+	return Promise.resolve();
+}
+
+returnMaybePromise();
+
 ```
 
 # Diagnostics
@@ -1604,6 +1614,23 @@ invalid.ts:337:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
   > 337 │ returnPromiseResult();
         │ ^^^^^^^^^^^^^^^^^^^^^^
     338 │ 
+    339 │ function returnMaybePromise(): Promise<void> | undefined {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:347:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    345 │ }
+    346 │ 
+  > 347 │ returnMaybePromise();
+        │ ^^^^^^^^^^^^^^^^^^^^^
+    348 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -95,6 +95,21 @@ impl Type {
         self.id.id()
     }
 
+    /// Returns `true` if this type represents a **union type** that has a
+    /// variant for which the given `predicate` returns `true`.
+    ///
+    /// Returns `false` otherwise.
+    pub fn has_variant(&self, predicate: impl Fn(Self) -> bool) -> bool {
+        match self.deref() {
+            TypeData::Union(union) => union
+                .types()
+                .iter()
+                .filter_map(|ty| self.resolve(ty))
+                .any(predicate),
+            _ => false,
+        }
+    }
+
     /// Returns whether this type is the `Promise` class.
     pub fn is_promise(&self) -> bool {
         self.id.is_global() && self.id() == PROMISE_ID


### PR DESCRIPTION
## Summary

Sometimes a statement resolves not just to `Promise`, but to `Promise | undefined`, or another union that includes a `Promise`. Such statements should be awaited too for proper handling, so `noFloatingPromises` will now trigger on those too.

## Test Plan

Test case added.
