### PR TITLE
mark noFlatMapIdentity fix as unsafe

### DIFF
--- a/crates/biome_js_analyze/src/lint/complexity/no_flat_map_identity.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_flat_map_identity.rs
@@ -42,7 +42,7 @@ declare_lint_rule! {
         recommended: true,
         severity: Severity::Information,
         sources: &[RuleSource::Clippy("flat_map_identity")],
-        fix_kind: FixKind::Safe,
+        fix_kind: FixKind::Unsafe,
     }
 }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

closes #6142 

Marks noFlatMapIdentity as unsafe as it assumes the object `.flatMap` is called on is an array which could not be the case

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
