### PR TITLE
fix(useArrayLiterals): Preserve array type

### DIFF
--- a/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/invalid.ts
@@ -1,0 +1,14 @@
+var xs = new Array<string>();
+
+var xs = new Array<number>(0, 1, 2);
+
+var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+
+void new Array<number>();
+
+void new Array<number>(1, 2, 3);
+
+void new Array<1 | 2 | 3 | 4>(1, 2, 3);
+
+// it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+var xs: string[] = new Array<number>();

--- a/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/invalid.ts.snap
@@ -1,0 +1,198 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.ts
+---
+# Input
+```ts
+var xs = new Array<string>();
+
+var xs = new Array<number>(0, 1, 2);
+
+var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+
+void new Array<number>();
+
+void new Array<number>(1, 2, 3);
+
+void new Array<1 | 2 | 3 | 4>(1, 2, 3);
+
+// it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+var xs: string[] = new Array<number>();
+
+```
+
+# Diagnostics
+```
+invalid.ts:1:10 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+  > 1 │ var xs = new Array<string>();
+      │          ^^^^^^^^^^^^^^^^^^^
+    2 │ 
+    3 │ var xs = new Array<number>(0, 1, 2);
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     1    │ - var·xs·=·new·Array<string>();
+        1 │ + var·xs·:(string)[]=·[];
+     2  2 │   
+     3  3 │   var xs = new Array<number>(0, 1, 2);
+  
+
+```
+
+```
+invalid.ts:3:10 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+    1 │ var xs = new Array<string>();
+    2 │ 
+  > 3 │ var xs = new Array<number>(0, 1, 2);
+      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+    5 │ var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     1  1 │   var xs = new Array<string>();
+     2  2 │   
+     3    │ - var·xs·=·new·Array<number>(0,·1,·2);
+        3 │ + var·xs·:(number)[]=·[0,·1,·2];
+     4  4 │   
+     5  5 │   var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+  
+
+```
+
+```
+invalid.ts:5:26 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+    3 │ var xs = new Array<number>(0, 1, 2);
+    4 │ 
+  > 5 │ var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+      │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ void new Array<number>();
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     3  3 │   var xs = new Array<number>(0, 1, 2);
+     4  4 │   
+     5    │ - var·xs·/*·A·*/·=·/*·B·*/·new·/*·C·*/·Array·/*·D·*/·<·/*·E·*/·number·/*·F·*/·>·/*·G·*/·(·/*·H·*/·1·/*·I·*/·,·/*·J·*/·2·/*·K·*/·,·/*·L·*/)·/*·M·*/;
+        5 │ + var·xs·/*·A·*/·:·/*·E·*/·(number)[]·/*·F·*/··/*·G·*/·=·/*·B·*/·[·/*·H·*/·1·/*·I·*/·,·/*·J·*/·2·/*·K·*/·,·/*·L·*/]·/*·M·*/;
+     6  6 │   
+     7  7 │   void new Array<number>();
+  
+
+```
+
+```
+invalid.ts:7:6 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+    5 │ var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+    6 │ 
+  > 7 │ void new Array<number>();
+      │      ^^^^^^^^^^^^^^^^^^^
+    8 │ 
+    9 │ void new Array<number>(1, 2, 3);
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     5  5 │   var xs /* A */ = /* B */ new /* C */ Array /* D */ < /* E */ number /* F */ > /* G */ ( /* H */ 1 /* I */ , /* J */ 2 /* K */ , /* L */) /* M */;
+     6  6 │   
+     7    │ - void·new·Array<number>();
+        7 │ + void·[]·as·(number)[];
+     8  8 │   
+     9  9 │   void new Array<number>(1, 2, 3);
+  
+
+```
+
+```
+invalid.ts:9:6 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+     7 │ void new Array<number>();
+     8 │ 
+   > 9 │ void new Array<number>(1, 2, 3);
+       │      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+    11 │ void new Array<1 | 2 | 3 | 4>(1, 2, 3);
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     7  7 │   void new Array<number>();
+     8  8 │   
+     9    │ - void·new·Array<number>(1,·2,·3);
+        9 │ + void·[1,·2,·3]·satisfies·(number)[]·as·(number)[];
+    10 10 │   
+    11 11 │   void new Array<1 | 2 | 3 | 4>(1, 2, 3);
+  
+
+```
+
+```
+invalid.ts:11:6 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+     9 │ void new Array<number>(1, 2, 3);
+    10 │ 
+  > 11 │ void new Array<1 | 2 | 3 | 4>(1, 2, 3);
+       │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+     9  9 │   void new Array<number>(1, 2, 3);
+    10 10 │   
+    11    │ - void·new·Array<1·|·2·|·3·|·4>(1,·2,·3);
+       11 │ + void·[1,·2,·3]·satisfies·(1·|·2·|·3·|·4)[]·as·(1·|·2·|·3·|·4)[];
+    12 12 │   
+    13 13 │   // it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+  
+
+```
+
+```
+invalid.ts:14:20 lint/style/useArrayLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Use an array literal instead of the Array constructor.
+  
+    13 │ // it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+  > 14 │ var xs: string[] = new Array<number>();
+       │                    ^^^^^^^^^^^^^^^^^^^
+    15 │ 
+  
+  i The Array constructor is misleading because it can be used to preallocate an array of a given length or to create an array with a given list of elements.
+  
+  i Safe fix: Use an array literal.
+  
+    12 12 │   
+    13 13 │   // it already has a type annotation, it should still trigger a diagnostic but should not change the existing type
+    14    │ - var·xs:·string[]·=·new·Array<number>();
+       14 │ + var·xs:·string[]·=·[]·as·(number)[];
+    15 15 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/valid.ts
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+let xs = Array<number>(500);
+
+let xs = new Array<number>(500);
+
+let xs = Array<number>(n);

--- a/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useArrayLiterals/valid.ts.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+let xs = Array<number>(500);
+
+let xs = new Array<number>(500);
+
+let xs = Array<number>(n);
+
+```

