### PR TITLE
fix(biome_js_analyze/noShadow): false positive for arg in ts function type

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/invalid-06.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/invalid-06.ts
@@ -1,2 +1,1 @@
-const test = 1;
-type Fn = (test: string) => typeof test;
+type foo = <T>(bar: <T>() => T) => T;

--- a/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/invalid-06.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/invalid-06.ts.snap
@@ -4,28 +4,25 @@ expression: invalid-06.ts
 ---
 # Input
 ```ts
-const test = 1;
-type Fn = (test: string) => typeof test;
+type foo = <T>(bar: <T>() => T) => T;
 
 ```
 
 # Diagnostics
 ```
-invalid-06.ts:2:12 lint/nursery/noShadow ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid-06.ts:1:22 lint/nursery/noShadow ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This variable shadows another variable with the same name in the outer scope.
   
-    1 │ const test = 1;
-  > 2 │ type Fn = (test: string) => typeof test;
-      │            ^^^^
-    3 │ 
+  > 1 │ type foo = <T>(bar: <T>() => T) => T;
+      │                      ^
+    2 │ 
   
   i This is the shadowed variable, which is now inaccessible in the inner scope.
   
-  > 1 │ const test = 1;
-      │       ^^^^
-    2 │ type Fn = (test: string) => typeof test;
-    3 │ 
+  > 1 │ type foo = <T>(bar: <T>() => T) => T;
+      │             ^
+    2 │ 
   
   i Consider renaming this variable. It's easy to confuse the origin of variables if they share the same name.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/valid-05.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/valid-05.ts
@@ -1,0 +1,3 @@
+/* should not generate diagnostics */
+const test = 1;
+type Fn = (test: string) => typeof test;

--- a/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/valid-05.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noShadow/typescript-eslint/valid-05.ts.snap
@@ -1,0 +1,11 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid-05.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+const test = 1;
+type Fn = (test: string) => typeof test;
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Handles an edge case where the argument within a ts function type is being marked as shadowing.
E.g.
```ts
const test = 1;
type Fn = (test: string) => typeof test;
```
This should not happen, especially since this is not the behavior for typescript-eslint as discussed in #6038 .

It seems like this case was marked in the tests as invalid in `invalid-06.ts`. This case is exactly like the one discussed in #6038 . So I've moved this test case to the valid files as `valid-05.ts`.

Since I didn't wanted to push the indices of the other test cases following index 6 and screw up with the git history - I've fixed another edge case not handled that I've found and replaced the `invalid-06.ts` file with it.
The use case playground can be found here:
- typescript ESLint marks it as invalid: https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=C4TwDgpgBAZg9nKBeKAeAKgPgBQCMCGATgFxpbYCUymU6VSN6A3AFBA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1uQAsBDACYcA7uiiJo0DtEjgwAXxDygA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false
- Biome mark it as valid: https://next.biomejs.dev/playground/?lintRules=all&analyzerFixMode=safeAndUnsafeFixes&code=dAB5AHAAZQAgAGYAbwBvACAAPQAgADwAVAA%2BACgAYgBhAHIAOgAgADwAVAA%2BACgAKQAgAD0APgAgAFQAKQAgAD0APgAgAFQAOwA%3D&ruleDomains.react=all&ruleDomains.test=all&ruleDomains.solid=all&ruleDomains.next=all

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Closes #6038 

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
The snapshot tests includes the relevant cases
