### PR TITLE
fix(biome_js_analyze): Fixes useExhaustiveDependencies missing depend…

### DIFF
--- a/.changeset/fix_use_exhaustive_dependencies_missing_deps_declared_after_hook.md
+++ b/.changeset/fix_use_exhaustive_dependencies_missing_deps_declared_after_hook.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixes useExhaustiveDependencies missing dependencies being defined after the hook itself failure.
+
+Example:
+
+```jsx
+import { useState, useEffect } from 'react';
+
+function MyComponent() {
+  useEffect(() => {
+    console.log(a);
+  }, []);
+
+  let a = 1;
+}
+```

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -857,7 +857,9 @@ impl Rule for UseExhaustiveDependencies {
                         .entry(capture.text_trimmed().into_text().into())
                         .or_default();
 
-                    captures.push(capture.clone());
+                    if !captures.iter().any(|existing| existing == capture) {
+                        captures.push(capture.clone());
+                    }
                 }
             }
 

--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -18,6 +18,7 @@ use biome_rowan::AstNode;
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
+use biome_analyze::QueryMatch;
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 
@@ -72,7 +73,10 @@ impl ReactCallWithDependencyResult {
                 closure
                     .descendents()
                     .flat_map(|closure| closure.all_captures())
-                    .filter(move |capture| !range.contains(capture.declaration_range().start()))
+                    .filter(move |capture| {
+                        !range.contains(capture.declaration_range().start())
+                            && range.contains(capture.node().text_range().start())
+                    })
             })
             .into_iter()
             .flatten()

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx
@@ -168,3 +168,22 @@ function MissingFunctionDeclaration() {
 
   return <>{value}</>
 }
+
+function HoistedDeclaration() {
+	useEffect(() => {
+		console.log(a);
+	}, []);
+
+	let a = 1;
+}
+
+
+function HoistedDeclarations() {
+	useEffect(() => {
+		console.log(a, b);
+	}, []);
+
+	let a = 1;
+	let b = a + 1;
+}
+

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
 expression: missingDependenciesInvalid.jsx
 ---
 # Input
@@ -174,6 +175,25 @@ function MissingFunctionDeclaration() {
 
   return <>{value}</>
 }
+
+function HoistedDeclaration() {
+	useEffect(() => {
+		console.log(a);
+	}, []);
+
+	let a = 1;
+}
+
+
+function HoistedDeclarations() {
+	useEffect(() => {
+		console.log(a, b);
+	}, []);
+
+	let a = 1;
+	let b = a + 1;
+}
+
 
 ```
 
@@ -990,5 +1010,92 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
   
     167 │ ··},·[func])
         │       ++++  
+
+```
+
+```
+missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
+
+  × This hook does not specify all of its dependencies: a
+  
+    172 │ function HoistedDeclaration() {
+  > 173 │ 	useEffect(() => {
+        │ 	^^^^^^^^^
+    174 │ 		console.log(a);
+    175 │ 	}, []);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    172 │ function HoistedDeclaration() {
+    173 │ 	useEffect(() => {
+  > 174 │ 		console.log(a);
+        │ 		            ^
+    175 │ 	}, []);
+    176 │ 
+  
+  i Either include it or remove the dependency array
+  
+  i Unsafe fix: Add the missing dependencies to the list.
+  
+    175 │ → },·[a]);
+        │       +   
+
+```
+
+```
+missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
+
+  × This hook does not specify all of its dependencies: a
+  
+    181 │ function HoistedDeclarations() {
+  > 182 │ 	useEffect(() => {
+        │ 	^^^^^^^^^
+    183 │ 		console.log(a, b);
+    184 │ 	}, []);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    181 │ function HoistedDeclarations() {
+    182 │ 	useEffect(() => {
+  > 183 │ 		console.log(a, b);
+        │ 		            ^
+    184 │ 	}, []);
+    185 │ 
+  
+  i Either include it or remove the dependency array
+  
+  i Unsafe fix: Add the missing dependencies to the list.
+  
+    184 │ → },·[a]);
+        │       +   
+
+```
+
+```
+missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
+
+  × This hook does not specify all of its dependencies: b
+  
+    181 │ function HoistedDeclarations() {
+  > 182 │ 	useEffect(() => {
+        │ 	^^^^^^^^^
+    183 │ 		console.log(a, b);
+    184 │ 	}, []);
+  
+  i This dependency is not specified in the hook dependency list.
+  
+    181 │ function HoistedDeclarations() {
+    182 │ 	useEffect(() => {
+  > 183 │ 		console.log(a, b);
+        │ 		               ^
+    184 │ 	}, []);
+    185 │ 
+  
+  i Either include it or remove the dependency array
+  
+  i Unsafe fix: Add the missing dependencies to the list.
+  
+    184 │ → },·[b]);
+        │       +   
 
 ```

--- a/crates/biome_js_semantic/src/semantic_model/closure.rs
+++ b/crates/biome_js_semantic/src/semantic_model/closure.rs
@@ -249,6 +249,19 @@ impl Closure {
         self.data.scopes[self.scope_id.index()].range
     }
 
+    fn is_parent_reference_in_scope(
+        &self,
+        scope: &SemanticModelScopeData,
+        reference: &ReferenceId,
+    ) -> bool {
+        let binding_id = reference.binding_id();
+        let binding = self.data.binding(binding_id);
+        binding
+            .references
+            .iter()
+            .any(|parent_reference| scope.range.contains(parent_reference.range_start))
+    }
+
     /// Return all [Reference] this closure captures, not taking into
     /// consideration any capture of children closures
     ///
@@ -266,9 +279,23 @@ impl Closure {
         let scope = &self.data.scopes[self.scope_id.index()];
 
         let scopes = scope.children.clone();
-
+        let parent_scope = &self.data.scopes[scope.parent.unwrap().index()];
         let mut references = scope.read_references.clone();
+
+        let parent_read_references: Vec<_> = parent_scope
+            .read_references
+            .iter()
+            .filter(|reference| self.is_parent_reference_in_scope(scope, reference))
+            .collect();
+        let parent_write_references: Vec<_> = parent_scope
+            .write_references
+            .iter()
+            .filter(|reference| self.is_parent_reference_in_scope(scope, reference))
+            .collect();
+
         references.extend(scope.write_references.iter().copied());
+        references.extend(parent_read_references.iter().copied());
+        references.extend(parent_write_references.iter().copied());
 
         AllCapturesIter {
             data: self.data.clone(),


### PR DESCRIPTION
## Summary
Fixes useExhaustiveDependencies missing dependencies being defined after the hook itself failure.

Example:

```jsx
import { useState, useEffect } from 'react';

function MyComponent() {
  useEffect(() => {
    console.log(a);
  }, []);

  let a = 1;
}
```

closes #3262
