### PR TITLE
feat(analyzer): allow static id attributes in SVG elements in useUniqueElementIds rule

### DIFF
--- a/.changeset/svg-support-use-unique-element-ids.md
+++ b/.changeset/svg-support-use-unique-element-ids.md
@@ -1,0 +1,25 @@
+---
+"@biomejs/biome": patch
+---
+
+The `useUniqueElementIds` rule now ignores SVG elements and their children. SVG elements are allowed to have static `id` attributes since they have local scope within the SVG context, unlike HTML elements where IDs must be globally unique.
+
+This change allows SVG elements like `<circle>`, `<path>`, `<rect>`, `<linearGradient>`, etc. to use static `id` attributes without triggering the rule, while continuing to flag HTML elements with static IDs.
+
+The rule now correctly handles:
+- Direct SVG elements with static `id` attributes
+- Nested elements within SVG contexts  
+- React.createElement calls with SVG element types
+- All 82 standard SVG element types
+
+Example of now-valid code:
+```jsx
+function SvgIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <circle id="circle1" cx="12" cy="12" r="10" />
+      <path id="path1" d="M12 2L2 7v10l10 5 10-5V7z" />
+    </svg>
+  );
+}
+```

--- a/crates/biome_js_analyze/src/lint/nursery/use_unique_element_ids.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_unique_element_ids.rs
@@ -3,13 +3,163 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{
-    AnyJsExpression, AnyJsxAttributeValue, JsCallExpression, JsPropertyObjectMember, JsxAttribute,
+    AnyJsExpression, AnyJsxAttributeValue, AnyJsxElementName, JsCallExpression, JsPropertyObjectMember, JsxAttribute,
     jsx_ext::AnyJsxElement,
 };
 use biome_rowan::{AstNode, declare_node_union};
 
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::services::semantic::Semantic;
+
+/// SVG element tags where `id` attributes have local scope within the SVG
+const SVG_TAGS: [&str; 82] = [
+    "a",
+    "altGlyph",
+    "altGlyphDef",
+    "altGlyphItem",
+    "animate",
+    "animateColor",
+    "animateMotion",
+    "animateTransform",
+    "circle",
+    "clipPath",
+    "color-profile",
+    "cursor",
+    "defs",
+    "desc",
+    "ellipse",
+    "feBlend",
+    "feColorMatrix",
+    "feComponentTransfer",
+    "feComposite",
+    "feConvolveMatrix",
+    "feDiffuseLighting",
+    "feDisplacementMap",
+    "feDistantLight",
+    "feDropShadow",
+    "feFlood",
+    "feFuncA",
+    "feFuncB",
+    "feFuncG",
+    "feFuncR",
+    "feGaussianBlur",
+    "feImage",
+    "feMerge",
+    "feMergeNode",
+    "feMorphology",
+    "feOffset",
+    "fePointLight",
+    "feSpecularLighting",
+    "feSpotLight",
+    "feTile",
+    "feTurbulence",
+    "filter",
+    "font",
+    "font-face",
+    "font-face-format",
+    "font-face-name",
+    "font-face-src",
+    "font-face-uri",
+    "foreignObject",
+    "g",
+    "glyph",
+    "glyphRef",
+    "hatch",
+    "hatchpath",
+    "hkern",
+    "image",
+    "line",
+    "linearGradient",
+    "marker",
+    "mask",
+    "metadata",
+    "missing-glyph",
+    "mpath",
+    "path",
+    "pattern",
+    "polygon",
+    "polyline",
+    "radialGradient",
+    "rect",
+    "script",
+    "set",
+    "stop",
+    "style",
+    "svg",
+    "switch",
+    "symbol",
+    "text",
+    "textPath",
+    "title",
+    "tspan",
+    "use",
+    "view",
+    "vkern",
+];
+
+/// Checks if the given element name is an SVG tag
+fn is_svg_element(element_name: &str) -> bool {
+    SVG_TAGS.binary_search(&element_name).is_ok()
+}
+
+/// Checks if an element is an SVG element or is nested within an SVG context
+fn is_in_svg_context(element: &AnyJsxElement) -> bool {
+    // Check if current element is SVG
+    if let Ok(name) = element.name() {
+        if let Some(element_name) = get_element_name(&name) {
+            if is_svg_element(&element_name) {
+                return true;
+            }
+        }
+    }
+
+    // Walk up the tree to find if we're inside an SVG element
+    let mut current = element.syntax().parent();
+    while let Some(parent) = current {
+        // Check if parent is a JSX element
+        if let Some(jsx_element) = AnyJsxElement::cast(parent.clone()) {
+            if let Ok(name) = jsx_element.name() {
+                if let Some(element_name) = get_element_name(&name) {
+                    if is_svg_element(&element_name) {
+                        return true;
+                    }
+                }
+            }
+        }
+        current = parent.parent();
+    }
+
+    false
+}
+
+/// Extracts the element name from AnyJsxElementName
+fn get_element_name(name: &AnyJsxElementName) -> Option<String> {
+    match name {
+        AnyJsxElementName::JsxName(jsx_name) => {
+            jsx_name.value_token().ok().map(|token| token.text_trimmed().to_string())
+        }
+        AnyJsxElementName::JsxMemberName(member_name) => {
+            // For member names like React.Fragment, we only care about the first part
+            member_name.object().ok().and_then(|obj| {
+                if let biome_js_syntax::AnyJsxObjectName::JsxReferenceIdentifier(ref_id) = obj {
+                    ref_id.value_token().ok().map(|token| token.text_trimmed().to_string())
+                } else {
+                    None
+                }
+            })
+        }
+        AnyJsxElementName::JsxNamespaceName(namespace_name) => {
+            // For namespace names like svg:circle, we care about the namespace part
+            namespace_name.namespace().ok().and_then(|ns| {
+                ns.value_token().ok().map(|token| token.text_trimmed().to_string())
+            })
+        }
+        AnyJsxElementName::JsxReferenceIdentifier(ref_id) => {
+            ref_id.value_token().ok().map(|token| token.text_trimmed().to_string())
+        }
+        AnyJsxElementName::JsMetavariable(_) => None,
+    }
+}
 
 declare_lint_rule! {
     /// Prevent the usage of static string literal `id` attribute on elements.
@@ -74,6 +224,26 @@ impl UseUniqueElementIdsQuery {
             }
         }
     }
