### PR TITLE
docs(contributing): biome.lspBin to biome.lsp.bin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ If you're debugging an LSP reproduction, make sure that the client allows to use
 
 ```json
 {
-  "biome.lspBin": "/Users/john/www/biome/target/debug/biome"
+  "biome.lsp.bin": "/Users/john/www/biome/target/debug/biome"
 }
 ```
 


### PR DESCRIPTION
## Summary

`biome.lspBin` was deprecated in favor of `biome.lsp.bin`.
This PR fixes the contributing guide.
