### PR TITLE
fix(linter): change default syntax from explicit to shorthand for useConsistentObjectDefinition

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_consistent_object_definition.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_consistent_object_definition.rs
@@ -29,39 +29,6 @@ declare_lint_rule! {
     /// ```json,options
     /// {
     ///     "options": {
-    ///         "syntax": "explicit"
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// ```js,expect_diagnostic,use_options
-    /// let foo = 1;
-    /// let invalid = {
-    ///     foo
-    /// };
-    /// ```
-    ///
-    /// ```js,expect_diagnostic,use_options
-    /// let invalid = {
-    ///     bar() { return "bar"; },
-    /// };
-    /// ```
-    ///
-    /// ### Valid
-    ///
-    /// ```js,use_options
-    /// let foo = 1;
-    /// let valid = {
-    ///     foo: foo,
-    ///     bar: function() { return "bar"; },
-    /// };
-    /// ```
-    ///
-    /// ### Invalid
-    ///
-    /// ```json,options
-    /// {
-    ///     "options": {
     ///         "syntax": "shorthand"
     ///     }
     /// }
@@ -90,6 +57,39 @@ declare_lint_rule! {
     /// };
     /// ```
     ///
+    /// ### Invalid
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "syntax": "explicit"
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,expect_diagnostic,use_options
+    /// let foo = 1;
+    /// let invalid = {
+    ///     foo
+    /// };
+    /// ```
+    ///
+    /// ```js,expect_diagnostic,use_options
+    /// let invalid = {
+    ///     bar() { return "bar"; },
+    /// };
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js,use_options
+    /// let foo = 1;
+    /// let valid = {
+    ///     foo: foo,
+    ///     bar: function() { return "bar"; },
+    /// };
+    /// ```
+    ///
     /// ## Options
     ///
     /// Use the options to specify the syntax of object literals to enforce.
@@ -105,10 +105,10 @@ declare_lint_rule! {
     /// ### syntax
     ///
     /// The syntax to use:
-    /// - `explicit`: enforces the use of explicit object property syntax in every case.
     /// - `shorthand`: enforces the use of shorthand object property syntax when possible.
+    /// - `explicit`: enforces the use of explicit object property syntax in every case.
     ///
-    /// **Default:** `explicit`
+    /// **Default:** `shorthand`
     ///
     pub UseConsistentObjectDefinition {
         version: "2.0.0",
@@ -135,9 +135,9 @@ pub struct UseConsistentObjectDefinitionOptions {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub enum ObjectPropertySyntax {
     /// `{foo: foo}`
-    #[default]
     Explicit,
     /// `{foo}`
+    #[default]
     Shorthand,
 }
 

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -5362,7 +5362,7 @@
 			"properties": {
 				"syntax": {
 					"description": "The preferred syntax to enforce.",
-					"default": "explicit",
+					"default": "shorthand",
 					"allOf": [{ "$ref": "#/definitions/ObjectPropertySyntax" }]
 				}
 			},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I left my reasoning [here](https://github.com/biomejs/biome/issues/4816#issuecomment-2870063333): 
> I wonder about default value for this rule. Right now rule uses "explicit" syntax, but given that:
> 
> * Eslint equivalent rule has default option set to always use shorthand.
> * Popular Eslint configs such as [Airbnb](https://github.com/search?q=repo%3Aairbnb%2Fjavascript+object-shorthand&type=code) and  [Antfu](https://github.com/search?q=repo%3Aantfu%2Feslint-config%20object-shorthand&type=code) also use shorthand by default.
> 
> Should default option be switched from "explicit" to "shorthand", because thats what most users would expect?

I consider this a fix, because even original changelog entry for this lint rule says, default should be shorthand.
https://github.com/biomejs/biome/blob/5aecb1d9dc7e3675e2206ecfdbe68480c54c701f/.changeset/famous-ravens-cross.md


## Test Plan

All tests pass