### PR TITLE
docs: fix typos in RELEASES & ROME_CHANGELOG

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@ We publish pre-releases of the main `@biomejs/biome` package twice a week. These
 These releases are published to `pkg.pr.new`, and an automated message is sent on [Discord](https://biomejs.dev/chat), in the `#release` channel.
 
 > [!WARNING]
-> **Don't** use prerelease in **production**. Artefacts in `pkg.pr.new` are purged after roughly 30 days.
+> **Don't** use prerelease in **production**. Artifacts in `pkg.pr.new` are purged after roughly 30 days.
 
 ## Beta release
 

--- a/ROME_CHANGELOG.md
+++ b/ROME_CHANGELOG.md
@@ -203,7 +203,7 @@ Note that, `noExtraSemicolons` and `noExtraLabels` are renamed to [`noExtraSemic
 - Fix false positive diagnostics that [`useCamelCase`](https://docs.rome.tools/lint/rules/usecamelcase/) caused to private class members
 - Fix false positive diagnostics that [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) caused to arrow functions, export default functions and function expressions.
 - Fix false positive diagnostics that [`useHookAtTopLevel`](https://docs.rome.tools/lint/rules/usehookattoplevel/) caused to `as` or `satisfies` expression.
-- Fix false positive diagnostics that [`noHeadeScope`](https://docs.rome.tools/lint/rules/noheaderscope/) caused to custom components
+- Fix false positive diagnostics that [`noHeaderScope`](https://docs.rome.tools/lint/rules/noheaderscope/) caused to custom components
 - Fix false negative diagnostics that [`noNoninteractiveElementToInteractiveRole`](https://docs.rome.tools/lint/rules/nononinteractiveelementtointeractiverole/) and [`noNoninteractiveTabindex`](https://docs.rome.tools/lint/rules/nononinteractivetabindex/) caused to non-interactive elements.
 
 


### PR DESCRIPTION
## Summary

fix typos in RELEASES & ROME_CHANGELOG

“Artefact” seems to be the correct spelling in British English, 
but all the other files in the biome spell it “Artifact”, so I adapted it.


## Test Plan