### PR TITLE
fix(linter): exclude dependencies from `noPrivateImports`

### DIFF
--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -19,6 +19,7 @@ biome_control_flow       = { workspace = true }
 biome_deserialize        = { workspace = true, features = ["smallvec"] }
 biome_deserialize_macros = { workspace = true }
 biome_diagnostics        = { workspace = true }
+biome_fs                 = { workspace = true }
 biome_glob               = { workspace = true, features = ["biome_deserialize", "serde"] }
 biome_js_factory         = { workspace = true }
 biome_js_semantic        = { workspace = true }

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -8,6 +8,7 @@ use biome_js_syntax::{
     AnyJsImportClause, AnyJsImportLike, AnyJsNamedImportSpecifier, JsModuleSource, JsSyntaxToken,
 };
 use biome_module_graph::{JsModuleInfo, ModuleGraph, ResolvedPath};
+use biome_resolver::is_relative_specifier;
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,7 @@ declare_lint_rule! {
     ///
     /// This rule recognizes the JSDoc tags `@public`, `@package`, and
     /// `@private` so that you are free to set the visibility of exports.
-    /// Exports without tag have a default visibility of **public**, but  this
+    /// Exports without tag have a default visibility of **public**, but this
     /// can be configured.
     ///
     /// The `@access` tag is also supported if it's used with one of the values
@@ -51,25 +52,23 @@ declare_lint_rule! {
     /// import the symbol. Modules that only share a common folder higher up in
     /// the hierarchy are not allowed to import the symbol.
     ///
-    /// For a visual explanation, see
-    /// [this illustration](https://github.com/uhyo/eslint-plugin-import-access?tab=readme-ov-file#what).
+    /// For a visual explanation, see [this
+    /// illustration](https://github.com/uhyo/eslint-plugin-import-access?tab=readme-ov-file#what).
     ///
     /// ## Private visibility
     ///
     /// Private visibility means that a symbol may not be imported from other
     /// modules.
     ///
-    /// The key thing to understanding the usefulness of `@private` is that
-    /// this rule doesn't treat modules and files as one and the same thing.
-    /// While files are indeed modules, folders are considered modules too, with
-    /// their files and subfolders being submodules. Therefore, symbols exported
-    /// as `@private` from an index file, such as `index.js`, can _still_ be
+    /// The key thing to understanding the usefulness of `@private` is that this
+    /// rule doesn't treat modules and files as one and the same thing. While
+    /// files are indeed modules, folders are considered modules too, with their
+    /// files and subfolders being submodules. Therefore, symbols exported as
+    /// `@private` from an index file, such as `index.js`, can _still_ be
     /// imported from other submodules in that same module.
     ///
-    /// :::note
-    /// For the sake of compatibility with conventions used with Deno, modules
-    /// named `mod.js`/`mod.ts` are considered index files too.
-    /// :::
+    /// :::note For the sake of compatibility with conventions used with Deno,
+    /// modules named `mod.js`/`mod.ts` are considered index files too. :::
     ///
     /// Another reason why private visibility may still be useful is that it
     /// allows you to choose specific exceptions. For example, using
@@ -85,6 +84,15 @@ declare_lint_rule! {
     ///   regardless of the default visibility setting.
     /// * This rule does not validate imports through dynamic `import()`
     ///   expressions or CommonJS `require()` calls.
+    /// * This rule only works for _relative_ imports. Imports from external
+    ///   packages, but also from path aliases, are considered out of scope.
+    ///   Note you may also use this to your advantage: You can set the default
+    ///   of this rule to _package visibility_ and use path aliases as an
+    ///   exception. The rationale behind this is that if you set up path
+    ///   aliases, you probably intent for their symbols to be available
+    ///   everywhere. (If not, maybe
+    ///   ]`noRestrictedImports`](https://biomejs.dev/linter/rules/no-restricted-imports/`)
+    ///   is what you are looking for.)
     ///
     /// ## Examples
     ///
@@ -110,10 +118,10 @@ declare_lint_rule! {
     /// export function getTestStuff() {}
     /// ```
     ///
-    /// **`bar.test.js`**
-    /// // Attempt to import a private export. To allow this, you probably want
-    /// // to configure an `override` to disable this rule in test files.
-    /// // See: https://biomejs.dev/reference/configuration/#overrides
+    /// **`bar.test.js`** // Attempt to import a private export. To allow this,
+    /// you probably want // to configure an `override` to disable this rule in
+    /// test files. // See:
+    /// https://biomejs.dev/reference/configuration/#overrides
     /// ```js
     /// import { getTestStuff } from "./bar.js";
     /// ```
@@ -220,8 +228,12 @@ impl Rule for NoPrivateImports {
         };
 
         let node = ctx.query();
-        let Some(target_path) = module_info
-            .get_import_path_by_js_node(node)
+        let Some(target_path) = node
+            .is_static_import()
+            .then(|| node.inner_string_text())
+            .flatten()
+            .filter(|specifier| is_relative_specifier(specifier.text()))
+            .and_then(|specifier| module_info.static_import_paths.get(specifier.text()))
             .and_then(ResolvedPath::as_path)
         else {
             return Vec::new();

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/default_package.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/default_package.js
@@ -1,3 +1,5 @@
+import { unknown } from "external-package";
+
 // Importing a symbol without any visibility from sub package is NOT allowed when the default visibility is package.
 import { fooDefaultVariable } from "./sub/foo.js";
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/default_package.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/default_package.js.snap
@@ -4,6 +4,8 @@ expression: default_package.js
 ---
 # Input
 ```js
+import { unknown } from "external-package";
+
 // Importing a symbol without any visibility from sub package is NOT allowed when the default visibility is package.
 import { fooDefaultVariable } from "./sub/foo.js";
 
@@ -23,15 +25,15 @@ import { fooPrivateVariable as subPrivate } from "./sub/foo.js";
 
 # Diagnostics
 ```
-default_package.js:2:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+default_package.js:4:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! You may not import a symbol with package visibility from here.
   
-    1 │ // Importing a symbol without any visibility from sub package is NOT allowed when the default visibility is package.
-  > 2 │ import { fooDefaultVariable } from "./sub/foo.js";
+    3 │ // Importing a symbol without any visibility from sub package is NOT allowed when the default visibility is package.
+  > 4 │ import { fooDefaultVariable } from "./sub/foo.js";
       │          ^^^^^^^^^^^^^^^^^^
-    3 │ 
-    4 │ // Re-exporting widens the allowed import scope for package private, so this is allowed:
+    5 │ 
+    6 │ // Re-exporting widens the allowed import scope for package private, so this is allowed:
   
   i You may need to import an alternative symbol, or relax the visibility of this symbol.
   
@@ -41,15 +43,15 @@ default_package.js:2:10 lint/correctness/noPrivateImports ━━━━━━━�
 ```
 
 ```
-default_package.js:13:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+default_package.js:15:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! You may not import a symbol with package visibility from here.
   
-    12 │ // Tighter visibility also takes precedence, so these imports are NOT allowed.
-  > 13 │ import { fooPackageVariable as subPackage } from "./sub/foo.js";
+    14 │ // Tighter visibility also takes precedence, so these imports are NOT allowed.
+  > 15 │ import { fooPackageVariable as subPackage } from "./sub/foo.js";
        │          ^^^^^^^^^^^^^^^^^^
-    14 │ import { fooPrivateVariable as subPrivate } from "./sub/foo.js";
-    15 │ 
+    16 │ import { fooPrivateVariable as subPrivate } from "./sub/foo.js";
+    17 │ 
   
   i You may need to import an alternative symbol, or relax the visibility of this symbol.
   
@@ -59,15 +61,15 @@ default_package.js:13:10 lint/correctness/noPrivateImports ━━━━━━━
 ```
 
 ```
-default_package.js:14:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+default_package.js:16:10 lint/correctness/noPrivateImports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! You may not import a symbol with private visibility from here.
   
-    12 │ // Tighter visibility also takes precedence, so these imports are NOT allowed.
-    13 │ import { fooPackageVariable as subPackage } from "./sub/foo.js";
-  > 14 │ import { fooPrivateVariable as subPrivate } from "./sub/foo.js";
+    14 │ // Tighter visibility also takes precedence, so these imports are NOT allowed.
+    15 │ import { fooPackageVariable as subPackage } from "./sub/foo.js";
+  > 16 │ import { fooPrivateVariable as subPrivate } from "./sub/foo.js";
        │          ^^^^^^^^^^^^^^^^^^
-    15 │ 
+    17 │ 
   
   i You may need to import an alternative symbol, or relax the visibility of this symbol.
   

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js
@@ -1,5 +1,7 @@
 /* should not generate diagnostics */
 
+import { unknown } from "external-package";
+
 // Importing a package-private symbol within the same package is allowed.
 import { fooPackageVariable } from "./foo.js";
 import { fooPackageVariable as fooPackage2 } from "./sub";

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js.snap
@@ -6,6 +6,8 @@ expression: valid.js
 ```js
 /* should not generate diagnostics */
 
+import { unknown } from "external-package";
+
 // Importing a package-private symbol within the same package is allowed.
 import { fooPackageVariable } from "./foo.js";
 import { fooPackageVariable as fooPackage2 } from "./sub";

--- a/crates/biome_resolver/src/lib.rs
+++ b/crates/biome_resolver/src/lib.rs
@@ -581,7 +581,7 @@ fn resolve_path_info(
     }
 }
 
-fn is_relative_specifier(specifier: &str) -> bool {
+pub fn is_relative_specifier(specifier: &str) -> bool {
     specifier == "." || specifier.starts_with("./") || specifier.starts_with("../")
 }
 


### PR DESCRIPTION
## Summary

Fixes #6214.

@minht11 I've made the decision to restrict `noPrivateImports` to relative imports only to prevent this. This means path aliases are excluded too, which to me feels right, because if you set up an alias for those paths, you probably _intent_ for their exports to be available everywhere, but let me know your thoughts on this!

## Test Plan

Tests updated.
