### PR TITLE
feat(biome_js_analyze): useExhaustiveDependencies add reactCompilerEna…

### DIFF
--- a/.changeset/funny-knives-marry.md
+++ b/.changeset/funny-knives-marry.md
@@ -1,0 +1,22 @@
+---
+"@biomejs/biome": minor
+---
+
+Introduces a new option `reactCompilerEnabled` to useExhaustiveDependencies rule.
+Accepts a boolean value to enable or disable the use of the React compiler for checking dependencies in hooks.
+Defaults to `false`.
+
+Example configuration:
+```json
+{
+  "rules": {
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "reactCompilerEnabled": true
+      }
+    ]
+  }
+}
+```
+

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+const Component = () => {
+    const [things, setThings] = useState(undefined);
+
+    const fetchThings = async () => {
+        const t = await fetchSomething();
+        if (t) {
+            setThings('done');
+        }
+    }
+
+    function fetchMoreThings() {
+        return fetchThings();
+    }
+
+    const mapping = {
+        something: things
+    };
+
+    useEffect(() => {
+        fetchThings();
+        const fetchData = async () => {
+            await fetchMoreThings();
+        }
+
+        fetchData().then((res) => {
+            return mapping[res.body] || res;
+        });
+    }, [fetchThings, fetchMoreThings, mapping]);
+
+    if (!things) {
+        return <div>Loading...</div>;
+    }
+
+    return (
+        <div>Loaded some things</div>
+    );
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.jsx.snap
@@ -1,0 +1,66 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
+expression: reactCompilerEnabled.jsx
+---
+# Input
+```jsx
+import { useEffect, useState } from "react";
+
+const Component = () => {
+    const [things, setThings] = useState(undefined);
+
+    const fetchThings = async () => {
+        const t = await fetchSomething();
+        if (t) {
+            setThings('done');
+        }
+    }
+
+    function fetchMoreThings() {
+        return fetchThings();
+    }
+
+    const mapping = {
+        something: things
+    };
+
+    useEffect(() => {
+        fetchThings();
+        const fetchData = async () => {
+            await fetchMoreThings();
+        }
+
+        fetchData().then((res) => {
+            return mapping[res.body] || res;
+        });
+    }, [fetchThings, fetchMoreThings, mapping]);
+
+    if (!things) {
+        return <div>Loading...</div>;
+    }
+
+    return (
+        <div>Loaded some things</div>
+    );
+}
+
+```
+
+# Diagnostics
+```
+reactCompilerEnabled.jsx:30:39 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × mapping changes on every re-render and should not be used as a hook dependency.
+  
+    28 │             return mapping[res.body] || res;
+    29 │         });
+  > 30 │     }, [fetchThings, fetchMoreThings, mapping]);
+       │                                       ^^^^^^^
+    31 │ 
+    32 │     if (!things) {
+  
+  i To fix this, wrap the definition of mapping in its own useMemo() hook.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/reactCompilerEnabled.options.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "correctness": {
+        "useExhaustiveDependencies": {
+          "level": "error",
+          "options": {
+            "reportMissingDependenciesArray": true,
+            "reactCompilerEnabled": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -2977,6 +2977,10 @@ export interface UseExhaustiveDependenciesOptions {
 	 */
 	hooks?: Hook[];
 	/**
+	 * Whether to report a diagnostic when using functions that are not wrapped with useCallback as a dependency when react compiler is in scope. Defaults to false.
+	 */
+	reactCompilerEnabled?: boolean;
+	/**
 	 * Whether to report an error when a hook has no dependencies array.
 	 */
 	reportMissingDependenciesArray?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -5426,6 +5426,11 @@
 					"type": "array",
 					"items": { "$ref": "#/definitions/Hook" }
 				},
+				"reactCompilerEnabled": {
+					"description": "Whether to report a diagnostic when using functions that are not wrapped with useCallback as a dependency when react compiler is in scope. Defaults to false.",
+					"default": false,
+					"type": "boolean"
+				},
 				"reportMissingDependenciesArray": {
 					"description": "Whether to report an error when a hook has no dependencies array.",
 					"default": false,


### PR DESCRIPTION
## Summary

Introduces a new option `reactCompilerEnabled` to useExhaustiveDependencies rule.
Accepts a boolean value to enable or disable the use of the React compiler for checking dependencies in hooks.
Defaults to `false`.

Example configuration:
```json
{
  "rules": {
    "react-hooks/exhaustive-deps": [
      "warn",
      {
        "reactCompilerEnabled": true
      }
    ]
  }
}
```