### PR TITLE
feat: add plugins to override config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,7 @@ name = "biome_plugin_loader"
 version = "0.0.1"
 dependencies = [
  "biome_analyze",
+ "biome_configuration",
  "biome_console",
  "biome_deserialize",
  "biome_deserialize_macros",

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -3,6 +3,7 @@ use crate::analyzer::{LinterEnabled, RuleDomains};
 use crate::formatter::{FormatWithErrorsEnabled, FormatterEnabled};
 use crate::html::HtmlConfiguration;
 use crate::max_size::MaxSize;
+use crate::plugins::Plugins;
 use crate::{
     CssConfiguration, GraphqlConfiguration, GritConfiguration, JsConfiguration, JsonConfiguration,
     Rules,
@@ -68,6 +69,10 @@ pub struct OverridePattern {
     /// Specific configuration for the filesystem
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<OverrideFilesConfiguration>,
+
+    /// Specific configuration for additional plugins
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugins: Option<Plugins>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/biome_configuration/src/plugins.rs
+++ b/crates/biome_configuration/src/plugins.rs
@@ -3,7 +3,10 @@ use biome_deserialize::{
 };
 use biome_deserialize_macros::{Deserializable, Merge};
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
 
 #[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, Merge, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -12,7 +15,7 @@ pub struct Plugins(pub Vec<PluginConfiguration>);
 
 impl Plugins {
     pub fn iter(&self) -> impl Iterator<Item = &PluginConfiguration> {
-        self.0.iter()
+        self.deref().iter()
     }
 }
 
@@ -21,6 +24,20 @@ impl FromStr for Plugins {
 
     fn from_str(_s: &str) -> Result<Self, Self::Err> {
         Ok(Self::default())
+    }
+}
+
+impl Deref for Plugins {
+    type Target = Vec<PluginConfiguration>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Plugins {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/crates/biome_configuration/tests/invalid/overrides/incorrect_key.json.snap
+++ b/crates/biome_configuration/tests/invalid/overrides/incorrect_key.json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_configuration/tests/spec_tests.rs
+assertion_line: 58
 expression: incorrect_key.json
 ---
 incorrect_key.json:4:4 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -26,3 +27,4 @@ incorrect_key.json:4:4 deserialize ━━━━━━━━━━━━━━━
   - linter
   - assist
   - files
+  - plugins

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -12,6 +12,7 @@ version              = "0.0.1"
 
 [dependencies]
 biome_analyze            = { workspace = true }
+biome_configuration      = { workspace = true }
 biome_console            = { workspace = true }
 biome_deserialize        = { workspace = true }
 biome_deserialize_macros = { workspace = true }

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -92,24 +92,12 @@ impl PluginDiagnostic {
         })
     }
 
-    pub fn not_loaded_for_single_plugin(path: Utf8PathBuf) -> Self {
+    pub fn not_loaded(path: Utf8PathBuf) -> Self {
         Self::NotLoaded(NotLoaded {
             message: MessageAndDescription::from(
                 markup! {
                     "Plugin is requested but not loaded: "
                     <Emphasis>{path.to_string()}</Emphasis>
-                }
-                .to_owned(),
-            ),
-        })
-    }
-
-    pub fn not_loaded_for_whole_project(project: impl Display) -> Self {
-        Self::NotLoaded(NotLoaded {
-            message: MessageAndDescription::from(
-                markup! {
-                    "No plugin loaded for project: "
-                    <Emphasis>{project}</Emphasis>
                 }
                 .to_owned(),
             ),

--- a/crates/biome_plugin_loader/src/diagnostics.rs
+++ b/crates/biome_plugin_loader/src/diagnostics.rs
@@ -33,6 +33,9 @@ pub enum PluginDiagnostic {
 
     /// When an analyzer rule plugin uses an unsupported file format.
     UnsupportedRuleFormat(UnsupportedRuleFormat),
+
+    /// When plugin is requested but not loaded
+    NotLoaded(NotLoaded),
 }
 
 impl From<CompileError> for PluginDiagnostic {
@@ -86,6 +89,30 @@ impl PluginDiagnostic {
     pub fn unsupported_rule_format(message: impl Display) -> Self {
         Self::UnsupportedRuleFormat(UnsupportedRuleFormat {
             message: MessageAndDescription::from(markup! {{message}}.to_owned()),
+        })
+    }
+
+    pub fn not_loaded_for_single_plugin(path: Utf8PathBuf) -> Self {
+        Self::NotLoaded(NotLoaded {
+            message: MessageAndDescription::from(
+                markup! {
+                    "Plugin is requested but not loaded: "
+                    <Emphasis>{path.to_string()}</Emphasis>
+                }
+                .to_owned(),
+            ),
+        })
+    }
+
+    pub fn not_loaded_for_whole_project(project: impl Display) -> Self {
+        Self::NotLoaded(NotLoaded {
+            message: MessageAndDescription::from(
+                markup! {
+                    "No plugin loaded for project: "
+                    <Emphasis>{project}</Emphasis>
+                }
+                .to_owned(),
+            ),
         })
     }
 }
@@ -156,6 +183,17 @@ pub struct CantResolve {
     severity = Error,
 )]
 pub struct UnsupportedRuleFormat {
+    #[message]
+    #[description]
+    pub message: MessageAndDescription,
+}
+
+#[derive(Debug, Serialize, Deserialize, Diagnostic)]
+#[diagnostic(
+    category = "plugin",
+    severity = Error,
+)]
+pub struct NotLoaded {
     #[message]
     #[description]
     pub message: MessageAndDescription,

--- a/crates/biome_plugin_loader/src/plugin_cache.rs
+++ b/crates/biome_plugin_loader/src/plugin_cache.rs
@@ -39,8 +39,7 @@ impl PluginCache {
                                 result.extend_from_slice(&plugin.analyzer_plugins);
                             }
                             None => {
-                                diagnostics
-                                    .push(PluginDiagnostic::not_loaded_for_single_plugin(path_buf));
+                                diagnostics.push(PluginDiagnostic::not_loaded(path_buf));
                             }
                         }
                     }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -220,13 +220,13 @@ impl Settings {
         result
     }
 
-    /// Return plugins taking overrides into account
-    pub fn as_plugins(&self, path: &Utf8Path) -> Cow<Plugins> {
+    /// Returns the plugins that should be enabled for the given `path`, taking overrides into account.
+    pub fn get_plugins_for_path(&self, path: &Utf8Path) -> Cow<Plugins> {
         let mut result = Cow::Borrowed(&self.plugins);
 
         for pattern in &self.override_settings.patterns {
             if pattern.is_file_included(path) {
-                result.to_mut().0.extend_from_slice(&pattern.plugins.0);
+                result.to_mut().extend_from_slice(&pattern.plugins);
             }
         }
 
@@ -241,7 +241,7 @@ impl Settings {
             .override_settings
             .patterns
             .iter()
-            .flat_map(|pattern| pattern.plugins.0.iter().cloned())
+            .flat_map(|pattern| pattern.plugins.iter().cloned())
             .collect::<Vec<_>>();
 
         if !all_override_plugins.is_empty() {

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__diagnostics___project__a.ts.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__diagnostics___project__a.ts.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_service/src/workspace.tests.rs
+expression: plugin_diagnostics
+---
+[
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Error,
+        description: "Prefer object spread instead of `Object.assign()`",
+        message: "Prefer object spread instead of `Object.assign()`",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/a.ts",
+                ),
+            ),
+            span: Some(
+                25..39,
+            ),
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+]

--- a/crates/biome_service/src/snapshots/biome_service__workspace__tests__diagnostics___project__lib__b.ts.snap
+++ b/crates/biome_service/src/snapshots/biome_service__workspace__tests__diagnostics___project__lib__b.ts.snap
@@ -1,0 +1,74 @@
+---
+source: crates/biome_service/src/workspace.tests.rs
+expression: plugin_diagnostics
+---
+[
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Error,
+        description: "Prefer object spread instead of `Object.assign()`",
+        message: "Prefer object spread instead of `Object.assign()`",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/lib/b.ts",
+                ),
+            ),
+            span: Some(
+                25..39,
+            ),
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+    Diagnostic {
+        category: Some(
+            Category {
+                name: "plugin",
+                link: None,
+            },
+        ),
+        severity: Error,
+        description: "Consider using `for...in` loop instead of `Object.keys()` for simple object iteration.",
+        message: "Consider using `for...in` loop instead of `Object.keys()` for simple object iteration.",
+        advices: Advices {
+            advices: [],
+        },
+        verbose_advices: Advices {
+            advices: [],
+        },
+        location: Location {
+            path: Some(
+                File(
+                    "/project/lib/b.ts",
+                ),
+            ),
+            span: Some(
+                67..81,
+            ),
+            source_code: None,
+        },
+        tags: DiagnosticTags(
+            BitFlags<DiagnosticTag> {
+                bits: 0b0,
+            },
+        ),
+        source: None,
+    },
+]

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -1,9 +1,13 @@
 use std::num::NonZeroU64;
+use std::str::FromStr;
 
 use biome_analyze::RuleCategories;
 use biome_configuration::analyzer::{RuleGroup, RuleSelector};
 use biome_configuration::plugins::{PluginConfiguration, Plugins};
-use biome_configuration::{Configuration, FilesConfiguration};
+use biome_configuration::{
+    Configuration, FilesConfiguration, OverrideGlobs, OverridePattern, Overrides,
+};
+use biome_diagnostics::Diagnostic;
 use biome_fs::{BiomePath, MemoryFileSystem};
 use biome_js_syntax::{JsFileSource, TextSize};
 use camino::Utf8PathBuf;
@@ -635,6 +639,134 @@ fn plugins_may_use_invalid_span() {
         .unwrap();
     assert_debug_snapshot!(result.diagnostics);
     assert_eq!(result.errors, 0);
+}
+
+#[test]
+fn correctly_apply_plugins_in_override() {
+    let files: &[(&str, &[u8])] = &[
+    (
+        "/project/plugin_a.grit",
+        br#"`Object.assign($args)` where {
+    register_diagnostic(
+        span = $args,
+        message = "Prefer object spread instead of `Object.assign()`"
+    )
+}"#,
+    ),
+    (
+        "/project/plugin_b.grit",
+        br#"`Object.keys($args)` where {
+    register_diagnostic(
+        span = $args,
+        message = "Consider using `for...in` loop instead of `Object.keys()` for simple object iteration."
+    )
+}"#,
+    ),
+    (
+        "/project/plugin_c.grit",
+        br#"`Object.hasOwn($args)` where {
+    register_diagnostic(
+        span = $args,
+        message = "Ensure compatibility: `Object.hasOwn()` may not be supported in all environments."
+    )
+}"#,
+    ),
+    (
+        "/project/a.ts",
+        br#"
+const a = Object.assign({ foo: 'bar' });
+const keys = Object.keys({ foo: 'bar' });
+const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
+    ),
+    (
+        "/project/lib/b.ts",
+        br#"
+const a = Object.assign({ foo: 'bar' });
+const keys = Object.keys({ foo: 'bar' });
+const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
+    ),
+];
+
+    let mut fs = MemoryFileSystem::default();
+    for (path, content) in files {
+        fs.insert(Utf8PathBuf::from(*path), *content);
+    }
+
+    let workspace = server(Box::new(fs), None);
+    let OpenProjectResult { project_key, .. } = workspace
+        .open_project(OpenProjectParams {
+            path: Utf8PathBuf::from("/project").into(),
+            open_uninitialized: true,
+            only_rules: Some(Vec::new()),
+            skip_rules: None,
+        })
+        .unwrap();
+
+    workspace
+        .update_settings(UpdateSettingsParams {
+            project_key,
+            configuration: Configuration {
+                plugins: Some(Plugins(vec![PluginConfiguration::Path(
+                    "./plugin_a.grit".to_string(),
+                )])),
+                overrides: Some(Overrides(vec![
+                    OverridePattern {
+                        includes: Some(OverrideGlobs::Globs(Box::new([
+                            biome_glob::NormalizedGlob::from_str("./lib/**").unwrap(),
+                        ]))),
+                        plugins: Some(Plugins(vec![PluginConfiguration::Path(
+                            "./plugin_b.grit".to_string(),
+                        )])),
+                        ..OverridePattern::default()
+                    },
+                    OverridePattern {
+                        includes: Some(OverrideGlobs::Globs(Box::new([
+                            biome_glob::NormalizedGlob::from_str("./utils/**").unwrap(),
+                        ]))),
+                        plugins: Some(Plugins(vec![PluginConfiguration::Path(
+                            "./plugin_c.grit".to_string(),
+                        )])),
+                        ..OverridePattern::default()
+                    },
+                ])),
+                ..Default::default()
+            },
+            workspace_directory: Some(BiomePath::new("/project")),
+        })
+        .unwrap();
+
+    workspace
+        .scan_project_folder(ScanProjectFolderParams {
+            project_key,
+            path: None,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::Project,
+        })
+        .unwrap();
+
+    for (path, expect_diagnosis_count) in [("/project/a.ts", 1), ("/project/lib/b.ts", 2)] {
+        let result = workspace
+            .pull_diagnostics(PullDiagnosticsParams {
+                project_key,
+                path: BiomePath::new(path),
+                categories: RuleCategories::default(),
+                only: Vec::new(),
+                skip: Vec::new(),
+                enabled_rules: Vec::new(),
+                pull_code_actions: true,
+            })
+            .unwrap();
+        // Filter only diagnostics with category name "plugin"
+        let plugin_diagnostics: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|diag| diag.category().is_some_and(|cat| cat.name() == "plugin"))
+            .collect();
+        let snapshot_name = format!("diagnostics_{path}");
+        assert_debug_snapshot!(snapshot_name, plugin_diagnostics);
+        assert!(plugin_diagnostics.len() == expect_diagnosis_count);
+    }
 }
 
 #[test]

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -581,21 +581,10 @@ impl WorkspaceServer {
         project_key: ProjectKey,
         plugins: Cow<Plugins>,
     ) -> Result<AnalyzerPluginVec, Vec<PluginDiagnostic>> {
-        self.plugin_caches
-            .pin()
-            .get(&project_key)
-            .ok_or_else(|| {
-                if let Some(path) = self.projects.get_project_path(project_key) {
-                    vec![PluginDiagnostic::not_loaded_for_whole_project(
-                        path.to_string(),
-                    )]
-                } else {
-                    vec![PluginDiagnostic::not_loaded_for_whole_project(
-                        project_key.to_string(),
-                    )]
-                }
-            })
-            .and_then(|cache| cache.get_analyzer_plugins(&plugins))
+        match self.plugin_caches.pin().get(&project_key) {
+            Some(cache) => cache.get_analyzer_plugins(&plugins),
+            None => Ok(Vec::new()),
+        }
     }
 
     /// It accepts a list of ignore files. If the VCS integration is enabled, the files

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -800,6 +800,10 @@ export interface OverridePattern {
 	 * Specific configuration for the Json language
 	 */
 	linter?: OverrideLinterConfiguration;
+	/**
+	 * Specific configuration for additional plugins
+	 */
+	plugins?: Plugins;
 }
 export type PluginConfiguration = string;
 export type VcsClientKind = "git";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3180,6 +3180,10 @@
 						{ "$ref": "#/definitions/OverrideLinterConfiguration" },
 						{ "type": "null" }
 					]
