### PR TITLE
fix(js-semantic): don't bind the parameter to its parameter

### DIFF
--- a/.changeset/moody-cobras-win.md
+++ b/.changeset/moody-cobras-win.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6144](https://github.com/biomejs/biome/issues/6144): [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports/) reported incorrectly imports that were used as the type of parameters with the same name.
+In the following code, the import `name` was reported as unused.
+
+```ts
+import name from "mod";
+function f(name: name.Readable): void {}
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue6144.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue6144.ts
@@ -1,0 +1,29 @@
+import type name0 from "mod";
+import type name1 from "mod";
+import type name2 from "mod";
+import type name3 from "mod";
+import type name4 from "mod";
+import other0 from "mod";
+import other1 from "mod";
+import other2 from "mod";
+import other3 from "mod";
+import other4 from "mod";
+
+const f0 = (name0: name0.T): void => {};
+
+function f1(name1: name1.T): void {};
+
+function f2(...name2: name2.U): void {};
+
+const f3 = (other0: other0.T): void => {};
+
+function f4(other1: other1.T): void {};
+
+function f5(...other2: other2.U): void {};
+
+class C0 {
+    constructor(readonly name3: name3.T, readonly other3: other3.T) {}
+}
+
+try {} catch(name4: name4.T) {}
+try {} catch(other4: other4.T) {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue6144.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue6144.ts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6144.ts
+---
+# Input
+```ts
+import type name0 from "mod";
+import type name1 from "mod";
+import type name2 from "mod";
+import type name3 from "mod";
+import type name4 from "mod";
+import other0 from "mod";
+import other1 from "mod";
+import other2 from "mod";
+import other3 from "mod";
+import other4 from "mod";
+
+const f0 = (name0: name0.T): void => {};
+
+function f1(name1: name1.T): void {};
+
+function f2(...name2: name2.U): void {};
+
+const f3 = (other0: other0.T): void => {};
+
+function f4(other1: other1.T): void {};
+
+function f5(...other2: other2.U): void {};
+
+class C0 {
+    constructor(readonly name3: name3.T, readonly other3: other3.T) {}
+}
+
+try {} catch(name4: name4.T) {}
+try {} catch(other4: other4.T) {}
+
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -206,7 +206,19 @@ impl BindingInfo {
                 | JsSyntaxKind::JS_NAMESPACE_IMPORT_SPECIFIER
                 | JsSyntaxKind::JS_BOGUS_NAMED_IMPORT_SPECIFIER
                 | JsSyntaxKind::JS_SHORTHAND_NAMED_IMPORT_SPECIFIER
-                | JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER
+                | JsSyntaxKind::JS_NAMED_IMPORT_SPECIFIER,
+        )
+    }
+
+    fn is_parameter(&self) -> bool {
+        matches!(
+            self.declaration_kind,
+            JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
+                | JsSyntaxKind::JS_BOGUS_PARAMETER
+                | JsSyntaxKind::JS_FORMAL_PARAMETER
+                | JsSyntaxKind::JS_REST_PARAMETER
+                | JsSyntaxKind::TS_PROPERTY_PARAMETER
+                | JsSyntaxKind::JS_CATCH_DECLARATION,
         )
     }
 }
@@ -250,6 +262,10 @@ enum Reference {
 impl Reference {
     const fn is_write(&self) -> bool {
         matches!(self, Self::Write { .. })
+    }
+
+    const fn is_ambient_read(&self) -> bool {
+        matches!(self, Self::AmbientRead { .. })
     }
 
     /// Range of the referenced binding
@@ -959,12 +975,8 @@ impl SemanticEventExtractor {
 
         // Bind references to declarations
         for (name, mut references) in scope.references {
-            if let Some(&BindingInfo {
-                range_start: declaration_range_start,
-                declaration_kind,
-            }) = self.bindings.get(&name)
-            {
-                let declaration_at = declaration_range_start;
+            if let Some(info) = self.bindings.get(&name) {
+                let declaration_at = info.range_start;
                 // We know the declaration of these reference.
                 for reference in references {
                     let declaration_before_reference = declaration_at < reference.range().start();
@@ -988,8 +1000,8 @@ impl SemanticEventExtractor {
                                 }
                             }
                         }
-                        Reference::Read(range) | Reference::AmbientRead(range) => {
-                            if declaration_kind == JsSyntaxKind::JS_NAMESPACE_IMPORT_SPECIFIER
+                        reference @ (Reference::Read(_) | Reference::AmbientRead(_)) => {
+                            if info.declaration_kind == JsSyntaxKind::JS_NAMESPACE_IMPORT_SPECIFIER
                                 && matches!(name, BindingName::Type(_))
                             {
                                 // An import namespace imported as a type can only be
@@ -1003,15 +1015,29 @@ impl SemanticEventExtractor {
                                 });
                                 continue;
                             }
+                            // Handle edge case where a parameter has the same name that a parameter type name
+                            // For example `(stream: stream.T) => {}`
+                            // In this particular case, the reference should be promoted to the parent scope.
+                            if reference.is_ambient_read() && info.is_parameter() {
+                                // A parent scope should exist because the binding is a parameter.
+                                if let Some(parent) = self.scopes.last_mut() {
+                                    // Promote this reference to the parent scope
+                                    let parent_references =
+                                        parent.references.entry(name.clone()).or_default();
+                                    parent_references
+                                        .push(Reference::AmbientRead(reference.range()));
+                                    continue;
+                                }
+                            }
                             if declaration_before_reference {
                                 SemanticEvent::Read {
-                                    range,
+                                    range: reference.range(),
                                     declaration_at,
                                     scope_id,
                                 }
                             } else {
                                 SemanticEvent::HoistedRead {
-                                    range,
+                                    range: reference.range(),
                                     declaration_at,
                                     scope_id,
                                 }


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/6144

This adds an exception to the semantic model to avoid binding a parameter type to a parameter.

## Test Plan

I added several tests.