### PR TITLE
fix(core): strip qualifiers in scoped resolver

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_lint/linter_can_resolve_imported_symbols.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/linter_can_resolve_imported_symbols.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noFloatingPromises": "on"
+      }
+    }
+  }
+}
+```
+
+## `src/foo.ts`
+
+```ts
+export function foo(): Foo {}
+
+export async function bar() {}
+```
+
+## `src/index.ts`
+
+```ts
+import { foo, bar } from "./foo.ts";
+
+fn(foo());
+
+bar();
+```
+
+# Emitted Messages
+
+```block
+src/index.ts:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ fn(foo());
+    4 │ 
+  > 5 │ bar();
+      │ ^^^^^^
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_js_type_info/CONTRIBUTING.md
+++ b/crates/biome_js_type_info/CONTRIBUTING.md
@@ -245,15 +245,12 @@ we have _type resolvers_. There's a `TypeResolver` trait, defined in
   because at least so far that's all we need to determine types of exports
   (we don't determine the return type of functions without annotations yet, and
   it's not yet decided when or if we'll do this).
-* **`ScopeRestrictedRegistrationResolver`** may sound impressive, but is but a
-  helper for `ScopedResolver` to conveniently set the correct scope ID on
-  certain references, so that when the time comes for the `ScopedResolver` to
-  resolve it, it will still know which scope should be used for resolving it.
 
 I've mentioned before that types are stored in vectors. Those type vectors are
-stored inside the structures that implement `TypeResolver`, and with the
-exception of `ScopeRestrictedRegistrationResolver`, they all have their own
-internal storage for types.
+stored inside `TypeStore` structures which are kept inside the various
+`TypeResolver` implementations. The nice thing about `TypeStore` is that it
+provides lookups that are as fast as a vector when the `TypeId` is known, while
+also maintaining a hash table for when the `TypeId` is not known.
 
 ## Flattening
 

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -253,7 +253,7 @@ impl TypeResolverLevel {
 }
 
 /// Identifier that indicates which module a type is defined in.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ModuleId(u32);
 
 impl ModuleId {
@@ -699,6 +699,12 @@ impl Resolvable for TypeReference {
 
     fn with_module_id(self, module_id: ModuleId) -> Self {
         match self {
+            Self::Qualifier(_) => {
+                // When we assign a module ID in order to store a type in the
+                // scoped resolver, we also clear out qualifiers to avoid
+                // resolving from an incorrect scope.
+                Self::Unknown
+            }
             Self::Resolved(resolved_type_id) => {
                 Self::Resolved(resolved_type_id.with_module_id(module_id))
             }

--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -623,12 +623,6 @@ pub trait Resolvable: Sized {
     ///
     /// Does not perform any resolving in the process.
     fn with_module_id(self, module_id: ModuleId) -> Self;
-
-    /// Returns the instance with all scoped references augmented with the
-    /// given `scope_id`.
-    ///
-    /// Does not perform any resolving in the process.
-    fn with_scope_id(self, scope_id: ScopeId) -> Self;
 }
 
 impl Resolvable for TypeReference {
@@ -711,13 +705,6 @@ impl Resolvable for TypeReference {
             other => other,
         }
     }
-
-    fn with_scope_id(self, scope_id: ScopeId) -> Self {
-        match self {
-            Self::Qualifier(qualifier) => Self::from(qualifier.with_scope_id(scope_id)),
-            other => other,
-        }
-    }
 }
 
 impl Resolvable for TypeofValue {
@@ -767,13 +754,6 @@ impl Resolvable for TypeofValue {
             scope_id,
         }
     }
-
-    fn with_scope_id(self, scope_id: ScopeId) -> Self {
-        Self {
-            scope_id: Some(scope_id),
-            ..self
-        }
-    }
 }
 
 macro_rules! derive_primitive_resolved {
@@ -792,10 +772,6 @@ macro_rules! derive_primitive_resolved {
             }
 
             fn with_module_id(self, _module_id: ModuleId) -> Self {
-                self
-            }
-
-            fn with_scope_id(self, _scope_id: ScopeId) -> Self {
                 self
             }
         })+

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -1106,11 +1106,6 @@ impl TypeReferenceQualifier {
         self
     }
 
-    pub fn with_scope_id(mut self, scope_id: ScopeId) -> Self {
-        self.scope_id = scope_id;
-        self
-    }
-
     pub fn without_type_parameters(&self) -> Self {
         Self {
             path: self.path.clone(),

--- a/crates/biome_js_type_info_macros/src/resolvable_derive.rs
+++ b/crates/biome_js_type_info_macros/src/resolvable_derive.rs
@@ -131,14 +131,6 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
         None => quote! { Self::#ident => Self::#ident },
     });
 
-    let variants_with_scope_id = variants.iter().map(|VariantData { ident, ty }| match ty {
-        Some(ty) => {
-            let ty_with_scope_id = unit_type_with_scope_id(ty);
-            quote! { Self::#ident(ty) => Self::#ident(#ty_with_scope_id) }
-        }
-        None => quote! { Self::#ident => Self::#ident },
-    });
-
     quote! {
         impl crate::Resolvable for #ident {
             fn resolved(&self, resolver: &mut dyn crate::TypeResolver) -> Self {
@@ -162,12 +154,6 @@ pub(crate) fn generate_resolvable_enum(ident: Ident, variants: Vec<VariantData>)
                     #( #variants_with_module_id ),*
                 }
             }
-
-            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
-                match self {
-                    #( #variants_with_scope_id ),*
-                }
-            }
         }
     }
 }
