### PR TITLE
feat(biome_js_analyze): adds a new propertyAssignment option to the noParameterAssign rule.

### DIFF
--- a/.changeset/curvy-ducks-judge.md
+++ b/.changeset/curvy-ducks-judge.md
@@ -1,0 +1,8 @@
+---
+"@biomejs/biome": minor
+---
+
+Added a new `propertyAssignment` option to the `noParameterAssign` rule.
+This option allows to configure whether property assignments on function parameters are permitted.
+By default, `propertyAssignment` is set to `allow`.
+Setting it to `deny` enforces stricter immutability by disallowing property mutations on function parameters.

--- a/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_parameter_assign.rs
@@ -1,15 +1,24 @@
 use crate::services::semantic::Semantic;
 use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
 use biome_console::markup;
+use biome_deserialize::TextRange;
+use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::Severity;
-use biome_js_semantic::{AllBindingWriteReferencesIter, Reference, ReferencesExtensions};
-use biome_js_syntax::{JsIdentifierBinding, binding_ext::AnyJsBindingDeclaration};
+use biome_js_semantic::{Reference, ReferencesExtensions};
+use biome_js_syntax::AnyJsAssignment;
+use biome_js_syntax::{
+    AnyJsStatement, JsExpressionStatement, JsIdentifierBinding,
+    binding_ext::AnyJsBindingDeclaration,
+};
+use biome_js_syntax::{JsAssignmentExpression, JsPostUpdateExpression, JsPreUpdateExpression};
 use biome_rowan::AstNode;
