### PR TITLE
fix(lsp): always identify .cjs files as CommonJS

### DIFF
--- a/.changeset/thin-dragons-raise.md
+++ b/.changeset/thin-dragons-raise.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4665](https://github.com/biomejs/biome/issues/4665): the LSP previously
+identified `.cjs` files as ESM files, making rules like `noRedundantUseStrict`
+reports incorrectly valid `"use strict"` directives.

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -347,13 +347,19 @@ impl WorkspaceServer {
         let mut source = document_file_source.unwrap_or(DocumentFileSource::from_path(&path));
 
         if let DocumentFileSource::Js(js) = &mut source {
-            if path.extension().is_some_and(|extension| extension == "js") {
-                let manifest = self.project_layout.find_node_manifest_for_path(&path);
-                if let Some((_, manifest)) = manifest {
-                    if manifest.r#type == Some(PackageType::CommonJs) {
-                        js.set_module_kind(ModuleKind::Script);
+            match path.extension() {
+                Some("js") => {
+                    let manifest = self.project_layout.find_node_manifest_for_path(&path);
+                    if let Some((_, manifest)) = manifest {
+                        if manifest.r#type == Some(PackageType::CommonJs) {
+                            js.set_module_kind(ModuleKind::Script);
+                        }
                     }
                 }
+                Some("cjs") => {
+                    js.set_module_kind(ModuleKind::Script);
+                }
+                _ => {}
             }
         }
 


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/4665

## Test Plan

I manually tested the ix on the provided reproduction.