@@ -186,11 +172,6 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
     let fields_with_module_id = fields.iter().map(|FieldData { ident, ty }| {
         let ty_with_module_id = type_with_module_id(IdentOrZero::Ident(ident), ty);
         quote! { #ident: #ty_with_module_id }
-    });
-
-    let fields_with_scope_id = fields.iter().map(|FieldData { ident, ty }| {
-        let ty_with_scope_id = type_with_scope_id(IdentOrZero::Ident(ident), ty);
-        quote! { #ident: #ty_with_scope_id }
     });
 
     quote! {
@@ -216,12 +197,6 @@ pub(crate) fn generate_resolvable_struct(ident: Ident, fields: Vec<FieldData>) -
                     #( #fields_with_module_id ),*
                 }
             }
-
-            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
-                Self {
-                    #( #fields_with_scope_id ),*
-                }
-            }
         }
     }
 }
@@ -233,8 +208,6 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
         resolved_type_with_mapped_references(IdentOrZero::Zero, &ty);
 
     let field_with_module_id = type_with_module_id(IdentOrZero::Zero, &ty);
-
-    let field_with_scope_id = type_with_scope_id(IdentOrZero::Zero, &ty);
 
     quote! {
         impl crate::Resolvable for #ident {
@@ -252,10 +225,6 @@ fn generate_resolvable_unit_type(ident: Ident, ty: Type) -> TokenStream {
 
             fn with_module_id(self, module_id: crate::ModuleId) -> Self {
                 Self(#field_with_module_id)
-            }
-
-            fn with_scope_id(self, scope_id: crate::ScopeId) -> Self {
-                Self(#field_with_scope_id)
             }
         }
     }
@@ -640,123 +609,6 @@ fn unit_type_with_module_id(ty: &Type) -> TokenStream {
         },
         _ => {
             quote! { ty.with_module_id(module_id) }
-        }
-    }
-}
-
-fn type_with_scope_id(ident: IdentOrZero, ty: &Type) -> TokenStream {
-    let Type::Path(path) = ty else {
-        abort!(ty, "Resolvable derive requires plain path types");
-    };
-
-    match path.path.segments.last() {
-        Some(segment) if segment.ident == "Text" => {
-            quote! { self.#ident }
-        }
-        Some(segment) if segment.ident == "Box" => match &segment.arguments {
-            PathArguments::None => abort!(segment, "Box is missing argument"),
-            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
-                match args.args.iter().next().unwrap() {
-                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
-                        Type::Path(ty) if ty.path.is_ident("Text") => {
-                            quote! { self.#ident }
-                        }
-                        Type::Path(_) => quote! {
-                            self.#ident.into_iter().map(|elem| elem.with_scope_id(scope_id)).collect()
-                        },
-                        _ => abort!(slice, "Unsupported arguments"),
-                    },
-                    GenericArgument::Type(Type::Path(ty)) => {
-                        if ty.path.is_ident("Text") {
-                            quote! { self.#ident }
-                        } else {
-                            quote! {
-                                Box::new(self.#ident.with_scope_id(scope_id))
-                            }
-                        }
-                    }
-                    _ => abort!(args, "Unsupported arguments"),
-                }
-            }
-            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
-                abort!(path, "Unsupported type arguments in path")
-            }
-        },
-        Some(segment) if segment.ident == "Option" => match &segment.arguments {
-            PathArguments::None => abort!(segment, "Option is missing argument"),
-            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
-                match args.args.iter().next().unwrap() {
-                    GenericArgument::Type(Type::Path(ty)) => {
-                        if ty.path.is_ident("Text") {
-                            quote! { self.#ident }
-                        } else {
-                            quote! { self.#ident.map(|f| f.with_scope_id(scope_id)) }
-                        }
-                    }
-                    _ => abort!(args, "Unsupported arguments"),
-                }
-            }
-            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
-                abort!(path, "Unsupported type arguments in path")
-            }
-        },
-        _ => {
-            quote! { self.#ident.with_scope_id(scope_id) }
-        }
-    }
-}
-
-fn unit_type_with_scope_id(ty: &Type) -> TokenStream {
-    let Type::Path(path) = ty else {
-        abort!(ty, "Resolvable derive requires plain path types");
-    };
-
-    match path.path.segments.last() {
-        Some(segment) if segment.ident == "Text" => {
-            quote! { ty }
-        }
-        Some(segment) if segment.ident == "Box" => match &segment.arguments {
-            PathArguments::None => abort!(segment, "Box is missing argument"),
-            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
-                match args.args.iter().next().unwrap() {
-                    GenericArgument::Type(Type::Slice(slice)) => match slice.elem.as_ref() {
-                        Type::Path(ty) if ty.path.is_ident("Text") => quote! { ty.clone() },
-                        _ => abort!(args, "Unsupported arguments"),
-                    },
-                    GenericArgument::Type(Type::Path(ty)) => {
-                        if ty.path.is_ident("Text") {
-                            quote! { ty }
-                        } else {
-                            quote! { Box::new(ty.with_scope_id(scope_id)) }
-                        }
-                    }
-                    _ => abort!(args, "Unsupported arguments"),
-                }
-            }
-            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
-                abort!(path, "Unsupported type arguments in path")
-            }
-        },
-        Some(segment) if segment.ident == "Option" => match &segment.arguments {
-            PathArguments::None => abort!(segment, "Option is missing argument"),
-            PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
-                match args.args.iter().next().unwrap() {
-                    GenericArgument::Type(Type::Path(ty)) => {
-                        if ty.path.is_ident("Text") {
-                            quote! { ty }
-                        } else {
-                            quote! { ty.map(|f| f.with_scope_id(scope_id)) }
-                        }
-                    }
-                    _ => abort!(args, "Unsupported arguments"),
-                }
-            }
-            PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => {
-                abort!(path, "Unsupported type arguments in path")
-            }
-        },
-        _ => {
-            quote! { ty.with_scope_id(scope_id) }
         }
     }
 }

