### PR TITLE
fix: gritql mismatch import pattern

### DIFF
--- a/.changeset/modern-meals-end.md
+++ b/.changeset/modern-meals-end.md
@@ -1,0 +1,15 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed grit pattern matching for different kinds of import statements.
+
+The grit pattern `import $imports from "foo"` will match the following code:
+
+```ts
+import bar from "foo"
+import { bar } from "foo"
+import { bar, baz } from "foo"
+```
+
+

--- a/crates/biome_grit_patterns/src/grit_context.rs
+++ b/crates/biome_grit_patterns/src/grit_context.rs
@@ -20,6 +20,7 @@ use grit_pattern_matcher::pattern::{
 use grit_util::error::GritPatternError;
 use grit_util::{AnalysisLogs, FileOrigin, InputRanges, MatchRanges, error::GritResult};
 use path_absolutize::Absolutize;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -163,8 +164,15 @@ impl<'a> ExecContext<'a, GritQueryContext> for GritExecContext<'a> {
         let (variables, ranges, suppressed) =
             state.bindings_history_to_ranges(&self.lang, self.name());
 
+        // Deduplicate ranges to avoid duplicate matches
+        let unique_ranges: Vec<_> = ranges
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
         let input_ranges = InputRanges {
-            ranges,
+            ranges: unique_ranges,
             variables,
             suppressed,
         };

--- a/crates/biome_grit_patterns/tests/quick_test.rs
+++ b/crates/biome_grit_patterns/tests/quick_test.rs
@@ -10,10 +10,9 @@ use biome_js_syntax::JsFileSource;
 #[test]
 fn test_query() {
     let parse_grit_result = parse_grit(
-        "`console.log($arg)` => . where {
-  log(message=\"This is a debug log\", variable=$arg),
-}
-",
+        "
+        `import $what from $where`
+        ",
     );
     if !parse_grit_result.diagnostics().is_empty() {
         panic!("Cannot parse query:\n{:?}", parse_grit_result.diagnostics());
@@ -31,12 +30,11 @@ fn test_query() {
         println!("Diagnostics from compiling query:\n{:?}", query.diagnostics);
     }
 
-    let body = r#"console.log("grape");"#;
+    let body = r#"import { PrismaClient } from "@prisma/client/runtime";"#;
 
-    let file = GritTargetFile::new(
-        "test.js",
-        parse(body, JsFileSource::tsx(), JsParserOptions::default()).into(),
-    );
+    let parsed = parse(body, JsFileSource::js_module(), JsParserOptions::default());
+
+    let file = GritTargetFile::new("test.js", parsed.into());
     let GritQueryResult { effects, logs, .. } =
         query.execute(file).expect("could not execute query");
 

--- a/crates/biome_grit_patterns/tests/specs/ts/import_patterns.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/import_patterns.grit
@@ -1,0 +1,1 @@
+`import $import from "foo"`

--- a/crates/biome_grit_patterns/tests/specs/ts/import_patterns.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/import_patterns.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/biome_grit_patterns/tests/spec_tests.rs
-expression: withinUntilClause
+expression: import_patterns
 ---
 SnapshotResult {
     messages: [],
     matched_ranges: [
-        "8:5-10:8",
+        "2:1-2:27",
     ],
     rewritten_files: [],
     created_files: [],

--- a/crates/biome_grit_patterns/tests/specs/ts/import_patterns.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/import_patterns.ts
@@ -1,0 +1,2 @@
+// Named import
+import { baz } from "foo";


### PR DESCRIPTION
## Summary

closes: #5801 

Align the biome grit patten behaviour with griftql.

i am not sure if my change is valid, but it seems the bug was caused by the pattern of grit in `biome_grit_patterns` don't match the import kind, so i add the judge for that case to align the behaviour with `gritql`

## Test Plan

I add the case under `crates/biome_grit_patterns`.
