### PR TITLE
feat(cli): verbosity argument

### DIFF
--- a/.changeset/dirty-trains-smoke.md
+++ b/.changeset/dirty-trains-smoke.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added a new CLI flag `--minimal` that prints only the header of the diagnostics.

--- a/.changeset/orange-teams-love.md
+++ b/.changeset/orange-teams-love.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+The argument `--verbose` was deprecated. Use `--verbosity=full` instead.

--- a/.changeset/thirty-mice-eat.md
+++ b/.changeset/thirty-mice-eat.md
@@ -1,0 +1,13 @@
+---
+"@biomejs/biome": minor
+---
+
+Added a new CLI argument `--verbosity`, which replaced the now deprecated `--verbose` argument. The argument accepts three values, which behave as follow:
+- `--verboity=simple`, the default value, which prints simple diagnostics.
+- `--verbosity=full`, which replaces the functionality provided by `--verbose`. It prints additional diagnostics and information.
+- `--verbosity=minimal`, which prints only the "header" of non-verbose diagnostics
+  ```
+  check.js:1:6 lint/correctness/noConstantCondition
+  check.js:1:6 lint/correctness/noConstantCondition
+  check.js:1:6 lint/correctness/noConstantCondition
+  ```

--- a/crates/biome_cli/examples/text_reporter.rs
+++ b/crates/biome_cli/examples/text_reporter.rs
@@ -1,5 +1,6 @@
 use biome_cli::{
     DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary, VcsTargeted,
+    Verbosity,
 };
 
 /// This will be the visitor, which where we **write** the data
@@ -16,7 +17,7 @@ impl Reporter for TextReport {
             staged: false,
             changed: false,
         });
-        visitor.report_summary(&execution, self.summary, false)?;
+        visitor.report_summary(&execution, self.summary, Verbosity::Simple)?;
         Ok(())
     }
 }
