### PR TITLE
fix(analyzer): useSortedProperties should skip unknown properties

### DIFF
--- a/.changeset/light-things-relate.md
+++ b/.changeset/light-things-relate.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fix [#6105](https://github.com/biomejs/biome/issues/6105): css lint rules `useSortedProperties` should skip unknown properties.

--- a/crates/biome_css_analyze/src/assist/source/use_sorted_properties.rs
+++ b/crates/biome_css_analyze/src/assist/source/use_sorted_properties.rs
@@ -116,15 +116,17 @@ impl Rule for UseSortedProperties {
             .into_iter()
             .collect::<Vec<AnyCssDeclarationOrRule>>();
 
-        if contains_shorthand_after_longhand(&original_properties)
-            || contains_unknown_property(&original_properties)
-        {
+        if contains_shorthand_after_longhand(&original_properties) {
             // This would be unsafe to sort
             return Some(UseSortedPropertiesState {
                 block: node.clone(),
                 original_properties,
                 sorted_properties: None,
             });
+        }
+
+        if contains_unknown_property(&original_properties) {
+            return None;
         }
 
         let sorted_properties = Some(RecessOrderProperties::new(&original_properties));

--- a/crates/biome_css_analyze/tests/quick_test.rs
+++ b/crates/biome_css_analyze/tests/quick_test.rs
@@ -1,0 +1,73 @@
+use biome_analyze::{AnalysisFilter, AnalyzerOptions, ControlFlow, Never, RuleFilter};
+use biome_css_parser::{CssParserOptions, parse_css};
+use biome_css_syntax::TextRange;
+use biome_diagnostics::{Diagnostic, DiagnosticExt, Severity, print_diagnostic_to_string};
+use std::slice;
+
+use biome_css_analyze::analyze;
+
+// use this test check if your snippet produces the diagnostics you wish, without using a snapshot
+#[ignore]
+#[test]
+fn quick_test() {
+    const FILENAME: &str = "dummyFile.css";
+    const SOURCE: &str = r#"
+.foo {
+  position-anchor: --position-anchor;
+}
+
+.bar {
+  position-anchor: --position-anchor;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.baz {
+  position: relative;
+  position-anchor: --position-anchor;
+  box-sizing: border-box;
+}
+
+.qux {
+  position: relative;
+  box-sizing: border-box;
+  position-anchor: --position-anchor;
+}
+"#;
+
+    let parsed = parse_css(SOURCE, CssParserOptions::default());
+
+    let mut error_ranges: Vec<TextRange> = Vec::new();
+    let options = AnalyzerOptions::default();
+    let rule_filter = RuleFilter::Rule("source", "useSortedProperties");
+
+    analyze(
+        &parsed.tree(),
+        AnalysisFilter {
+            enabled_rules: Some(slice::from_ref(&rule_filter)),
+            ..AnalysisFilter::default()
+        },
+        &options,
+        &[],
+        |signal| {
+            if let Some(diag) = signal.diagnostic() {
+                error_ranges.push(diag.location().span.unwrap());
+                let error = diag
+                    .with_severity(Severity::Warning)
+                    .with_file_path(FILENAME)
+                    .with_file_source_code(SOURCE);
+                let text = print_diagnostic_to_string(&error);
+                eprintln!("{text}");
+            }
+
+            for action in signal.actions() {
+                let new_code = action.mutation.commit();
+                eprintln!("{new_code}");
+            }
+
+            ControlFlow::<Never>::Continue(())
+        },
+    );
+
+    // assert_eq!(error_ranges.as_slice(), &[]);
+}

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: invalid.css
-snapshot_kind: text
 ---
 # Input
 ```css

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css
@@ -78,3 +78,29 @@
   border:·1px·solid·black;
   transition:·opactity·1s·ease;
 }
+
+
+/**
+ * https://github.com/biomejs/biome/issues/6105
+ */
+.foo {
+  position-anchor: --position-anchor;
+}
+
+.bar {
+  position-anchor: --position-anchor;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.baz {
+  position: relative;
+  position-anchor: --position-anchor;
+  box-sizing: border-box;
+}
+
+.qux {
+  position: relative;
+  box-sizing: border-box;
+  position-anchor: --position-anchor;
+}

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: valid.css
-snapshot_kind: text
 ---
 # Input
 ```css
@@ -86,4 +85,29 @@ snapshot_kind: text
   transition:·opactity·1s·ease;
 }
 
+
+/**
+ * https://github.com/biomejs/biome/issues/6105
+ */
+.foo {
+  position-anchor: --position-anchor;
+}
+
+.bar {
+  position-anchor: --position-anchor;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.baz {
+  position: relative;
+  position-anchor: --position-anchor;
+  box-sizing: border-box;
+}
+
+.qux {
+  position: relative;
+  box-sizing: border-box;
+  position-anchor: --position-anchor;
+}
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes: #6105 

Skip the unknown properties when [`useSortedProeprties`](https://next.biomejs.dev/assist/actions/use-sorted-properties/) check. 

## Test Plan

I add test case under `crates/biome_css_analyzer` and add a quick_test file.

<!-- What demonstrates that your implementation is correct? -->
