### PR TITLE
fix(lsp): custom configuration path should not override the working directory

### DIFF
--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -533,6 +533,7 @@ pub enum ConfigurationPathHint {
     /// The configuration path provided by the LSP, not having a configuration file is not an error.
     /// The path will always be a directory path.
     FromLsp(Utf8PathBuf),
+
     /// The configuration path provided by the user, not having a configuration file is an error.
     /// The path can either be a directory path or a file path.
     /// Throws any kind of I/O errors.

--- a/crates/biome_lsp/src/extension_settings.rs
+++ b/crates/biome_lsp/src/extension_settings.rs
@@ -76,9 +76,10 @@ impl ExtensionSettings {
     }
 
     pub(crate) fn configuration_path(&self) -> Option<Utf8PathBuf> {
-        self.settings
-            .configuration_path
-            .as_deref()
-            .map(|config_path| Utf8PathBuf::from_str(config_path).unwrap()) // infallible
+        match self.settings.configuration_path.as_deref() {
+            // Ignore if empty as VS Code responses an empty string even if it's not set.
+            Some(config_path) if !config_path.is_empty() => Utf8PathBuf::from_str(config_path).ok(),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
## Summary

During the initialisation process of the workspace from LSP, the root directory of the project is overriden by the specified configuration path. I believe it's not intended when we use any custom configuration file, and replaced the logic to always use the current working directory even if the configuration path is provided.

## Test Plan

Manually tested with VS Code.
