### PR TITLE
feat(core): populate members of namespaces and modules

### DIFF
--- a/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
@@ -49,7 +49,19 @@ Module TypeId(1) => Namespace {
             "shared",
         ),
     ],
-    members: [],
+    members: [
+        TypeMember {
+            kind: Named(
+                Borrowed(
+                    "Result",
+                ),
+            ),
+            is_static: true,
+            ty: Resolved(
+                Module(0) TypeId(2),
+            ),
+        },
+    ],
 }
 
 Module TypeId(2) => string


### PR DESCRIPTION
## Summary

Another small step towards `.d.ts` inference: Making sure that namespaces and modules have their members populated. The semantic analysis would already discover them, so it was just a matter of looking them up in the right scope during the resolve step.

## Test Plan

Test updated.
