### PR TITLE
fix(core): don't ignore required files

### DIFF
--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -149,9 +149,20 @@ impl BiomePath {
     pub fn is_dir(&self) -> bool {
         matches!(self.kind, FileKinds::Directory)
     }
+
     #[inline(always)]
     pub fn is_handleable(&self) -> bool {
         matches!(self.kind, FileKinds::Handleable)
+    }
+
+    /// Returns `true` for file types that must be scanned (if the scanner is
+    /// enabled) because Biome's own functionality relies on them.
+    #[inline(always)]
+    pub fn is_required_during_scan(&self) -> bool {
+        matches!(
+            self.kind,
+            FileKinds::Config | FileKinds::Ignore | FileKinds::Manifest
+        )
     }
 
     /// Returns `true` if the path is inside `node_modules`

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -16,7 +16,7 @@ use crate::workspace::DocumentFileSource;
 use crate::{Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
 use biome_diagnostics::{Diagnostic as _, Error, Severity};
-use biome_fs::{BiomePath, PathInterner, TraversalContext, TraversalScope};
+use biome_fs::{BiomePath, PathInterner, PathKind, TraversalContext, TraversalScope};
 use camino::Utf8Path;
 use crossbeam::channel::{Receiver, Sender, unbounded};
 use std::collections::BTreeSet;
@@ -268,7 +268,7 @@ impl TraversalContext for ScanContext<'_> {
         }
 
         match self.workspace.fs().symlink_path_kind(path) {
-            Ok(path_kind) if path_kind.is_dir() => {
+            Ok(PathKind::Directory { .. }) => {
                 if self.scan_kind.is_project() && path.is_dependency() {
                     // In project mode, the scanner always scans dependencies
                     // because they're a valuable source of type information.
@@ -286,17 +286,19 @@ impl TraversalContext for ScanContext<'_> {
                         .unwrap_or_default()
                 }
             }
-            Ok(path_kind) if path_kind.is_file() => {
-                if self.scan_kind.is_known_files() {
-                    (path.is_ignore() || path.is_config() || path.is_manifest())
-                        && !path.is_dependency()
-                } else if path.is_dependency() {
-                    path.is_package_json() || path.is_type_declaration()
-                } else {
-                    DocumentFileSource::try_from_path(path).is_ok() || path.is_ignore()
+            Ok(PathKind::File { .. }) => match self.scan_kind {
+                ScanKind::KnownFiles => path.is_required_during_scan() && !path.is_dependency(),
+                ScanKind::Project => {
+                    if path.is_dependency() {
+                        path.is_package_json() || path.is_type_declaration()
+                    } else {
+                        path.is_required_during_scan()
+                            || DocumentFileSource::try_from_path(path).is_ok()
+                    }
                 }
-            }
-            _ => {
+                ScanKind::None => false,
+            },
+            Err(_) => {
                 // bail on fifo and socket files
                 false
             }
@@ -322,18 +324,33 @@ impl TraversalContext for ScanContext<'_> {
 /// so panics are caught, and diagnostics are submitted in case of panic too.
 fn open_file(ctx: &ScanContext, path: &BiomePath) {
     match catch_unwind(move || {
-        let is_ignored = ctx
-            .workspace
-            .is_path_ignored(IsPathIgnoredParams {
-                project_key: ctx.project_key,
-                path: path.clone(),
-                features: FeaturesBuilder::new().build(),
-            })
-            .unwrap_or_default();
-
+        let is_ignored = if path.is_required_during_scan() {
+            // Required files are only ignored if they are in an ignored
+            // directory.
+            path.parent()
+                .and_then(|dir_path| {
+                    ctx.workspace
+                        .is_path_ignored(IsPathIgnoredParams {
+                            project_key: ctx.project_key,
+                            path: dir_path.into(),
+                            features: FeaturesBuilder::new().build(),
+                        })
+                        .ok()
+                })
+                .unwrap_or_default()
+        } else {
+            ctx.workspace
+                .is_path_ignored(IsPathIgnoredParams {
+                    project_key: ctx.project_key,
+                    path: path.clone(),
+                    features: FeaturesBuilder::new().build(),
+                })
+                .unwrap_or_default()
+        };
         if is_ignored {
             return Ok(());
         }
+
         ctx.workspace
             .open_file_during_initial_scan(ctx.project_key, path.clone())
     }) {

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -324,7 +324,9 @@ impl TraversalContext for ScanContext<'_> {
 /// so panics are caught, and diagnostics are submitted in case of panic too.
 fn open_file(ctx: &ScanContext, path: &BiomePath) {
     match catch_unwind(move || {
-        let is_ignored = if path.is_required_during_scan() {
+        let is_ignored = if ctx.scan_kind.is_project() && path.is_dependency() {
+            !(path.is_package_json() || path.is_type_declaration())
+        } else if path.is_required_during_scan() {
             // Required files are only ignored if they are in an ignored
             // directory.
             path.parent()

--- a/crates/biome_service/tests/fixtures/with_ignored_required_files/.gitignore
+++ b/crates/biome_service/tests/fixtures/with_ignored_required_files/.gitignore
@@ -1,0 +1,2 @@
+!dist
+!node_modules

--- a/crates/biome_service/tests/fixtures/with_ignored_required_files/biome.jsonc
+++ b/crates/biome_service/tests/fixtures/with_ignored_required_files/biome.jsonc
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "files": {
+    "includes": [
+      "**/*.js",
+      "!dist",
+      "!node_modules"
+    ]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "correctness": {
+        "noUndeclaredDependencies": "error"
+      }
+    }
+  },
+  "vcs": {
+    "clientKind": "git",
+    "enabled": true,
+    "useIgnoreFile": true
+  }
+}

--- a/crates/biome_service/tests/fixtures/with_ignored_required_files/dist/package.json
+++ b/crates/biome_service/tests/fixtures/with_ignored_required_files/dist/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "with_ignored_required_files_dist",
+    "dependencies": {
+        "declared": "0.1.0"
+    }
+}

--- a/crates/biome_service/tests/fixtures/with_ignored_required_files/file.js
+++ b/crates/biome_service/tests/fixtures/with_ignored_required_files/file.js
@@ -1,0 +1,5 @@
+import { declared } from "declared";
+
+function f() {
+
+}

--- a/crates/biome_service/tests/fixtures/with_ignored_required_files/package.json
+++ b/crates/biome_service/tests/fixtures/with_ignored_required_files/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "with_ignored_required_files",
+    "dependencies": {
+        "declared": "0.1.0"
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6089. Also fixes an issue in our own CI: https://github.com/biomejs/biome/actions/runs/15120815401/job/42502525360?pr=6090

Now that we respect users `files.includes` and ignore settings better, we should also be even more careful to always load relevant manifests and other required files, _even when those are excluded by the users settings_. To fix this, we check whether required files are part of an ignored directory, and only ignore them when this is the case. Whether the file itself is ignored in the configuration is then irrelevant in such cases.

## Test Plan

Added another test.
