### PR TITLE
chore: add test case for config `extends` in `biome_cli`

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_from_npm_package.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_from_npm_package.snap
@@ -1,0 +1,80 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `node_modules/@shared/linter/biome.jsonc`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
+## `biome.json`
+
+```json
+{ "extends": ["@shared/format/biome", "@shared/linter/biome"] }
+```
+
+## `node_modules/@shared/format/biome.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `node_modules/@shared/format/package.json`
+
+```json
+{
+    "name": "@shared/format",
+    "exports": {
+        "./biome": "./biome.json"
+    }
+}
+```
+
+## `node_modules/@shared/linter/package.json`
+
+```json
+{
+    "name": "@shared/linter",
+    "exports": {
+        "./biome": "./biome.jsonc"
+    }
+}
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - debugger;·console.log("string");·
+      1 │ + debugger;
+      2 │ + console.log('string');
+      3 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```


### PR DESCRIPTION
## Summary

Adds an e2e test case for extending configs from NPM packages with the new resolver.

## Test Plan

It should pass.