+use biome_rowan::declare_node_union;
+use serde::{Deserialize, Serialize};
 
 declare_lint_rule! {
     /// Disallow reassigning `function` parameters.
     ///
-    /// Assignment to a `function` parameters can be misleading and confusing,
+    /// Assignment to `function` parameters can be misleading and confusing,
     /// as modifying parameters will also mutate the `arguments` object.
     /// It is often unintended and indicative of a programmer error.
     ///
@@ -41,7 +50,7 @@ declare_lint_rule! {
     /// ```ts,expect_diagnostic
     /// class C {
     ///     constructor(readonly prop: number) {
-    ///         prop++
+    ///         prop++;
     ///     }
     /// }
     /// ```
@@ -54,6 +63,53 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
+    /// ## Options
+    ///
+    /// ### propertyAssignment
+    ///
+    /// The `noParameterAssign` rule can be configured using the `propertyAssignment` option, which determines whether property assignments on function parameters are allowed or denied. By default, `propertyAssignment` is set to `allow`.
+    ///
+    /// ```json
+    /// {
+    ///     "options": {
+    ///         "propertyAssignment": "allow"
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - **allow**: Allows property assignments on function parameters. This is the default behavior.
+    ///   - Example:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "propertyAssignment": "allow"
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options
+    /// function update(obj) {
+    ///     obj.key = "value"; // No diagnostic
+    /// }
+    /// ```
+    ///
+    /// - **deny**: Disallows property assignments on function parameters, enforcing stricter immutability.
+    ///   - Example:
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "propertyAssignment": "deny"
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```js,use_options,diagnostic
+    /// function update(obj) {
+    ///     obj.key = "value"; // Diagnostic: Assignment to a property of function parameter is not allowed.
+    /// }
+    /// ```
     pub NoParameterAssign {
         version: "1.0.0",
         name: "noParameterAssign",
@@ -64,15 +120,76 @@ declare_lint_rule! {
     }
 }
 
+/// Options for the rule `NoParameterAssign`
+#[derive(Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NoParameterAssignOptions {
+    /// Whether to report an error when a dependency is listed in the dependencies array but isn't used. Defaults to `allow`.
+    #[serde(default)]
+    pub property_assignment: PropertyAssignmentMode,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+/// Specifies whether property assignments on function parameters are allowed or denied.
+pub enum PropertyAssignmentMode {
+    /// Allows property assignments on function parameters.
+    /// This is the default behavior, enabling flexibility in parameter usage.
+    #[default]
+    Allow,
+
+    /// Disallows property assignments on function parameters.
+    /// Enforces stricter immutability to prevent unintended side effects.
+    Deny,
+}
+
 impl Rule for NoParameterAssign {
     type Query = Semantic<JsIdentifierBinding>;
-    type State = Reference;
-    type Signals = AllBindingWriteReferencesIter;
-    type Options = ();
+    type State = ProblemType;
+    type Signals = Vec<Self::State>;
+    type Options = NoParameterAssignOptions;
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let binding = ctx.query();
+        let mut signals = Vec::new();
+        let model = ctx.model();
+
         if let Some(declaration) = binding.declaration() {
+            let options = ctx.options();
+            if options.property_assignment == PropertyAssignmentMode::Deny
+                && matches!(declaration, AnyJsBindingDeclaration::JsFormalParameter(_))
+            {
+                let expressions: Vec<_> = binding
+                    .all_reads(model)
+                    .filter_map(|reference| extract_statement_from_reference(&reference))
+                    .filter_map(|statement| {
+                        let left = statement
+                            .expression()
+                            .ok()?
+                            .as_js_assignment_expression()?
+                            .left()
+                            .ok()?;
+
+                        match left.as_any_js_assignment()? {
+                            AnyJsAssignment::JsComputedMemberAssignment(assignment) => {
+                                assignment.object().ok()
+                            }
+                            AnyJsAssignment::JsStaticMemberAssignment(assignment) => {
+                                assignment.object().ok()
+                            }
+                            _ => None,
+                        }
+                    })
+                    .map(|expression| {
+                        ProblemType::PropertyAssignment(expression.syntax().text_trimmed_range())
+                    })
+                    .collect();
+
+                signals.extend(expressions);
+            }
+
             if matches!(
                 declaration,
                 AnyJsBindingDeclaration::JsFormalParameter(_)
@@ -80,32 +197,78 @@ impl Rule for NoParameterAssign {
                     | AnyJsBindingDeclaration::JsArrowFunctionExpression(_)
                     | AnyJsBindingDeclaration::TsPropertyParameter(_)
             ) {
-                return binding.all_writes(ctx.model());
+                let param_reassignments: Vec<_> = binding
+                    .all_writes(model)
+                    .map(|expression| {
+                        ProblemType::ParameterAssignment(expression.syntax().text_trimmed_range())
+                    })
+                    .collect();
+
+                signals.extend(param_reassignments);
             }
         }
-        // Empty iterator that conforms to `AllBindingWriteReferencesIter` type.
-        std::iter::successors(None, |_| None)
+
+        signals
     }
 
-    fn diagnostic(ctx: &RuleContext<Self>, reference: &Self::State) -> Option<RuleDiagnostic> {
-        let param = ctx.query();
-        Some(
-            RuleDiagnostic::new(
-                rule_category!(),
-                reference.syntax().text_trimmed_range(),
-                markup! {
-                    "Reassigning a "<Emphasis>"function parameter"</Emphasis>" is confusing."
-                },
-            )
-            .detail(
-                param.syntax().text_trimmed_range(),
-                markup! {
-                    "The "<Emphasis>"parameter"</Emphasis>" is declared here:"
-                },
-            )
-            .note(markup! {
-                "Use a local variable instead."
-            }),
-        )
+    fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        match state {
+            ProblemType::ParameterAssignment(text_range) => Some(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    text_range,
+                    markup! {
+                        "Assigning a "<Emphasis>"function parameter"</Emphasis>" is confusing."
+                    },
+                )
+                    .detail(
+                        ctx.query().syntax().text_trimmed_range(),
+                        markup! {
+                        "The "<Emphasis>"parameter"</Emphasis>" is declared here:"
+                    },
+                    )
+                    .note(markup! {
+                    "Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead."
+                }),
+            ),
+
+            ProblemType::PropertyAssignment(text_range) => {
+                Some(
+                    RuleDiagnostic::new(
+                        rule_category!(),
+                        text_range,
+                        markup! {
+                        "Assigning to a "<Emphasis>"property of a function parameter"</Emphasis>" is confusing."
+                    })
+                        .note(markup! {"Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller."}),
+                )
+            }
+        }
     }
+}
+
+fn extract_statement_from_reference(reference: &Reference) -> Option<JsExpressionStatement> {
+    reference
+        .syntax()
+        .ancestors()
+        .skip(2) // skip the reference identifier and its expression
+        .skip_while(|node| AnyJsAssignmentLike::can_cast(node.kind()))
+        .find_map(AnyJsStatement::cast)
+        .and_then(|stmt| match stmt {
+            AnyJsStatement::JsExpressionStatement(statement) => Some(statement),
+            _ => None,
+        })
+}
+
+declare_node_union! {
+    pub AnyJsAssignmentLike =
+        JsPostUpdateExpression
+        | JsPreUpdateExpression
+        | JsAssignmentExpression
+}
+
+#[derive(Debug)]
+pub enum ProblemType {
+    ParameterAssignment(TextRange),
+    PropertyAssignment(TextRange),
 }

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalid.jsonc.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
 expression: invalid.jsonc
 ---
 # Input
@@ -11,7 +12,7 @@ function foo(bar) { bar = 13; }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { bar = 13; }
       │                     ^^^
@@ -21,7 +22,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { bar = 13; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -35,7 +36,7 @@ function foo(bar) { bar += 13; }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { bar += 13; }
       │                     ^^^
@@ -45,7 +46,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { bar += 13; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -59,7 +60,7 @@ function foo(bar) { (function() { bar = 13; })(); }
 ```
 invalid.jsonc:1:35 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { (function() { bar = 13; })(); }
       │                                   ^^^
@@ -69,7 +70,7 @@ invalid.jsonc:1:35 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { (function() { bar = 13; })(); }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -83,7 +84,7 @@ function foo(bar) { ++bar; }
 ```
 invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { ++bar; }
       │                       ^^^
@@ -93,7 +94,7 @@ invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { ++bar; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -107,7 +108,7 @@ function foo(bar) { ++bar; }
 ```
 invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { ++bar; }
       │                       ^^^
@@ -117,7 +118,7 @@ invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { ++bar; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -131,7 +132,7 @@ function foo(bar) { --bar; }
 ```
 invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { --bar; }
       │                       ^^^
@@ -141,7 +142,7 @@ invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { --bar; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -155,7 +156,7 @@ function foo(bar) { bar--; }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { bar--; }
       │                     ^^^
@@ -165,7 +166,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { bar--; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -179,7 +180,7 @@ function foo(bar) { bar--; }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { bar--; }
       │                     ^^^
@@ -189,7 +190,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { bar--; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -203,7 +204,7 @@ function foo(bar) { bar--; }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { bar--; }
       │                     ^^^
@@ -213,7 +214,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { bar--; }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -227,7 +228,7 @@ function foo(bar) { ({bar} = {}); }
 ```
 invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { ({bar} = {}); }
       │                       ^^^
@@ -237,7 +238,7 @@ invalid.jsonc:1:23 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { ({bar} = {}); }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -251,7 +252,7 @@ function foo(bar) { ({x: [, bar = 0]} = {}); }
 ```
 invalid.jsonc:1:29 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { ({x: [, bar = 0]} = {}); }
       │                             ^^^
@@ -261,7 +262,7 @@ invalid.jsonc:1:29 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { ({x: [, bar = 0]} = {}); }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -275,7 +276,7 @@ function foo(bar) { for (bar in baz); }
 ```
 invalid.jsonc:1:26 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { for (bar in baz); }
       │                          ^^^
@@ -285,7 +286,7 @@ invalid.jsonc:1:26 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { for (bar in baz); }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -299,7 +300,7 @@ function foo(bar) { for (bar of baz); }
 ```
 invalid.jsonc:1:26 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(bar) { for (bar of baz); }
       │                          ^^^
@@ -309,7 +310,7 @@ invalid.jsonc:1:26 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(bar) { for (bar of baz); }
       │              ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -323,7 +324,7 @@ function foo(a) { ({a} = obj); }
 ```
 invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { ({a} = obj); }
       │                     ^
@@ -333,7 +334,7 @@ invalid.jsonc:1:21 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { ({a} = obj); }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -347,7 +348,7 @@ function foo(a) { ([...a] = obj); }
 ```
 invalid.jsonc:1:24 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { ([...a] = obj); }
       │                        ^
@@ -357,7 +358,7 @@ invalid.jsonc:1:24 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { ([...a] = obj); }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -371,7 +372,7 @@ function foo(a) { ({...a} = obj); }
 ```
 invalid.jsonc:1:24 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { ({...a} = obj); }
       │                        ^
@@ -381,7 +382,7 @@ invalid.jsonc:1:24 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { ({...a} = obj); }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -395,7 +396,7 @@ function foo(a) { a &&= b; }
 ```
 invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { a &&= b; }
       │                   ^
@@ -405,7 +406,7 @@ invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { a &&= b; }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -419,7 +420,7 @@ function foo(a) { a ||= b; }
 ```
 invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { a ||= b; }
       │                   ^
@@ -429,7 +430,7 @@ invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { a ||= b; }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -443,7 +444,7 @@ function foo(a) { a ??= b; }
 ```
 invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ function foo(a) { a ??= b; }
       │                   ^
@@ -453,7 +454,7 @@ invalid.jsonc:1:19 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ function foo(a) { a ??= b; }
       │              ^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```
@@ -467,7 +468,7 @@ const doSomething = req => { req = {}; };
 ```
 invalid.jsonc:1:30 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Reassigning a function parameter is confusing.
+  ! Assigning a function parameter is confusing.
   
   > 1 │ const doSomething = req => { req = {}; };
       │                              ^^^
@@ -477,7 +478,7 @@ invalid.jsonc:1:30 lint/style/noParameterAssign ━━━━━━━━━━�
   > 1 │ const doSomething = req => { req = {}; };
       │                     ^^^
   
-  i Use a local variable instead.
+  i Developers usually expect function parameters to be readonly. To align with this expectation, use a local variable instead.
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalidFixUnsafe.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/invalidFixUnsafe.js.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidFixUnsafe.js
+snapshot_kind: text
+---
+# Input
+```js
+let x = 0;
+```
+
+# Diagnostics
+```
+invalidFixUnsafe.js:1:1 lint/style/useConst  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This let declares a variable that is only assigned once.
+  
+  > 1 │ let x = 0;
+      │ ^^^
+  
+  i 'x' is never reassigned.
+  
+  > 1 │ let x = 0;
+      │     ^
+  
+  i Unsafe fix: Use const instead.
+  
+  - let·x·=·0;
+  + const·x·=·0;
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.js
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.js
@@ -1,0 +1,47 @@
+// Test case: Direct property assignment on a parameter
+function directPropertyAssignment(param) {
+	param.key = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Nested property assignment on a parameter
+function nestedPropertyAssignment(param) {
+	param.nested.key = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment inside a loop
+function propertyAssignmentInLoop(param) {
+	for (let i = 0; i < 5; i++) {
+		param.key = i; // Should trigger a diagnostic
+	}
+}
+
+// Test case: Property assignment inside a conditional block
+function propertyAssignmentInConditional(param) {
+	if (param.condition) {
+		param.key = "value"; // Should trigger a diagnostic
+	}
+}
+
+// Test case: Property assignment using a computed property
+function computedPropertyAssignment(param) {
+	param["key"] = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment via a function call
+function assignProperty(param) {
+	param.key = "mutatedValue"; // Mutates the parameter by assigning a property
+}
+
+function propertyAssignmentViaFunction(param) {
+	assignProperty(param); // Should trigger a diagnostic if `assignProperty` mutates `param`
+}
+
+// Test case: Property assignment with a postfix increment
+function propertyPostfixIncrement(param) {
+	param.count++; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment with a prefix decrement
+function propertyPrefixDecrement(param) {
+	--param.count; // Should trigger a diagnostic
+}

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.js.snap
@@ -1,0 +1,159 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
+expression: parameterMutationDenyInvalid.js
+---
+# Input
+```js
+// Test case: Direct property assignment on a parameter
+function directPropertyAssignment(param) {
+	param.key = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Nested property assignment on a parameter
+function nestedPropertyAssignment(param) {
+	param.nested.key = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment inside a loop
+function propertyAssignmentInLoop(param) {
+	for (let i = 0; i < 5; i++) {
+		param.key = i; // Should trigger a diagnostic
+	}
+}
+
+// Test case: Property assignment inside a conditional block
+function propertyAssignmentInConditional(param) {
+	if (param.condition) {
+		param.key = "value"; // Should trigger a diagnostic
+	}
+}
+
+// Test case: Property assignment using a computed property
+function computedPropertyAssignment(param) {
+	param["key"] = "value"; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment via a function call
+function assignProperty(param) {
+	param.key = "mutatedValue"; // Mutates the parameter by assigning a property
+}
+
+function propertyAssignmentViaFunction(param) {
+	assignProperty(param); // Should trigger a diagnostic if `assignProperty` mutates `param`
+}
+
+// Test case: Property assignment with a postfix increment
+function propertyPostfixIncrement(param) {
+	param.count++; // Should trigger a diagnostic
+}
+
+// Test case: Property assignment with a prefix decrement
+function propertyPrefixDecrement(param) {
+	--param.count; // Should trigger a diagnostic
+}
+
+```
+
+# Diagnostics
+```
+parameterMutationDenyInvalid.js:3:2 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+    1 │ // Test case: Direct property assignment on a parameter
+    2 │ function directPropertyAssignment(param) {
+  > 3 │ 	param.key = "value"; // Should trigger a diagnostic
+      │ 	^^^^^
+    4 │ }
+    5 │ 
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```
+
+```
+parameterMutationDenyInvalid.js:8:2 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+     6 │ // Test case: Nested property assignment on a parameter
+     7 │ function nestedPropertyAssignment(param) {
+   > 8 │ 	param.nested.key = "value"; // Should trigger a diagnostic
+       │ 	^^^^^^^^^^^^
+     9 │ }
+    10 │ 
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```
+
+```
+parameterMutationDenyInvalid.js:14:3 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+    12 │ function propertyAssignmentInLoop(param) {
+    13 │ 	for (let i = 0; i < 5; i++) {
+  > 14 │ 		param.key = i; // Should trigger a diagnostic
+       │ 		^^^^^
+    15 │ 	}
+    16 │ }
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```
+
+```
+parameterMutationDenyInvalid.js:21:3 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+    19 │ function propertyAssignmentInConditional(param) {
+    20 │ 	if (param.condition) {
+  > 21 │ 		param.key = "value"; // Should trigger a diagnostic
+       │ 		^^^^^
+    22 │ 	}
+    23 │ }
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```
+
+```
+parameterMutationDenyInvalid.js:27:2 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+    25 │ // Test case: Property assignment using a computed property
+    26 │ function computedPropertyAssignment(param) {
+  > 27 │ 	param["key"] = "value"; // Should trigger a diagnostic
+       │ 	^^^^^
+    28 │ }
+    29 │ 
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```
+
+```
+parameterMutationDenyInvalid.js:32:2 lint/style/noParameterAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Assigning to a property of a function parameter is confusing.
+  
+    30 │ // Test case: Property assignment via a function call
+    31 │ function assignProperty(param) {
+  > 32 │ 	param.key = "mutatedValue"; // Mutates the parameter by assigning a property
+       │ 	^^^^^
+    33 │ }
+    34 │ 
+  
+  i Function callers usually don't expect the parameters they pass in to be modified. To avoid mutation, create a new instance and return it to the caller.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.options.json
+++ b/crates/biome_js_analyze/tests/specs/style/noParameterAssign/parameterMutationDenyInvalid.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "style": {
+        "noParameterAssign": {
+          "level": "error",
+          "options": {
+            "propertyAssignment": "deny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1834,7 +1834,7 @@ export interface Style {
 	/**
 	 * Disallow reassigning function parameters.
 	 */
-	noParameterAssign?: RuleConfiguration_for_Null;
+	noParameterAssign?: RuleConfiguration_for_NoParameterAssignOptions;
 	/**
 	 * Disallow the use of parameter properties in class constructors.
 	 */
@@ -2445,6 +2445,9 @@ export type RuleFixConfiguration_for_UtilityClassSortingOptions =
 export type RuleFixConfiguration_for_NoBlankTargetOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_NoBlankTargetOptions;
+export type RuleConfiguration_for_NoParameterAssignOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_NoParameterAssignOptions;
 export type RuleConfiguration_for_RestrictedGlobalsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_RestrictedGlobalsOptions;
@@ -2729,6 +2732,16 @@ export interface RuleWithFixOptions_for_NoBlankTargetOptions {
 	 * Rule's options
 	 */
 	options: NoBlankTargetOptions;
+}
+export interface RuleWithOptions_for_NoParameterAssignOptions {
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: NoParameterAssignOptions;
 }
 export interface RuleWithOptions_for_RestrictedGlobalsOptions {
 	/**
@@ -3053,6 +3066,15 @@ export interface NoBlankTargetOptions {
 	allowNoReferrer?: boolean;
 }
 /**
+ * Options for the rule `NoParameterAssign`
+ */
+export interface NoParameterAssignOptions {
+	/**
+	 * Whether to report an error when a dependency is listed in the dependencies array but isn't used. Defaults to `allow`.
+	 */
+	propertyAssignment?: PropertyAssignmentMode;
+}
+/**
  * Options for the rule `noRestrictedGlobals`.
  */
 export interface RestrictedGlobalsOptions {
@@ -3196,6 +3218,10 @@ For example, for React's `useRef()` hook the value would be `true`, while for `u
 }
 export type CustomRestrictedElements = Record<string, string>;
 export type ObjectPropertySyntax = "explicit" | "shorthand";
+/**
+ * Specifies whether property assignments on function parameters are allowed or denied.
+ */
+export type PropertyAssignmentMode = "allow" | "deny";
 export type CustomRestrictedImport = string | CustomRestrictedImportOptions;
 export type CustomRestrictedType = string | CustomRestrictedTypeOptions;
 export type ConsistentArrayType = "shorthand" | "generic";

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2581,6 +2581,24 @@
 			},
 			"additionalProperties": false
 		},
+		"NoParameterAssignConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoParameterAssignOptions" }
+			]
+		},
+		"NoParameterAssignOptions": {
+			"description": "Options for the rule `NoParameterAssign`",
+			"type": "object",
+			"properties": {
+				"propertyAssignment": {
+					"description": "Whether to report an error when a dependency is listed in the dependencies array but isn't used. Defaults to `allow`.",
+					"default": "allow",
+					"allOf": [{ "$ref": "#/definitions/PropertyAssignmentMode" }]
+				}
+			},
+			"additionalProperties": false
+		},
 		"NoPrivateImportsConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
@@ -3295,6 +3313,21 @@
 			"type": "array",
 			"items": { "$ref": "#/definitions/PluginConfiguration" }
 		},
+		"PropertyAssignmentMode": {
+			"description": "Specifies whether property assignments on function parameters are allowed or denied.",
+			"oneOf": [
+				{
+					"description": "Allows property assignments on function parameters. This is the default behavior, enabling flexibility in parameter usage.",
+					"type": "string",
+					"enum": ["allow"]
+				},
+				{
+					"description": "Disallows property assignments on function parameters. Enforces stricter immutability to prevent unintended side effects.",
+					"type": "string",
+					"enum": ["deny"]
+				}
+			]
+		},
 		"QuoteProperties": { "type": "string", "enum": ["asNeeded", "preserve"] },
 		"QuoteStyle": { "type": "string", "enum": ["double", "single"] },
 		"Regex": { "type": "string" },
@@ -3725,6 +3758,21 @@
 				"level": {
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoParameterAssignOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoParameterAssignOptions" }]
 				}
 			},
 			"additionalProperties": false
@@ -4386,7 +4434,7 @@
 				"noParameterAssign": {
 					"description": "Disallow reassigning function parameters.",
 					"anyOf": [
-						{ "$ref": "#/definitions/RuleConfiguration" },
+						{ "$ref": "#/definitions/NoParameterAssignConfiguration" },
 						{ "type": "null" }
 					]
 				},


### PR DESCRIPTION
## Summary

Added a new `propertyAssignment` option to the `noParameterAssign` rule.
This option allows to configure whether property assignments on function parameters are permitted.
By default, `propertyAssignment` is set to `allow`.
Setting it to `deny` enforces stricter immutability by disallowing property mutations on function parameters.

closes #5205
