### PR TITLE
fix(biome_js_analyze): useConsistentCurlyBraces prserve curly braces …

### DIFF
--- a/.changeset/use_consistent_curly_braces_add_forbidden_chars_check.md
+++ b/.changeset/use_consistent_curly_braces_add_forbidden_chars_check.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+
+Fixed [`useConsistentCurlyBraces breaks react/no-unescaped-entities rule`](https://github.com/biomejs/biome/issues/5391)
+
+Added a check for forbidden characters: `>`, `"`, `'` and `}`.
+If any of these characters are detected, curly braces will be preserved.
+
+Example:
+
+```jsx
+function MyComponent() {
+  return <Foo>Jupiter {'>'} Venus</Foo>;
+}
+```

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
@@ -21,4 +21,22 @@ let baz = 4;
 <Foo>{/*comment*/}Hello world{/*comment*/}</Foo>
 
 <Foo>{' '}</Foo>
+
+<Foo>Invalid closing tag {'}'}</Foo>
+
+<Foo>{'Invalid closing tag }'}</Foo>
+
+<Foo>Jupiter {">"} Venus</Foo>
+
+<Foo>Jupiter {'>'} Venus</Foo>
+
+<Foo>{'Jupiter > Venus'}</Foo>
+
+<Foo>{'Invalid double quotes " '}</Foo>
+
+<Foo>{'Invalid single quote \' '}</Foo>
+
+<Foo>{"Invalid single quote ' "}</Foo>
+
+<Foo>{"Invalid double quotes \" "}</Foo>
 </>

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
@@ -27,6 +27,24 @@ let baz = 4;
 <Foo>{/*comment*/}Hello world{/*comment*/}</Foo>
 
 <Foo>{' '}</Foo>
+
+<Foo>Invalid closing tag {'}'}</Foo>
+
+<Foo>{'Invalid closing tag }'}</Foo>
+
+<Foo>Jupiter {">"} Venus</Foo>
+
+<Foo>Jupiter {'>'} Venus</Foo>
+
+<Foo>{'Jupiter > Venus'}</Foo>
+
+<Foo>{'Invalid double quotes " '}</Foo>
+
+<Foo>{'Invalid single quote \' '}</Foo>
+
+<Foo>{"Invalid single quote ' "}</Foo>
+
+<Foo>{"Invalid double quotes \" "}</Foo>
 </>
 
 ```


### PR DESCRIPTION
## Summary

Adds an additonal check for forbidden characters: ['>', '"', ''', '}'].
If any of these characters are detected, curly braces will be preserved.

Example:

```jsx
function MyComponent() {
  return <Foo>Jupiter {'>'} Venus</Foo>;
}
```

closes  #5391