### PR TITLE
chore: disable `RedisCommander.d.ts` benchmark for now

### DIFF
--- a/xtask/bench/benches/module_graph.rs
+++ b/xtask/bench/benches/module_graph.rs
@@ -30,10 +30,11 @@ fn bench_module_graph(criterion: &mut Criterion) {
                 "../../../crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/@types/react/index.d.ts"
             ) as &[u8],
         ),
-        (
-            "RedisCommander.d.ts",
-            include_bytes!("./RedisCommander.d.ts") as &[u8],
-        ),
+        // TODO: Uncomment when https://github.com/biomejs/biome/issues/6172 is fixed.
+        //(
+        //    "RedisCommander.d.ts",
+        //    include_bytes!("./RedisCommander.d.ts") as &[u8],
+        //),
     ];
 
     let mut group = criterion.benchmark_group("module_graph");


### PR DESCRIPTION
## Summary

It's eating our CI time for no good reason. We already have #6172 to improve it.

## Test Plan

CI should be green.
