### PR TITLE
fix(core): fix `Text` hasher

### DIFF
--- a/crates/biome_cli/tests/cases/config_extends.rs
+++ b/crates/biome_cli/tests/cases/config_extends.rs
@@ -103,6 +103,67 @@ fn extends_config_ok_from_npm_package() {
     ));
 }
 
+// See: https://github.com/biomejs/biome/issues/6217
+#[test]
+fn extends_config_ok_from_npm_package_with_author_field() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let biome_json = Utf8Path::new("biome.json");
+    fs.insert(
+        biome_json.into(),
+        r#"{ "extends": ["@shared/format/biome", "@shared/linter/biome"] }"#,
+    );
+
+    fs.insert(
+        "node_modules/@shared/format/biome.json".into(),
+        r#"{ "javascript": { "formatter": { "quoteStyle": "single" } } }"#,
+    );
+    fs.insert(
+        "node_modules/@shared/format/package.json".into(),
+        r#"{
+    "name": "@shared/format",
+    "author": "this breaks extending biome",
+    "exports": {
+        "./biome": "./biome.json"
+    }
+}"#,
+    );
+
+    fs.insert(
+        "node_modules/@shared/linter/biome.jsonc".into(),
+        r#"{ "linter": { "enabled": false, } }"#,
+    );
+    fs.insert(
+        "node_modules/@shared/linter/package.json".into(),
+        r#"{
+    "name": "@shared/linter",
+    "exports": {
+        "./biome": "./biome.jsonc"
+    }
+}"#,
+    );
+
+    let test_file = Utf8Path::new("test.js");
+    fs.insert(test_file.into(), r#"debugger; console.log("string"); "#);
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", test_file.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "extends_config_ok_from_npm_package_with_author_field",
+        fs,
+        console,
+        result,
+    ));
+}
+
 #[test]
 fn extends_config_ok_linter_not_formatter() {
     let mut fs = MemoryFileSystem::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_from_npm_package_with_author_field.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_config_extends/extends_config_ok_from_npm_package_with_author_field.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `node_modules/@shared/linter/biome.jsonc`
+
+```json
+{ "linter": { "enabled": false } }
+```
+
+## `biome.json`
+
+```json
+{ "extends": ["@shared/format/biome", "@shared/linter/biome"] }
+```
+
+## `node_modules/@shared/format/biome.json`
+
+```json
+{ "javascript": { "formatter": { "quoteStyle": "single" } } }
+```
+
+## `node_modules/@shared/format/package.json`
+
+```json
+{
+    "name": "@shared/format",
+    "author": "this breaks extending biome",
+    "exports": {
+        "./biome": "./biome.json"
+    }
+}
+```
+
+## `node_modules/@shared/linter/package.json`
+
+```json
+{
+    "name": "@shared/linter",
+    "exports": {
+        "./biome": "./biome.jsonc"
+    }
+}
+```
+
+## `test.js`
+
+```js
+debugger; console.log("string"); 
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - debugger;·console.log("string");·
+      1 │ + debugger;
+      2 │ + console.log('string');
+      3 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_json_value/src/json_value.rs
+++ b/crates/biome_json_value/src/json_value.rs
@@ -272,6 +272,16 @@ impl From<String> for JsonString {
     }
 }
 
+impl From<Text> for JsonString {
+    fn from(text: Text) -> Self {
+        match text {
+            Text::Borrowed(token_text) => token_text.into(),
+            Text::Owned(string) => Self(Text::Owned(string)),
+            Text::Static(string) => Self(Text::Static(string)),
+        }
+    }
+}
+
 impl From<TokenText> for JsonString {
     fn from(text: TokenText) -> Self {
         Self(unescape_json_string(text))

--- a/crates/biome_package/src/node_js_package/mod.rs
+++ b/crates/biome_package/src/node_js_package/mod.rs
@@ -68,11 +68,14 @@ impl Package for NodeJsPackage {
             .and_then(|manifest| manifest.license.as_ref())
         {
             if !LICENSE_LIST.is_valid(license) {
-                diagnostics
-                    .push(ProjectAnalyzeDiagnostic::new_invalid_license(license).with_range(range))
+                diagnostics.push(
+                    ProjectAnalyzeDiagnostic::new_invalid_license(license.to_string())
+                        .with_range(range),
+                )
             } else if !LICENSE_LIST.is_deprecated(license) {
                 diagnostics.push(
-                    ProjectAnalyzeDiagnostic::new_deprecated_license(license).with_range(range),
+                    ProjectAnalyzeDiagnostic::new_deprecated_license(license.to_string())
+                        .with_range(range),
                 )
             }
         }

--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -192,7 +192,7 @@ fn resolve_module_with_package_json(
     }
 
     if let Some(package_name) = &package_json.name {
-        if specifier.starts_with(package_name)
+        if specifier.starts_with(package_name.text())
             && specifier
                 .as_bytes()
                 .get(package_name.len())

--- a/crates/biome_rowan/src/text.rs
+++ b/crates/biome_rowan/src/text.rs
@@ -55,7 +55,7 @@ impl From<&'static str> for Text {
 
 impl Hash for Text {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(self.text().as_bytes());
+        self.text().hash(state);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6217.

Really glad we managed to fix this before the 2.0 release, because it's a particularly nasty hidden edge case: The hash implementation for `Text` wasn't consistent with hashes created from `&str`. This caused lookups into hash/index maps to fail if you used a hardcoded `&str` value to look for something parsed from a `Text`, but only if such a map contained 2 or more entries.

This manifested through our resolver, which relies on our parsing of `PackageJson`, which stores unrecognised (raw) fields as a map from `JsonString` to `JsonValue`, and indeed `JsonValue` is also a wrapper around `Text`. The resolver looks up `extends` as a hardcoded `&str` key in that map, which could then fail **if** there were other unrecognised fields in the `package.json` too.

So #6217 was never about the author field, it merely failed because there were additional unrecognised fields that happened to trigger a mismatch in the hash lookup.

While I was at it, I changed a few fields in `PackageJson` from `String` to `Text` as well, which may save a few allocations. The `description` field was dropped, because we don't use it anywhere (any `package.json` that does have the field will just end up putting it in `raw_json`, just like the `author` field).

## Test Plan

Tests added.