--- a/crates/biome_module_graph/src/js_module_info/scoped_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/scoped_resolver.rs
@@ -140,6 +140,7 @@ impl ScopedResolver {
             let ty = unsafe { self.types.take_from_index_temporarily(i) };
             let ty = ty.resolved_with_mapped_references(
                 |reference, resolver| match reference {
+                    TypeReference::Qualifier(_qualifier) => TypeReference::Unknown,
                     TypeReference::Import(import) => resolver
                         .resolve_import(&import)
                         .map_or(TypeReference::Unknown, Into::into),

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
@@ -21616,7 +21616,7 @@ Module TypeId(635) => sync Function {
 Module TypeId(636) => sync Function {
   accepts: {
     params: [
-      required nextProps: Module(0) TypeId(631) (bindings: nextProps:instanceof unresolved reference "Readonly"<Module(0) TypeId(630)> (scope ID: 132))
+      required nextProps: Module(0) TypeId(631) (bindings: nextProps:instanceof unknown reference)
       required prevState: Module(0) TypeId(632) (bindings: prevState:instanceof Module(0) TypeId(500))
     ]
     type_args: []
@@ -23670,7 +23670,7 @@ Module TypeId(1035) => T = unknown reference
 
 Module TypeId(1036) => instanceof Module(0) TypeId(1035)
 
-Module TypeId(1037) => instanceof unresolved reference "ClipboardEvent" (scope ID: 2)
+Module TypeId(1037) => instanceof unknown reference
 
 Module TypeId(1038) => instanceof Module(0) TypeId(1033)
 
@@ -23688,7 +23688,7 @@ Module TypeId(1042) => T = unknown reference
 
 Module TypeId(1043) => instanceof Module(0) TypeId(1042)
 
-Module TypeId(1044) => instanceof unresolved reference "CompositionEvent" (scope ID: 3)
+Module TypeId(1044) => instanceof unknown reference
 
 Module TypeId(1045) => instanceof Module(0) TypeId(1033)
 
@@ -23704,7 +23704,7 @@ Module TypeId(1048) => T = unknown reference
 
 Module TypeId(1049) => instanceof Module(0) TypeId(1048)
 
-Module TypeId(1050) => instanceof unresolved reference "DragEvent" (scope ID: 4)
+Module TypeId(1050) => instanceof unknown reference
 
 Module TypeId(1051) => instanceof Module(0) TypeId(1130)
 
@@ -23722,7 +23722,7 @@ Module TypeId(1055) => T = unknown reference
 
 Module TypeId(1056) => instanceof Module(0) TypeId(1055)
 
-Module TypeId(1057) => instanceof unresolved reference "PointerEvent" (scope ID: 9)
+Module TypeId(1057) => instanceof unknown reference
 
 Module TypeId(1058) => instanceof Module(0) TypeId(1130)
 
@@ -23759,7 +23759,7 @@ Module TypeId(1066) => RelatedTarget = unknown reference
 
 Module TypeId(1067) => instanceof Module(0) TypeId(1065)
 
-Module TypeId(1068) => instanceof unresolved reference "FocusEvent" (scope ID: 5)
+Module TypeId(1068) => instanceof unknown reference
 
 Module TypeId(1069) => instanceof Module(0) TypeId(1033)
 
@@ -23904,7 +23904,7 @@ Module TypeId(1111) => T = unknown reference
 
 Module TypeId(1112) => instanceof Module(0) TypeId(1111)
 
-Module TypeId(1113) => instanceof unresolved reference "KeyboardEvent" (scope ID: 6)
+Module TypeId(1113) => instanceof unknown reference
 
 Module TypeId(1114) => instanceof Module(0) TypeId(1150)
 
@@ -23946,7 +23946,7 @@ Module TypeId(1119) => instanceof unresolved reference "Element" (scope ID: 269)
 
 Module TypeId(1120) => T = unknown reference
 
-Module TypeId(1121) => instanceof unresolved reference "MouseEvent" (scope ID: 7)
+Module TypeId(1121) => instanceof unknown reference
 
 Module TypeId(1122) => E = unknown reference
 
@@ -24003,7 +24003,7 @@ Module TypeId(1133) => T = unknown reference
 
 Module TypeId(1134) => instanceof Module(0) TypeId(1133)
 
-Module TypeId(1135) => instanceof unresolved reference "TouchEvent" (scope ID: 8)
+Module TypeId(1135) => instanceof unknown reference
 
 Module TypeId(1136) => instanceof Module(0) TypeId(1150)
 
@@ -24042,7 +24042,7 @@ Module TypeId(1142) => instanceof unresolved reference "Element" (scope ID: 273)
 
 Module TypeId(1143) => T = unknown reference
 
-Module TypeId(1144) => instanceof unresolved reference "UIEvent" (scope ID: 12)
+Module TypeId(1144) => instanceof unknown reference
 
 Module TypeId(1145) => E = unknown reference
 
@@ -24066,7 +24066,7 @@ Module TypeId(1152) => T = unknown reference
 
 Module TypeId(1153) => instanceof Module(0) TypeId(1152)
 
-Module TypeId(1154) => instanceof unresolved reference "WheelEvent" (scope ID: 13)
+Module TypeId(1154) => instanceof unknown reference
 
 Module TypeId(1155) => instanceof Module(0) TypeId(1130)
 
@@ -24087,7 +24087,7 @@ Module TypeId(1158) => T = unknown reference
 
 Module TypeId(1159) => instanceof Module(0) TypeId(1158)
 
-Module TypeId(1160) => instanceof unresolved reference "AnimationEvent" (scope ID: 1)
+Module TypeId(1160) => instanceof unknown reference
 
 Module TypeId(1161) => instanceof Module(0) TypeId(1033)
 
@@ -24107,7 +24107,7 @@ Module TypeId(1164) => T = unknown reference
 
 Module TypeId(1165) => instanceof Module(0) TypeId(1164)
 
-Module TypeId(1166) => instanceof unresolved reference "ToggleEvent" (scope ID: 10)
+Module TypeId(1166) => instanceof unknown reference
 
 Module TypeId(1167) => instanceof Module(0) TypeId(1033)
 
@@ -24132,7 +24132,7 @@ Module TypeId(1173) => T = unknown reference
 
 Module TypeId(1174) => instanceof Module(0) TypeId(1173)
 
-Module TypeId(1175) => instanceof unresolved reference "TransitionEvent" (scope ID: 11)
+Module TypeId(1175) => instanceof unknown reference
 
 Module TypeId(1176) => instanceof Module(0) TypeId(1033)
 


### PR DESCRIPTION
## Summary

Fixes an issue that could lead to panics if the scoped resolver imported a type from another module and then tried to resolve one of its type qualifiers from the scope of its own module.

## Test Plan

Test added.