--- a/crates/biome_js_factory/src/make.rs
+++ b/crates/biome_js_factory/src/make.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use biome_js_syntax::{AnyJsExpression, JsParenthesizedExpression, JsSyntaxKind, JsSyntaxToken};
+use biome_js_syntax::{
+    AnyJsExpression, AnyTsType, JsParenthesizedExpression, JsSyntaxKind, JsSyntaxToken,
+    TsParenthesizedType,
+};
 use biome_rowan::TriviaPiece;
 
 pub use crate::generated::node_factory::*;
@@ -108,6 +111,15 @@ pub fn parenthesized(expr: impl Into<AnyJsExpression>) -> JsParenthesizedExpress
     js_parenthesized_expression(
         token(JsSyntaxKind::L_PAREN),
         expr.into(),
+        token(JsSyntaxKind::R_PAREN),
+    )
+}
+
+/// Wrap `ts_type` in a new parenthesized type
+pub fn parenthesized_ts(ts_type: impl Into<AnyTsType>) -> TsParenthesizedType {
+    ts_parenthesized_type(
+        token(JsSyntaxKind::L_PAREN),
+        ts_type.into(),
         token(JsSyntaxKind::R_PAREN),
     )
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #6079

This prevents useArrayLiterals from removing type information from expressions like `new Array<number>()`.

The new behavior is as follows:

 * If the parent node is a declaration: `const myvar = new Array<T>(...items)` -> `const myvar: (T)[] = [...items]`
 * Else if the array is empty: `new Array<T>()` -> `[] as (T)[]`
 * Else: `new Array<T>(...items)` -> `[...items] satisfies (T)[] as (T)[]`

## Test Plan

I've added a new set of typescript snapshot tests.