### PR TITLE
fix(core): use single ignore list for scanner

### DIFF
--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -13,7 +13,7 @@ use super::{FeaturesBuilder, IsPathIgnoredParams};
 use crate::diagnostics::Panic;
 use crate::projects::ProjectKey;
 use crate::workspace::DocumentFileSource;
-use crate::{Workspace, WorkspaceError};
+use crate::{IGNORE_ENTRIES, Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
 use biome_diagnostics::{Diagnostic as _, Error, Severity};
 use biome_fs::{BiomePath, PathInterner, PathKind, TraversalContext, TraversalScope};
@@ -251,17 +251,6 @@ impl ScanContext<'_> {
     }
 }
 
-/// Path entries that we want to ignore during the scanning phase.
-pub const SCANNER_IGNORE_ENTRIES: &[&[u8]] = &[
-    b".cache",
-    b".git",
-    b".hg",
-    b".svn",
-    b".yarn",
-    b".timestamp",
-    b".DS_Store",
-];
-
 impl TraversalContext for ScanContext<'_> {
     fn interner(&self) -> &PathInterner {
         &self.interner
@@ -281,7 +270,7 @@ impl TraversalContext for ScanContext<'_> {
     fn can_handle(&self, path: &BiomePath) -> bool {
         if path
             .file_name()
-            .is_some_and(|file_name| SCANNER_IGNORE_ENTRIES.contains(&file_name.as_bytes()))
+            .is_some_and(|file_name| IGNORE_ENTRIES.contains(&file_name.as_bytes()))
         {
             return false;
         }


### PR DESCRIPTION
## Summary

Looks like we had two definitions of the scanner's ignore list lying around :) Removed one.

## Test Plan

Everything should remain green.