+				},
+				"plugins": {
+					"description": "Specific configuration for additional plugins",
+					"anyOf": [{ "$ref": "#/definitions/Plugins" }, { "type": "null" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
Related: https://github.com/biomejs/biome/issues/5953

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Allow add plugins that runs only in certain files.

```
{
  "plugins": [
    "./biome-rules/custom-card-rule.grit",
    // ...
  ],
  "overrides": [{
    "includes": ["src/routes/**"],
    "plugins": ["./biome-rules/no-components-in-routes.grit"]
  }]
}
```

## Changes

1. crates/biome_configuration/src/overrides.rs : add a new field `plugins` to overrides settings
2. crates/biome_service/src/settings.rs : 

- add method `as_all_plugins`, traverse settings to collect all plugins (including global plugins and all plugins in overrides)
- add method `as_plugins`, take `path` as parameter, this method return applicable plugins for the path. (including global plugins and matched plugins in overrides)

3. crates/biome_plugin_loader/src/plugin_cache.rs

- change method `get_analyzer_plugins`, add `plugins` as parameter, it no longer return all BiomePlugins stored in cache. Now it only returns BiomePlugins specified in the parameter `plugins`

4. crates/biome_service/src/workspace/server.rs

- self.load_plugins now loads `settings.as_all_plugins()` instead of `settings.plugins`. This ensures all plugins (global + overrides) are all loaded here.
- Whenever need plugins (`fix_file`, `pull_diagnostics`), call `settings.as_plugins(&path)` to get list of plugins needed, then pass to `get_analyzer_plugins_for_project` -> `plugin_cache.get_analyzer_plugins`. This way we'll have the BiomePlugins needed for a file (global + overrides matched by path)

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Add test to check basic plugins override
crates/biome_service/src/workspace.tests.rs correctly_apply_plugins_in_override

<!-- What demonstrates that your implementation is correct? -->
