### PR TITLE
refactor: avoid unnecessary document retrieval

### DIFF
--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -74,8 +74,8 @@ impl ModuleGraph {
         &self,
         fs: &dyn FsWithResolverProxy,
         project_layout: &ProjectLayout,
-        added_or_updated_paths: &[(&BiomePath, Option<AnyJsRoot>)],
-        removed_paths: &[BiomePath],
+        added_or_updated_paths: &[(&BiomePath, AnyJsRoot)],
+        removed_paths: &[&BiomePath],
     ) {
         // Make sure all directories are registered for the added/updated paths.
         let path_info = self.path_info.pin();
@@ -99,12 +99,9 @@ impl ModuleGraph {
         // Traverse all the added and updated paths and insert their resolved
         // imports.
         let imports = self.data.pin();
-        for (path, root) in added_or_updated_paths
-            .iter()
-            .filter_map(|(path, root)| root.clone().map(|root| (path, root)))
-        {
+        for (path, root) in added_or_updated_paths {
             let directory = path.parent().unwrap_or(path);
-            let visitor = JsModuleVisitor::new(root, directory, &fs_proxy);
+            let visitor = JsModuleVisitor::new(root.clone(), directory, &fs_proxy);
             imports.insert(path.to_path_buf(), visitor.collect_info());
         }
 

--- a/crates/biome_parser/src/lib.rs
+++ b/crates/biome_parser/src/lib.rs
@@ -679,6 +679,10 @@ impl AnyParse {
         Self { root, diagnostics }
     }
 
+    pub fn root(&self) -> SendNode {
+        self.root.clone()
+    }
+
     pub fn syntax<L>(&self) -> SyntaxNode<L>
     where
         L: Language + 'static,

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -15,10 +15,7 @@ use biome_fs::{FileSystemDiagnostic, PathKind};
 use camino::Utf8Path;
 use papaya::{Compute, Operation};
 
-use crate::{
-    IGNORE_ENTRIES, WorkspaceError,
-    workspace_watcher::{OpenFileReason, WatcherSignalKind},
-};
+use crate::{IGNORE_ENTRIES, WorkspaceError, workspace_watcher::WatcherSignalKind};
 
 use super::{
     ScanKind, ScanProjectFolderParams, ServiceDataNotification, Workspace, WorkspaceServer,
@@ -75,12 +72,7 @@ impl WorkspaceServer {
             return Ok(()); // file events outside our projects can be safely ignored.
         };
 
-        self.open_file_by_watcher(project_key, path)?;
-
-        self.update_service_data(
-            WatcherSignalKind::AddedOrChanged(OpenFileReason::WatcherUpdate),
-            path,
-        )
+        self.open_file_by_watcher(project_key, path)
     }
 
     /// Used indirectly by the watcher to open an individual folder.
@@ -147,7 +139,9 @@ impl WorkspaceServer {
             }
         });
         match result {
-            Compute::Removed(_, _) => self.update_service_data(WatcherSignalKind::Removed, path),
+            Compute::Removed(_, _) => {
+                self.update_service_data(WatcherSignalKind::Removed, path, None)
+            }
             _ => Ok(()),
         }
     }

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -193,10 +193,10 @@ pub fn module_graph_for_test_file(
 pub fn get_added_paths<'a>(
     fs: &dyn FileSystem,
     paths: &'a [BiomePath],
-) -> Vec<(&'a BiomePath, Option<AnyJsRoot>)> {
+) -> Vec<(&'a BiomePath, AnyJsRoot)> {
     paths
         .iter()
-        .map(|path| {
+        .filter_map(|path| {
             let root = fs.read_file_from_path(path).ok().and_then(|content| {
                 let file_source = JsFileSource::try_from(path.as_path()).unwrap_or_default();
                 let parsed =
@@ -207,8 +207,8 @@ pub fn get_added_paths<'a>(
                     "Unexpected diagnostics: {diagnostics:?}"
                 );
                 parsed.try_tree()
-            });
-            (path, root)
+            })?;
+            Some((path, root))
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

Whenever we insert a file using `open_file_internal()`, we call `update_service_data()` afterwards. But `update_service_data()` called `update_module_graph()`, which was responsible for retrieving the document so we can process it there. This was wasteful, because `open_file_internal()` just inserted the document, and now we need to look it up again. So instead of doing these lookups, we can just pass the root for processing directly.

Also, I found that the watcher explicitly called `update_service_data()` even though this was also done through the call to `open_file_by_watcher()` right above it. So I think the watcher was doing some work twice there.

## Test Plan

Tests should remain green.