+
+    fn is_in_svg_context(&self, model: &SemanticModel) -> bool {
+        match self {
+            Self::AnyJsxElement(jsx) => is_in_svg_context(jsx),
+            Self::JsCallExpression(expression) => {
+                // For React.createElement calls, check if the element type is an SVG element
+                if let Some(react_create_element) = ReactCreateElementCall::from_call_expression(expression, model) {
+                    // Extract element name from the element_type argument
+                    if let Some(element_expr) = react_create_element.element_type.as_any_js_expression() {
+                        if let Some(static_value) = element_expr.as_static_value() {
+                            if let Some(element_name) = static_value.as_string_constant() {
+                                return is_svg_element(element_name);
+                            }
+                        }
+                    }
+                }
+                false
+            }
+        }
+    }
 }
 
 impl Rule for UseUniqueElementIds {
@@ -85,6 +255,12 @@ impl Rule for UseUniqueElementIds {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let model = ctx.model();
+
+        // Skip validation for SVG elements and elements within SVG context
+        if node.is_in_svg_context(model) {
+            return None;
+        }
+
         let id_attribute = node.find_id_attribute(model)?;
 
         match id_attribute {

--- a/crates/biome_js_analyze/tests/specs/nursery/useUniqueElementIds/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useUniqueElementIds/valid.jsx
@@ -44,3 +44,41 @@ import { createElement } from "not-react";
 function Foo() {
 	return createElement("div", { id: "foo" });
 }
+
+// SVG elements should be allowed to have static id attributes
+function SvgIcon() {
+	return (
+		<svg viewBox="0 0 24 24">
+			<circle id="circle1" cx="12" cy="12" r="10" />
+			<path id="path1" d="M12 2L2 7v10l10 5 10-5V7z" />
+			<rect id="rect1" x="10" y="10" width="4" height="4" />
+		</svg>
+	);
+}
+
+function ComplexSvg() {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+			<defs>
+				<linearGradient id="gradient1">
+					<stop id="stop1" offset="0%" stopColor="red" />
+					<stop id="stop2" offset="100%" stopColor="blue" />
+				</linearGradient>
+				<filter id="filter1">
+					<feGaussianBlur id="blur1" stdDeviation="2" />
+				</filter>
+			</defs>
+			<g id="group1">
+				<circle id="circle2" cx="50" cy="50" r="20" fill="url(#gradient1)" />
+				<text id="text1" x="50" y="50">Hello</text>
+			</g>
+		</svg>
+	);
+}
+
+// React.createElement with SVG elements should also be allowed
+function SvgWithCreateElement() {
+	return React.createElement("svg", { viewBox: "0 0 24 24" },
+		React.createElement("circle", { id: "circle3", cx: "12", cy: "12", r: "10" })
+	);
+}


### PR DESCRIPTION
Updates the `useUniqueElementIds` rule to ignore SVG elements and their children, allowing them to have static `id` attributes since they have local scope within SVG contexts.

Fixes #6206 