@@ -26,7 +27,7 @@ impl ReporterVisitor for BufferVisitor {
         &mut self,
         _execution: &Execution,
         summary: TraversalSummary,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> std::io::Result<()> {
         self.0
             .push_str(&format!("Total is {}", summary.changed + summary.unchanged));
@@ -37,7 +38,7 @@ impl ReporterVisitor for BufferVisitor {
         &mut self,
         _execution: &Execution,
         _payload: DiagnosticsPayload,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> std::io::Result<()> {
         todo!()
     }

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -344,6 +344,17 @@ impl Execution {
         }
     }
 
+    pub(crate) fn command_name(&self) -> &'static str {
+        match self.traversal_mode {
+            TraversalMode::Check { .. } => "check",
+            TraversalMode::Lint { .. } => "lint",
+            TraversalMode::CI { .. } => "ci",
+            TraversalMode::Format { .. } => "format",
+            TraversalMode::Migrate { .. } => "migrate",
+            TraversalMode::Search { .. } => "search",
+        }
+    }
+
     pub(crate) const fn is_ci(&self) -> bool {
         matches!(self.traversal_mode, TraversalMode::CI { .. })
     }
@@ -611,7 +622,7 @@ pub fn execute_mode(
                     summary,
                     diagnostics_payload,
                     execution: execution.clone(),
-                    verbose: cli_options.verbose,
+                    verbosity: cli_options.verbosity,
                     working_directory: fs.working_directory().clone(),
                     evaluated_paths,
                 };
@@ -622,7 +633,7 @@ pub fn execute_mode(
                     diagnostics_payload,
                     execution: execution.clone(),
                     evaluated_paths,
-                    verbose: cli_options.verbose,
+                    verbosity: cli_options.verbosity,
                     working_directory: fs.working_directory().clone(),
                 };
                 reporter.write(&mut ConsoleReporterVisitor(console))?;
@@ -636,7 +647,7 @@ pub fn execute_mode(
                 summary,
                 diagnostics: diagnostics_payload,
                 execution: execution.clone(),
-                verbose: cli_options.verbose,
+                verbosity: cli_options.verbosity,
             };
             let mut buffer = JsonReporterVisitor::new(summary);
             reporter.write(&mut buffer)?;
@@ -675,7 +686,7 @@ pub fn execute_mode(
             let reporter = GithubReporter {
                 diagnostics_payload,
                 execution: execution.clone(),
-                verbose: cli_options.verbose,
+                verbosity: cli_options.verbosity,
             };
             reporter.write(&mut GithubReporterVisitor(console))?;
         }
@@ -683,7 +694,7 @@ pub fn execute_mode(
             let reporter = GitLabReporter {
                 diagnostics: diagnostics_payload,
                 execution: execution.clone(),
-                verbose: cli_options.verbose,
+                verbosity: cli_options.verbosity,
             };
             reporter.write(&mut GitLabReporterVisitor::new(
                 console,
@@ -695,7 +706,7 @@ pub fn execute_mode(
                 summary,
                 diagnostics_payload,
                 execution: execution.clone(),
-                verbose: cli_options.verbose,
+                verbosity: cli_options.verbosity,
             };
             reporter.write(&mut JunitReporterVisitor::new(console))?;
         }

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -52,22 +52,13 @@ pub(crate) fn run<'a>(
 
         if file_features.is_protected() {
             let protected_diagnostic = WorkspaceError::protected_file(biome_path.to_string());
-
-            match cli_options.verbosity {
-                Verbosity::Simple => {
-                    console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
+            if protected_diagnostic.tags().is_verbose() {
+                if cli_options.verbosity.is_verbose() {
+                    console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
                 }
-                Verbosity::Full => {
-                    if protected_diagnostic.tags().is_verbose() {
-                        console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
-                    }
-                }
-                Verbosity::Minimal => {
-                    console.error(markup! {{PrintDiagnostic::minimal(&protected_diagnostic)}})
-                }
+                console.append(markup! {{content}});
+                return Ok(());
             }
-            console.append(markup! {{content}});
-            return Ok(());
         };
         if file_features.supports_format() {
             workspace.open_file(OpenFileParams {

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -3,7 +3,7 @@
 use crate::cli_options::CliOptions;
 use crate::diagnostics::StdinDiagnostic;
 use crate::execute::Execution;
-use crate::{CliDiagnostic, CliSession, TraversalMode};
+use crate::{CliDiagnostic, CliSession, TraversalMode, Verbosity};
 use biome_analyze::RuleCategoriesBuilder;
 use biome_console::{ConsoleExt, markup};
 use biome_diagnostics::Diagnostic;
@@ -52,12 +52,19 @@ pub(crate) fn run<'a>(
 
         if file_features.is_protected() {
             let protected_diagnostic = WorkspaceError::protected_file(biome_path.to_string());
-            if protected_diagnostic.tags().is_verbose() {
-                if cli_options.verbose {
-                    console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
+
+            match cli_options.verbosity {
+                Verbosity::Simple => {
+                    console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
                 }
-            } else {
-                console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
+                Verbosity::Full => {
+                    if protected_diagnostic.tags().is_verbose() {
+                        console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
+                    }
+                }
+                Verbosity::Minimal => {
+                    console.error(markup! {{PrintDiagnostic::minimal(&protected_diagnostic)}})
+                }
             }
             console.append(markup! {{content}});
             return Ok(());
@@ -126,12 +133,18 @@ pub(crate) fn run<'a>(
 
         if file_features.is_protected() {
             let protected_diagnostic = WorkspaceError::protected_file(biome_path.to_string());
-            if protected_diagnostic.tags().is_verbose() {
-                if cli_options.verbose {
-                    console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
+            match cli_options.verbosity {
+                Verbosity::Simple => {
+                    console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
                 }
-            } else {
-                console.error(markup! {{PrintDiagnostic::simple(&protected_diagnostic)}})
+                Verbosity::Full => {
+                    if protected_diagnostic.tags().is_verbose() {
+                        console.error(markup! {{PrintDiagnostic::verbose(&protected_diagnostic)}})
+                    }
+                }
+                Verbosity::Minimal => {
+                    console.error(markup! {{PrintDiagnostic::minimal(&protected_diagnostic)}})
+                }
             }
             console.append(markup! {{content}});
 

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -55,7 +55,7 @@ pub(crate) fn traverse(
 
     let working_directory = fs.working_directory();
     let printer = DiagnosticsPrinter::new(execution, working_directory.as_deref())
-        .with_verbose(cli_options.verbose)
+        .with_verbose(cli_options.verbosity.is_verbose())
         .with_diagnostic_level(cli_options.diagnostic_level)
         .with_max_diagnostics(max_diagnostics);
 

--- a/crates/biome_cli/src/lib.rs
+++ b/crates/biome_cli/src/lib.rs
@@ -32,6 +32,7 @@ use crate::commands::lint::LintCommandPayload;
 use crate::commands::migrate::MigrateCommandPayload;
 pub use crate::commands::{BiomeCommand, biome_command};
 pub use crate::logging::{LoggingLevel, setup_cli_subscriber};
+pub use cli_options::Verbosity;
 pub use diagnostics::CliDiagnostic;
 pub use execute::{Execution, TraversalMode, VcsTargeted, execute_mode};
 pub use panic::setup_panic_handler;
@@ -93,7 +94,7 @@ impl<'app> CliSession<'app> {
                 since,
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 CheckCommandPayload {
                     write,
                     fix,
@@ -133,7 +134,7 @@ impl<'app> CliSession<'app> {
                 graphql_linter,
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 LintCommandPayload {
                     write,
                     suppress,
@@ -169,7 +170,7 @@ impl<'app> CliSession<'app> {
                 ..
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 CiCommandPayload {
                     linter_enabled,
                     formatter_enabled,
@@ -200,7 +201,7 @@ impl<'app> CliSession<'app> {
                 since,
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 FormatCommandPayload {
                     javascript_formatter,
                     formatter_configuration,
@@ -233,7 +234,7 @@ impl<'app> CliSession<'app> {
                 sub_command,
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 MigrateCommandPayload {
                     write,
                     fix,
@@ -252,7 +253,7 @@ impl<'app> CliSession<'app> {
                 vcs_configuration,
             } => run_command(
                 self,
-                &cli_options,
+                cli_options,
                 SearchCommandPayload {
                     files_configuration,
                     paths,
@@ -292,7 +293,7 @@ pub fn to_color_mode(color: Option<&ColorsArg>) -> ColorMode {
 
 pub(crate) fn run_command(
     session: CliSession,
-    cli_options: &CliOptions,
+    cli_options: CliOptions,
     mut command: impl CommandRunner,
 ) -> Result<(), CliDiagnostic> {
     let command = &mut command;

--- a/crates/biome_cli/src/reporter/github.rs
+++ b/crates/biome_cli/src/reporter/github.rs
@@ -1,3 +1,4 @@
+use crate::cli_options::Verbosity;
 use crate::{DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary};
 use biome_console::{Console, ConsoleExt, markup};
 use biome_diagnostics::PrintGitHubDiagnostic;
@@ -6,12 +7,12 @@ use std::io;
 pub(crate) struct GithubReporter {
     pub(crate) diagnostics_payload: DiagnosticsPayload,
     pub(crate) execution: Execution,
-    pub(crate) verbose: bool,
+    pub(crate) verbosity: Verbosity,
 }
 
 impl Reporter for GithubReporter {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> io::Result<()> {
-        visitor.report_diagnostics(&self.execution, self.diagnostics_payload, self.verbose)?;
+        visitor.report_diagnostics(&self.execution, self.diagnostics_payload, self.verbosity)?;
         Ok(())
     }
 }
@@ -22,7 +23,7 @@ impl ReporterVisitor for GithubReporterVisitor<'_> {
         &mut self,
         _execution: &Execution,
         _summary: TraversalSummary,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> io::Result<()> {
         Ok(())
     }
@@ -31,13 +32,13 @@ impl ReporterVisitor for GithubReporterVisitor<'_> {
         &mut self,
         _execution: &Execution,
         diagnostics_payload: DiagnosticsPayload,
-        verbose: bool,
+        verbosity: Verbosity,
     ) -> io::Result<()> {
         for diagnostic in &diagnostics_payload.diagnostics {
             if diagnostic.severity() >= diagnostics_payload.diagnostic_level {
-                if diagnostic.tags().is_verbose() && verbose {
+                if diagnostic.tags().is_verbose() && verbosity.is_verbose() {
                     self.0.log(markup! {{PrintGitHubDiagnostic(diagnostic)}});
-                } else if !verbose {
+                } else if !verbosity.is_verbose() {
                     self.0.log(markup! {{PrintGitHubDiagnostic(diagnostic)}});
                 }
             }

--- a/crates/biome_cli/src/reporter/gitlab.rs
+++ b/crates/biome_cli/src/reporter/gitlab.rs
@@ -1,3 +1,4 @@
+use crate::cli_options::Verbosity;
 use crate::{DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary};
 use biome_console::fmt::{Display, Formatter};
 use biome_console::{Console, ConsoleExt, markup};
@@ -16,12 +17,11 @@ use std::{
 pub struct GitLabReporter {
     pub(crate) execution: Execution,
     pub(crate) diagnostics: DiagnosticsPayload,
-    pub(crate) verbose: bool,
+    pub(crate) verbosity: Verbosity,
 }
-
 impl Reporter for GitLabReporter {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> std::io::Result<()> {
-        visitor.report_diagnostics(&self.execution, self.diagnostics, self.verbose)?;
+        visitor.report_diagnostics(&self.execution, self.diagnostics, self.verbosity)?;
         Ok(())
     }
 }
@@ -64,7 +64,7 @@ impl ReporterVisitor for GitLabReporterVisitor<'_> {
         &mut self,
         _: &Execution,
         _: TraversalSummary,
-        _verbose: bool,
+        _: Verbosity,
     ) -> std::io::Result<()> {
         Ok(())
     }
@@ -73,14 +73,14 @@ impl ReporterVisitor for GitLabReporterVisitor<'_> {
         &mut self,
         _execution: &Execution,
         payload: DiagnosticsPayload,
-        verbose: bool,
+        verbosity: Verbosity,
     ) -> std::io::Result<()> {
         let hasher = RwLock::default();
         let diagnostics = GitLabDiagnostics {
             payload,
             lock: &hasher,
             path: self.repository_root.as_deref(),
-            verbose,
+            verbose: verbosity.is_verbose(),
         };
         self.console.log(markup!({ diagnostics }));
         Ok(())

--- a/crates/biome_cli/src/reporter/json.rs
+++ b/crates/biome_cli/src/reporter/json.rs
@@ -1,3 +1,4 @@
+use crate::cli_options::Verbosity;
 use crate::{DiagnosticsPayload, Execution, Reporter, ReporterVisitor, TraversalSummary};
 use biome_console::fmt::Formatter;
 use serde::Serialize;
@@ -31,13 +32,13 @@ pub struct JsonReporter {
     pub execution: Execution,
     pub diagnostics: DiagnosticsPayload,
     pub summary: TraversalSummary,
-    pub verbose: bool,
+    pub verbosity: Verbosity,
 }
 
 impl Reporter for JsonReporter {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> std::io::Result<()> {
-        visitor.report_summary(&self.execution, self.summary, self.verbose)?;
-        visitor.report_diagnostics(&self.execution, self.diagnostics, self.verbose)?;
+        visitor.report_summary(&self.execution, self.summary, self.verbosity)?;
+        visitor.report_diagnostics(&self.execution, self.diagnostics, self.verbosity)?;
 
         Ok(())
     }
@@ -48,7 +49,7 @@ impl ReporterVisitor for JsonReporterVisitor {
         &mut self,
         execution: &Execution,
         summary: TraversalSummary,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> std::io::Result<()> {
         self.summary = summary;
         self.command = format!("{}", execution.traversal_mode());
@@ -60,12 +61,12 @@ impl ReporterVisitor for JsonReporterVisitor {
         &mut self,
         _execution: &Execution,
         payload: DiagnosticsPayload,
-        verbose: bool,
+        verbosity: Verbosity,
     ) -> std::io::Result<()> {
         for diagnostic in payload.diagnostics {
             if diagnostic.severity() >= payload.diagnostic_level {
                 if diagnostic.tags().is_verbose() {
-                    if verbose {
+                    if verbosity.is_verbose() {
                         self.diagnostics
                             .push(biome_diagnostics::serde::Diagnostic::new(diagnostic))
                     }

--- a/crates/biome_cli/src/reporter/mod.rs
+++ b/crates/biome_cli/src/reporter/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod junit;
 pub(crate) mod summary;
 pub(crate) mod terminal;
 
-use crate::cli_options::MaxDiagnostics;
+use crate::cli_options::{MaxDiagnostics, Verbosity};
 use crate::execute::Execution;
 use biome_diagnostics::advice::ListAdvice;
 use biome_diagnostics::{Diagnostic, Error, Severity};
@@ -55,7 +55,7 @@ pub trait ReporterVisitor {
         &mut self,
         _execution: &Execution,
         _summary: TraversalSummary,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> io::Result<()>;
 
     /// Writes the paths handled during a run.
@@ -72,7 +72,7 @@ pub trait ReporterVisitor {
         &mut self,
         _execution: &Execution,
         _payload: DiagnosticsPayload,
-        _verbose: bool,
+        _verbosity: Verbosity,
     ) -> io::Result<()>;
 }
 

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -167,6 +167,38 @@ fn max_diagnostics_verbose() {
 }
 
 #[test]
+fn max_diagnostics_minimal() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    for i in 0..8 {
+        let file_path = Utf8PathBuf::from(format!("src/file_{i}.js"));
+        fs.insert(file_path, "a == b".as_bytes());
+    }
+
+    let (mut fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["ci", "--max-diagnostics=10", "--verbosity=minimal", "src"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    for i in 0..8 {
+        let file_path = Utf8PathBuf::from(format!("src/folder_{i}/package-lock.json"));
+        fs.remove(Utf8Path::new(&file_path));
+    }
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "max_diagnostics_minimal",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn diagnostic_level() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/cases/diagnostics.rs
+++ b/crates/biome_cli/tests/cases/diagnostics.rs
@@ -168,7 +168,7 @@ fn max_diagnostics_verbose() {
 
 #[test]
 fn max_diagnostics_minimal() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     for i in 0..8 {
@@ -176,7 +176,7 @@ fn max_diagnostics_minimal() {
         fs.insert(file_path, "a == b".as_bytes());
     }
 
-    let (mut fs, result) = run_cli(
+    let (fs, result) = run_cli(
         fs,
         &mut console,
         Args::from(["ci", "--max-diagnostics=10", "--verbosity=minimal", "src"].as_slice()),

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -1331,7 +1331,7 @@ fn print_verbose() {
 
 #[test]
 fn print_minimal() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     let file_path = Utf8Path::new("check.js");

--- a/crates/biome_cli/tests/commands/check.rs
+++ b/crates/biome_cli/tests/commands/check.rs
@@ -1330,6 +1330,31 @@ fn print_verbose() {
 }
 
 #[test]
+fn print_minimal() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("check.js");
+    fs.insert(file_path.into(), LINT_ERROR.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["check", "--verbosity=minimal", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "print_minimal",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn print_verbose_write() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/commands/ci.rs
+++ b/crates/biome_cli/tests/commands/ci.rs
@@ -641,6 +641,31 @@ fn print_verbose() {
 }
 
 #[test]
+fn print_minimal() {
+    let mut fs = MemoryFileSystem::default();
+
+    let file_path = Utf8Path::new("ci.js");
+    fs.insert(file_path.into(), LINT_ERROR.as_bytes());
+
+    let mut console = BufferConsole::default();
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["ci", "--verbosity=minimal", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "print_minimal",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn ci_formatter_linter_organize_imports() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/commands/ci.rs
+++ b/crates/biome_cli/tests/commands/ci.rs
@@ -642,7 +642,7 @@ fn print_verbose() {
 
 #[test]
 fn print_minimal() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
 
     let file_path = Utf8Path::new("ci.js");
     fs.insert(file_path.into(), LINT_ERROR.as_bytes());

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1875,6 +1875,31 @@ fn print_verbose() {
 }
 
 #[test]
+fn print_minimal() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("format.js");
+    fs.insert(file_path.into(), UNFORMATTED.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--verbosity=minimal", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "print_minimal",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn vcs_absolute_path() {
     let git_ignore = r#"file.js"#;
     let config = r#"{

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -1876,7 +1876,7 @@ fn print_verbose() {
 
 #[test]
 fn print_minimal() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     let file_path = Utf8Path::new("format.js");

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -1534,7 +1534,7 @@ fn print_verbose() {
 
 #[test]
 fn print_minimal() {
-    let mut fs = MemoryFileSystem::default();
+    let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     let file_path = Utf8Path::new("check.js");

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -1533,6 +1533,31 @@ fn print_verbose() {
 }
 
 #[test]
+fn print_minimal() {
+    let mut fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("check.js");
+    fs.insert(file_path.into(), LINT_ERROR.as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--verbosity=minimal", file_path.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "print_minimal",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn unsupported_file() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_minimal.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_minimal.snap
@@ -1,0 +1,134 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `src/file_0.js`
+
+```js
+a == b
+```
+
+## `src/file_1.js`
+
+```js
+a == b
+```
+
+## `src/file_2.js`
+
+```js
+a == b
+```
+
+## `src/file_3.js`
+
+```js
+a == b
+```
+
+## `src/file_4.js`
+
+```js
+a == b
+```
+
+## `src/file_5.js`
+
+```js
+a == b
+```
+
+## `src/file_6.js`
+
+```js
+a == b
+```
+
+## `src/file_7.js`
+
+```js
+a == b
+```
+
+# Termination Message
+
+```block
+ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+src/file_0.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_0.js format 
+
+```
+
+```block
+src/file_1.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_1.js format 
+
+```
+
+```block
+src/file_2.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_2.js format 
+
+```
+
+```block
+src/file_3.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_3.js format 
+
+```
+
+```block
+src/file_4.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_4.js format 
+
+```
+
+```block
+src/file_5.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_6.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+src/file_7.js:1:3 lint/suspicious/noDoubleEquals  FIXABLE  
+
+```
+
+```block
+Checked 8 files in <TIME>. No fixes applied.
+Found 16 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `src/file.js`
 
 ```js
-  statement(  )  
+  statement(  )
 ```
 
 # Termination Message
@@ -14,7 +14,7 @@ expression: redactor(content)
 ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some errors were emitted while running checks.
-  
+
 
 
 ```
@@ -25,11 +25,11 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_0/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -37,11 +37,11 @@ src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_1/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_1/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -49,11 +49,11 @@ src/folder_1/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_2/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_2/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -61,11 +61,11 @@ src/folder_2/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_3/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_3/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -73,11 +73,11 @@ src/folder_3/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_4/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_4/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -85,11 +85,11 @@ src/folder_4/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_5/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_5/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -97,11 +97,11 @@ src/folder_5/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_6/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_6/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -109,11 +109,11 @@ src/folder_6/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_7/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_7/package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
+
   Verbose advice
-  
+
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
+
 
 ```
 
@@ -121,11 +121,11 @@ src/folder_7/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × File content differs from formatting output
-  
+
     1   │ - ··statement(··)··
       1 │ + statement();
-      2 │ + 
-  
+      2 │ +
+
 
 ```
 
@@ -133,9 +133,9 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
-  
+
   - src/file.js
-  
+
 
 ```
 
@@ -143,9 +143,9 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files fixed:
-  
+
   ! The list is empty.
-  
+
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
@@ -5,7 +5,7 @@ expression: redactor(content)
 ## `src/file.js`
 
 ```js
-  statement(  )
+  statement(  )  
 ```
 
 # Termination Message
@@ -14,7 +14,7 @@ expression: redactor(content)
 ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Some errors were emitted while running checks.
-
+  
 
 
 ```
@@ -22,14 +22,26 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome ci --verbosity=full
+  
+
+```
+
+```block
 src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_0/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -37,11 +49,11 @@ src/folder_0/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_1/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_1/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -49,11 +61,11 @@ src/folder_1/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_2/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_2/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -61,11 +73,11 @@ src/folder_2/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_3/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_3/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -73,11 +85,11 @@ src/folder_3/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_4/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_4/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -85,11 +97,11 @@ src/folder_4/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_5/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_5/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -97,11 +109,11 @@ src/folder_5/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_6/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_6/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
+    
 
 ```
 
@@ -109,23 +121,11 @@ src/folder_6/package-lock.json project  VERBOSE  ━━━━━━━━━━�
 src/folder_7/package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file src/folder_7/package-lock.json is protected because is handled by another tool. Biome won't process it.
-
+  
   Verbose advice
-
+  
     i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-
-
-```
-
-```block
-src/file.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × File content differs from formatting output
-
-    1   │ - ··statement(··)··
-      1 │ + statement();
-      2 │ +
-
+    
 
 ```
 
@@ -133,9 +133,9 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
-
+  
   - src/file.js
-
+  
 
 ```
 
@@ -143,9 +143,9 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files fixed:
-
+  
   ! The list is empty.
-
+  
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
@@ -28,6 +28,18 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
+  
+
+```
+
+```block
 package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The file package-lock.json is protected because is handled by another tool. Biome won't process it.

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_format.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_format.snap
@@ -11,17 +11,5 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The file package-lock.json is protected because is handled by another tool. Biome won't process it.
-  
-  Verbose advice
-  
-    i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
-    
-
-```
-
-```block
 { "name": "test" }
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_format.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_format.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -11,7 +11,17 @@ expression: content
 # Emitted Messages
 
 ```block
-{ "name": "test" }
+package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The file package-lock.json is protected because is handled by another tool. Biome won't process it.
+  
+  Verbose advice
+  
+    i You can hide this diagnostic by using --diagnostic-level=warn to increase the diagnostic level shown by CLI.
+    
+
 ```
 
-
+```block
+{ "name": "test" }
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_format.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_format.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -9,6 +9,18 @@ expression: content
 ```
 
 # Emitted Messages
+
+```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
+  
+
+```
 
 ```block
 package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -25,5 +37,3 @@ package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━�
 ```block
 { "name": "test" }
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_lint.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_stdin_verbose_lint.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -9,6 +9,18 @@ expression: content
 ```
 
 # Emitted Messages
+
+```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
+  
+
+```
 
 ```block
 package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -25,5 +37,3 @@ package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━�
 ```block
 { "name": "test" }
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
@@ -34,13 +34,13 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Formatter would have printed the following content:
+  ! The --verbose argument is deprecated
   
-    1   │ - {}
-      1 │ + {}
-      2 │ + 
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
@@ -34,13 +34,13 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-other.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Formatter would have printed the following content:
+  ! The --verbose argument is deprecated
   
-    1   │ - {}
-      1 │ + {}
-      2 │ + 
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_verbose_command.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_summary/reports_diagnostics_summary_check_verbose_command.snap
@@ -78,6 +78,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome check --verbosity=full
+  
+
+```
+
+```block
 reporter/parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The following files have parsing errors.

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -78,85 +78,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a declaration item but instead found '}'.
+  ! The --verbose argument is deprecated
   
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
+  i Use the following command instead
   
-  i Expected a declaration item here.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-
-```
-
-```block
-index.css:3:23 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown function: f
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                       ^
-    4 │ 
-    5 │ .style {
-  
-  i Use a known function instead.
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```block
-index.css:7:17 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown function: fakeFunction
-  
-    5 │ .style {
-    6 │                 color:
-  > 7 │                 fakeFunction()
-      │                 ^^^^^^^^^^^^
-    8 │ }
-    9 │ 
-  
-  i Use a known function instead.
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```block
-index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a declaration item but instead found '}'.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-  i Expected a declaration item here.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-
-```
-
-```block
-index.css format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
+  $ biome check --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
@@ -80,85 +80,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected a declaration item but instead found '}'.
+  ! The --verbose argument is deprecated
   
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
+  i Use the following command instead
   
-  i Expected a declaration item here.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-
-```
-
-```block
-index.css:3:23 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown function: f
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                       ^
-    4 │ 
-    5 │ .style {
-  
-  i Use a known function instead.
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```block
-index.css:7:17 lint/correctness/noUnknownFunction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Unexpected unknown function: fakeFunction
-  
-    5 │ .style {
-    6 │                 color:
-  > 7 │                 fakeFunction()
-      │                 ^^^^^^^^^^^^
-    8 │ }
-    9 │ 
-  
-  i Use a known function instead.
-  
-  i See MDN web docs for more details.
-  
-
-```
-
-```block
-index.css:3:26 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a declaration item but instead found '}'.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-  i Expected a declaration item here.
-  
-  > 3 │ .brokenStyle { color: f( }
-      │                          ^
-    4 │ 
-    5 │ .style {
-  
-
-```
-
-```block
-index.css format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
+  $ biome check --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -185,14 +185,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_check_file_when_assist_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_check_file_when_assist_is_disabled.snap
@@ -27,6 +27,18 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome check --verbosity=full
+  
+
+```
+
+```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_minimal.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_minimal.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `check.js`
+
+```js
+for(;true;);
+
+```
+
+# Termination Message
+
+```block
+check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+check.js:1:6 lint/correctness/noConstantCondition 
+
+```
+
+```block
+check.js format 
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
@@ -23,24 +23,14 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Unexpected constant condition.
+  ! The --verbose argument is deprecated
   
-  > 1 │ for(;true;);
-      │      ^^^^
-    2 │ 
+  i Use the following command instead
   
-
-```
-
-```block
-check.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Formatter would have printed the following content:
+  $ biome check --verbosity=full
   
-    1 │ for·(;·true;·);
-      │    +  +     +  
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose_write.snap
@@ -23,13 +23,13 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Unexpected constant condition.
+  ! The --verbose argument is deprecated
   
-  > 1 │ for(;true;);
-      │      ^^^^
-    2 │ 
+  i Use the following command instead
+  
+  $ biome check --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
@@ -29,6 +29,18 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome check --verbosity=full
+  
+
+```
+
+```block
 check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Biome could not determine the language for the file extension txt

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -186,14 +186,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/print_minimal.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/print_minimal.snap
@@ -1,0 +1,38 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `ci.js`
+
+```js
+for(;true;);
+
+```
+
+# Termination Message
+
+```block
+ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+ci.js:1:6 lint/correctness/noConstantCondition 
+
+```
+
+```block
+ci.js format 
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
@@ -23,24 +23,14 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-ci.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Unexpected constant condition.
+  ! The --verbose argument is deprecated
   
-  > 1 │ for(;true;);
-      │      ^^^^
-    2 │ 
+  i Use the following command instead
   
-
-```
-
-```block
-ci.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × File content differs from formatting output
+  $ biome ci --verbosity=full
   
-    1 │ for·(;·true;·);
-      │    +  +     +  
 
 ```
 

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -98,14 +98,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_cli/tests/snapshots/main_commands_format/print_minimal.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/print_minimal.snap
@@ -1,0 +1,32 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `format.js`
+
+```js
+  statement(  )  
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+format.js format 
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
@@ -22,13 +22,13 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 # Emitted Messages
 
 ```block
-format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Formatter would have printed the following content:
+  ! The --verbose argument is deprecated
   
-    1   │ - ··statement(··)··
-      1 │ + statement();
-      2 │ + 
+  i Use the following command instead
+  
+  $ biome format --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -43,14 +43,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/print_minimal.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/print_minimal.snap
@@ -1,0 +1,33 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `check.js`
+
+```js
+for(;true;);
+
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+check.js:1:6 lint/correctness/noConstantCondition 
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
@@ -23,13 +23,13 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
-check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Unexpected constant condition.
+  ! The --verbose argument is deprecated
   
-  > 1 │ for(;true;);
-      │      ^^^^
-    2 │ 
+  i Use the following command instead
+  
+  $ biome lint --verbosity=full
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
@@ -29,6 +29,18 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 # Emitted Messages
 
 ```block
+flags/deprecated  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The --verbose argument is deprecated
+  
+  i Use the following command instead
+  
+  $ biome lint --verbosity=full
+  
+
+```
+
+```block
 check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Biome could not determine the language for the file extension txt

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/migrate_help.snap
@@ -14,14 +14,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_rage/rage_help.snap
@@ -14,14 +14,17 @@ Global options applied to all commands
                               text, "force" forces the formatting of markup using ANSI even if the
                               console output is determined to be incompatible
         --use-server          Connect to a running instance of the Biome daemon server.
-        --verbose             Print additional diagnostics, and some diagnostics show more
-                              information. Also, print out what files were processed and which ones
-                              were modified.
+        --verbose             [DEPRECATED] Print additional diagnostics, and some diagnostics show
+                              more information. Also, print out what files were processed and which
+                              ones were modified.
+        --verbosity=<default|verbose|minimal>  If affects how diagnostics are printed in different
+                              commands
+                              [default: simple]
         --config-path=PATH    Set the file path to the configuration file, or the directory path to
                               find `biome.json` or `biome.jsonc`. If used, it disables the default
                               configuration file resolution.
                               [env:BIOME_CONFIG_PATH: N/A]
-        --max-diagnostics=<none|<NUMBER>>  Cap the amount of diagnostics displayed. When `none` is
+        --max-diagnostics=<none|<NUMBER>>  Cap the number of diagnostics displayed. When `none` is
                               provided, the limit is lifted.
                               [default: 20]
         --skip-parse-errors   Skip over files containing syntax errors instead of emitting an error

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -434,5 +434,6 @@ define_categories! {
     // Used in tests and examples
     "args/fileNotFound",
     "flags/invalid",
+    "flags/deprecated",
     "semanticTests",
 }

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8574,6 +8574,7 @@ export type Category =
 	| "suppressions/incorrect"
 	| "args/fileNotFound"
 	| "flags/invalid"
+	| "flags/deprecated"
 	| "semanticTests";
 export interface Location {
 	path?: Resource_for_String;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary


This PR adds a new `--verbosity` argument, and closs https://github.com/biomejs/biome/discussions/6084

The `--verbosity` argument is going to replace `--verbose`. The reason I added a new argument that goes in "conflict" with `--verbose` is because I wanted to avoid having `--verbose` and `--minimal`. Plus, with an enum, we can provide more functionality in the future.

To replicate `--verbose` (which is deprecated, but still available), users will use `--verbosity=full`. 

**Please bikeshed and provide better names if you see fit**.

The new feature is `--verbosity=minimal`, which prints minimal diagnostics (only the header).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated tests, added new diagnostics, added new tests. 

<!-- What demonstrates that your implementation is correct? -->
