### PR TITLE
refactor: module type and type member refactoring

### DIFF
--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -1,10 +1,10 @@
 use crate::globals::global_type_name;
 use crate::{
-    CallArgumentType, CallSignatureTypeMember, Class, DestructureField, Function,
-    FunctionParameter, FunctionParameterBinding, GenericTypeParameter, ImportSymbol, Literal,
-    MethodTypeMember, NUM_PREDEFINED_TYPES, Object, ObjectLiteral, PropertyTypeMember, ReturnType,
-    Type, TypeData, TypeImportQualifier, TypeInstance, TypeMember, TypeReference,
-    TypeReferenceQualifier, TypeResolverLevel, TypeofAwaitExpression, TypeofExpression, Union,
+    CallArgumentType, Class, DestructureField, Function, FunctionParameter,
+    FunctionParameterBinding, GenericTypeParameter, ImportSymbol, Literal, NUM_PREDEFINED_TYPES,
+    Object, ObjectLiteral, ReturnType, Type, TypeData, TypeImportQualifier, TypeInstance,
+    TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolverLevel,
+    TypeofAwaitExpression, TypeofExpression, Union,
 };
 use biome_formatter::prelude::*;
 use biome_formatter::{
@@ -95,6 +95,7 @@ impl Format<FormatTypeContext> for TypeData {
             Self::Class(class) => write!(f, [&class.as_ref()]),
             Self::Constructor(ty) => write!(f, [FmtVerbatim(ty.as_ref())]),
             Self::Function(function) => write!(f, [&function.as_ref()]),
+            Self::Module(ty) => write!(f, [FmtVerbatim(ty.as_ref())]),
             Self::Namespace(ty) => write!(f, [FmtVerbatim(ty.as_ref())]),
             Self::Object(object) => write!(f, [object.as_ref()]),
             Self::Tuple(ty) => write!(f, [FmtVerbatim(&ty.as_ref())]),
@@ -142,9 +143,7 @@ impl Format<FormatTypeContext> for Object {
                     hard_line_break(),
                     text("members:"),
                     space(),
-                    text("{"),
                     FmtTypeMembers(self.members.as_ref()),
-                    text("}"),
                 ])),
                 text("}")
             ]]
@@ -280,24 +279,35 @@ impl Format<FormatTypeContext> for FunctionParameter {
 
 impl Format<FormatTypeContext> for TypeMember {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
+        let format_static = format_with(|f| {
+            if self.is_static() {
+                write!(f, [text("static"), space()])
+            } else {
+                Ok(())
+            }
+        });
+
+        write!(
+            f,
+            [&format_args![
+                format_static,
+                &self.kind,
+                text(":"),
+                space(),
+                &group(&soft_block_indent(&self.ty)),
+            ]]
+        )
+    }
+}
+
+impl Format<FormatTypeContext> for TypeMemberKind {
+    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
         match self {
-            Self::CallSignature(ty) => {
-                write!(
-                    f,
-                    [&format_args![
-                        text("CallSignature"),
-                        text("("),
-                        &group(&soft_block_indent(&ty)),
-                        text(")")
-                    ]]
-                )
-            }
-            Self::Constructor(ty) => write!(f, [FmtVerbatim(&ty)]),
-            Self::Method(method) => {
-                write!(f, [&format_args![&method]])
-            }
-            Self::Property(property) => {
-                write!(f, [&format_args![&property]])
+            Self::CallSignature => write!(f, [text("()")]),
+            Self::Constructor => write!(f, [text("constructor")]),
+            Self::Named(name) => {
+                let quoted = std::format!("\"{name}\"");
+                write!(f, [dynamic_text(&quoted, TextSize::default())])
             }
         }
     }
@@ -310,7 +320,7 @@ impl Format<FormatTypeContext> for TypeofAwaitExpression {
     ) -> FormatResult<()> {
         write!(
             f,
-            [&format_args![group(&soft_block_indent(&self.argument)),]]
+            [&format_args![group(&soft_block_indent(&self.argument))]]
         )
     }
 }
