### PR TITLE
feat(core): resolve React symbols

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -7,6 +7,7 @@ use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsImportClause, AnyJsImportLike, AnyJsNamedImportSpecifier, JsModuleSource, JsSyntaxToken,
 };
+use biome_jsdoc_comment::JsdocComment;
 use biome_module_graph::{JsModuleInfo, ModuleGraph, ResolvedPath};
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -411,8 +412,9 @@ fn get_restricted_import_visibility(
 ) -> Option<Visibility> {
     let visibility = options
         .target_info
-        .find_exported_symbol(options.module_graph, import_name.text())
-        .and_then(|export| export.jsdoc_comment.as_deref().and_then(parse_visibility))
+        .find_jsdoc_for_exported_symbol(options.module_graph, import_name.text())
+        .as_ref()
+        .and_then(parse_visibility)
         .unwrap_or(options.default_visibility);
 
     let is_restricted = match visibility {
@@ -427,7 +429,7 @@ fn get_restricted_import_visibility(
 /// Searches JSDoc comments to find the first `@public`, `@package`, `@private`,
 /// or `@access` tag, and maps it to one of the supported [Visibility] values,
 /// if possible.
-fn parse_visibility(jsdoc_comment: &str) -> Option<Visibility> {
+fn parse_visibility(jsdoc_comment: &JsdocComment) -> Option<Visibility> {
     jsdoc_comment.lines().find_map(|line| {
         line.strip_prefix('@')
             .map(|tag| tag.strip_prefix("access ").unwrap_or(tag))

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -1135,7 +1135,7 @@ impl TypeReferenceQualifier {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct BindingId(u32);
 
 impl BindingId {

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -1,4 +1,4 @@
-use crate::js_module_info::{Exports, Imports};
+use crate::js_module_info::{Exports, Imports, JsBindingData};
 use crate::{JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport};
 use biome_formatter::prelude::*;
 use biome_formatter::{format_args, write};
@@ -209,7 +209,7 @@ impl Format<FormatTypeContext> for JsExport {
                 write!(
                     f,
                     [&format_args![
-                        text("OnwType"),
+                        text("OwnType"),
                         space(),
                         text("=>"),
                         space(),
@@ -242,6 +242,79 @@ impl Format<FormatTypeContext> for JsExport {
                 )
             }
         }
+    }
+}
+
+impl std::fmt::Display for JsBindingData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let formatted = biome_formatter::format!(FormatTypeContext, [&self])
+            .expect("Formatting not to throw any FormatErrors");
+        f.write_str(
+            formatted
+                .print()
+                .expect("Expected a valid document")
+                .as_code(),
+        )
+    }
+}
+
+impl Format<FormatTypeContext> for JsBindingData {
+    fn fmt(
+        &self,
+        f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
+    ) -> FormatResult<()> {
+        let jsdoc_comment = format_with(|f| {
+            if let Some(jsdoc) = &self.jsdoc {
+                write!(
+                    f,
+                    [&format_args![
+                        text("JSDoc comment:"),
+                        space(),
+                        jsdoc,
+                        text(","),
+                        hard_line_break()
+                    ]]
+                )
+            } else {
+                Ok(())
+            }
+        });
+
+        let content = format_with(|f| {
+            write!(
+                f,
+                [&format_args![
+                    text("Name:"),
+                    space(),
+                    dynamic_text(&self.name, TextSize::default()),
+                    text(","),
+                    hard_line_break(),
+                    text("Type:"),
+                    space(),
+                    &self.ty,
+                    text(","),
+                    hard_line_break(),
+                    jsdoc_comment,
+                    text("Declaration kind:"),
+                    space(),
+                    dynamic_text(
+                        &std::format!("{:?}", self.declaration_kind),
+                        TextSize::default()
+                    ),
+                ]]
+            )
+        });
+
+        write!(
+            f,
+            [&format_args![
+                text("JsBindingData {"),
+                block_indent(&content),
+                text("}")
+            ],]
+        )?;
+
+        Ok(())
     }
 }
 
@@ -279,39 +352,24 @@ impl Format<FormatTypeContext> for JsOwnExport {
         &self,
         f: &mut biome_formatter::formatter::Formatter<FormatTypeContext>,
     ) -> FormatResult<()> {
-        let content = format_with(|f| {
-            write!(f, [&self.ty])?;
-
-            write!(f, [hard_line_break()])?;
-
-            write!(f, [text("Local name: ")])?;
-            if let Some(name) = &self.local_name {
-                write!(f, [&format_args![dynamic_text(name, TextSize::default())]])?;
-            } else {
-                write!(f, [&format_args![text("None")]])?;
-            }
-
-            write!(f, [hard_line_break()])?;
-
-            if let Some(comment) = &self.jsdoc_comment {
-                write!(f, [&format_args![&comment]])?;
-                write!(f, [&format_args![soft_line_break()]])?;
-            }
-
-            Ok(())
-        });
-
-        write!(
-            f,
-            [&format_args![
-                text("JsOwnExport"),
-                text("("),
-                block_indent(&content),
-                text(")")
-            ],]
-        )?;
-
-        Ok(())
+        match self {
+            Self::Binding(binding_id) => write!(
+                f,
+                [&format_args![
+                    text("JsOwnExport::Binding("),
+                    dynamic_text(&binding_id.index().to_string(), TextSize::default()),
+                    text(")")
+                ]]
+            ),
+            Self::Type(resolved_type_id) => write!(
+                f,
+                [&format_args![
+                    text("JsOwnExport::Type("),
+                    dynamic_text(&std::format!("{resolved_type_id:?}"), TextSize::default()),
+                    text(")")
+                ]]
+            ),
+        }
     }
 }
 

--- a/crates/biome_module_graph/src/js_module_info/binding.rs
+++ b/crates/biome_module_graph/src/js_module_info/binding.rs
@@ -28,13 +28,11 @@ pub enum JsBindingReferenceKind {
 
 /// Internal type with all the semantic data of a specific reference
 #[derive(Clone, Debug)]
-#[expect(unused)]
 pub struct JsBindingReference {
     pub range_start: TextSize,
     pub kind: JsBindingReferenceKind,
 }
 
-#[expect(unused)]
 impl JsBindingReference {
     #[inline(always)]
     pub fn is_read(&self) -> bool {

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -73,7 +73,7 @@ pub(super) struct JsModuleInfoCollector {
     /// All collected exports.
     ///
     /// When we've completed a pass over the module, we will attempt to resolve
-    /// the references of
+    /// the references of these exports and construct the final exports.
     exports: Vec<JsCollectedExport>,
 
     /// All imports nodes.

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -70,8 +70,11 @@ pub(super) struct JsModuleInfoCollector {
     /// Map with all dynamic import paths, from the import source to the resolved path.
     dynamic_import_paths: BTreeMap<Text, ResolvedPath>,
 
-    /// Map with exports, from the exported symbol name to a [JsExport] definition.
-    exports: BTreeMap<Text, JsExport>,
+    /// All collected exports.
+    ///
+    /// When we've completed a pass over the module, we will attempt to resolve
+    /// the references of
+    exports: Vec<JsCollectedExport>,
 
     /// All imports nodes.
     imports: Vec<biome_js_syntax::JsImport>,
@@ -81,6 +84,32 @@ pub(super) struct JsModuleInfoCollector {
 
     /// Types collected in the module.
     types: TypeStore,
+}
+
+/// Intermediary representation for an exported symbol.
+pub(super) enum JsCollectedExport {
+    ExportNamedSymbol {
+        /// Name under which the symbol will be exported.
+        export_name: Text,
+
+        /// Local name of the symbol in the global scope.
+        local_name: TokenText,
+    },
+    ExportDefault {
+        /// Reference to the type being exported.
+        ty: TypeReference,
+    },
+    ExportDefaultAssignment {
+        /// Reference to the type assigned to the export.
+        ty: TypeReference,
+    },
+    Reexport {
+        /// Name under which the import will be re-exported.
+        export_name: Text,
+
+        /// Re-export definition.
+        reexport: JsReexport,
+    },
 }
 
 impl JsModuleInfoCollector {
@@ -111,25 +140,19 @@ impl JsModuleInfoCollector {
         self.extractor.leave(node);
     }
 
-    pub fn register_export(&mut self, name: impl Into<Text>, export: JsExport) -> Option<()> {
-        self.exports.insert(name.into(), export);
-
-        Some(())
+    pub fn register_export(&mut self, export: JsCollectedExport) {
+        self.exports.push(export)
     }
 
     pub fn register_export_with_name(
         &mut self,
         export_name: impl Into<Text>,
-        local_name: Option<TokenText>,
-    ) -> Option<()> {
-        self.register_export(
-            export_name,
-            JsExport::Own(JsOwnExport {
-                jsdoc_comment: None,
-                local_name,
-                ty: TypeReference::Unknown,
-            }),
-        )
+        local_name: TokenText,
+    ) {
+        self.register_export(JsCollectedExport::ExportNamedSymbol {
+            export_name: export_name.into(),
+            local_name,
+        })
     }
 
     pub fn register_blanket_reexport(&mut self, reexport: JsReexport) {
@@ -388,11 +411,14 @@ impl JsModuleInfoCollector {
     /// module's semantic data, and `ResolvedTypeId` is only 8 bytes. So during
     /// resolving, we "downgrade" the import references from
     /// [`TypeReference::Resolved`] to [`TypeReference::Import`].
-    fn resolve_all_and_downgrade_project_references(&mut self, bag: &JsModuleInfoBag) {
+    fn resolve_all_and_downgrade_project_references(
+        &mut self,
+        static_imports: &BTreeMap<Text, JsImport>,
+    ) {
         let bindings = self.bindings.clone(); // TODO: Can we omit the clone?
         let downgrade_import_reference = |id: BindingId| {
             let binding = &bindings[id.index()];
-            bag.static_imports
+            static_imports
                 .get(&binding.name)
                 .map_or(TypeReference::Unknown, |import| {
                     TypeImportQualifier {
@@ -615,7 +641,12 @@ impl JsModuleInfoBag {
     pub(super) fn from_collector(collector: &mut JsModuleInfoCollector) -> Self {
         let mut info = Self::default();
         info.collect_imports(collector);
+
+        collector.resolve_all_and_downgrade_project_references(&info.static_imports);
+        collector.flatten_all();
+
         info.collect_exports(collector);
+
         info
     }
 
@@ -756,43 +787,106 @@ impl JsModuleInfoBag {
     }
 
     fn collect_exports(&mut self, collector: &mut JsModuleInfoCollector) {
-        self.exports.clone_from(&collector.exports);
-        self.blanket_reexports
-            .clone_from(&collector.blanket_reexports);
+        self.blanket_reexports = std::mem::take(&mut collector.blanket_reexports);
 
-        // Lookup types from the bindings in the global scope.
-        for export in self.exports.values_mut() {
-            let Some(export) = export.as_own_export_mut() else {
-                continue;
-            };
+        let exports = std::mem::take(&mut collector.exports);
+        for export in exports {
+            match export {
+                JsCollectedExport::ExportNamedSymbol {
+                    export_name,
+                    local_name,
+                } => {
+                    let Some(binding_ref) = collector.scopes[0].bindings_by_name.get(&local_name)
+                    else {
+                        continue;
+                    };
 
-            let Some(local_name) = &export.local_name else {
-                continue;
-            };
+                    let export = match binding_ref {
+                        TsBindingReference::Merged {
+                            ty,
+                            value_ty,
+                            namespace_ty,
+                        } => {
+                            let ty = ty.map(|ty| &collector.bindings[ty.index()].ty);
+                            let value_ty = value_ty.map(|ty| &collector.bindings[ty.index()].ty);
+                            let namespace_ty =
+                                namespace_ty.map(|ty| &collector.bindings[ty.index()].ty);
+                            match (ty, value_ty, namespace_ty) {
+                                (Some(ty1), Some(ty2), None)
+                                | (Some(ty1), None, Some(ty2))
+                                | (None, Some(ty1), Some(ty2))
+                                    if ty1 == ty2 =>
+                                {
+                                    let ty = collector
+                                        .register_and_resolve(TypeData::reference(ty1.clone()));
+                                    JsOwnExport::Type(ty)
+                                }
+                                (Some(ty1), Some(ty2), Some(ty3)) if ty1 == ty2 && ty2 == ty3 => {
+                                    let ty = collector
+                                        .register_and_resolve(TypeData::reference(ty1.clone()));
+                                    JsOwnExport::Type(ty)
+                                }
+                                _ => {
+                                    let ty =
+                                        collector.register_and_resolve(TypeData::merged_reference(
+                                            ty.cloned(),
+                                            value_ty.cloned(),
+                                            namespace_ty.cloned(),
+                                        ));
+                                    JsOwnExport::Type(ty)
+                                }
+                            }
+                        }
+                        TsBindingReference::Type(binding_id)
+                        | TsBindingReference::ValueType(binding_id)
+                        | TsBindingReference::TypeAndValueType(binding_id)
+                        | TsBindingReference::NamespaceAndValueType(binding_id) => {
+                            JsOwnExport::Binding(*binding_id)
+                        }
+                    };
 
-            if let Some(binding_ref) = collector.scopes[0].bindings_by_name.get(local_name) {
-                match binding_ref {
-                    TsBindingReference::Merged {
-                        ty,
-                        value_ty,
-                        namespace_ty,
-                    } => {
-                        export.ty = collector
-                            .register_and_resolve(TypeData::merged_reference(
-                                ty.map(|ty| collector.bindings[ty.index()].ty.clone()),
-                                value_ty.map(|ty| collector.bindings[ty.index()].ty.clone()),
-                                namespace_ty.map(|ty| collector.bindings[ty.index()].ty.clone()),
-                            ))
-                            .into();
+                    self.exports.insert(export_name, JsExport::Own(export));
+                }
+                JsCollectedExport::ExportDefault { ty } => {
+                    let resolved = collector
+                        .resolve_reference(&ty)
+                        .unwrap_or(GLOBAL_UNKNOWN_ID);
+
+                    let export = JsExport::Own(JsOwnExport::Type(resolved));
+                    self.exports.insert(Text::Static("default"), export);
+                }
+                JsCollectedExport::ExportDefaultAssignment { ty } => {
+                    let resolved = collector
+                        .resolve_reference(&ty)
+                        .unwrap_or(GLOBAL_UNKNOWN_ID);
+
+                    if let Some(data) = collector.get_by_resolved_id(resolved) {
+                        for member in data.as_raw_data().own_members() {
+                            let Some(name) = member.name() else {
+                                continue;
+                            };
+
+                            // DANGER: Normally, when resolving a type reference retrieved through
+                            //         `as_raw_data()`, we should call
+                            //         `apply_module_id_to_reference()` on the reference first. But
+                            //         because we know we are resolving inside the collector, before
+                            //         any module IDs _could_ be applied, we can omit this here.
+                            if let Some(resolved_member) = collector.resolve_reference(&member.ty) {
+                                let export = JsExport::Own(JsOwnExport::Type(resolved_member));
+                                self.exports.insert(name, export);
+                            }
+                        }
                     }
-                    TsBindingReference::Type(binding_id)
-                    | TsBindingReference::ValueType(binding_id)
-                    | TsBindingReference::TypeAndValueType(binding_id)
-                    | TsBindingReference::NamespaceAndValueType(binding_id) => {
-                        let binding = &collector.bindings[binding_id.index()];
-                        export.jsdoc_comment.clone_from(&binding.jsdoc);
-                        export.ty.clone_from(&binding.ty);
-                    }
+
+                    let export = JsExport::Own(JsOwnExport::Type(resolved));
+                    self.exports.insert(Text::Static("default"), export);
+                }
+                JsCollectedExport::Reexport {
+                    export_name,
+                    reexport,
+                } => {
+                    self.exports
+                        .insert(export_name, JsExport::Reexport(reexport));
                 }
             }
         }
@@ -802,9 +896,6 @@ impl JsModuleInfoBag {
 impl JsModuleInfo {
     pub(super) fn new(mut collector: JsModuleInfoCollector) -> Self {
         let bag = JsModuleInfoBag::from_collector(&mut collector);
-
-        collector.resolve_all_and_downgrade_project_references(&bag);
-        collector.flatten_all();
 
         Self(Arc::new(JsModuleInfoInner {
             static_imports: Imports(bag.static_imports),

--- a/crates/biome_module_graph/src/js_module_info/visitor.rs
+++ b/crates/biome_module_graph/src/js_module_info/visitor.rs
@@ -3,7 +3,7 @@ use biome_js_syntax::{
     AnyJsExportClause, AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsImportLike,
     AnyJsObjectBindingPatternMember, AnyJsRoot, AnyTsIdentifierBinding, AnyTsModuleName,
     JsExportFromClause, JsExportNamedFromClause, JsExportNamedSpecifierList, JsIdentifierBinding,
-    JsVariableDeclaratorList, unescape_js_string,
+    JsVariableDeclaratorList, TsExportAssignmentClause, unescape_js_string,
 };
 use biome_js_type_info::{ImportSymbol, TypeData, TypeReference, TypeResolver};
 use biome_jsdoc_comment::JsdocComment;
@@ -12,8 +12,8 @@ use biome_rowan::{AstNode, TokenText, WalkEvent};
 use camino::Utf8Path;
 
 use crate::{
-    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, SUPPORTED_TYPE_EXTENSIONS,
-    module_graph::ModuleGraphFsProxy,
+    JsImport, JsModuleInfo, JsReexport, SUPPORTED_TYPE_EXTENSIONS,
+    js_module_info::collector::JsCollectedExport, module_graph::ModuleGraphFsProxy,
 };
 
 use super::{ResolvedPath, collector::JsModuleInfoCollector};
@@ -100,18 +100,34 @@ impl<'a> JsModuleVisitor<'a> {
             AnyJsExportClause::JsExportNamedFromClause(node) => {
                 self.visit_export_named_from_clause(node, collector)
             }
-            AnyJsExportClause::TsExportAsNamespaceClause(node) => {
-                let token = node.name().ok()?.value_token().ok()?;
-                let name = token.token_text_trimmed();
-                collector.register_export_with_name(name, None)
+            AnyJsExportClause::TsExportAsNamespaceClause(_node) => {
+                // FIXME: We may need to implement this if we want to fully
+                //        support global namespace merging.
+                None
             }
             AnyJsExportClause::TsExportAssignmentClause(node) => {
-                self.visit_export_default_expression(&node.expression().ok()?, collector)
+                self.visit_export_assignment_clause(node, collector)
             }
             AnyJsExportClause::TsExportDeclareClause(node) => {
                 self.visit_export_declaration_clause(node.declaration().ok()?, collector)
             }
         }
+    }
+
+    /// Handles `export =` clauses.
+    ///
+    /// Export assignments create both a `default` export as well as named
+    /// exports for any members of the symbol being exported.
+    fn visit_export_assignment_clause(
+        &self,
+        node: TsExportAssignmentClause,
+        collector: &mut JsModuleInfoCollector,
+    ) -> Option<()> {
+        let type_data = TypeData::from_any_js_expression(collector, &node.expression().ok()?);
+        let ty = TypeReference::from(collector.register_and_resolve(type_data));
+        collector.register_export(JsCollectedExport::ExportDefaultAssignment { ty });
+
+        Some(())
     }
 
     fn visit_export_declaration_clause(
@@ -151,7 +167,8 @@ impl<'a> JsModuleVisitor<'a> {
             }
         };
 
-        collector.register_export_with_name(name.clone(), Some(name))
+        collector.register_export_with_name(name.clone(), name);
+        Some(())
     }
 
     fn visit_export_default_declaration_clause(
@@ -174,7 +191,8 @@ impl<'a> JsModuleVisitor<'a> {
             }
         };
 
-        collector.register_export_with_name("default", Some(name))
+        collector.register_export_with_name("default", name);
+        Some(())
     }
 
     fn visit_export_default_expression(
@@ -183,15 +201,10 @@ impl<'a> JsModuleVisitor<'a> {
         collector: &mut JsModuleInfoCollector,
     ) -> Option<()> {
         let type_data = TypeData::from_any_js_expression(collector, node);
-        let ty: TypeReference = collector.register_and_resolve(type_data).into();
-        collector.register_export(
-            "default",
-            JsExport::Own(JsOwnExport {
-                jsdoc_comment: None,
-                local_name: None,
-                ty,
-            }),
-        )
+        let ty = TypeReference::from(collector.register_and_resolve(type_data));
+
+        collector.register_export(JsCollectedExport::ExportDefault { ty });
+        Some(())
     }
 
     fn visit_export_from_clause(
@@ -215,18 +228,18 @@ impl<'a> JsModuleVisitor<'a> {
             .and_then(|parent| JsdocComment::try_from(parent).ok());
 
         if let Some(export_as) = node.export_as() {
-            let name = export_as
+            let export_name = export_as
                 .exported_name()
                 .and_then(|name| name.inner_string_text())
                 .map(unescape_js_string)
                 .ok()?;
-            collector.register_export(
-                name,
-                JsExport::Reexport(JsReexport {
+            collector.register_export(JsCollectedExport::Reexport {
+                export_name,
+                reexport: JsReexport {
                     import,
                     jsdoc_comment,
-                }),
-            );
+                },
+            });
         } else {
             collector.register_blanket_reexport(JsReexport {
                 import,
@@ -259,22 +272,22 @@ impl<'a> JsModuleVisitor<'a> {
                 .ok()
                 .and_then(|name| name.inner_string_text().ok())
                 .map(unescape_js_string)?;
-            let exported_name = specifier
+            let export_name = specifier
                 .export_as()
                 .and_then(|export_as| export_as.exported_name().ok())
                 .and_then(|name| name.inner_string_text().ok())
                 .map_or_else(|| imported_name.clone(), unescape_js_string);
-            collector.register_export(
-                exported_name,
-                JsExport::Reexport(JsReexport {
+            collector.register_export(JsCollectedExport::Reexport {
+                export_name,
+                reexport: JsReexport {
                     import: JsImport {
                         specifier: import_specifier.clone().into(),
                         resolved_path: resolved_path.clone(),
                         symbol: ImportSymbol::Named(imported_name),
                     },
                     jsdoc_comment: None,
-                }),
-            );
+                },
+            });
         }
 
         Some(())
@@ -295,7 +308,9 @@ impl<'a> JsModuleVisitor<'a> {
                     .ok()
                     .and_then(|name| name.value_token().ok())
                     .map(|name_token| name_token.token_text_trimmed());
-                collector.register_export_with_name(export_name, local_name);
+                if let Some(local_name) = local_name {
+                    collector.register_export_with_name(export_name, local_name);
+                }
             }
         }
 
@@ -393,7 +408,8 @@ impl<'a> JsModuleVisitor<'a> {
         collector: &mut JsModuleInfoCollector,
     ) -> Option<()> {
         let name = binding.name_token().ok()?.token_text_trimmed();
-        collector.register_export_with_name(name.clone(), Some(name))
+        collector.register_export_with_name(name.clone(), name);
+        Some(())
     }
 
     fn resolved_path_from_specifier(&self, specifier: &str) -> ResolvedPath {

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use biome_fs::MemoryFileSystem;
 use biome_js_formatter::context::JsFormatOptions;
 use biome_js_formatter::format_node;
@@ -90,7 +92,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
                 content.push_str(&data.to_string());
                 content.push_str("\n```\n\n");
 
-                let exported_binding_ids: Vec<_> = data
+                let exported_binding_ids: BTreeSet<_> = data
                     .exports
                     .values()
                     .filter_map(JsExport::as_own_export)

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -84,14 +84,14 @@ impl<'a> ModuleGraphSnapshot<'a> {
             content.push_str(formatted.as_code().trim());
             content.push_str("\n```");
 
-            let data = dependency_data.get(file_name.as_path()).unwrap().clone();
+            if let Some(data) = dependency_data.get(file_name.as_path()) {
+                content.push_str("\n\n## Module Info\n\n");
+                content.push_str("```\n");
+                content.push_str(&data.to_string());
+                content.push_str("\n```\n\n");
 
-            content.push_str("\n\n## Module Info\n\n");
-            content.push_str("```\n");
-            content.push_str(&data.to_string());
-            content.push_str("\n```\n\n");
-
-            dump_registered_types(&mut content, data.as_resolver());
+                dump_registered_types(&mut content, data.as_resolver());
+            }
         }
 
         if let Some(resolver) = self.resolver {

--- a/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
@@ -23,10 +23,10 @@ export = shared;
 ```
 Exports {
   "default" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: None
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(0))
+  }
+  "foo" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(3))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_default_function_declaration.snap
@@ -19,18 +19,25 @@ export default function Component(): JSX.Element {}
 ```
 Exports {
   "default" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(1)
-      Local name: Component
-      JsDoc(
-        @public
-        @returns {JSX.Element}
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: Component,
+  Type: Module(0) TypeId(1),
+  JSDoc comment: JsDoc(
+    @public
+    @returns {JSX.Element}
+  ),
+  Declaration kind: Unknown
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -20,17 +20,24 @@ export { foo };
 ```
 Exports {
   "foo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: foo
-      JsDoc(
-        @returns {string}
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: foo,
+  Type: Module(0) TypeId(0),
+  JSDoc comment: JsDoc(
+    @returns {string}
+  ),
+  Declaration kind: HoistedValue
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -21,10 +21,7 @@ export { returnPromiseResult };
 ```
 Exports {
   "returnPromiseResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(1)
-      Local name: returnPromiseResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(1)
   }
 }
 Imports {
@@ -33,6 +30,16 @@ Imports {
     Resolved path: "/src/promisedResult.ts"
     Import Symbol: PromisedResult
   }
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(1) => JsBindingData {
+  Name: returnPromiseResult,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
 }
 ```
 
@@ -63,14 +70,21 @@ export type PromisedResult = Promise<{ result: true | false }>;
 ```
 Exports {
   "PromisedResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(4)
-      Local name: PromisedResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: PromisedResult,
+  Type: Module(0) TypeId(4),
+  Declaration kind: Type
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -57,15 +57,15 @@ Imports {
 ## Exported Bindings
 
 ```
-BindingId(3) => JsBindingData {
-  Name: superComputer,
-  Type: Module(0) TypeId(6),
-  Declaration kind: Value
-}
-
 BindingId(0) => JsBindingData {
   Name: theAnswer,
   Type: Module(0) TypeId(0),
+  Declaration kind: Value
+}
+
+BindingId(3) => JsBindingData {
+  Name: superComputer,
+  Type: Module(0) TypeId(6),
   Declaration kind: Value
 }
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -43,20 +43,30 @@ export const superComputer = new DeepThought();
 ```
 Exports {
   "superComputer" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(6)
-      Local name: superComputer
-    )
+    ExportOwnExport => JsOwnExport::Binding(3)
   }
   "theAnswer" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: theAnswer
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(3) => JsBindingData {
+  Name: superComputer,
+  Type: Module(0) TypeId(6),
+  Declaration kind: Value
+}
+
+BindingId(0) => JsBindingData {
+  Name: theAnswer,
+  Type: Module(0) TypeId(0),
+  Declaration kind: Value
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -116,6 +116,45 @@ Imports {
 ## Exported Bindings
 
 ```
+BindingId(0) => JsBindingData {
+  Name: foo,
+  Type: Module(0) TypeId(0),
+  JSDoc comment: JsDoc(
+    @returns {string}
+  ),
+  Declaration kind: HoistedValue
+}
+
+BindingId(1) => JsBindingData {
+  Name: bar,
+  Type: Module(0) TypeId(1),
+  JSDoc comment: JsDoc(
+    @package
+  ),
+  Declaration kind: HoistedValue
+}
+
+BindingId(2) => JsBindingData {
+  Name: quz,
+  Type: Module(0) TypeId(2),
+  JSDoc comment: JsDoc(
+    @private
+  ),
+  Declaration kind: Value
+}
+
+BindingId(3) => JsBindingData {
+  Name: baz,
+  Type: Module(0) TypeId(4),
+  Declaration kind: HoistedValue
+}
+
+BindingId(4) => JsBindingData {
+  Name: qux,
+  Type: Module(0) TypeId(5),
+  Declaration kind: HoistedValue
+}
+
 BindingId(5) => JsBindingData {
   Name: a,
   Type: Module(0) TypeId(7),
@@ -128,24 +167,15 @@ BindingId(6) => JsBindingData {
   Declaration kind: Value
 }
 
-BindingId(1) => JsBindingData {
-  Name: bar,
-  Type: Module(0) TypeId(1),
-  JSDoc comment: JsDoc(
-    @package
-  ),
-  Declaration kind: HoistedValue
-}
-
-BindingId(3) => JsBindingData {
-  Name: baz,
-  Type: Module(0) TypeId(4),
-  Declaration kind: HoistedValue
-}
-
 BindingId(7) => JsBindingData {
   Name: d,
   Type: Module(0) TypeId(10),
+  Declaration kind: Value
+}
+
+BindingId(8) => JsBindingData {
+  Name: e,
+  Type: Module(0) TypeId(11),
   Declaration kind: Value
 }
 
@@ -157,36 +187,6 @@ BindingId(11) => JsBindingData {
     @returns {JSX.Element}
   ),
   Declaration kind: Unknown
-}
-
-BindingId(8) => JsBindingData {
-  Name: e,
-  Type: Module(0) TypeId(11),
-  Declaration kind: Value
-}
-
-BindingId(0) => JsBindingData {
-  Name: foo,
-  Type: Module(0) TypeId(0),
-  JSDoc comment: JsDoc(
-    @returns {string}
-  ),
-  Declaration kind: HoistedValue
-}
-
-BindingId(4) => JsBindingData {
-  Name: qux,
-  Type: Module(0) TypeId(5),
-  Declaration kind: HoistedValue
-}
-
-BindingId(2) => JsBindingData {
-  Name: quz,
-  Type: Module(0) TypeId(2),
-  JSDoc comment: JsDoc(
-    @private
-  ),
-  Declaration kind: Value
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -61,62 +61,28 @@ export * as renamed2 from "./renamed-reexports";
 ```
 Exports {
   "a" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(7)
-      Local name: a
-    )
+    ExportOwnExport => JsOwnExport::Binding(5)
   }
   "b" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(8)
-      Local name: b
-    )
+    ExportOwnExport => JsOwnExport::Binding(6)
   }
   "bar" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(1)
-      Local name: bar
-      JsDoc(
-        @package
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(1)
   }
   "baz" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(4)
-      Local name: baz
-    )
+    ExportOwnExport => JsOwnExport::Binding(3)
   }
   "d" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(10)
-      Local name: d
-    )
+    ExportOwnExport => JsOwnExport::Binding(7)
   }
   "default" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(21)
-      Local name: Component
-      JsDoc(
-        @public
-        @returns {JSX.Element}
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(11)
   }
   "e" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(11)
-      Local name: e
-    )
+    ExportOwnExport => JsOwnExport::Binding(8)
   }
   "foo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: foo
-      JsDoc(
-        @returns {string}
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
   "oh\nno" => {
     ExportReexport => Reexport(
@@ -126,19 +92,10 @@ Exports {
     )
   }
   "qux" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(5)
-      Local name: qux
-    )
+    ExportOwnExport => JsOwnExport::Binding(4)
   }
   "quz" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(2)
-      Local name: quz
-      JsDoc(
-        @private
-      )
-    )
+    ExportOwnExport => JsOwnExport::Binding(2)
   }
   "renamed2" => {
     ExportReexport => Reexport(
@@ -153,6 +110,83 @@ Exports {
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(5) => JsBindingData {
+  Name: a,
+  Type: Module(0) TypeId(7),
+  Declaration kind: Value
+}
+
+BindingId(6) => JsBindingData {
+  Name: b,
+  Type: Module(0) TypeId(8),
+  Declaration kind: Value
+}
+
+BindingId(1) => JsBindingData {
+  Name: bar,
+  Type: Module(0) TypeId(1),
+  JSDoc comment: JsDoc(
+    @package
+  ),
+  Declaration kind: HoistedValue
+}
+
+BindingId(3) => JsBindingData {
+  Name: baz,
+  Type: Module(0) TypeId(4),
+  Declaration kind: HoistedValue
+}
+
+BindingId(7) => JsBindingData {
+  Name: d,
+  Type: Module(0) TypeId(10),
+  Declaration kind: Value
+}
+
+BindingId(11) => JsBindingData {
+  Name: Component,
+  Type: Module(0) TypeId(21),
+  JSDoc comment: JsDoc(
+    @public
+    @returns {JSX.Element}
+  ),
+  Declaration kind: Unknown
+}
+
+BindingId(8) => JsBindingData {
+  Name: e,
+  Type: Module(0) TypeId(11),
+  Declaration kind: Value
+}
+
+BindingId(0) => JsBindingData {
+  Name: foo,
+  Type: Module(0) TypeId(0),
+  JSDoc comment: JsDoc(
+    @returns {string}
+  ),
+  Declaration kind: HoistedValue
+}
+
+BindingId(4) => JsBindingData {
+  Name: qux,
+  Type: Module(0) TypeId(5),
+  Declaration kind: HoistedValue
+}
+
+BindingId(2) => JsBindingData {
+  Name: quz,
+  Type: Module(0) TypeId(2),
+  JSDoc comment: JsDoc(
+    @private
+  ),
+  Declaration kind: Value
 }
 ```
 
@@ -319,14 +353,21 @@ export function ohNo() {}
 ```
 Exports {
   "ohNo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: ohNo
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: ohNo,
+  Type: Module(0) TypeId(0),
+  Declaration kind: HoistedValue
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_namespace_with_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_namespace_with_type.snap
@@ -19,10 +19,7 @@ export type Foo = Foo.Bar;
 ```
 Exports {
   "Foo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(3)
-      Local name: Foo
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(3))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
@@ -26,32 +26,36 @@ export { A, B };
 ```
 Exports {
   "A" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(13)
-      Local name: A
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(0))
   }
   "B" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(14)
-      Local name: B
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(13))
   }
   "Union" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(6)
-      Local name: Union
-    )
+    ExportOwnExport => JsOwnExport::Binding(3)
   }
   "Union2" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(12)
-      Local name: Union2
-    )
+    ExportOwnExport => JsOwnExport::Binding(7)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(3) => JsBindingData {
+  Name: Union,
+  Type: Module(0) TypeId(6),
+  Declaration kind: Type
+}
+
+BindingId(7) => JsBindingData {
+  Name: Union2,
+  Type: Module(0) TypeId(12),
+  Declaration kind: Type
 }
 ```
 
@@ -84,7 +88,5 @@ Module TypeId(11) => value: true
 
 Module TypeId(12) => Module(0) TypeId(9) | Module(0) TypeId(10) | Module(0) TypeId(11)
 
-Module TypeId(13) => value: a
-
-Module TypeId(14) => (type: Module(0) TypeId(1), value: Module(0) TypeId(7), namespace: )
+Module TypeId(13) => (type: Module(0) TypeId(1), value: Module(0) TypeId(7), namespace: )
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -19,14 +19,21 @@ export const promise = returnsPromise();
 ```
 Exports {
   "promise" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(2)
-      Local name: promise
-    )
+    ExportOwnExport => JsOwnExport::Binding(1)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(1) => JsBindingData {
+  Name: promise,
+  Type: Module(0) TypeId(2),
+  Declaration kind: Value
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -48,14 +48,21 @@ export type PromisedResult = Promise<{ result: true | false }>;
 ```
 Exports {
   "PromisedResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(4)
-      Local name: PromisedResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: PromisedResult,
+  Type: Module(0) TypeId(4),
+  Declaration kind: Type
 }
 ```
 
@@ -97,10 +104,7 @@ export { returnPromiseResult };
 ```
 Exports {
   "returnPromiseResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(1)
-      Local name: returnPromiseResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(1)
   }
 }
 Imports {
@@ -109,6 +113,16 @@ Imports {
     Resolved path: "/src/promisedResult.ts"
     Import Symbol: PromisedResult
   }
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(1) => JsBindingData {
+  Name: returnPromiseResult,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -74,14 +74,21 @@ export type PromisedResult = Promise<{ result: true | false }>;
 ```
 Exports {
   "PromisedResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(4)
-      Local name: PromisedResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(0)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: PromisedResult,
+  Type: Module(0) TypeId(4),
+  Declaration kind: Type
 }
 ```
 
@@ -123,10 +130,7 @@ export { returnPromiseResult };
 ```
 Exports {
   "returnPromiseResult" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(1)
-      Local name: returnPromiseResult
-    )
+    ExportOwnExport => JsOwnExport::Binding(1)
   }
 }
 Imports {
@@ -135,6 +139,16 @@ Imports {
     Resolved path: "/src/reexport.ts"
     Import Symbol: PromisedResult
   }
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(1) => JsBindingData {
+  Name: returnPromiseResult,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
@@ -2,7 +2,53 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-# `/node_modules/@types/react/index.d.ts`
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+import { useCallback } from "react";
+
+const fn = useCallback(async () => {});
+const promise = fn();
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "useCallback" => {
+    Specifier: "react"
+    Resolved path: "/node_modules/@types/react/index.d.ts"
+    Import Symbol: useCallback
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => instanceof Promise
+
+Module TypeId(1) => async Function {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(0)
+}
+
+Module TypeId(2) => Call Import Symbol: useCallback from "/node_modules/@types/react/index.d.ts"(
+  Module(0) TypeId(1)
+)
+
+Module TypeId(3) => Call Module(0) TypeId(2)(No parameters)
+```
+
+# `/node_modules/@types/react/index.d.ts` (Module 1)
 
 ## Source
 
@@ -24549,3 +24595,5 @@ Module TypeId(1629) => instanceof Array<T = string>
 
 Module TypeId(1630) => instanceof Promise<T = Module(0) TypeId(34)>
 ```
+
+# Scoped Type Resolver

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
@@ -4838,119 +4838,812 @@ type ReactManagedAttributes<C, P> = C extends { defaultProps: infer D }
 
 ```
 Exports {
+  "" => {
+    ExportOwnExport => JsOwnExport::Type(unknown)
+  }
+  "AbstractView" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1285))
+  }
+  "ActionDispatch" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(369))
+  }
+  "AllHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(871))
+  }
+  "AnchorHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(892))
+  }
+  "AnimationEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(550))
+  }
+  "AnimationEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(601))
+  }
+  "AnyActionArg" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(366))
+  }
+  "AreaHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(895))
+  }
+  "AriaAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(735))
+  }
+  "AriaRole" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(798))
+  }
+  "Attributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(76))
+  }
+  "AudioHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(894))
+  }
+  "AutoFill" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1011))
+  }
+  "AutoFillAddressKind" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(947))
+  }
+  "AutoFillBase" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(948))
+  }
+  "AutoFillContactField" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(956))
+  }
+  "AutoFillContactKind" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(960))
+  }
+  "AutoFillCredentialField" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(961))
+  }
+  "AutoFillField" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1007))
+  }
+  "AutoFillNormalField" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(998))
+  }
+  "AutoFillSection" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1008))
+  }
+  "BaseHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(896))
+  }
+  "BaseSyntheticEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(478))
+  }
+  "BlockquoteHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(897))
+  }
+  "ButtonHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(904))
+  }
+  "CElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(103))
+  }
   "CSSProperties" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: CSSProperties
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(669))
+  }
+  "CanvasHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(905))
+  }
+  "ChangeEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(512))
+  }
+  "ChangeEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(580))
+  }
+  "ClassAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(82))
+  }
+  "ClassType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(279))
+  }
+  "ClassicComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(259))
+  }
+  "ClassicComponentClass" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(276))
+  }
+  "ClassicElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(109))
+  }
+  "ClipboardEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(487))
+  }
+  "ClipboardEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(565))
+  }
+  "ColHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(906))
+  }
+  "ColgroupHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(907))
+  }
+  "Component" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(58))
+  }
+  "ComponentClass" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(272))
+  }
+  "ComponentElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(105))
+  }
+  "ComponentLifecycle" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(292))
+  }
+  "ComponentProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(61))
+  }
+  "ComponentPropsWithRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(61))
+  }
+  "ComponentPropsWithoutRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(339))
+  }
+  "ComponentRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(61))
+  }
+  "ComponentState" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(42))
+  }
+  "ComponentType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(49))
+  }
+  "CompositionEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(490))
+  }
+  "CompositionEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(568))
+  }
+  "Consumer" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(189))
+  }
+  "ConsumerProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(175))
+  }
+  "Context" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(192))
+  }
+  "ContextType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(183))
+  }
+  "CustomComponentPropsWithRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(61))
+  }
+  "DOMAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(666))
+  }
+  "DOMElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(111))
+  }
+  "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(60))
+  }
+  "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(853))
+  }
+  "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_IMG_SRC_TYPES" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(921))
+  }
+  "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_MEDIA_SRC_TYPES" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1030))
+  }
+  "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(125))
+  }
+  "DataHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(908))
+  }
+  "DelHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(910))
+  }
+  "DependencyList" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(375))
+  }
+  "DeprecatedLifecycle" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(324))
+  }
+  "DetailedHTMLProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(610))
+  }
+  "DetailedReactHTMLElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(117))
+  }
+  "DetailsHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(909))
+  }
+  "DialogHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(911))
+  }
+  "Dispatch" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(363))
+  }
+  "DispatchWithoutAction" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(252))
+  }
+  "DragEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(493))
+  }
+  "DragEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(571))
+  }
+  "EffectCallback" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(378))
+  }
+  "ElementRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(71))
+  }
+  "ElementType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(45))
+  }
+  "EmbedHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(912))
+  }
+  "ErrorInfo" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1292))
+  }
+  "EventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(560))
+  }
+  "ExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(177))
+  }
+  "FC" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(260))
+  }
+  "FieldsetHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(913))
+  }
+  "FocusEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(508))
+  }
+  "FocusEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(574))
+  }
+  "FormEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(510))
+  }
+  "FormEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(577))
+  }
+  "FormHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(914))
+  }
+  "ForwardRefExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(327))
+  }
+  "ForwardRefRenderFunction" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(267))
+  }
+  "ForwardedRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(264))
   }
   "FragmentProps" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: FragmentProps
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(214))
+  }
+  "FunctionComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(261))
+  }
+  "FunctionComponentElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(101))
+  }
+  "GetDerivedStateFromError" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(305))
+  }
+  "GetDerivedStateFromProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(303))
+  }
+  "HTMLAttributeAnchorTarget" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(885))
+  }
+  "HTMLAttributeReferrerPolicy" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(880))
+  }
+  "HTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(852))
+  }
+  "HTMLElementType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1229))
+  }
+  "HTMLInputAutoCompleteAttribute" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1013))
+  }
+  "HTMLInputTypeAttribute" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(944))
+  }
+  "HTMLProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(608))
+  }
+  "HtmlHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(915))
+  }
+  "IframeHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(920))
+  }
+  "ImgHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(932))
+  }
+  "InputHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1023))
+  }
+  "InsHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(933))
+  }
+  "InvalidEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(511))
+  }
+  "JSX" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1293))
+  }
+  "JSXElementConstructor" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(57))
+  }
+  "Key" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(72))
+  }
+  "KeyboardEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(532))
+  }
+  "KeyboardEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(583))
+  }
+  "KeygenHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1024))
+  }
+  "LabelHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1025))
+  }
+  "LazyExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(352))
+  }
+  "LegacyRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(68))
+  }
+  "LiHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1026))
+  }
+  "LinkHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1027))
+  }
+  "MapHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1028))
+  }
+  "MediaHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1031))
+  }
+  "MemoExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(344))
+  }
+  "MenuHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1029))
+  }
+  "MetaHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1032))
+  }
+  "MeterHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1033))
   }
   "ModifierKey" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: ModifierKey
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(527))
   }
-  "React" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: None
-    )
+  "MouseEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(536))
+  }
+  "MouseEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(586))
+  }
+  "MutableRefObject" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(379))
+  }
+  "NamedExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(181))
+  }
+  "NewLifecycle" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(311))
+  }
+  "ObjectHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1035))
+  }
+  "OlHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1043))
+  }
+  "OptgroupHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1044))
+  }
+  "OptionHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1045))
+  }
+  "OptionalPostfixToken" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1004))
+  }
+  "OptionalPrefixToken" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1001))
+  }
+  "OutputHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1046))
+  }
+  "ParamHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1047))
+  }
+  "PointerEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(500))
+  }
+  "PointerEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(592))
+  }
+  "ProfilerOnRenderCallback" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(228))
+  }
+  "ProfilerProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(230))
+  }
+  "ProgressHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1048))
+  }
+  "PropsWithChildren" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(337))
+  }
+  "PropsWithRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(335))
+  }
+  "PropsWithoutRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(333))
+  }
+  "Provider" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(186))
+  }
+  "ProviderExoticComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(182))
+  }
+  "ProviderProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(173))
+  }
+  "PureComponent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(253))
+  }
+  "QuoteHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1034))
+  }
+  "ReactComponentElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(97))
+  }
+  "ReactElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(87))
+  }
+  "ReactEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(562))
+  }
+  "ReactHTMLElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(114))
+  }
+  "ReactInstance" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(235))
+  }
+  "ReactNode" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(130))
+  }
+  "ReactPortal" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(124))
+  }
+  "ReactSVGElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(122))
+  }
+  "Reducer" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(371))
+  }
+  "ReducerState" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(373))
+  }
+  "ReducerWithoutAction" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(372))
+  }
+  "Ref" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(66))
+  }
+  "RefAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(80))
+  }
+  "RefCallback" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(61))
+  }
+  "RefObject" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(59))
+  }
+  "SVGAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1127))
+  }
+  "SVGElementType" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1282))
+  }
+  "SVGLineElementAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(614))
+  }
+  "SVGProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(612))
+  }
+  "SVGTextElementAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(615))
+  }
+  "ScriptHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1050))
+  }
+  "SelectHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1051))
+  }
+  "SetStateAction" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(360))
+  }
+  "SlotHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1049))
+  }
+  "SourceHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1052))
+  }
+  "StaticLifecycle" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(299))
+  }
+  "StyleHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1053))
+  }
+  "SuspenseProps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(220))
+  }
+  "SyntheticEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(483))
+  }
+  "TableHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1064))
+  }
+  "TdHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1076))
+  }
+  "TextareaHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1065))
+  }
+  "ThHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1077))
+  }
+  "TimeHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1078))
+  }
+  "ToggleEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(556))
+  }
+  "ToggleEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(604))
+  }
+  "Touch" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1286))
+  }
+  "TouchEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(540))
+  }
+  "TouchEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(589))
+  }
+  "TouchList" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1290))
+  }
+  "TrackHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1079))
+  }
+  "TransitionEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(559))
+  }
+  "TransitionEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(607))
   }
   "TransitionFunction" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: TransitionFunction
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(420))
   }
   "TransitionStartFunction" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: TransitionStartFunction
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(423))
+  }
+  "UIEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(544))
+  }
+  "UIEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(595))
   }
   "Usable" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: Usable
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(454))
+  }
+  "VideoHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1080))
+  }
+  "WebViewHTMLAttributes" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1128))
+  }
+  "WheelEvent" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(547))
+  }
+  "WheelEventHandler" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(598))
   }
   "act" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: act
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(434))
+  }
+  "action" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(464))
   }
   "cache" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: cache
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(469))
+  }
+  "callback" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(433))
+  }
+  "captureOwnerStack" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(470))
+  }
+  "children" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(206))
+  }
+  "cloneElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(170))
+  }
+  "context" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(193))
+  }
+  "createContext" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(194))
+  }
+  "createElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(157))
+  }
+  "createRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(325))
   }
   "default" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: None
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(0))
+  }
+  "defaultValue" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(58))
+  }
+  "deps" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(406))
+  }
+  "effect" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(405))
+  }
+  "element" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(156))
+  }
+  "factory" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(413))
+  }
+  "fn" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(468))
+  }
+  "format" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(415))
+  }
+  "forwardRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(332))
+  }
+  "getServerSnapshot" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(439))
+  }
+  "getSnapshot" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(439))
+  }
+  "init" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(410))
+  }
+  "initialArg" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(396))
+  }
+  "initialState" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(457))
+  }
+  "initialValue" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(58))
+  }
+  "isValidElement" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(196))
+  }
+  "lazy" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(357))
+  }
+  "load" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(355))
+  }
+  "memo" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(350))
+  }
+  "object" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(195))
+  }
+  "passthrough" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(441))
+  }
+  "permalink" => {
+    ExportOwnExport => JsOwnExport::Type(string)
+  }
+  "props" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(39))
+  }
+  "propsAreEqual" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(348))
+  }
+  "reducer" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(448))
+  }
+  "ref" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(78))
+  }
+  "render" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(329))
+  }
+  "scope" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(421))
   }
   "startTransition" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: startTransition
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(428))
+  }
+  "subscribe" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(437))
+  }
+  "type" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(155))
+  }
+  "usable" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(455))
   }
   "use" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: use
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(456))
   }
   "useActionState" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useActionState
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(467))
+  }
+  "useCallback" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(412))
+  }
+  "useContext" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(380))
+  }
+  "useDebugValue" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(416))
   }
   "useDeferredValue" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useDeferredValue
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(424))
+  }
+  "useEffect" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(408))
   }
   "useId" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useId
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(435))
+  }
+  "useImperativeHandle" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(411))
   }
   "useInsertionEffect" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useInsertionEffect
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(436))
+  }
+  "useLayoutEffect" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(407))
+  }
+  "useMemo" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(414))
   }
   "useOptimistic" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useOptimistic
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(451))
+  }
+  "useReducer" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(398))
+  }
+  "useRef" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(404))
+  }
+  "useState" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(391))
   }
   "useSyncExternalStore" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useSyncExternalStore
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(440))
   }
   "useTransition" => {
-    ExportOwnExport => JsOwnExport(
-      unknown reference
-      Local name: useTransition
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(427))
+  }
+  "value" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(58))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -67,44 +67,54 @@ export const codes: {
 ```
 Exports {
   "CountryInfo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(22)
-      Local name: CountryInfo
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(22))
   }
   "SubdivisionInfo" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(23)
-      Local name: SubdivisionInfo
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(23))
   }
   "codes" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(20)
-      Local name: codes
-    )
+    ExportOwnExport => JsOwnExport::Binding(18)
   }
   "country" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(17)
-      Local name: country
-    )
+    ExportOwnExport => JsOwnExport::Binding(15)
   }
   "data" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(18)
-      Local name: data
-    )
+    ExportOwnExport => JsOwnExport::Binding(17)
   }
   "subdivision" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(14)
-      Local name: subdivision
-    )
+    ExportOwnExport => JsOwnExport::Binding(12)
   }
 }
 Imports {
   No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(18) => JsBindingData {
+  Name: codes,
+  Type: Module(0) TypeId(20),
+  Declaration kind: Value
+}
+
+BindingId(15) => JsBindingData {
+  Name: country,
+  Type: Module(0) TypeId(17),
+  Declaration kind: HoistedValue
+}
+
+BindingId(17) => JsBindingData {
+  Name: data,
+  Type: Module(0) TypeId(18),
+  Declaration kind: Value
+}
+
+BindingId(12) => JsBindingData {
+  Name: subdivision,
+  Type: Module(0) TypeId(14),
+  Declaration kind: HoistedValue
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -93,10 +93,10 @@ Imports {
 ## Exported Bindings
 
 ```
-BindingId(18) => JsBindingData {
-  Name: codes,
-  Type: Module(0) TypeId(20),
-  Declaration kind: Value
+BindingId(12) => JsBindingData {
+  Name: subdivision,
+  Type: Module(0) TypeId(14),
+  Declaration kind: HoistedValue
 }
 
 BindingId(15) => JsBindingData {
@@ -111,10 +111,10 @@ BindingId(17) => JsBindingData {
   Declaration kind: Value
 }
 
-BindingId(12) => JsBindingData {
-  Name: subdivision,
-  Type: Module(0) TypeId(14),
-  Declaration kind: HoistedValue
+BindingId(18) => JsBindingData {
+  Name: codes,
+  Type: Module(0) TypeId(20),
+  Declaration kind: Value
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
@@ -175,10 +175,7 @@ export = vfile;
 ```
 Exports {
   "default" => {
-    ExportOwnExport => JsOwnExport(
-      Module(0) TypeId(0)
-      Local name: None
-    )
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(0))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -943,7 +943,7 @@ fn test_resolve_react_types() {
     let _ty_string = format!("{ty:?}"); // for debugging
     let ty = ty.inferred(&mut resolver);
     let _ty_string = format!("{ty:?}"); // for debugging
-    let ty = Type::from_data(Box::new(resolver), ty);
+    //let ty = Type::from_data(Box::new(resolver), ty);
     // assert!(ty.is_promise_instance()); // FIXME: Let's make this pass
 }
 


### PR DESCRIPTION
## Summary

This PR revises slightly how we track exported symbols. The reason is that the `export = someNamespace` syntax can be used not only to export the namespace itself, it also serves to define exports for all the members of `someNamespace`. This can be clearly witnessed in React exports, which effectively does something like this:

```ts
export = React;

declare namespace React {
    function useCallback<T extends Function>(callback: T, deps: DependencyList): T;
    
    // All the other functions.
}
```

In this example, `useCallback()` needs to be importable through `import { useCallback } from "react";` _as well as_ be usable like this:

```ts
import React from "react";

React.useCallback // <- Same symbol.
```

This required a bit of a refactoring, since at the point where we used to register the export as `export = React`, we hadn't discovered the `React` declaration yet, nor done any type resolving. So now I track the exports first, then create their definitions after the type resolution phase.

## Test Plan

Tests added & updated.
