### PR TITLE
fix(organizeImports): emit correct code when merging imports

### DIFF
--- a/.changeset/grumpy-eels-create.md
+++ b/.changeset/grumpy-eels-create.md
@@ -1,5 +1,5 @@
 ---
-"@biomejs/biome": major
+"@biomejs/biome": patch
 ---
 
 Fixed [#6211](https://github.com/biomejs/biome/issues/6211): previously the

--- a/.changeset/grumpy-eels-create.md
+++ b/.changeset/grumpy-eels-create.md
@@ -1,0 +1,16 @@
+---
+"@biomejs/biome": major
+---
+
+Fixed [#6211](https://github.com/biomejs/biome/issues/6211): previously the
+import organizer emitted broken code when it merged an import at the start of
+the file with another import and placed the merged result after a third import.
+
+The following code is now correctly organized:
+
+```diff
+- import { B } from "bc";
+- import { C } from "bc";
+  import { A } from "a";
++ import { B, C } from "bc";
+```

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -913,12 +913,12 @@ impl Rule for OrganizeImports {
                     let mut i = import_keys.len() - 1;
                     while i > 0 {
                         let KeyedItem {
-                            key: pre_key,
+                            key: prev_key,
                             item: prev_item,
                             ..
                         } = &import_keys[i - 1];
                         let KeyedItem { key, item, .. } = &import_keys[i];
-                        if pre_key.is_mergeable(key) {
+                        if prev_key.is_mergeable(key) {
                             if let Some(merged) = merge(prev_item.as_ref(), item.as_ref()) {
                                 import_keys[i - 1].was_merged = true;
                                 import_keys[i - 1].item = Some(merged);

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -910,22 +910,22 @@ impl Rule for OrganizeImports {
                     );
                     // Merge imports/exports
                     // We use `while` and indexing to allow both iteration and mutation of `import_keys`.
-                    let mut i = 0;
-                    while (i + 1) < import_keys.len() {
-                        let KeyedItem { key, item, .. } = &import_keys[i];
+                    let mut i = import_keys.len() - 1;
+                    while i > 0 {
                         let KeyedItem {
-                            key: next_key,
-                            item: next_item,
+                            key: pre_key,
+                            item: prev_item,
                             ..
-                        } = &import_keys[i + 1];
-                        if key.is_mergeable(next_key) {
-                            if let Some(merged) = merge(item.as_ref(), next_item.as_ref()) {
+                        } = &import_keys[i - 1];
+                        let KeyedItem { key, item, .. } = &import_keys[i];
+                        if pre_key.is_mergeable(key) {
+                            if let Some(merged) = merge(prev_item.as_ref(), item.as_ref()) {
+                                import_keys[i - 1].was_merged = true;
+                                import_keys[i - 1].item = Some(merged);
                                 import_keys[i].item = None;
-                                import_keys[i + 1].was_merged = true;
-                                import_keys[i + 1].item = Some(merged);
                             }
                         }
-                        i += 1;
+                        i -= 1;
                     }
                     // Swap the items to obtain a sorted chunk
                     let mut prev_group: u16 = 0;
@@ -954,7 +954,12 @@ impl Rule for OrganizeImports {
                         }
                         if index == slot_indexes.start {
                             if index == key.slot_index && was_merged {
-                                // DOn't change anything
+                                // Merged imports always have a leading newline.
+                                // We remove it if the merged import is at the start and
+                                // if the old first import has no leading newline.
+                                if index == 0 && leading_newlines(&old_item).count() == 0 {
+                                    new_item = new_item.trim_leading_trivia()?;
+                                }
                             } else if let Some(detached) = detached_trivia(&old_item) {
                                 if leading_newlines(&old_item).count() == 1 {
                                     let newline = old_item.first_leading_trivia()?.pieces().take(1);
@@ -1075,9 +1080,15 @@ fn merge(
             if let Some(meregd_specifiers) = merge_export_specifiers(&specifiers1, &specifiers2) {
                 let meregd_clause = clause1.with_specifiers(meregd_specifiers);
                 let merged_item = item2.clone().with_export_clause(meregd_clause.into());
-                let merged_item = merged_item
-                    .trim_leading_trivia()?
-                    .prepend_trivia_pieces(item1.syntax().first_leading_trivia()?.pieces())?;
+
+                let item1_leading_trivia = item1.syntax().first_leading_trivia()?;
+                let merged_item = if item1_leading_trivia.is_empty() {
+                    merged_item
+                } else {
+                    merged_item
+                        .trim_leading_trivia()?
+                        .prepend_trivia_pieces(item1.syntax().first_leading_trivia()?.pieces())?
+                };
                 return Some(merged_item.into());
             }
         }
@@ -1106,9 +1117,15 @@ fn merge(
                     )
                     .build();
                     let merged_item = item2.clone().with_import_clause(merged_clause.into());
-                    let merged_item = merged_item
-                        .trim_leading_trivia()?
-                        .prepend_trivia_pieces(item1.syntax().first_leading_trivia()?.pieces())?;
+
+                    let item1_leading_trivia = item1.syntax().first_leading_trivia()?;
+                    let merged_item = if item1_leading_trivia.is_empty() {
+                        merged_item
+                    } else {
+                        merged_item.trim_leading_trivia()?.prepend_trivia_pieces(
+                            item1.syntax().first_leading_trivia()?.pieces(),
+                        )?
+                    };
                     return Some(merged_item.into());
                 }
                 (
@@ -1130,10 +1147,15 @@ fn merge(
                     {
                         let merged_clause = clause1.with_specifier(meregd_specifiers.into());
                         let merged_item = item2.clone().with_import_clause(merged_clause.into());
-                        let merged_item =
+
+                        let item1_leading_trivia = item1.syntax().first_leading_trivia()?;
+                        let merged_item = if item1_leading_trivia.is_empty() {
+                            merged_item
+                        } else {
                             merged_item.trim_leading_trivia()?.prepend_trivia_pieces(
                                 item1.syntax().first_leading_trivia()?.pieces(),
-                            )?;
+                            )?
+                        };
                         return Some(merged_item.into());
                     }
                 }
@@ -1148,10 +1170,14 @@ fn merge(
                     {
                         let merged_clause = clause1.with_named_specifiers(meregd_specifiers);
                         let merged_item = item2.clone().with_import_clause(merged_clause.into());
-                        let merged_item =
+                        let item1_leading_trivia = item1.syntax().first_leading_trivia()?;
+                        let merged_item = if item1_leading_trivia.is_empty() {
+                            merged_item
+                        } else {
                             merged_item.trim_leading_trivia()?.prepend_trivia_pieces(
                                 item1.syntax().first_leading_trivia()?.pieces(),
-                            )?;
+                            )?
+                        };
                         return Some(merged_item.into());
                     }
                 }
@@ -1176,9 +1202,14 @@ fn merge(
                     )
                     .build();
                     let merged_item = item2.clone().with_import_clause(merged_clause.into());
-                    let merged_item = merged_item
-                        .trim_leading_trivia()?
-                        .prepend_trivia_pieces(item1.syntax().first_leading_trivia()?.pieces())?;
+                    let item1_leading_trivia = item1.syntax().first_leading_trivia()?;
+                    let merged_item = if item1_leading_trivia.is_empty() {
+                        merged_item
+                    } else {
+                        merged_item.trim_leading_trivia()?.prepend_trivia_pieces(
+                            item1.syntax().first_leading_trivia()?.pieces(),
+                        )?
+                    };
                     return Some(merged_item.into());
                 }
                 _ => {}

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js
@@ -1,0 +1,4 @@
+import { B } from "bc";
+import { C } from "bc";
+import { A } from "a";
+

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/issue6211.js.snap
@@ -1,0 +1,36 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6211.js
+---
+# Input
+```js
+import { B } from "bc";
+import { C } from "bc";
+import { A } from "a";
+
+
+```
+
+# Diagnostics
+```
+issue6211.js:1:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 1 │ import { B } from "bc";
+      │ ^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ import { C } from "bc";
+    3 │ import { A } from "a";
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1   │ - import·{·B·}·from·"bc";
+    2   │ - import·{·C·}·from·"bc";
+    3   │ - import·{·A·}·from·"a";
+      1 │ + import·{·A·}·from·"a";
+      2 │ + import·{·B,·C·}·from·"bc";
+    4 3 │   
+    5 4 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js
@@ -1,0 +1,4 @@
+// Header comment
+
+import moment from 'moment';
+import { Moment } from 'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_header.js.snap
@@ -1,0 +1,37 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: mergeable-with_header.js
+---
+# Input
+```js
+// Header comment
+
+import moment from 'moment';
+import { Moment } from 'moment';
+
+```
+
+# Diagnostics
+```
+mergeable-with_header.js:3:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+    1 │ // Header comment
+    2 │ 
+  > 3 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ import { Moment } from 'moment';
+    5 │ 
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1 1 │   // Header comment
+    2 2 │   
+    3   │ - import·moment·from·'moment';
+    4   │ - import·{·Moment·}·from·'moment';
+      3 │ + import·moment,·{·Moment·}·from·'moment';
+    5 4 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js
@@ -1,0 +1,3 @@
+
+import moment from 'moment';
+import { Moment } from 'moment';

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable-with_leading_newline.js.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: mergeable-with_leading_newline.js
+---
+# Input
+```js
+
+import moment from 'moment';
+import { Moment } from 'moment';
+
+```
+
+# Diagnostics
+```
+mergeable-with_leading_newline.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+  > 2 │ import moment from 'moment';
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ import { Moment } from 'moment';
+    4 │ 
+  
+  i Safe fix: Organize Imports (Biome)
+  
+    1 1 │   
+    2   │ - import·moment·from·'moment';
+    3   │ - import·{·Moment·}·from·'moment';
+      2 │ + import·moment,·{·Moment·}·from·'moment';
+    4 3 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_export.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: mergeable_export.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -30,17 +29,16 @@ mergeable_export.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━�
   
   i Safe fix: Organize Imports (Biome)
   
-    1   │ - //·Comment·1
+    1 1 │   // Comment 1
     2   │ - export·type·{·T4,·T2·}·from·"mod";
-      1 │ + //·Comment·1
-    3 2 │   // Comment 2
+    3   │ - //·Comment·2
     4   │ - export·type·{·T3,·T1·}·from·"mod";
-    5   │ - //·Comment·3
+      2 │ + //·Comment·2
+      3 │ + export·type·{·T1,·T2,·T3,·T4·}·from·"mod";
+    5 4 │   // Comment 3
     6   │ - export·{·A,·D·}·from·"mod";
     7   │ - //·Comment·4
     8   │ - export·{·B,·C·}·from·"mod";
-      3 │ + export·type·{·T1,·T2,·T3,·T4·}·from·"mod";
-      4 │ + //·Comment·3
       5 │ + //·Comment·4
       6 │ + export·{·A,·B,·C,·D·}·from·"mod";
     9 7 │   

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_imports.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: mergeable_imports.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -37,10 +36,9 @@ mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━
   
   i Safe fix: Organize Imports (Biome)
   
-     1    │ - //·Comment·1
+     1  1 │   // Comment 1
      2    │ - import·type·{·T4,·T2·}·from·"mod";
-        1 │ + //·Comment·1
-     3  2 │   // Comment 2
+     3    │ - //·Comment·2
      4    │ - import·type·{·T3,·T1·}·from·"mod";
      5    │ - //·Comment·3
      6    │ - import·{·A,·D·}·from·"mod";
@@ -53,6 +51,7 @@ mergeable_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━━━━
     13    │ - //·Comment·7
     14    │ - import·I·from·"mod";
     15    │ - import·*·as·ns·from·"mod";
+        2 │ + //·Comment·2
         3 │ + import·type·{·T1,·T2,·T3,·T4·}·from·"mod";
         4 │ + //·Comment·7
         5 │ + import·I,·*·as·ns·from·"mod";

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/mergeable_unsorted_imports.ts.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: mergeable_unsorted_imports.ts
-snapshot_kind: text
 ---
 # Input
 ```ts
@@ -45,16 +44,13 @@ mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━
   
   i Safe fix: Organize Imports (Biome)
   
-     1    │ - //·File·header·comment
+     1  1 │   // File header comment
      2    │ - import·type·{·T1,·T2·}·from·"mod";
      3    │ - //·Comment·2
      4    │ - import·type·{·U1·}·from·"package";
      5    │ - //·Comment·3
      6    │ - import·type·{·T3,·T4·}·from·"mod";
-        1 │ + //·File·header·comment
-        2 │ + //·Comment·3
-        3 │ + import·type·{·T1,·T2,·T3,·T4·}·from·"mod";
-     7  4 │   // Comment 4
+     7    │ - //·Comment·4
      8    │ - import·{·A,·B·}·from·"mod";
      9    │ - //·Comment·5
     10    │ - import·{·X·}·from·"package";
@@ -64,6 +60,9 @@ mergeable_unsorted_imports.ts:2:1 assist/source/organizeImports  FIXABLE  ━━
     14    │ - import·{·Y·}·from·"package";
     15    │ - //·Comment·8
     16    │ - import·type·{·U2·}·from·"package";
+        2 │ + //·Comment·3
+        3 │ + import·type·{·T1,·T2,·T3,·T4·}·from·"mod";
+        4 │ + //·Comment·4
         5 │ + //·Comment·6
         6 │ + import·{·A,·B,·C,·D·}·from·"mod";
         7 │ + //·Comment·2


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/6211

The issue comes from merging the first import of the file with another one and moving the result after a third import.
This only arises when the first import has no leading trivia.

To fix the issue, we now keep the leading newline of the second import and remove it only if the merged import is placed at the start of the file and the previous first import had no leading newline.

I had to reverse the traversal order to merge imports in order to ensure that the merged of the first import with another import has the same slot index as the first import.
This is required to have proper trivia handling.

## Test Plan

I added three tests and updated the snapshots.