@@ -395,102 +405,6 @@ impl Format<FormatTypeContext> for TypeofExpression {
             Self::Super(_) => write!(f, [&format_args![text("super")]]),
             Self::This(_) => write!(f, [&format_args![text("this")]]),
         }
-    }
-}
-
-impl Format<FormatTypeContext> for PropertyTypeMember {
-    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        let is_optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("optional")]])
-            } else {
-                write!(f, [&format_args![text("required")]])
-            }
-        });
-        write!(
-            f,
-            [&format_args![
-                is_optional,
-                space(),
-                text("property"),
-                space(),
-                dynamic_text(&std::format!("\"{}\"", &self.name), TextSize::default()),
-                text(":"),
-                space(),
-                group(&soft_block_indent(&self.ty))
-            ]]
-        )
-    }
-}
-
-impl Format<FormatTypeContext> for MethodTypeMember {
-    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        let is_async = format_with(|f| {
-            if self.is_async {
-                write!(f, [&format_args![text("async")]])
-            } else {
-                write!(f, [&format_args![text("sync")]])
-            }
-        });
-
-        let is_optional = format_with(|f| {
-            if self.is_optional {
-                write!(f, [&format_args![text("optional")]])
-            } else {
-                write!(f, [&format_args![text("required")]])
-            }
-        });
-        write!(
-            f,
-            [&format_args![
-                is_optional,
-                space(),
-                is_async,
-                space(),
-                text("method"),
-                space(),
-                dynamic_text(&std::format!("\"{}\"", &self.name), TextSize::default()),
-                space(),
-                text("{"),
-                &group(&soft_block_indent(&format_args![
-                    text("accepts:"),
-                    space(),
-                    text("{"),
-                    &group(&block_indent(&format_args![
-                        text("params:"),
-                        space(),
-                        FmtFunctionParameters(&self.parameters),
-                        hard_line_break(),
-                        text("type_args:"),
-                        space(),
-                        FmtGenericTypeParameters(&self.type_parameters),
-                    ])),
-                    text("}"),
-                    hard_line_break(),
-                    text("returns:"),
-                    space(),
-                    &self.return_type,
-                    space(),
-                ])),
-                text("}"),
-            ]]
-        )
-    }
-}
-
-impl Format<FormatTypeContext> for CallSignatureTypeMember {
-    fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        write!(
-            f,
-            [&format_args![
-                FmtGenericTypeParameters(&self.type_parameters),
-                FmtFunctionParameters(&self.parameters),
-                text("ReturnType"),
-                text("("),
-                group(&soft_block_indent(&self.return_type)),
-                text(")")
-            ]]
-        )
     }
 }
 
