### PR TITLE
feat(core): improve inference on `.d.ts` files

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -232,6 +232,7 @@ impl TryFrom<&AnyJsBindingDeclaration> for DeclarationKind {
             | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
             | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
             | AnyJsBindingDeclaration::TsEnumDeclaration(_)
+            | AnyJsBindingDeclaration::TsExternalModuleDeclaration(_)
             | AnyJsBindingDeclaration::TsModuleDeclaration(_)
             | AnyJsBindingDeclaration::JsShorthandNamedImportSpecifier(_)
             | AnyJsBindingDeclaration::JsNamedImportSpecifier(_)

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_variables.rs
@@ -231,6 +231,7 @@ fn suggested_fix_if_unused(
         | AnyJsBindingDeclaration::JsClassDeclaration(_)
         | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
         | AnyJsBindingDeclaration::TsEnumDeclaration(_)
+        | AnyJsBindingDeclaration::TsExternalModuleDeclaration(_)
         | AnyJsBindingDeclaration::TsModuleDeclaration(_)) => {
             if is_in_ambient_context(node.syntax()) {
                 None

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -515,6 +515,7 @@ fn capture_needs_to_be_in_the_dependency_list(
         | AnyJsBindingDeclaration::TsEnumDeclaration(_)
         | AnyJsBindingDeclaration::TsTypeAliasDeclaration(_)
         | AnyJsBindingDeclaration::TsInterfaceDeclaration(_)
+        | AnyJsBindingDeclaration::TsExternalModuleDeclaration(_)
         | AnyJsBindingDeclaration::TsModuleDeclaration(_)
         | AnyJsBindingDeclaration::TsInferType(_)
         | AnyJsBindingDeclaration::TsMappedType(_)

--- a/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_naming_convention.rs
@@ -1413,6 +1413,9 @@ impl Selector {
             | AnyJsBindingDeclaration::TsMappedType(_)
             | AnyJsBindingDeclaration::TsTypeParameter(_)
             | AnyJsBindingDeclaration::TsEnumMember(_) => None,
+            // External modules are identified by source specifiers and are out
+            // of scope of this rule.
+            AnyJsBindingDeclaration::TsExternalModuleDeclaration(_) => None
         }
     }
 
@@ -1608,7 +1611,7 @@ pub enum Kind {
     EnumMember,
     /// TypeScript namespaces, import and export namespaces
     NamespaceLike,
-    /// TypeScript mamespaces
+    /// TypeScript namespaces
     Namespace,
     ImportNamespace,
     ExportNamespace,

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -598,14 +598,15 @@ impl SemanticEventExtractor {
                             .map(|scope| scope.scope_id);
                         self.push_binding(hoisted_scope_id, BindingName::Type(name), info);
                     }
-                    AnyJsBindingDeclaration::TsModuleDeclaration(_) => {
-                        // This declarations has its own scope.
+                    AnyJsBindingDeclaration::TsExternalModuleDeclaration(_)
+                    | AnyJsBindingDeclaration::TsModuleDeclaration(_) => {
+                        // This declaration has its own scope.
                         // Thus we need to hoist the declaration to the parent scope.
                         hoisted_scope_id = self
                             .scopes
                             .get(self.scopes.len() - 2)
                             .map(|scope| scope.scope_id);
-                        self.push_binding(hoisted_scope_id, BindingName::Value(name.clone()), info);
+                        self.push_binding(hoisted_scope_id, BindingName::Value(name), info);
                     }
                     AnyJsBindingDeclaration::TsMappedType(_)
                     | AnyJsBindingDeclaration::TsTypeParameter(_) => {

--- a/crates/biome_js_syntax/src/binding_ext.rs
+++ b/crates/biome_js_syntax/src/binding_ext.rs
@@ -12,9 +12,9 @@ use crate::{
     JsSyntaxNode, JsSyntaxToken, JsVariableDeclarator, TsCallSignatureTypeMember,
     TsConstructSignatureTypeMember, TsConstructorSignatureClassMember, TsConstructorType,
     TsDeclareFunctionDeclaration, TsDeclareFunctionExportDefaultDeclaration, TsEnumDeclaration,
-    TsEnumMember, TsFunctionType, TsIdentifierBinding, TsImportEqualsDeclaration,
-    TsIndexSignatureClassMember, TsIndexSignatureParameter, TsInferType, TsInterfaceDeclaration,
-    TsLiteralEnumMemberName, TsMappedType, TsMethodSignatureClassMember,
+    TsEnumMember, TsExternalModuleDeclaration, TsFunctionType, TsIdentifierBinding,
+    TsImportEqualsDeclaration, TsIndexSignatureClassMember, TsIndexSignatureParameter, TsInferType,
+    TsInterfaceDeclaration, TsLiteralEnumMemberName, TsMappedType, TsMethodSignatureClassMember,
     TsMethodSignatureTypeMember, TsModuleDeclaration, TsPropertyParameter,
     TsSetterSignatureClassMember, TsSetterSignatureTypeMember, TsTypeAliasDeclaration,
     TsTypeParameter, TsTypeParameterName,
@@ -43,7 +43,8 @@ declare_node_union! {
             | TsEnumMember
         // classes, objects, interface, type, enum, module
             | JsClassDeclaration | JsClassExpression
-            | TsInterfaceDeclaration | TsTypeAliasDeclaration | TsEnumDeclaration | TsModuleDeclaration
+            | TsInterfaceDeclaration | TsTypeAliasDeclaration | TsEnumDeclaration
+            | TsExternalModuleDeclaration | TsModuleDeclaration
         // import
             | JsShorthandNamedImportSpecifier
                 | JsNamedImportSpecifier | JsBogusNamedImportSpecifier | JsDefaultImportSpecifier
@@ -214,6 +215,7 @@ impl AnyJsBindingDeclaration {
             | Self::JsClassDeclaration(_)
             | Self::TsTypeAliasDeclaration(_)
             | Self::TsEnumDeclaration(_)
+            | Self::TsExternalModuleDeclaration(_)
             | Self::TsModuleDeclaration(_) => self.syntax().parent(),
             Self::TsInterfaceDeclaration(_) => {
                 // interfaces can be in a default export clause

--- a/crates/biome_js_type_info/src/flattening.rs
+++ b/crates/biome_js_type_info/src/flattening.rs
@@ -420,10 +420,12 @@ fn flattened(mut ty: TypeData, resolver: &mut dyn TypeResolver, depth: usize) ->
                     None => return ty,
                 },
             },
-            TypeData::TypeofValue(value) => match resolver.resolve_reference(&value.ty) {
-                Some(type_id) => ty = TypeData::reference(type_id),
-                None => return ty,
-            },
+            TypeData::TypeofValue(value) if value.ty.is_known() => {
+                match resolver.resolve_reference(&value.ty) {
+                    Some(type_id) => ty = TypeData::reference(type_id),
+                    None => return ty,
+                }
+            }
             _ => return ty,
         }
     }

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -260,6 +260,18 @@ impl From<Literal> for TypeData {
     }
 }
 
+impl From<Module> for TypeData {
+    fn from(value: Module) -> Self {
+        Self::Module(Box::new(value))
+    }
+}
+
+impl From<Namespace> for TypeData {
+    fn from(value: Namespace) -> Self {
+        Self::Namespace(Box::new(value))
+    }
+}
+
 impl From<TypeofValue> for TypeData {
     fn from(value: TypeofValue) -> Self {
         Self::TypeofValue(Box::new(value))
@@ -267,6 +279,14 @@ impl From<TypeofValue> for TypeData {
 }
 
 impl TypeData {
+    pub fn array_of(ty: TypeReference) -> Self {
+        Self::instance_of(TypeReference::Qualifier(TypeReferenceQualifier {
+            path: [Text::Static("Array")].into(),
+            type_parameters: [ty].into(),
+            scope_id: None,
+        }))
+    }
+
     pub fn as_class(&self) -> Option<&Class> {
         match self {
             Self::Class(class) => Some(class.as_ref()),
@@ -505,18 +525,14 @@ pub enum Literal {
 #[derive(Clone, Debug, PartialEq, Resolvable)]
 pub struct Module {
     pub name: Text,
-
     pub members: Box<[TypeMember]>,
 }
 
 /// A namespace definition.
 #[derive(Clone, Debug, PartialEq, Resolvable)]
-pub struct Namespace(pub(super) Box<[TypeMember]>);
-
-impl Namespace {
-    pub fn from_type_members(members: Box<[TypeMember]>) -> Self {
-        Self(members)
-    }
+pub struct Namespace {
+    pub path: Box<[Text]>,
+    pub members: Box<[TypeMember]>,
 }
 
 /// An object definition.
@@ -870,6 +886,7 @@ impl From<TypeImportQualifier> for TypeReference {
 }
 
 impl TypeReference {
+    #[inline]
     pub fn is_known(&self) -> bool {
         *self != Self::Unknown
     }

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -123,7 +123,7 @@ impl JsBinding {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum JsDeclarationKind {
     /// A `class` declaration.
     Class,
@@ -164,6 +164,38 @@ pub enum JsDeclarationKind {
 }
 
 impl JsDeclarationKind {
+    /// Returns whether this declaration declares a type.
+    #[expect(unused)] // TODO: We need to handle value/type duality better.
+    pub fn declares_type(&self) -> bool {
+        matches!(
+            self,
+            Self::Class
+                | Self::Enum
+                | Self::Import
+                | Self::ImportType
+                | Self::Interface
+                | Self::Namespace
+                | Self::Type
+                | Self::Unknown
+        )
+    }
+
+    /// Returns whether this declaration declares a runtime value.
+    #[expect(unused)] // TODO: We need to handle value/type duality better.
+    pub fn declares_value(&self) -> bool {
+        matches!(
+            self,
+            Self::Class
+                | Self::Enum
+                | Self::HoistedValue
+                | Self::Import
+                | Self::Namespace
+                | Self::Unknown
+                | Self::Using
+                | Self::Value
+        )
+    }
+
     pub fn from_node(node: &JsSyntaxNode) -> Self {
         let Some(declaration) = node.ancestors().find_map(AnyJsDeclaration::cast) else {
             return match node.ancestors().find_map(JsImport::cast) {

--- a/crates/biome_module_graph/src/js_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/js_module_info/visitor.rs
@@ -1,11 +1,11 @@
 use biome_js_syntax::{
     AnyJsArrayBindingPatternElement, AnyJsBinding, AnyJsBindingPattern, AnyJsDeclarationClause,
-    AnyJsExportClause, AnyJsExportDefaultDeclaration, AnyJsImportLike,
+    AnyJsExportClause, AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsImportLike,
     AnyJsObjectBindingPatternMember, AnyJsRoot, AnyTsIdentifierBinding, AnyTsModuleName,
-    JsExportDefaultExpressionClause, JsExportFromClause, JsExportNamedFromClause,
-    JsExportNamedSpecifierList, JsIdentifierBinding, JsVariableDeclaratorList, unescape_js_string,
+    JsExportFromClause, JsExportNamedFromClause, JsExportNamedSpecifierList, JsIdentifierBinding,
+    JsVariableDeclaratorList, unescape_js_string,
 };
-use biome_js_type_info::{ImportSymbol, TypeData, TypeResolver};
+use biome_js_type_info::{ImportSymbol, TypeData, TypeReference, TypeResolver};
 use biome_jsdoc_comment::JsdocComment;
 use biome_resolver::{ResolveOptions, resolve};
 use biome_rowan::{AstNode, TokenText, WalkEvent};
@@ -89,7 +89,7 @@ impl<'a> JsModuleVisitor<'a> {
                 self.visit_export_default_declaration_clause(&node.declaration().ok()?, collector)
             }
             AnyJsExportClause::JsExportDefaultExpressionClause(node) => {
-                self.visit_export_default_expression_clause(&node, collector)
+                self.visit_export_default_expression(&node.expression().ok()?, collector)
             }
             AnyJsExportClause::JsExportFromClause(node) => {
                 self.visit_export_from_clause(node, collector)
@@ -105,12 +105,8 @@ impl<'a> JsModuleVisitor<'a> {
                 let name = token.token_text_trimmed();
                 collector.register_export_with_name(name, None)
             }
-            AnyJsExportClause::TsExportAssignmentClause(_) => {
-                // This is somewhat misleading, since the `export =` syntax is
-                // used for CommonJS exports rather than ES6 `default` exports.
-                // Thankfully, bundlers are responsible for normalising this,
-                // which isn't really Biome's concern.
-                collector.register_export_with_name("default", None)
+            AnyJsExportClause::TsExportAssignmentClause(node) => {
+                self.visit_export_default_expression(&node.expression().ok()?, collector)
             }
             AnyJsExportClause::TsExportDeclareClause(node) => {
                 self.visit_export_declaration_clause(node.declaration().ok()?, collector)
@@ -181,13 +177,13 @@ impl<'a> JsModuleVisitor<'a> {
         collector.register_export_with_name("default", Some(name))
     }
 
-    fn visit_export_default_expression_clause(
+    fn visit_export_default_expression(
         &self,
-        node: &JsExportDefaultExpressionClause,
+        node: &AnyJsExpression,
         collector: &mut JsModuleInfoCollector,
     ) -> Option<()> {
-        let type_data = TypeData::from_any_js_expression(collector, &node.expression().ok()?);
-        let ty = collector.register_and_resolve(type_data).into();
+        let type_data = TypeData::from_any_js_expression(collector, node);
+        let ty: TypeReference = collector.register_and_resolve(type_data).into();
         collector.register_export(
             "default",
             JsExport::Own(JsOwnExport {

--- a/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
@@ -1,0 +1,76 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/index.d.ts`
+
+## Source
+
+```ts
+declare namespace shared {
+	type Result = string;
+}
+
+declare const shared: {
+	// FIXME: This return type is not properly resolved
+	foo(): shared.Result;
+};
+
+export = shared;
+```
+
+## Module Info
+
+```
+Exports {
+  "default" => {
+    ExportOwnExport => JsOwnExport(
+      Module(0) TypeId(0)
+      Local name: None
+    )
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => Object {
+  prototype: No prototype
+  members: ["foo": Module(0) TypeId(4)]
+}
+
+Module TypeId(1) => Namespace {
+    path: [
+        Borrowed(
+            "shared",
+        ),
+    ],
+    members: [],
+}
+
+Module TypeId(2) => string
+
+Module TypeId(3) => instanceof unresolved reference "shared.Result"
+
+Module TypeId(4) => sync Function "foo" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(3)
+}
+
+Module TypeId(5) => Object {
+  prototype: No prototype
+  members: ["foo": Module(0) TypeId(4)]
+}
+
+Module TypeId(6) => Object {
+  prototype: No prototype
+  members: ["foo": Module(0) TypeId(4)]
+}
+```

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -331,6 +331,36 @@ fn test_export_default_function_declaration() {
 }
 
 #[test]
+fn test_export_const_type_declaration_with_namespace() {
+    let mut fs = MemoryFileSystem::default();
+    fs.insert(
+        "/src/index.d.ts".into(),
+        r#"
+            declare namespace shared {
+                type Result = string;
+            }
+
+            declare const shared: {
+                // FIXME: This return type is not properly resolved
+                foo(): shared.Result;
+            }
+
+            export = shared;
+        "#,
+    );
+
+    let added_paths = [BiomePath::new("/src/index.d.ts")];
+    let added_paths = get_added_paths(&fs, &added_paths);
+
+    let module_graph = ModuleGraph::default();
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, &[]);
+
+    let snapshot = ModuleGraphSnapshot::new(&module_graph, &fs);
+
+    snapshot.assert_snapshot("test_export_const_type_declaration_with_namespace");
+}
+
+#[test]
 fn test_resolve_exports() {
     let mut fs = MemoryFileSystem::default();
     fs.insert(

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2276,7 +2276,7 @@
 					"enum": ["namespaceLike"]
 				},
 				{
-					"description": "TypeScript mamespaces",
+					"description": "TypeScript namespaces",
 					"type": "string",
 					"enum": ["namespace"]
 				},


### PR DESCRIPTION
## Summary

This adds some minor improvements on inference from `.d.ts` files:
* Recognise function declarations.
* Partially infer namespaces and external module declarations. Heavy emphasis on **partial** since the members aren't populated yet. However, I did add a test that shows the members _are_ being recognised and interpreted during semantic analysis, so we should be able to populate the members there. (Doing it during local inference would only make the computation more expensive.)
* Handle `export =` assignments.

## Test Plan

Tests added.