@@ -835,14 +749,12 @@ struct FmtTypeMembers<'a>(&'a [TypeMember]);
 
 impl Format<FormatTypeContext> for FmtTypeMembers<'_> {
     fn fmt(&self, f: &mut Formatter<FormatTypeContext>) -> FormatResult<()> {
-        if self.0.is_empty() {
-            return Ok(());
-        }
-
-        write!(f, [&format_args![text("TypeMembers"), text("("),]])?;
+        write!(f, [text("[")])?;
 
         let types = format_with(|f| {
-            let mut joiner = f.join_with(soft_line_break());
+            let separator =
+                format_with(|f| write!(f, [&format_args![text(","), soft_line_break_or_space()]]));
+            let mut joiner = f.join_with(separator);
             for part in self.0 {
                 joiner.entry(&format_args![part]);
             }
@@ -850,7 +762,7 @@ impl Format<FormatTypeContext> for FmtTypeMembers<'_> {
         });
         write!(
             f,
-            [&format_args![group(&soft_block_indent(&types)), text(")")]]
+            [&format_args![group(&soft_block_indent(&types)), text("]")]]
         )
     }
 }

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -179,6 +179,7 @@ pub enum TypeData {
     Class(Box<Class>),
     Constructor(Box<Constructor>),
     Function(Box<Function>),
+    Module(Box<Module>),
     Namespace(Box<Namespace>),
     Object(Box<Object>),
     Tuple(Box<Tuple>),
@@ -239,6 +240,30 @@ pub enum TypeData {
 
     /// The `void` keyword.
     VoidKeyword,
+}
+
+impl From<Constructor> for TypeData {
+    fn from(value: Constructor) -> Self {
+        Self::Constructor(Box::new(value))
+    }
+}
+
+impl From<Function> for TypeData {
+    fn from(value: Function) -> Self {
+        Self::Function(Box::new(value))
+    }
+}
+
+impl From<Literal> for TypeData {
+    fn from(value: Literal) -> Self {
+        Self::Literal(Box::new(value))
+    }
+}
+
+impl From<TypeofValue> for TypeData {
+    fn from(value: TypeofValue) -> Self {
+        Self::TypeofValue(Box::new(value))
+    }
 }
 
 impl TypeData {
@@ -476,10 +501,12 @@ pub enum Literal {
     Template(Text), // TODO: Custom impl of PartialEq for template literals
 }
 
-impl From<Literal> for TypeData {
-    fn from(value: Literal) -> Self {
-        Self::Literal(Box::new(value))
-    }
+/// A module definition.
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct Module {
+    pub name: Text,
+
+    pub members: Box<[TypeMember]>,
 }
 
 /// A namespace definition.
@@ -513,6 +540,48 @@ impl ObjectLiteral {
     pub fn members(&self) -> &[TypeMember] {
         &self.0
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub enum ReturnType {
+    Type(TypeReference),
+    Predicate(PredicateReturnType),
+    Asserts(AssertsReturnType),
+}
+
+impl Default for ReturnType {
+    fn default() -> Self {
+        Self::Type(TypeReference::Unknown)
+    }
+}
+
+impl ReturnType {
+    pub fn as_type(&self) -> Option<&TypeReference> {
+        match self {
+            Self::Type(ty) => Some(ty),
+            _ => None,
+        }
+    }
+}
+
+/// Defines the function to which it applies to be a predicate that tests
+/// whether one of its arguments is of a given type.
+///
+/// Predicate functions return `boolean` at runtime.
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct PredicateReturnType {
+    pub parameter_name: Text,
+    pub ty: TypeReference,
+}
+
+/// Defines the function to which it applies to be an assertion that asserts
+/// one of its arguments to be of a given type.
+///
+/// Assertion functions throw at runtime if the type assertion fails.
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub struct AssertsReturnType {
+    pub parameter_name: Text,
+    pub ty: TypeReference,
 }
 
 /// Tuple type.
@@ -577,180 +646,53 @@ pub struct TupleElementType {
     pub is_rest: bool,
 }
 
-/// Members of an object definition.
-// TODO: Include getters, setters and index signatures.
+/// Members of a definition, such as an object, namespace or module.
 #[derive(Clone, Debug, PartialEq, Resolvable)]
-pub enum TypeMember {
-    CallSignature(CallSignatureTypeMember),
-    Constructor(ConstructorTypeMember),
-    Method(MethodTypeMember),
-    Property(PropertyTypeMember),
+pub struct TypeMember {
+    pub kind: TypeMemberKind,
+    pub is_static: bool,
+    pub ty: TypeReference,
 }
 
 impl TypeMember {
     pub fn has_name(&self, name: &str) -> bool {
-        match self {
-            Self::CallSignature(_) => false,
-            Self::Constructor(_) => name == "constructor",
-            Self::Method(member) => member.name == name,
-            Self::Property(member) => member.name == name,
-        }
+        self.kind.has_name(name)
     }
 
     pub fn is_static(&self) -> bool {
+        self.is_static
+    }
+
+    pub fn name(&self) -> Option<Text> {
+        self.kind.name()
+    }
+}
+
+/// Kind of a [`TypeMember`], with an optional name.
+// TODO: Include getters, setters and index signatures.
+#[derive(Clone, Debug, PartialEq, Resolvable)]
+pub enum TypeMemberKind {
+    CallSignature,
+    Constructor,
+    Named(Text),
+}
+
+impl TypeMemberKind {
+    pub fn has_name(&self, name: &str) -> bool {
         match self {
-            Self::CallSignature(_) | Self::Constructor(_) => false,
-            Self::Method(member) => member.is_static,
-            Self::Property(member) => member.is_static,
+            Self::CallSignature => false,
+            Self::Constructor => name == "constructor",
+            Self::Named(own_name) => *own_name == name,
         }
     }
 
     pub fn name(&self) -> Option<Text> {
         match self {
-            Self::CallSignature(_) => None,
-            Self::Constructor(_) => Some(Text::Static("constructor")),
-            Self::Method(member) => Some(member.name.clone()),
-            Self::Property(member) => Some(member.name.clone()),
+            Self::CallSignature => None,
+            Self::Constructor => Some(Text::Static("constructor")),
+            Self::Named(name) => Some(name.clone()),
         }
     }
-}
-
-/// Defines a call signature on an object definition.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct CallSignatureTypeMember {
-    /// Generic type parameters defined in the call signature.
-    pub type_parameters: Box<[GenericTypeParameter]>,
-
-    /// Call parameters of the signature.
-    pub parameters: Box<[FunctionParameter]>,
-
-    /// Return type when the object is called.
-    pub return_type: ReturnType,
-}
-
-/// Defines a call signature for an object's constructor.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct ConstructorTypeMember {
-    /// Generic type parameters defined in the constructor.
-    pub type_parameters: Box<[GenericTypeParameter]>,
-
-    /// Call parameters of the constructor.
-    pub parameters: Box<[FunctionParameter]>,
-
-    /// Return type when the constructor is called.
-    pub return_type: Option<TypeReference>,
-}
-
-/// Defines a method on an object.
-#[derive(Clone, Debug, Default, PartialEq, Resolvable)]
-pub struct MethodTypeMember {
-    /// Whether the function has an `async` specifier or not.
-    pub is_async: bool,
-
-    /// Generic type parameters defined in the method.
-    pub type_parameters: Box<[GenericTypeParameter]>,
-
-    /// Name of the method.
-    pub name: Text,
-
-    /// Call parameters of the method.
-    pub parameters: Box<[FunctionParameter]>,
-
-    /// Return type of the method.
-    pub return_type: ReturnType,
-
-    /// Whether the method is optional.
-    pub is_optional: bool,
-
-    /// Whether the method is static.
-    pub is_static: bool,
-}
-
-impl MethodTypeMember {
-    pub fn with_name(mut self, name: Text) -> Self {
-        self.name = name;
-        self
-    }
-
-    pub fn with_return_type(mut self, ty: TypeReference) -> Self {
-        self.return_type = ReturnType::Type(ty);
-        self
-    }
-
-    pub fn with_static(mut self) -> Self {
-        self.is_static = true;
-        self
-    }
-}
-
-/// Defines an object property and its type.
-#[derive(Clone, Debug, Default, PartialEq, Resolvable)]
-pub struct PropertyTypeMember {
-    /// Name of the property.
-    pub name: Text,
-
-    /// Type of the property.
-    pub ty: TypeReference,
-
-    /// Whether the property is optional.
-    pub is_optional: bool,
-
-    /// Whether the property is static.
-    pub is_static: bool,
-}
-
-impl PropertyTypeMember {
-    pub fn with_name(mut self, name: Text) -> Self {
-        self.name = name;
-        self
-    }
-
-    pub fn with_type(mut self, ty: TypeReference) -> Self {
-        self.ty = ty;
-        self
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub enum ReturnType {
-    Type(TypeReference),
-    Predicate(PredicateReturnType),
-    Asserts(AssertsReturnType),
-}
-
-impl Default for ReturnType {
-    fn default() -> Self {
-        Self::Type(TypeReference::Unknown)
-    }
-}
-
-impl ReturnType {
-    pub fn as_type(&self) -> Option<&TypeReference> {
-        match self {
-            Self::Type(ty) => Some(ty),
-            _ => None,
-        }
-    }
-}
-
-/// Defines the function to which it applies to be a predicate that tests
-/// whether one of its arguments is of a given type.
-///
-/// Predicate functions return `boolean` at runtime.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct PredicateReturnType {
-    pub parameter_name: Text,
-    pub ty: TypeReference,
-}
-
-/// Defines the function to which it applies to be an assertion that asserts
-/// one of its arguments to be of a given type.
-///
-/// Assertion functions throw at runtime if the type assertion fails.
-#[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct AssertsReturnType {
-    pub parameter_name: Text,
-    pub ty: TypeReference,
 }
 
 /// Instance of another type.

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -27,12 +27,12 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
 Module TypeId(1) => instanceof Promise<T = number>
 
-Module TypeId(2) => sync Function "then" {
+Module TypeId(2) => sync Function "Promise.prototype.then" {
   accepts: {
     params: []
     type_args: []
@@ -48,15 +48,7 @@ Module TypeId(3) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(4) => sync Function "then" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Global TypeId(17) => instanceof Promise<T = number>
 
-Global TypeId(7) => instanceof Promise<T = number>
-
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
@@ -18,7 +18,7 @@ instanceof Promise
 ## Registered types
 
 ```
-Global TypeId(7) => sync Function {
+Global TypeId(17) => sync Function {
   accepts: {
     params: [
       required resolve: unknown (bindings: resolve:unknown)

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -29,12 +29,12 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
 Module TypeId(1) => instanceof Promise<T = number>
 
-Module TypeId(2) => sync Function "then" {
+Module TypeId(2) => sync Function "Promise.prototype.then" {
   accepts: {
     params: []
     type_args: []
@@ -52,7 +52,7 @@ Module TypeId(3) => sync Function {
 
 Module TypeId(4) => instanceof Promise
 
-Module TypeId(5) => sync Function "finally" {
+Module TypeId(5) => sync Function "Promise.prototype.finally" {
   accepts: {
     params: []
     type_args: []
@@ -60,23 +60,7 @@ Module TypeId(5) => sync Function "finally" {
   returns: instanceof Promise
 }
 
-Module TypeId(6) => sync Function "then" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Global TypeId(17) => instanceof Promise<T = number>
 
-Module TypeId(7) => sync Function "finally" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
-
-Global TypeId(7) => instanceof Promise<T = number>
-
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
@@ -27,8 +27,8 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
-Global TypeId(7) => instanceof unresolved reference "Promise"<number>
+Global TypeId(17) => instanceof unresolved reference "Promise"<number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
@@ -18,7 +18,7 @@ instanceof Promise
 ## Registered types
 
 ```
-Global TypeId(7) => sync Function "resolve" {
+Global TypeId(17) => sync Function "Promise.resolve" {
   accepts: {
     params: []
     type_args: []
@@ -26,13 +26,5 @@ Global TypeId(7) => sync Function "resolve" {
   returns: instanceof Promise
 }
 
-Global TypeId(8) => value: value
-
-Global TypeId(9) => sync Function "resolve" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Global TypeId(18) => value: value
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_async_function.snap
@@ -19,14 +19,14 @@ async Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(8)
+  returns: Global TypeId(18)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof unresolved reference "Promise"<Global TypeId(7)>
+Global TypeId(18) => instanceof unresolved reference "Promise"<Global TypeId(17)>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_array_element.snap
@@ -12,20 +12,20 @@ const [a]: Array<string> = [];
 ## Result
 
 ```
-a => Global TypeId(7) | undefined
+a => Global TypeId(17) | undefined
 
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof Array<T = Global TypeId(7)>
+Global TypeId(18) => instanceof Array<T = Global TypeId(17)>
 
-Global TypeId(9) => Global TypeId(7) | undefined
+Global TypeId(19) => Global TypeId(17) | undefined
 
-Global TypeId(10) => instanceof Array<T = Global TypeId(7)>
+Global TypeId(20) => instanceof Array<T = Global TypeId(17)>
 
-Global TypeId(11) => Global TypeId(7) | undefined
+Global TypeId(21) => Global TypeId(17) | undefined
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_promise_returning_function.snap
@@ -19,12 +19,12 @@ sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => instanceof unresolved reference "Promise"<number>
+Global TypeId(17) => instanceof unresolved reference "Promise"<number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
@@ -27,7 +27,7 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
 Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
@@ -42,7 +42,7 @@ Module TypeId(3) => sync Function {
   returns: unknown reference
 }
 
-Global TypeId(7) => instanceof Global TypeId(8)
+Global TypeId(17) => instanceof Global TypeId(18)
 
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
@@ -18,7 +18,7 @@ new Promise
 ## Registered types
 
 ```
-Global TypeId(7) => sync Function {
+Global TypeId(17) => sync Function {
   accepts: {
     params: [
       required resolve: unknown (bindings: resolve:unknown)

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -29,7 +29,7 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
 Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
@@ -48,7 +48,7 @@ Module TypeId(4) => Call Module(0) TypeId(2)(Module(0) TypeId(3))
 
 Module TypeId(5) => Module(0) TypeId(4).finally
 
-Global TypeId(7) => instanceof Global TypeId(8)
+Global TypeId(17) => instanceof Global TypeId(18)
 
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
@@ -27,10 +27,10 @@ Module TypeId(0) => sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 
-Global TypeId(7) => instanceof Global TypeId(8)
+Global TypeId(17) => instanceof Global TypeId(18)
 
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_static_promise_function.snap
@@ -12,13 +12,13 @@ Promise.resolve("value");
 ## Result
 
 ```
-Call Global TypeId(7)(Global TypeId(8))
+Call Global TypeId(17)(Global TypeId(18))
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => Promise.resolve
+Global TypeId(17) => Promise.resolve
 
-Global TypeId(8) => value: value
+Global TypeId(18) => value: value
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_async_function.snap
@@ -19,16 +19,16 @@ async Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(8)
+  returns: Global TypeId(18)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof Global TypeId(9)
+Global TypeId(18) => instanceof Global TypeId(19)
 
-Global TypeId(9) => instanceof Promise<T = Global TypeId(7)>
+Global TypeId(19) => instanceof Promise<T = Global TypeId(17)>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_destructured_array_element.snap
@@ -12,18 +12,18 @@ const [a]: Array<string> = [];
 ## Result
 
 ```
-a => Global TypeId(8)[0]
+a => Global TypeId(18)[0]
 
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof Global TypeId(10)
+Global TypeId(18) => instanceof Global TypeId(20)
 
-Global TypeId(9) => Global TypeId(8)[0]
+Global TypeId(19) => Global TypeId(18)[0]
 
-Global TypeId(10) => instanceof Array<T = Global TypeId(7)>
+Global TypeId(20) => instanceof Array<T = Global TypeId(17)>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_of_promise_returning_function.snap
@@ -19,14 +19,14 @@ sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => instanceof Global TypeId(8)
+Global TypeId(17) => instanceof Global TypeId(18)
 
-Global TypeId(8) => instanceof Promise<T = number>
+Global TypeId(18) => instanceof Promise<T = number>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_array.snap
@@ -12,12 +12,12 @@ const array: Array<string> = [];
 ## Result
 
 ```
-array => instanceof unresolved reference "Array"<Global TypeId(7)>
+array => instanceof unresolved reference "Array"<Global TypeId(17)>
 
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_async_function.snap
@@ -19,14 +19,14 @@ async Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(8)
+  returns: Global TypeId(18)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof unresolved reference "Promise"<Global TypeId(7)>
+Global TypeId(18) => instanceof unresolved reference "Promise"<Global TypeId(17)>
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_destructured_array_element.snap
@@ -12,16 +12,16 @@ const [a]: Array<string> = [];
 ## Result
 
 ```
-a => Global TypeId(8)[0]
+a => Global TypeId(18)[0]
 
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => instanceof unresolved reference "Array"<Global TypeId(7)>
+Global TypeId(18) => instanceof unresolved reference "Array"<Global TypeId(17)>
 
-Global TypeId(9) => Global TypeId(8)[0]
+Global TypeId(19) => Global TypeId(18)[0]
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
@@ -18,10 +18,10 @@ function destruct(
 sync Function "destruct" {
   accepts: {
     params: [
-      required (unnamed): Global TypeId(8) (bindings: a:Global TypeId(8).a,
-      b:Global TypeId(8).b)
-      required (unnamed): Global TypeId(12) (bindings: first:Global TypeId(12)[0],
-      rest:[(1 others)...Global TypeId(12)])
+      required (unnamed): Global TypeId(18) (bindings: a:Global TypeId(18).a,
+      b:Global TypeId(18).b)
+      required (unnamed): Global TypeId(22) (bindings: first:Global TypeId(22)[0],
+      rest:[(1 others)...Global TypeId(22)])
     ]
     type_args: []
   }
@@ -32,25 +32,22 @@ sync Function "destruct" {
 ## Registered types
 
 ```
-Global TypeId(7) => string
+Global TypeId(17) => string
 
-Global TypeId(8) => Object {
+Global TypeId(18) => Object {
   prototype: No prototype
-  members: {TypeMembers(
-    required property "a": number
-    required property "b": Global TypeId(7)
-  )}
+  members: ["a": number, "b": Global TypeId(17)]
 }
 
-Global TypeId(9) => Global TypeId(8).a
+Global TypeId(19) => Global TypeId(18).a
 
-Global TypeId(10) => Global TypeId(8).b
+Global TypeId(20) => Global TypeId(18).b
 
-Global TypeId(11) => boolean
+Global TypeId(21) => boolean
 
-Global TypeId(12) => instanceof unresolved reference "Array"<Global TypeId(11)>
+Global TypeId(22) => instanceof unresolved reference "Array"<Global TypeId(21)>
 
-Global TypeId(13) => Global TypeId(12)[0]
+Global TypeId(23) => Global TypeId(22)[0]
 
-Global TypeId(14) => [(1 others)...Global TypeId(12)]
+Global TypeId(24) => [(1 others)...Global TypeId(22)]
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_promise_returning_function.snap
@@ -19,12 +19,12 @@ sync Function "returnsPromise" {
     params: []
     type_args: []
   }
-  returns: Global TypeId(7)
+  returns: Global TypeId(17)
 }
 ```
 
 ## Registered types
 
 ```
-Global TypeId(7) => instanceof unresolved reference "Promise"<number>
+Global TypeId(17) => instanceof unresolved reference "Promise"<number>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -87,7 +87,7 @@ Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
 
 Module TypeId(3) => Object {
   prototype: No prototype
-  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
+  members: ["result": Module(0) TypeId(2)]
 }
 
 Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -44,7 +44,7 @@ export const superComputer = new DeepThought();
 Exports {
   "superComputer" => {
     ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(4)
+      Module(0) TypeId(7)
       Local name: superComputer
     )
   }
@@ -67,12 +67,38 @@ Module TypeId(0) => value: 42
 
 Module TypeId(1) => number
 
-Module TypeId(2) => unknown
+Module TypeId(2) => sync Function "answerMe" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(1)
+}
 
-Module TypeId(3) => class "DeepThought" {
+Module TypeId(3) => sync Function "giveMeABiggerAnswer" {
+  accepts: {
+    params: [
+      required delta: Module(0) TypeId(1) (bindings: delta:number)
+    ]
+    type_args: []
+  }
+  returns: unknown reference
+}
+
+Module TypeId(4) => unknown
+
+Module TypeId(5) => sync Function "whatWasTheUltimateQuestion" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(4)
+}
+
+Module TypeId(6) => class "DeepThought" {
   extends: none
   type_args: []
 }
 
-Module TypeId(4) => instanceof Module(0) TypeId(3)
+Module TypeId(7) => instanceof Module(0) TypeId(6)
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -177,7 +177,7 @@ Module TypeId(1) => sync Function "bar" {
 
 Module TypeId(2) => Object {
   prototype: No prototype
-  members: {}
+  members: []
 }
 
 Module TypeId(3) => instanceof Promise
@@ -194,11 +194,11 @@ Module TypeId(5) => value: 1
 
 Module TypeId(6) => Object {
   prototype: No prototype
-  members: {TypeMembers(
-    required property "a": Module(0) TypeId(12)
-    required property "b": Module(0) TypeId(14)
-    required property "c": Module(0) TypeId(18)
-  )}
+  members: [
+    "a": Module(0) TypeId(12),
+    "b": Module(0) TypeId(14),
+    "c": Module(0) TypeId(18)
+  ]
 }
 
 Module TypeId(7) => string
@@ -281,20 +281,20 @@ Module TypeId(18) => Tuple(
 
 Module TypeId(19) => Object {
   prototype: No prototype
-  members: {TypeMembers(
-    required property "a": Module(0) TypeId(12)
-    required property "b": Module(0) TypeId(14)
-    required property "c": Module(0) TypeId(18)
-  )}
+  members: [
+    "a": Module(0) TypeId(12),
+    "b": Module(0) TypeId(14),
+    "c": Module(0) TypeId(18)
+  ]
 }
 
 Module TypeId(20) => Object {
   prototype: No prototype
-  members: {TypeMembers(
-    required property "a": Module(0) TypeId(12)
-    required property "b": Module(0) TypeId(14)
-    required property "c": Module(0) TypeId(18)
-  )}
+  members: [
+    "a": Module(0) TypeId(12),
+    "b": Module(0) TypeId(14),
+    "c": Module(0) TypeId(18)
+  ]
 }
 
 Module TypeId(21) => sync Function "getObject" {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -72,7 +72,7 @@ Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
 
 Module TypeId(3) => Object {
   prototype: No prototype
-  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
+  members: ["result": Module(0) TypeId(2)]
 }
 
 Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -98,7 +98,7 @@ Module TypeId(2) => Module(0) TypeId(0) | Module(0) TypeId(1)
 
 Module TypeId(3) => Object {
   prototype: No prototype
-  members: {TypeMembers(required property "result": Module(0) TypeId(2))}
+  members: ["result": Module(0) TypeId(2)]
 }
 
 Module TypeId(4) => instanceof Promise<T = Module(0) TypeId(3)>

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_registered_types.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_registered_types.snap
@@ -2,6 +2,6 @@
 source: crates/biome_service/src/workspace.tests.rs
 expression: result.unwrap()
 ---
-TypeId(7) => string
+TypeId(17) => string
 
-TypeId(8) => instanceof unresolved reference "Person"
+TypeId(18) => instanceof unresolved reference "Person"

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_type_info.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__debug_type_info.snap
@@ -5,12 +5,12 @@ expression: result.unwrap()
 sync Function "foo" {
   accepts: {
     params: [
-      required name: Global TypeId(7) (bindings: name:string)
+      required name: Global TypeId(17) (bindings: name:string)
       required age: number (bindings: age:number)
     ]
     type_args: []
   }
-  returns: Global TypeId(8)
+  returns: Global TypeId(18)
 }
 class "Person" {
   extends: none


### PR DESCRIPTION
## Summary

This introduces the `TypeData::Module` variant, which I intend to use for `declare module` statements in `.d.ts` files.

However, the `Module` type contains `TypeMember`, which should now be able to hold arbitrary type definitions. I already felt `TypeMember` was implemented a bit awkwardly, causing some unnecessary duplication, so I've taken the opportunity to refactor it. Now all type members (whether they be object members, class members, or module members) refer to _registered_ types, which can be of any kind of `TypeData`.

This means we don't make an explicit distinction between properties and methods anymore, the difference is simply whether the reference points to a function or not. Optionality is also no longer an explicit field; it's simply a matter of the referenced type being a union with `undefined`.

Another side-effect is that our snapshots now make it easier to inspect inferred method signatures, since they've become an explicit part of the registered types.

## Test Plan

Tests are updated.
