### PR TITLE
refactor: invert expression inference order

### DIFF
--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -10,7 +10,7 @@ use biome_analyze::{
 use biome_aria::AriaRoles;
 use biome_diagnostics::Error as DiagnosticError;
 use biome_js_syntax::{JsFileSource, JsLanguage};
-use biome_module_graph::{ModuleGraph, ScopedResolver};
+use biome_module_graph::{ModuleGraph, ModuleResolver};
 use biome_project_layout::ProjectLayout;
 use biome_rowan::TextRange;
 use biome_suppression::{SuppressionDiagnostic, parse_suppression_comment};
@@ -155,7 +155,7 @@ where
     let type_resolver = module_graph
         .module_info_for_path(file_path.as_ref())
         .map(|module_info| {
-            let mut resolver = ScopedResolver::from_global_scope(module_info, module_graph.clone());
+            let mut resolver = ModuleResolver::for_module(module_info, module_graph.clone());
             resolver.run_inference();
             resolver
         })

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -173,7 +173,7 @@ impl Rule for NoFloatingPromises {
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let node = ctx.query();
         let expression = node.expression().ok()?;
-        let ty = ctx.type_for_expression(&expression);
+        let ty = ctx.type_of_expression(&expression);
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -98,7 +98,7 @@ impl Rule for NoMisusedPromises {
             _ => return None,
         };
 
-        let ty = ctx.type_for_expression(expression);
+        let ty = ctx.type_of_expression(expression);
 
         // Uncomment the following line for debugging convenience:
         //let printed = format!("type of {expression:?} = {ty:?}");

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -122,7 +122,7 @@ impl Rule for UseExhaustiveSwitchCases {
             .filter_map(|case| match case {
                 AnyJsSwitchClause::JsCaseClause(case) => {
                     let test = case.test().ok()?;
-                    flatten_type(&ctx.type_for_expression(&test))
+                    flatten_type(&ctx.type_of_expression(&test))
                         .as_deref()
                         .cloned()
                 }
@@ -133,7 +133,7 @@ impl Rule for UseExhaustiveSwitchCases {
         let mut missing_cases = Vec::new();
 
         let discriminant = stmt.discriminant().ok()?;
-        let discriminant_ty = flatten_type(&ctx.type_for_expression(&discriminant))?;
+        let discriminant_ty = flatten_type(&ctx.type_of_expression(&discriminant))?;
 
         for union_part in match discriminant_ty.deref() {
             TypeData::Union(union) => union
@@ -274,6 +274,7 @@ impl Rule for UseExhaustiveSwitchCases {
 fn flatten_type(ty: &Type) -> Option<Type> {
     match ty.deref() {
         TypeData::InstanceOf(instance) => ty.resolve(&instance.ty),
+        TypeData::Reference(reference) => ty.resolve(reference),
         TypeData::TypeofType(inner) => ty.resolve(inner),
         _ => Some(ty.clone()),
     }

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -4,21 +4,21 @@ use biome_analyze::{
 };
 use biome_js_syntax::{AnyJsExpression, AnyJsRoot, JsLanguage, JsSyntaxNode};
 use biome_js_type_info::Type;
-use biome_module_graph::ScopedResolver;
+use biome_module_graph::ModuleResolver;
 use biome_rowan::{AstNode, TextRange};
 use std::sync::Arc;
 
 /// Service for use with type inference rules.
 #[derive(Clone, Debug)]
 pub struct TypedService {
-    resolver: Option<Arc<ScopedResolver>>,
+    resolver: Option<Arc<ModuleResolver>>,
 }
 
 impl TypedService {
-    pub fn type_for_expression(&self, expr: &AnyJsExpression) -> Type {
+    pub fn type_of_expression(&self, expr: &AnyJsExpression) -> Type {
         self.resolver
             .as_ref()
-            .map(|resolver| resolver.resolved_type_for_expression(expr))
+            .map(|resolver| resolver.resolved_type_of_expression(expr))
             .unwrap_or_default()
     }
 }
@@ -41,7 +41,7 @@ impl FromServices for TypedService {
             }
         }
 
-        let resolver: Option<&Option<Arc<ScopedResolver>>> = services.get_service();
+        let resolver: Option<&Option<Arc<ModuleResolver>>> = services.get_service();
         let resolver = resolver.and_then(|resolver| resolver.as_ref().map(Arc::clone));
         Ok(Self { resolver })
     }

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -26,32 +26,17 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"type Props = {
-	a: string;
-	returnsPromise: () => Promise<void>;
-};
-async function testDestructuringAndCallingReturnsPromiseFromRest({
-	a,
-	...rest
-}: Props) {
-	rest
-		.returnsPromise()
-		.then(() => {})
-		.finally(() => {});
-}
+    const SOURCE: &str = r#"const promiseWithParentheses = new Promise((resolve, reject) =>
+	resolve("value")
+);
+promiseWithParentheses;
 "#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
     let mut fs = TemporaryFs::new("quick_test");
     fs.create_file(FILENAME, SOURCE);
-    fs.create_file(
-        "returnPromiseResult.ts",
-        r#"export function returnPromiseResult(): Promise<{ result: true | false }> {
-  return new Promise(resolve => resolve({ result: true }));
-}
-"#,
-    );
+
     let file_path = Utf8PathBuf::from(format!("{}/{FILENAME}", fs.cli_path()));
 
     let mut error_ranges: Vec<TextRange> = Vec::new();

--- a/crates/biome_js_type_info/CONTRIBUTING.md
+++ b/crates/biome_js_type_info/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Full inference is implemented in
 The thing about having all these type references all over the place is that you
 need to perform explicit type resolution to follow these references. That's why
 we have _type resolvers_. There's a `TypeResolver` trait, defined in
-[`resolver.rs`](src/resolver.rs). As of today, we have 6 implementations of it:
+[`resolver.rs`](src/resolver.rs). As of today, we have 4 implementations of it:
 
 * **`HardcodedSymbolResolver`**. This one is purely for test purposes.
 * **`GlobalsResolver`**. This is the one that is responsible for resolving
@@ -233,18 +233,11 @@ we have _type resolvers_. There's a `TypeResolver` trait, defined in
   [`es2023.array.d.ts`](https://github.com/microsoft/TypeScript/blob/main/src/lib/es2023.array.d.ts),
   directly.
 * **`JsModuleInfoCollector`**. This one is responsible for collecting
-  information about a module, and for performing our module-level inference.
-* **`JsModuleInfo`**. Once the `JsModuleInfoCollector` has done its job, a
-  `JsModuleInfo` instance is created, which is stored as an entry in our module
-  graph. But this data structure also implements `TypeResolver` so that our full
-  inference can access the module's types too.
-* **`ScopedResolver`**. This is the one that is responsible for our actual full
-  inference. It's named as it is because it is the only resolver that can really
-  resolve things in any arbitrary scope. Compare this to the
-  `JsModuleInfoCollector` which only cares about the global scope of a module,
-  because at least so far that's all we need to determine types of exports
-  (we don't determine the return type of functions without annotations yet, and
-  it's not yet decided when or if we'll do this).
+  information about a module, and for performing thin inference on it.
+* **`ModuleResolver`**. This is the one that is responsible for our actual full
+  inference, that is able to infer _across_ modules. Compare this to the
+  `JsModuleInfoCollector` which only collects information inside a single
+  module.
 
 I've mentioned before that types are stored in vectors. Those type vectors are
 stored inside `TypeStore` structures which are kept inside the various

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -488,7 +488,7 @@ impl Format<FormatTypeContext> for TypeReference {
                             ]]
                         )
                     }
-                } else if level == TypeResolverLevel::Module {
+                } else if level == TypeResolverLevel::Thin {
                     let module_id = resolved.module_id().index();
                     write!(
                         f,

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -2,7 +2,10 @@
 
 // FIXME: Implement inference from type definitions.
 
-use std::{borrow::Cow, sync::LazyLock};
+use std::{
+    borrow::Cow,
+    sync::{Arc, LazyLock},
+};
 
 use biome_js_syntax::AnyJsExpression;
 use biome_rowan::Text;
@@ -15,7 +18,8 @@ use crate::{
 
 const GLOBAL_LEVEL: TypeResolverLevel = TypeResolverLevel::Global;
 
-pub static GLOBAL_RESOLVER: LazyLock<GlobalsResolver> = LazyLock::new(GlobalsResolver::default);
+pub static GLOBAL_RESOLVER: LazyLock<Arc<GlobalsResolver>> =
+    LazyLock::new(|| Arc::new(GlobalsResolver::default()));
 
 pub static GLOBAL_TYPE_MEMBERS: LazyLock<Vec<TypeMember>> = LazyLock::new(|| {
     (0..NUM_PREDEFINED_TYPES)

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -22,7 +22,7 @@ instanceof Promise
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []
@@ -30,17 +30,11 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(0)
 }
 
-Module TypeId(1) => instanceof Promise<number>
+Thin TypeId(1) => instanceof Promise<number>
 
-Module TypeId(2) => sync Function "Promise.prototype.then" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Thin TypeId(2) => Promise.prototype.then
 
-Module TypeId(3) => sync Function {
+Thin TypeId(3) => sync Function {
   accepts: {
     params: []
     type_args: []

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -24,7 +24,7 @@ instanceof Promise
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []
@@ -32,17 +32,11 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(0)
 }
 
-Module TypeId(1) => instanceof Promise<number>
+Thin TypeId(1) => instanceof Promise<number>
 
-Module TypeId(2) => sync Function "Promise.prototype.then" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Thin TypeId(2) => Promise.prototype.then
 
-Module TypeId(3) => sync Function {
+Thin TypeId(3) => sync Function {
   accepts: {
     params: []
     type_args: []
@@ -50,15 +44,9 @@ Module TypeId(3) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(4) => instanceof Promise
+Thin TypeId(4) => instanceof Promise
 
-Module TypeId(5) => sync Function "Promise.prototype.finally" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Thin TypeId(5) => Promise.prototype.finally
 
 Global TypeId(0) => instanceof Promise<number>
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_invocation_of_promise_returning_function.snap
@@ -22,7 +22,7 @@ instanceof unresolved reference "Promise"<number> (scope ID: 0)
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_static_promise_function.snap
@@ -18,13 +18,7 @@ instanceof Promise
 ## Registered types
 
 ```
-Global TypeId(0) => sync Function "Promise.resolve" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Global TypeId(0) => Promise.resolve
 
 Global TypeId(1) => value: value
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_interface_field.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_interface_field.snap
@@ -30,15 +30,15 @@ sync Function "bar" {
 ## Registered types
 
 ```
-Module TypeId(0) => interface "Foo" {
+Thin TypeId(0) => interface "Foo" {
   extends: []
   type_args: []
   members: ["foo": Global TypeId(0)]
 }
 
-Module TypeId(1) => instanceof Module(0) TypeId(0)
+Thin TypeId(1) => instanceof Module(0) TypeId(0)
 
-Module TypeId(2) => sync Function "foo" {
+Thin TypeId(2) => sync Function "foo" {
   accepts: {
     params: []
     type_args: []

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_typeof_expression.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_typeof_expression.snap
@@ -14,13 +14,13 @@ typeof foo;
 ## Result
 
 ```
-value: string
+"string"
 ```
 
 ## Registered types
 
 ```
-Module TypeId(0) => value: foo
+Thin TypeId(0) => value: foo
 
 Global TypeId(0) => value: foo
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
@@ -22,7 +22,7 @@ Call Module(0) TypeId(2)(Module(0) TypeId(3))
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []
@@ -30,11 +30,11 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(0)
 }
 
-Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
+Thin TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
-Module TypeId(2) => Module(0) TypeId(1).then
+Thin TypeId(2) => Module(0) TypeId(1).then
 
-Module TypeId(3) => sync Function {
+Thin TypeId(3) => sync Function {
   accepts: {
     params: []
     type_args: []

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -24,7 +24,7 @@ Call Module(0) TypeId(5)(Module(0) TypeId(3))
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []
@@ -32,11 +32,11 @@ Module TypeId(0) => sync Function "returnsPromise" {
   returns: Global TypeId(0)
 }
 
-Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
+Thin TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
-Module TypeId(2) => Module(0) TypeId(1).then
+Thin TypeId(2) => Module(0) TypeId(1).then
 
-Module TypeId(3) => sync Function {
+Thin TypeId(3) => sync Function {
   accepts: {
     params: []
     type_args: []
@@ -44,9 +44,9 @@ Module TypeId(3) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(4) => Call Module(0) TypeId(2)(Module(0) TypeId(3))
+Thin TypeId(4) => Call Module(0) TypeId(2)(Module(0) TypeId(3))
 
-Module TypeId(5) => Module(0) TypeId(4).finally
+Thin TypeId(5) => Module(0) TypeId(4).finally
 
 Global TypeId(0) => instanceof Global TypeId(1)
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_invocation_of_promise_returning_function.snap
@@ -22,7 +22,7 @@ Call Module(0) TypeId(0)(No parameters)
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "returnsPromise" {
+Thin TypeId(0) => sync Function "returnsPromise" {
   accepts: {
     params: []
     type_args: []

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -12,14 +12,14 @@ fn test_resolved_type_id() {
     assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(0)); // Module ID shouldn't be applied to global level.
 
-    let id = ResolvedTypeId::new(TypeResolverLevel::Module, TypeId::new(3));
+    let id = ResolvedTypeId::new(TypeResolverLevel::Thin, TypeId::new(3));
     let id = id.with_module_id(ModuleId::new(5));
-    assert_eq!(id.level(), TypeResolverLevel::Module);
+    assert_eq!(id.level(), TypeResolverLevel::Thin);
     assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(5));
 
     let id = id.with_module_id(ModuleId::new(7));
-    assert_eq!(id.level(), TypeResolverLevel::Module);
+    assert_eq!(id.level(), TypeResolverLevel::Thin);
     assert_eq!(id.id(), TypeId::new(3));
     assert_eq!(id.module_id(), ModuleId::new(7));
 }

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -137,7 +137,7 @@ impl HardcodedSymbolResolver {
 
 impl TypeResolver for HardcodedSymbolResolver {
     fn level(&self) -> TypeResolverLevel {
-        TypeResolverLevel::Module
+        TypeResolverLevel::Thin
     }
 
     fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
@@ -153,10 +153,10 @@ impl TypeResolver for HardcodedSymbolResolver {
 
     fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
         match id.level() {
-            TypeResolverLevel::Scope => {
+            TypeResolverLevel::Full => {
                 panic!("Ad-hoc references unsupported by resolver")
             }
-            TypeResolverLevel::Module => Some((id, self.get_by_id(id.id())).into()),
+            TypeResolverLevel::Thin => Some((id, self.get_by_id(id.id())).into()),
             TypeResolverLevel::Import => {
                 panic!("Import references unsupported by resolver")
             }

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -1,20 +1,16 @@
 mod binding;
 mod collector;
+mod module_resolver;
 mod scope;
-mod scoped_resolver;
 mod visitor;
 
-use std::{borrow::Cow, collections::BTreeMap, ops::Deref, sync::Arc};
+use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
-use biome_js_syntax::{AnyJsExpression, AnyJsImportLike};
-use biome_js_type_info::{
-    BindingId, GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, ImportSymbol, ResolvedTypeData, ResolvedTypeId,
-    ScopeId, TypeData, TypeId, TypeReference, TypeReferenceQualifier, TypeResolver,
-    TypeResolverLevel,
-};
+use biome_js_syntax::AnyJsImportLike;
+use biome_js_type_info::{BindingId, ImportSymbol, ResolvedTypeId, ScopeId, TypeData};
 use biome_jsdoc_comment::JsdocComment;
 use biome_resolver::ResolvedPath;
-use biome_rowan::{AstNode, Text, TextRange};
+use biome_rowan::{Text, TextRange};
 use rust_lapper::Lapper;
 use rustc_hash::FxHashMap;
 
@@ -23,7 +19,7 @@ use crate::ModuleGraph;
 use scope::{JsScope, JsScopeData, TsBindingReference};
 
 pub(super) use binding::JsBindingData;
-pub use scoped_resolver::ScopedResolver;
+pub use module_resolver::ModuleResolver;
 pub(crate) use visitor::JsModuleVisitor;
 
 /// Information restricted to a single module in the [ModuleGraph].
@@ -47,10 +43,6 @@ impl JsModuleInfo {
             static_import_paths: module_info.static_import_paths.clone(),
             dynamic_import_paths: module_info.dynamic_import_paths.clone(),
         }
-    }
-
-    pub fn as_resolver(&self) -> &impl TypeResolver {
-        self.0.as_ref()
     }
 
     /// Finds an exported symbol by `name`, using the `module_graph` to
@@ -149,7 +141,7 @@ pub struct JsModuleInfoInner {
     pub(crate) bindings: Box<[JsBindingData]>,
 
     /// Parsed expressions, mapped from their range to their type ID.
-    pub(crate) expressions: FxHashMap<TextRange, TypeId>,
+    pub(crate) expressions: FxHashMap<TextRange, ResolvedTypeId>,
 
     /// All scopes in this module.
     ///
@@ -224,87 +216,8 @@ impl JsModuleInfoInner {
             self.dynamic_import_paths.get(specifier)
         }
     }
-}
 
-impl TypeResolver for JsModuleInfoInner {
-    fn level(&self) -> TypeResolverLevel {
-        TypeResolverLevel::Module
-    }
-
-    fn find_type(&self, type_data: &TypeData) -> Option<TypeId> {
-        self.types
-            .iter()
-            .position(|data| data == type_data)
-            .map(TypeId::new)
-    }
-
-    fn get_by_id(&self, id: TypeId) -> &TypeData {
-        &self.types[id.index()]
-    }
-
-    fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
-        match id.level() {
-            TypeResolverLevel::Module => Some((id, self.get_by_id(id.id())).into()),
-            TypeResolverLevel::Global => Some((id, GLOBAL_RESOLVER.get_by_id(id.id())).into()),
-            TypeResolverLevel::Scope | TypeResolverLevel::Import => None,
-        }
-    }
-
-    fn register_type(&mut self, _type_data: Cow<TypeData>) -> TypeId {
-        panic!("Cannot register new types after the module has been constructed");
-    }
-
-    fn resolve_reference(&self, ty: &TypeReference) -> Option<ResolvedTypeId> {
-        match ty {
-            TypeReference::Qualifier(qualifier) => self.resolve_qualifier(qualifier),
-            TypeReference::Resolved(resolved_id) => Some(*resolved_id),
-            TypeReference::Import(_) => None,
-            TypeReference::Unknown => Some(GLOBAL_UNKNOWN_ID),
-        }
-    }
-
-    fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
-        if qualifier.path.len() != 1 {
-            return None;
-        }
-
-        if let Some(export) = self.exports.get(&qualifier.path[0]) {
-            export
-                .as_own_export()
-                .and_then(|own_export| match own_export {
-                    JsOwnExport::Binding(binding_id) => {
-                        self.resolve_reference(&self.bindings[binding_id.index()].ty)
-                    }
-                    JsOwnExport::Type(type_id) => Some(*type_id),
-                })
-        } else {
-            GLOBAL_RESOLVER.resolve_qualifier(qualifier)
-        }
-    }
-
-    fn resolve_type_of(&self, identifier: &Text, scope_id: ScopeId) -> Option<ResolvedTypeId> {
-        if let Some(export) = self.exports.get(identifier) {
-            export
-                .as_own_export()
-                .and_then(|own_export| match own_export {
-                    JsOwnExport::Binding(binding_id) => {
-                        self.resolve_reference(&self.bindings[binding_id.index()].ty)
-                    }
-                    JsOwnExport::Type(type_id) => Some(*type_id),
-                })
-        } else {
-            GLOBAL_RESOLVER.resolve_type_of(identifier, scope_id)
-        }
-    }
-
-    fn resolve_expression(&mut self, _scope_id: ScopeId, expr: &AnyJsExpression) -> Cow<TypeData> {
-        self.expressions.get(&expr.range()).map_or_else(
-            || Cow::Owned(TypeData::unknown()),
-            |id| Cow::Borrowed(self.get_by_id(*id)),
-        )
-    }
-
-    fn registered_types(&self) -> &[TypeData] {
+    pub fn types(&self) -> &[TypeData] {
         &self.types
     }
 }

--- a/crates/biome_module_graph/src/js_module_info/scope.rs
+++ b/crates/biome_module_graph/src/js_module_info/scope.rs
@@ -301,6 +301,17 @@ impl TsBindingReference {
         }
     }
 
+    /// Returns the value type binding.
+    pub fn value_ty(self) -> Option<BindingId> {
+        match self {
+            Self::ValueType(binding_id)
+            | Self::TypeAndValueType(binding_id)
+            | Self::NamespaceAndValueType(binding_id) => Some(binding_id),
+            Self::Merged { value_ty, .. } => value_ty,
+            Self::Type(_) => None,
+        }
+    }
+
     /// Returns the value type binding, or the type binding if the value type
     /// binding is unknown.
     pub fn value_ty_or_ty(self) -> BindingId {

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -8,6 +8,6 @@ pub use biome_js_type_info::ImportSymbol;
 pub use biome_resolver::ResolvedPath;
 
 pub use js_module_info::{
-    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, ScopedResolver,
+    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, ModuleResolver,
 };
 pub use module_graph::{ModuleGraph, SUPPORTED_EXTENSIONS, SUPPORTED_TYPE_EXTENSIONS};

--- a/crates/biome_module_graph/src/module_graph.rs
+++ b/crates/biome_module_graph/src/module_graph.rs
@@ -97,8 +97,8 @@ impl ModuleGraph {
 
         let fs_proxy = ModuleGraphFsProxy::new(fs, self, project_layout);
 
-        // Traverse all the added and updated paths and insert their resolved
-        // imports.
+        // Traverse all the added and updated paths and insert their module
+        // info.
         let imports = self.data.pin();
         for (path, root) in added_or_updated_paths {
             let directory = path.parent().unwrap_or(path);

--- a/crates/biome_module_graph/tests/snap/mod.rs
+++ b/crates/biome_module_graph/tests/snap/mod.rs
@@ -5,16 +5,16 @@ use biome_js_formatter::context::JsFormatOptions;
 use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse};
 use biome_js_syntax::JsFileSource;
-use biome_module_graph::{JsExport, JsOwnExport, ModuleGraph, ScopedResolver};
+use biome_module_graph::{JsExport, JsOwnExport, ModuleGraph, ModuleResolver};
 use biome_resolver::ResolvedPath;
 use biome_rowan::AstNode;
-use biome_test_utils::dump_registered_types;
+use biome_test_utils::{dump_registered_module_types, dump_registered_types};
 use camino::Utf8PathBuf;
 
 pub struct ModuleGraphSnapshot<'a> {
     module_graph: &'a ModuleGraph,
     fs: &'a MemoryFileSystem,
-    resolver: Option<&'a ScopedResolver>,
+    resolver: Option<&'a ModuleResolver>,
 }
 
 impl<'a> ModuleGraphSnapshot<'a> {
@@ -26,7 +26,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
         }
     }
 
-    pub fn with_resolver(self, resolver: &'a ScopedResolver) -> Self {
+    pub fn with_resolver(self, resolver: &'a ModuleResolver) -> Self {
         Self {
             resolver: Some(resolver),
             ..self
@@ -113,7 +113,7 @@ impl<'a> ModuleGraphSnapshot<'a> {
                     content.push_str("```\n\n");
                 }
 
-                dump_registered_types(&mut content, data.as_resolver());
+                dump_registered_module_types(&mut content, data.types());
             }
         }
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -46,7 +46,20 @@ BindingId(1) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function {
+Module TypeId(0) => Promise
+
+Module TypeId(1) => Module(0) TypeId(10)
+
+Module TypeId(2) => value: true
+
+Module TypeId(3) => Object {
+  prototype: No prototype
+  members: ["result": Module(0) TypeId(2)]
+}
+
+Module TypeId(4) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
+
+Module TypeId(5) => sync Function {
   accepts: {
     params: [
       required resolve: unknown reference (bindings: resolve:unknown reference)
@@ -56,30 +69,7 @@ Module TypeId(0) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(1) => instanceof Promise
-
-Module TypeId(2) => class "Promise" {
-  extends: none
-  implements: []
-  type_args: [T]
-}
-
-Module TypeId(3) => value: true
-
-Module TypeId(4) => Object {
-  prototype: No prototype
-  members: ["result": Module(0) TypeId(3)]
-}
-
-Module TypeId(5) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
-
-Module TypeId(6) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(9)
-}
+Module TypeId(6) => instanceof Module(0) TypeId(0)
 
 Module TypeId(7) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -65,7 +65,7 @@ BindingId(0) => JsBindingData {
 
 BindingId(3) => JsBindingData {
   Name: superComputer,
-  Type: Module(0) TypeId(6),
+  Type: Module(0) TypeId(7),
   Declaration kind: Value
 }
 ```
@@ -75,23 +75,19 @@ BindingId(3) => JsBindingData {
 ```
 Module TypeId(0) => value: 42
 
-Module TypeId(1) => value: 42
+Module TypeId(1) => Module(0) TypeId(0)
 
-Module TypeId(2) => unknown
+Module TypeId(2) => Module(0) TypeId(0)
 
-Module TypeId(3) => value: 42
+Module TypeId(3) => number
 
-Module TypeId(4) => number
+Module TypeId(4) => unknown
 
 Module TypeId(5) => value: Life, The Universe, and Everything
 
-Module TypeId(6) => instanceof Module(0) TypeId(12)
+Module TypeId(6) => Module(0) TypeId(12)
 
-Module TypeId(7) => class "DeepThought" {
-  extends: none
-  implements: []
-  type_args: []
-}
+Module TypeId(7) => instanceof Module(0) TypeId(6)
 
 Module TypeId(8) => sync Function "answerMe" {
   accepts: {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -200,17 +200,11 @@ Module TypeId(0) => Object {
 
 Module TypeId(1) => value: 1
 
-Module TypeId(2) => Object {
+Module TypeId(2) => Module(0) TypeId(20)
+
+Module TypeId(3) => Object {
   prototype: No prototype
   members: ["a": string, "b": Module(0) TypeId(13), "c": Module(0) TypeId(17)]
-}
-
-Module TypeId(3) => sync Function "getObject" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(19)
 }
 
 Module TypeId(4) => string
@@ -343,9 +337,9 @@ Module TypeId(22) => sync Function "Component" {
 
 Module TypeId(23) => instanceof Array<number>
 
-Module TypeId(24) => boolean
+Module TypeId(24) => Module(0) TypeId(14)
 
-Module TypeId(25) => Module(0) TypeId(14) | Module(0) TypeId(15)
+Module TypeId(25) => Module(0) TypeId(16)
 ```
 
 # `/src/renamed-reexports.ts`

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value.snap
@@ -40,19 +40,19 @@ Imports {
 ```
 BindingId(4) => JsBindingData {
   Name: makePromise,
-  Type: Module(0) TypeId(1),
+  Type: Module(0) TypeId(5),
   Declaration kind: Value
 }
 
 BindingId(5) => JsBindingData {
   Name: makePromiseCb,
-  Type: Module(0) TypeId(6),
+  Type: Module(0) TypeId(8),
   Declaration kind: Value
 }
 
 BindingId(6) => JsBindingData {
   Name: promise,
-  Type: Module(0) TypeId(9),
+  Type: Module(0) TypeId(10),
   Declaration kind: Value
 }
 ```
@@ -60,70 +60,39 @@ BindingId(6) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => instanceof Promise
+Module TypeId(0) => Promise
 
-Module TypeId(1) => sync Function {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(0)
-}
+Module TypeId(1) => Promise.resolve
 
-Module TypeId(2) => sync Function "Promise.resolve" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Module TypeId(2) => value: 1
 
-Module TypeId(3) => value: 1
+Module TypeId(3) => instanceof Promise
 
 Module TypeId(4) => instanceof Promise
 
-Module TypeId(5) => class "Promise" {
-  extends: none
-  implements: []
-  type_args: [T]
-}
-
-Module TypeId(6) => sync Function {
+Module TypeId(5) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(4)
 }
 
-Module TypeId(7) => sync Function "useCallback" {
-  accepts: {
-    params: [
-      required callback: Module(0) TypeId(11) (bindings: callback:Module(0) TypeId(11))
-      required deps: Module(0) TypeId(12) (bindings: deps:Module(0) TypeId(12))
-    ]
-    type_args: [Module(0) TypeId(14)]
-  }
-  returns: Module(0) TypeId(11)
-}
+Module TypeId(6) => Module(0) TypeId(15)
+
+Module TypeId(7) => Module(0) TypeId(5)
 
 Module TypeId(8) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(4)
 }
 
-Module TypeId(9) => instanceof Promise
+Module TypeId(9) => Module(0) TypeId(8)
 
-Module TypeId(10) => sync Function {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(0)
-}
+Module TypeId(10) => instanceof Promise
 
 Module TypeId(11) => instanceof Module(0) TypeId(14)
 
@@ -150,33 +119,37 @@ Module TypeId(15) => sync Function "useCallback" {
 ## Registered types
 
 ```
-Scope TypeId(0) => instanceof Promise
+Full TypeId(0) => Promise
 
-Scope TypeId(1) => sync Function {
+Full TypeId(1) => Promise.resolve
+
+Full TypeId(2) => value: 1
+
+Full TypeId(3) => instanceof Promise
+
+Full TypeId(4) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(4)
 }
 
-Scope TypeId(2) => sync Function "Promise.resolve" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: instanceof Promise
-}
+Full TypeId(5) => Module(0) TypeId(15)
 
-Scope TypeId(3) => value: 1
+Full TypeId(6) => Module(0) TypeId(5)
 
-Scope TypeId(4) => class "Promise" {
-  extends: none
-  implements: []
-  type_args: [T]
-}
+Full TypeId(7) => Module(0) TypeId(8)
 
-Scope TypeId(5) => sync Function "useCallback" {
+Full TypeId(8) => instanceof Module(0) TypeId(14)
+
+Full TypeId(9) => instanceof unresolved reference "DependencyList" (scope ID: 1)
+
+Full TypeId(10) => instanceof unresolved reference "Function" (scope ID: 1)
+
+Full TypeId(11) => T extends Module(0) TypeId(13)
+
+Full TypeId(12) => sync Function "useCallback" {
   accepts: {
     params: [
       required callback: Module(0) TypeId(11) (bindings: callback:Module(0) TypeId(11))
@@ -186,12 +159,4 @@ Scope TypeId(5) => sync Function "useCallback" {
   }
   returns: Module(0) TypeId(11)
 }
-
-Scope TypeId(6) => instanceof Module(0) TypeId(14)
-
-Scope TypeId(7) => instanceof unresolved reference "DependencyList" (scope ID: 1)
-
-Scope TypeId(8) => instanceof unresolved reference "Function" (scope ID: 1)
-
-Scope TypeId(9) => T extends Module(0) TypeId(13)
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
@@ -89,18 +89,15 @@ Module TypeId(1) => Object {
   members: ["bar": Module(0) TypeId(0)]
 }
 
-Module TypeId(2) => Module(0) TypeId(7).bar
+Module TypeId(2) => instanceof Import Symbol: Bar from "/src/bar.ts"
 
-Module TypeId(3) => instanceof Import Symbol: Bar from "/src/bar.ts"
+Module TypeId(3) => Module(0) TypeId(2).bar
 
-Module TypeId(4) => value: 1
+Module TypeId(4) => Import Symbol: foo from "/src/foo.ts"
 
-Module TypeId(5) => Call Import Symbol: foo from "/src/foo.ts"(
-  Module(0) TypeId(2)
-  Module(0) TypeId(4)
-)
+Module TypeId(5) => value: 1
 
-Module TypeId(6) => Import Symbol: foo from "/src/foo.ts"
+Module TypeId(6) => Call Module(0) TypeId(4)(Module(0) TypeId(3)Module(0) TypeId(5))
 
 Module TypeId(7) => instanceof Import Symbol: Bar from "/src/bar.ts"
 ```
@@ -168,52 +165,34 @@ Module TypeId(3) => sync Function "foo" {
 ## Registered types
 
 ```
-Scope TypeId(0) => value: bar
+Full TypeId(0) => value: bar
 
-Scope TypeId(1) => Object {
+Full TypeId(1) => Object {
   prototype: No prototype
   members: ["bar": Module(0) TypeId(0)]
 }
 
-Scope TypeId(2) => value: bar
-
-Scope TypeId(3) => Object {
+Full TypeId(2) => Object {
   prototype: No prototype
   members: ["bar": Module(1) TypeId(0)]
 }
 
-Scope TypeId(4) => value: 1
+Full TypeId(3) => Module(1) TypeId(0)
 
-Scope TypeId(5) => value: bar
+Full TypeId(4) => Module(2) TypeId(3)
 
-Scope TypeId(6) => sync Function "foo" {
-  accepts: {
-    params: [
-      required foo: Module(2) TypeId(0) (bindings: foo:Module(2) TypeId(0))
-      required bar: Module(2) TypeId(1) (bindings: bar:Module(2) TypeId(1))
-    ]
-    type_args: [Module(2) TypeId(2)]
-  }
-  returns: Module(2) TypeId(0)
-}
+Full TypeId(5) => value: 1
 
-Scope TypeId(7) => value: bar
+Full TypeId(6) => value: bar
 
-Scope TypeId(8) => Object {
+Full TypeId(7) => Object {
   prototype: No prototype
   members: ["bar": Module(1) TypeId(0)]
 }
 
-Scope TypeId(9) => value: bar
+Full TypeId(8) => Module(1) TypeId(0)
 
-Scope TypeId(10) => sync Function "foo" {
-  accepts: {
-    params: [
-      required foo: Module(2) TypeId(0) (bindings: foo:Module(2) TypeId(0))
-      required bar: Module(2) TypeId(1) (bindings: bar:Module(2) TypeId(1))
-    ]
-    type_args: [Module(2) TypeId(2)]
-  }
-  returns: Module(2) TypeId(0)
-}
+Full TypeId(9) => Module(2) TypeId(3)
+
+Full TypeId(10) => value: bar
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
@@ -80,11 +80,11 @@ Module TypeId(7) => value: c
 
 Module TypeId(8) => Module(0) TypeId(5) | Module(0) TypeId(6) | Module(0) TypeId(7)
 
-Module TypeId(9) => value: a
+Module TypeId(9) => Module(0) TypeId(0)
 
-Module TypeId(10) => value: 1
+Module TypeId(10) => Module(0) TypeId(1)
 
-Module TypeId(11) => value: true
+Module TypeId(11) => Module(0) TypeId(2)
 
 Module TypeId(12) => Module(0) TypeId(9) | Module(0) TypeId(10) | Module(0) TypeId(11)
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
@@ -30,13 +30,13 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => Call Import Symbol: foo from "/src/foo.ts"(No parameters)
+Module TypeId(0) => unresolved reference "bar" (scope ID: 0)
 
-Module TypeId(1) => Call unresolved reference "bar" (scope ID: 0)(Module(0) TypeId(0))
+Module TypeId(1) => Import Symbol: foo from "/src/foo.ts"
 
-Module TypeId(2) => unresolved reference "bar" (scope ID: 0)
+Module TypeId(2) => Call Module(0) TypeId(1)(No parameters)
 
-Module TypeId(3) => Import Symbol: foo from "/src/foo.ts"
+Module TypeId(3) => Call Module(0) TypeId(0)(Module(0) TypeId(2))
 ```
 
 # `/src/foo.ts` (Module 1)
@@ -89,27 +89,15 @@ Module TypeId(1) => sync Function "foo" {
 ## Registered types
 
 ```
-Scope TypeId(0) => instanceof unknown reference
+Full TypeId(0) => unresolved reference "bar" (scope ID: 0)
 
-Scope TypeId(1) => Call unresolved reference "bar" (scope ID: 0)(Module(0) TypeId(0))
+Full TypeId(1) => Module(1) TypeId(1)
 
-Scope TypeId(2) => unresolved reference "bar" (scope ID: 0)
+Full TypeId(2) => instanceof unknown reference
 
-Scope TypeId(3) => sync Function "foo" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(0)
-}
+Full TypeId(3) => Call Module(0) TypeId(0)(Module(0) TypeId(2))
 
-Scope TypeId(4) => instanceof unknown reference
+Full TypeId(4) => Module(1) TypeId(1)
 
-Scope TypeId(5) => sync Function "foo" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(0)
-}
+Full TypeId(5) => instanceof unknown reference
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -32,7 +32,7 @@ Imports {
 ```
 BindingId(1) => JsBindingData {
   Name: promise,
-  Type: Module(0) TypeId(1),
+  Type: Module(0) TypeId(2),
   Declaration kind: Value
 }
 ```
@@ -42,15 +42,9 @@ BindingId(1) => JsBindingData {
 ```
 Module TypeId(0) => value: value
 
-Module TypeId(1) => instanceof Promise
+Module TypeId(1) => Module(0) TypeId(4)
 
-Module TypeId(2) => async Function "returnsPromise" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(3)
-}
+Module TypeId(2) => instanceof Promise
 
 Module TypeId(3) => instanceof Promise
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -30,11 +30,9 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => Call Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"(
-  No parameters
-)
+Module TypeId(0) => Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"
 
-Module TypeId(1) => Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 ```
 
 # `/src/promisedResult.ts` (Module 2)
@@ -131,7 +129,20 @@ BindingId(1) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function {
+Module TypeId(0) => Promise
+
+Module TypeId(1) => Module(0) TypeId(10)
+
+Module TypeId(2) => value: true
+
+Module TypeId(3) => Object {
+  prototype: No prototype
+  members: ["result": Module(0) TypeId(2)]
+}
+
+Module TypeId(4) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
+
+Module TypeId(5) => sync Function {
   accepts: {
     params: [
       required resolve: unknown reference (bindings: resolve:unknown reference)
@@ -141,30 +152,7 @@ Module TypeId(0) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(1) => instanceof Promise
-
-Module TypeId(2) => class "Promise" {
-  extends: none
-  implements: []
-  type_args: [T]
-}
-
-Module TypeId(3) => value: true
-
-Module TypeId(4) => Object {
-  prototype: No prototype
-  members: ["result": Module(0) TypeId(3)]
-}
-
-Module TypeId(5) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
-
-Module TypeId(6) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(9)
-}
+Module TypeId(6) => instanceof Module(0) TypeId(0)
 
 Module TypeId(7) => instanceof Import Symbol: PromisedResult from "/src/promisedResult.ts"
 
@@ -192,23 +180,11 @@ Module TypeId(10) => sync Function "returnPromiseResult" {
 ## Registered types
 
 ```
-Scope TypeId(0) => instanceof Promise<Module(2) TypeId(3)>
+Full TypeId(0) => Module(1) TypeId(8)
 
-Scope TypeId(1) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(7)
-}
+Full TypeId(1) => instanceof Promise<Module(2) TypeId(3)>
 
-Scope TypeId(2) => instanceof Promise<Module(2) TypeId(3)>
+Full TypeId(2) => Module(1) TypeId(8)
 
-Scope TypeId(3) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(7)
-}
+Full TypeId(3) => instanceof Promise<Module(2) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -56,11 +56,9 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => Call Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"(
-  No parameters
-)
+Module TypeId(0) => Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"
 
-Module TypeId(1) => Import Symbol: returnPromiseResult from "/src/returnPromiseResult.ts"
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 ```
 
 # `/src/promisedResult.ts` (Module 3)
@@ -157,7 +155,20 @@ BindingId(1) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function {
+Module TypeId(0) => Promise
+
+Module TypeId(1) => Module(0) TypeId(10)
+
+Module TypeId(2) => value: true
+
+Module TypeId(3) => Object {
+  prototype: No prototype
+  members: ["result": Module(0) TypeId(2)]
+}
+
+Module TypeId(4) => instanceof Import Symbol: PromisedResult from "/src/reexport.ts"
+
+Module TypeId(5) => sync Function {
   accepts: {
     params: [
       required resolve: unknown reference (bindings: resolve:unknown reference)
@@ -167,30 +178,7 @@ Module TypeId(0) => sync Function {
   returns: unknown reference
 }
 
-Module TypeId(1) => instanceof Promise
-
-Module TypeId(2) => class "Promise" {
-  extends: none
-  implements: []
-  type_args: [T]
-}
-
-Module TypeId(3) => value: true
-
-Module TypeId(4) => Object {
-  prototype: No prototype
-  members: ["result": Module(0) TypeId(3)]
-}
-
-Module TypeId(5) => instanceof Import Symbol: PromisedResult from "/src/reexport.ts"
-
-Module TypeId(6) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(9)
-}
+Module TypeId(6) => instanceof Module(0) TypeId(0)
 
 Module TypeId(7) => instanceof Import Symbol: PromisedResult from "/src/reexport.ts"
 
@@ -218,23 +206,11 @@ Module TypeId(10) => sync Function "returnPromiseResult" {
 ## Registered types
 
 ```
-Scope TypeId(0) => instanceof Promise<Module(3) TypeId(3)>
+Full TypeId(0) => Module(1) TypeId(8)
 
-Scope TypeId(1) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(7)
-}
+Full TypeId(1) => instanceof Promise<Module(3) TypeId(3)>
 
-Scope TypeId(2) => instanceof Promise<Module(3) TypeId(3)>
+Full TypeId(2) => Module(1) TypeId(8)
 
-Scope TypeId(3) => sync Function "returnPromiseResult" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(1) TypeId(7)
-}
+Full TypeId(3) => instanceof Promise<Module(3) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
@@ -31,37 +31,23 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => instanceof Promise
+Module TypeId(0) => Import Symbol: useCallback from "/node_modules/@types/react/index.d.ts"
 
-Module TypeId(1) => async Function {
+Module TypeId(1) => instanceof Promise
+
+Module TypeId(2) => async Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(1)
 }
 
-Module TypeId(2) => Call Import Symbol: useCallback from "/node_modules/@types/react/index.d.ts"(
-  Module(0) TypeId(1)
-)
+Module TypeId(3) => Call Module(0) TypeId(0)(Module(0) TypeId(2))
 
-Module TypeId(3) => Import Symbol: useCallback from "/node_modules/@types/react/index.d.ts"
+Module TypeId(4) => Module(0) TypeId(3)
 
-Module TypeId(4) => instanceof Promise
-
-Module TypeId(5) => async Function {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(4)
-}
-
-Module TypeId(6) => Call Module(0) TypeId(2)(No parameters)
-
-Module TypeId(7) => Call Import Symbol: useCallback from "/node_modules/@types/react/index.d.ts"(
-  Module(0) TypeId(1)
-)
+Module TypeId(5) => Call Module(0) TypeId(4)(No parameters)
 ```
 
 # `/node_modules/@types/react/index.d.ts` (Module 1)
@@ -5533,7 +5519,7 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(972))
   }
   "action" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(269))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(272))
   }
   "cache" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1001))
@@ -5563,7 +5549,7 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(817))
   }
   "default" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(0))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(2))
   }
   "defaultValue" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(83))
@@ -5584,7 +5570,7 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(274))
   }
   "format" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(228))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(229))
   }
   "forwardRef" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(824))
@@ -5602,7 +5588,7 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(204))
   }
   "initialState" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(265))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(268))
   }
   "initialValue" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(231))
@@ -5632,10 +5618,10 @@ Exports {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(132))
   }
   "propsAreEqual" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(178))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(181))
   }
   "reducer" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(251))
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(253))
   }
   "ref" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(218))
@@ -5728,6823 +5714,13 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => Namespace {
-    path: [
-        Borrowed(
-            "React",
-        ),
-    ],
-    members: [
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ElementType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(357),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(353),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Tag",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(356),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(370),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "JSXElementConstructor",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(380),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "RefObject",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(382),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_CALLBACK_REF_RETURN_VALUES",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(383),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "RefCallback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(384),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Ref",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(390),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "LegacyRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(393),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ElementRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(406),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(405),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(9),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(9),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Key",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(407),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Attributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(411),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "RefAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(417),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClassAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(420),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(429),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(422),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(425),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactComponentElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(447),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(434),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(443),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FunctionComponentElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(453),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(464),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(463),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(475),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(468),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClassicElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(480),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DOMElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(491),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(485),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(487),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactHTMLElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(497),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(493),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DetailedReactHTMLElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(506),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(500),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(502),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactSVGElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(511),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactPortal",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(514),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(515),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactNode",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(522),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(526),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(10),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(15),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(526),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(534),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(528),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(530),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(16),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(21),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(534),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(542),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(536),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(538),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(22),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(27),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(542),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(550),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(544),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(546),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                string,
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(32),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(550),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(555),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(551),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(34),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(37),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(555),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(564),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(551),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(558),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(560),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(41),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(44),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(564),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(568),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(551),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "type",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(48),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(51),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(568),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(575),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(570),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(572),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(54),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(52),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(575),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(582),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(577),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(579),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(56),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(57),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(582),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(590),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(585),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(587),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(58),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(59),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(590),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(596),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(591),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(593),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(62),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(64),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(596),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(599),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(66),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(69),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(599),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(605),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(602),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(72),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(75),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(605),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cloneElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(608),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "element",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(77),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(80),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(608),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ProviderProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(613),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ConsumerProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(617),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(621),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "NamedExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(626),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ProviderExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(629),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ContextType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(632),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(631),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Provider",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(636),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Consumer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(640),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Context",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(644),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createContext",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(646),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "defaultValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(83),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "isValidElement",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(649),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "object",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(86),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(288),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(90),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "fn",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(92),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(288),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(97),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "fn",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(99),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(9),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(288),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(101),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "children",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(104),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FragmentProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(652),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SuspenseProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(657),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ProfilerOnRenderCallback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(658),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ProfilerProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(663),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactInstance",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(666),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Component",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(673),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(667),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SS",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(668),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Component",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(682),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(109),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PureComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(685),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(667),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SS",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(668),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClassicComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(693),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(667),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FC",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(696),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FunctionComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(702),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ForwardedRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(708),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ForwardRefRenderFunction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(714),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentClass",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(727),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(716),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(131),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClassicComponentClass",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(734),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(132),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClassType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(745),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(742),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(744),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentLifecycle",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(763),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SS",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(668),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "StaticLifecycle",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(772),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "GetDerivedStateFromProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(779),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "GetDerivedStateFromError",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(784),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "NewLifecycle",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(796),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SS",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(785),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DeprecatedLifecycle",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(813),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "createRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(817),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ForwardRefExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(820),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(379),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "forwardRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(824),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(369),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "render",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(167),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PropsWithoutRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(826),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(825),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PropsWithRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(828),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Props",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(825),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PropsWithChildren",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(835),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(422),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(841),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(840),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentPropsWithRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(844),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(843),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CustomComponentPropsWithRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(847),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(846),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentPropsWithoutRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(853),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(852),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ComponentRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(856),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(855),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MemoExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(864),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(863),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "memo",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(868),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "P",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(866),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Component",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(169),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "propsAreEqual",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(172),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "memo",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(872),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(870),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Component",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(175),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "propsAreEqual",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(178),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "LazyExoticComponent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(878),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(874),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "lazy",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(882),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(880),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "load",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(185),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SetStateAction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(886),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Dispatch",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(890),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "A",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(889),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DispatchWithoutAction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(123),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AnyActionArg",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(893),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ActionDispatch",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(898),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ActionArg",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(897),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Reducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(907),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "A",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(889),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReducerWithoutAction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(910),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReducerState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(913),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "R",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(912),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DependencyList",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(915),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "EffectCallback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(918),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MutableRefObject",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(920),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useContext",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(921),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "context",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(192),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(925),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(195),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(932),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(926),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useReducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(937),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "A",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(934),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "reducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(198),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(196),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useReducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(943),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "S",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(674),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "I",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(938),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "A",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(940),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "reducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(202),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialArg",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(204),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "init",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(205),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(945),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(207),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(947),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(209),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useRef",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(949),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(211),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useLayoutEffect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(950),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "effect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(212),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(213),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useEffect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(951),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "effect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(214),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(215),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useImperativeHandle",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(953),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "R",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(952),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ref",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(218),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "init",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(220),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(221),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useCallback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(956),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(955),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "callback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(222),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(223),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useMemo",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(957),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "factory",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(225),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(226),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useDebugValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(958),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "value",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(227),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "format",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(228),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TransitionFunction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(962),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TransitionStartFunction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(965),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useDeferredValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(966),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "value",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(231),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialValue",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(231),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useTransition",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(969),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "startTransition",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(970),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "scope",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(232),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "act",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(971),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "callback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(234),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "act",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(972),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "callback",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(238),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useId",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(973),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useInsertionEffect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(974),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "effect",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(239),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "deps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(240),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useSyncExternalStore",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(976),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Snapshot",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(975),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "subscribe",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(241),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "getSnapshot",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(243),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "getServerSnapshot",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(243),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useOptimistic",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(982),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "State",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(977),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "passthrough",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(244),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useOptimistic",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(986),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "State",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(977),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Action",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(983),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "passthrough",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(249),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "reducer",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(251),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Usable",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(991),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "use",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(992),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "usable",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(256),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useActionState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(994),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "State",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(977),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "action",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(261),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(258),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "permalink",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                string,
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "useActionState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(998),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "State",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(977),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Payload",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(995),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "action",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(269),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "initialState",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(265),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "permalink",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                string,
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "cache",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1001),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CachedFunction",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1000),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "fn",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(274),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "captureOwnerStack",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1002),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "BaseSyntheticEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1014),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1003),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "C",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1004),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1005),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SyntheticEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1024),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1016),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1018),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClipboardEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1031),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1026),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CompositionEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1037),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1033),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DragEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1044),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1039),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PointerEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1054),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1046),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FocusEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1066),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Target",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1056),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "RelatedTarget",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1057),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FormEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1071),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1068),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "InvalidEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1078),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1073),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ChangeEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1085),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1080),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ModifierKey",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1100),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "KeyboardEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1108),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1102),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MouseEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1120),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1110),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1112),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TouchEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1129),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1122),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "UIEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1138),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1131),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1133),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "WheelEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1144),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1140),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AnimationEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1150),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1146),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ToggleEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1159),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1152),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TransitionEvent",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1165),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1161),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "EventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1168),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1167),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ReactEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1174),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1173),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ClipboardEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1180),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1179),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CompositionEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1186),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1185),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DragEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1192),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1191),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FocusEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1198),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1197),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FormEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1204),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1203),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ChangeEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1210),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1209),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "KeyboardEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1216),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1215),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MouseEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1222),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1221),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TouchEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1228),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1227),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "PointerEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1234),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1233),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "UIEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1240),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1239),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "WheelEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1246),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1245),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AnimationEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1252),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1251),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ToggleEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1258),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1257),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TransitionEventHandler",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1264),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1263),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1268),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DetailedHTMLProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1275),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "E",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1274),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SVGProps",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1279),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SVGLineElementAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1282),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SVGTextElementAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1285),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DOMAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1340),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CSSProperties",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1343),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AriaAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1409),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AriaRole",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1472),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1531),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_FORM_ACTIONS",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1532),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AllHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1553),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLAttributeReferrerPolicy",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1562),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLAttributeAnchorTarget",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1567),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AnchorHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1576),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AudioHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1579),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AreaHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1585),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "BaseHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1588),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "BlockquoteHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1591),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ButtonHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1608),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "CanvasHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1611),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ColHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1614),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ColgroupHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1617),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DataHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1624),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DetailsHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1627),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DelHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1630),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DialogHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1636),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "EmbedHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1639),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FieldsetHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1642),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "FormHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1651),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HtmlHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1654),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "IframeHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1664),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_IMG_SRC_TYPES",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1665),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ImgHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1683),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "InsHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1686),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLInputTypeAttribute",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1697),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillAddressKind",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1700),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillBase",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1701),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillContactField",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1709),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillContactKind",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1713),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillCredentialField",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1714),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillNormalField",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1751),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OptionalPrefixToken",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1755),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1754),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OptionalPostfixToken",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1758),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1754),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillField",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1761),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFillSection",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1762),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AutoFill",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1765),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLInputAutoCompleteAttribute",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1767),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "InputHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1789),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "KeygenHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1792),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "LabelHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1795),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "LiHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1802),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "LinkHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1810),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MapHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1813),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MenuHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1816),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_MEDIA_SRC_TYPES",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1817),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MediaHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1822),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MetaHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1825),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "MeterHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1832),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "QuoteHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1835),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ObjectHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1838),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OlHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1848),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OptgroupHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1851),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OptionHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1858),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "OutputHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1861),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ParamHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1868),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ProgressHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1875),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SlotHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1878),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ScriptHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1886),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SelectHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1896),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SourceHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1899),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "StyleHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1902),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TableHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1915),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TextareaHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1925),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TdHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1938),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ThHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1941),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TimeHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1944),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TrackHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1947),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "VideoHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(1953),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SVGAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2014),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "WebViewHTMLAttributes",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2017),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "T",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(287),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "HTMLElementType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2118),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "SVGElementType",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2171),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "AbstractView",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2174),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "Touch",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2176),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "TouchList",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2180),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "ErrorInfo",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2186),
-            ),
-        },
-        TypeMember {
-            kind: Named(
-                Borrowed(
-                    "JSX",
-                ),
-            ),
-            is_static: true,
-            ty: Resolved(
-                Module(0) TypeId(2187),
-            ),
-        },
-    ],
-}
+Module TypeId(0) => instanceof Module(0) TypeId(285)
 
 Module TypeId(1) => instanceof Module(0) TypeId(285)
 
-Module TypeId(2) => instanceof Module(0) TypeId(285)
+Module TypeId(2) => Module(0) TypeId(349)
 
-Module TypeId(3) => class "Component" {
-  extends: none
-  implements: []
-  type_args: [Module(0) TypeId(379), Module(0) TypeId(674)]
-}
+Module TypeId(3) => Module(0) TypeId(682)
 
 Module TypeId(4) => instanceof Module(0) TypeId(379)
 
@@ -12827,9 +6003,11 @@ Module TypeId(89) => TypeOperatorType {
 
 Module TypeId(90) => Module(0) TypeId(87) | Module(0) TypeId(89)
 
-Module TypeId(91) => instanceof Module(0) TypeId(287)
+Module TypeId(91) => instanceof Module(0) TypeId(288)
 
-Module TypeId(92) => sync Function {
+Module TypeId(92) => instanceof Module(0) TypeId(287)
+
+Module TypeId(93) => sync Function {
   accepts: {
     params: [
       required child: Module(0) TypeId(87) (bindings: child:Module(0) TypeId(87))
@@ -12837,10 +6015,8 @@ Module TypeId(92) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(91)
+  returns: Module(0) TypeId(92)
 }
-
-Module TypeId(93) => instanceof Module(0) TypeId(288)
 
 Module TypeId(94) => instanceof Module(0) TypeId(288)
 
@@ -12855,9 +6031,11 @@ Module TypeId(96) => TypeOperatorType {
 
 Module TypeId(97) => Module(0) TypeId(94) | Module(0) TypeId(96)
 
-Module TypeId(98) => void
+Module TypeId(98) => instanceof Module(0) TypeId(288)
 
-Module TypeId(99) => sync Function {
+Module TypeId(99) => void
+
+Module TypeId(100) => sync Function {
   accepts: {
     params: [
       required child: Module(0) TypeId(94) (bindings: child:Module(0) TypeId(94))
@@ -12865,10 +6043,8 @@ Module TypeId(99) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
-
-Module TypeId(100) => instanceof Module(0) TypeId(288)
 
 Module TypeId(101) => instanceof Module(0) TypeId(288)
 
@@ -12890,45 +6066,45 @@ Module TypeId(109) => instanceof Module(0) TypeId(379)
 
 Module TypeId(110) => instanceof Module(0) TypeId(674)
 
-Module TypeId(111) => instanceof unresolved reference "Readonly"<Module(0) TypeId(110)> (scope ID: 102)
+Module TypeId(111) => instanceof unresolved reference "Readonly"<Module(0) TypeId(110)> (scope ID: 103)
 
 Module TypeId(112) => instanceof Module(0) TypeId(379)
 
-Module TypeId(113) => instanceof unresolved reference "Readonly"<Module(0) TypeId(112)> (scope ID: 102)
+Module TypeId(113) => instanceof unresolved reference "Readonly"<Module(0) TypeId(112)> (scope ID: 103)
 
-Module TypeId(114) => instanceof Module(0) TypeId(684)
+Module TypeId(114) => instanceof Module(0) TypeId(674)
 
-Module TypeId(115) => instanceof unresolved reference "Pick"<Module(0) TypeId(110), Module(0) TypeId(114)> (scope ID: 102)
+Module TypeId(115) => instanceof unresolved reference "Readonly"<Module(0) TypeId(114)> (scope ID: 102)
 
-Module TypeId(116) => Module(0) TypeId(115) | Module(0) TypeId(110) | Module(0) TypeId(7)
+Module TypeId(116) => instanceof Module(0) TypeId(379)
 
-Module TypeId(117) => sync Function {
+Module TypeId(117) => instanceof unresolved reference "Readonly"<Module(0) TypeId(116)> (scope ID: 102)
+
+Module TypeId(118) => instanceof Module(0) TypeId(684)
+
+Module TypeId(119) => instanceof unresolved reference "Pick"<Module(0) TypeId(114), Module(0) TypeId(118)> (scope ID: 102)
+
+Module TypeId(120) => Module(0) TypeId(119) | Module(0) TypeId(114) | Module(0) TypeId(7)
+
+Module TypeId(121) => sync Function {
   accepts: {
     params: [
-      required prevState: Module(0) TypeId(111) (bindings: prevState:Module(0) TypeId(111))
-      required props: Module(0) TypeId(113) (bindings: props:Module(0) TypeId(113))
+      required prevState: Module(0) TypeId(115) (bindings: prevState:Module(0) TypeId(115))
+      required props: Module(0) TypeId(117) (bindings: props:Module(0) TypeId(117))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(116)
+  returns: Module(0) TypeId(120)
 }
 
-Module TypeId(118) => Module(0) TypeId(117) | Module(0) TypeId(116)
-
-Module TypeId(119) => instanceof Module(0) TypeId(674)
-
-Module TypeId(120) => instanceof unresolved reference "Readonly"<Module(0) TypeId(119)> (scope ID: 103)
-
-Module TypeId(121) => instanceof Module(0) TypeId(379)
-
-Module TypeId(122) => instanceof unresolved reference "Readonly"<Module(0) TypeId(121)> (scope ID: 103)
+Module TypeId(122) => Module(0) TypeId(121) | Module(0) TypeId(120)
 
 Module TypeId(123) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(124) => instanceof Module(0) TypeId(667)
@@ -13023,47 +6199,47 @@ Module TypeId(168) => instanceof Module(0) TypeId(866)
 
 Module TypeId(169) => instanceof Module(0) TypeId(702)
 
-Module TypeId(170) => instanceof unresolved reference "Readonly"<Module(0) TypeId(168)> (scope ID: 169)
+Module TypeId(170) => instanceof Module(0) TypeId(866)
 
-Module TypeId(171) => boolean
+Module TypeId(171) => instanceof unresolved reference "Readonly"<Module(0) TypeId(170)> (scope ID: 170)
 
-Module TypeId(172) => sync Function {
+Module TypeId(172) => instanceof unresolved reference "Readonly"<Module(0) TypeId(168)> (scope ID: 169)
+
+Module TypeId(173) => boolean
+
+Module TypeId(174) => sync Function {
   accepts: {
     params: [
-      required prevProps: Module(0) TypeId(170) (bindings: prevProps:Module(0) TypeId(170))
-      required nextProps: Module(0) TypeId(170) (bindings: nextProps:Module(0) TypeId(170))
+      required prevProps: Module(0) TypeId(172) (bindings: prevProps:Module(0) TypeId(172))
+      required nextProps: Module(0) TypeId(172) (bindings: nextProps:Module(0) TypeId(172))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
-
-Module TypeId(173) => instanceof Module(0) TypeId(866)
-
-Module TypeId(174) => instanceof unresolved reference "Readonly"<Module(0) TypeId(173)> (scope ID: 170)
 
 Module TypeId(175) => instanceof Module(0) TypeId(870)
 
-Module TypeId(176) => instanceof Module(0) TypeId(295)<Module(0) TypeId(840)>
+Module TypeId(176) => instanceof Module(0) TypeId(870)
 
-Module TypeId(177) => instanceof unresolved reference "Readonly"<Module(0) TypeId(176)> (scope ID: 171)
+Module TypeId(177) => instanceof Module(0) TypeId(295)<Module(0) TypeId(840)>
 
-Module TypeId(178) => sync Function {
+Module TypeId(178) => instanceof unresolved reference "Readonly"<Module(0) TypeId(177)> (scope ID: 172)
+
+Module TypeId(179) => instanceof Module(0) TypeId(295)<Module(0) TypeId(840)>
+
+Module TypeId(180) => instanceof unresolved reference "Readonly"<Module(0) TypeId(179)> (scope ID: 171)
+
+Module TypeId(181) => sync Function {
   accepts: {
     params: [
-      required prevProps: Module(0) TypeId(177) (bindings: prevProps:Module(0) TypeId(177))
-      required nextProps: Module(0) TypeId(177) (bindings: nextProps:Module(0) TypeId(177))
+      required prevProps: Module(0) TypeId(180) (bindings: prevProps:Module(0) TypeId(180))
+      required nextProps: Module(0) TypeId(180) (bindings: nextProps:Module(0) TypeId(180))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
-
-Module TypeId(179) => instanceof Module(0) TypeId(870)
-
-Module TypeId(180) => instanceof Module(0) TypeId(295)<Module(0) TypeId(840)>
-
-Module TypeId(181) => instanceof unresolved reference "Readonly"<Module(0) TypeId(180)> (scope ID: 172)
 
 Module TypeId(182) => instanceof Module(0) TypeId(880)
 
@@ -13110,49 +6286,49 @@ Module TypeId(195) => Module(0) TypeId(193) | Module(0) TypeId(194)
 
 Module TypeId(196) => instanceof Module(0) TypeId(674)
 
-Module TypeId(197) => instanceof Module(0) TypeId(934)
+Module TypeId(197) => instanceof Module(0) TypeId(674)
 
-Module TypeId(198) => sync Function {
+Module TypeId(198) => instanceof Module(0) TypeId(934)
+
+Module TypeId(199) => sync Function {
   accepts: {
     params: [
-      required prevState: Module(0) TypeId(196) (bindings: prevState:Module(0) TypeId(196))
-    ...(unnamed): Module(0) TypeId(197) (bindings: args:Module(0) TypeId(197))]
+      required prevState: Module(0) TypeId(197) (bindings: prevState:Module(0) TypeId(197))
+    ...(unnamed): Module(0) TypeId(198) (bindings: args:Module(0) TypeId(198))]
     type_args: []
   }
-  returns: Module(0) TypeId(196)
+  returns: Module(0) TypeId(197)
 }
-
-Module TypeId(199) => instanceof Module(0) TypeId(674)
 
 Module TypeId(200) => instanceof Module(0) TypeId(674)
 
-Module TypeId(201) => instanceof Module(0) TypeId(940)
+Module TypeId(201) => instanceof Module(0) TypeId(674)
 
-Module TypeId(202) => sync Function {
+Module TypeId(202) => instanceof Module(0) TypeId(940)
+
+Module TypeId(203) => sync Function {
   accepts: {
     params: [
-      required prevState: Module(0) TypeId(200) (bindings: prevState:Module(0) TypeId(200))
-    ...(unnamed): Module(0) TypeId(201) (bindings: args:Module(0) TypeId(201))]
+      required prevState: Module(0) TypeId(201) (bindings: prevState:Module(0) TypeId(201))
+    ...(unnamed): Module(0) TypeId(202) (bindings: args:Module(0) TypeId(202))]
     type_args: []
   }
-  returns: Module(0) TypeId(200)
+  returns: Module(0) TypeId(201)
 }
-
-Module TypeId(203) => instanceof Module(0) TypeId(674)
 
 Module TypeId(204) => instanceof Module(0) TypeId(938)
 
-Module TypeId(205) => sync Function {
+Module TypeId(205) => instanceof Module(0) TypeId(938)
+
+Module TypeId(206) => sync Function {
   accepts: {
     params: [
       required i: Module(0) TypeId(204) (bindings: i:Module(0) TypeId(204))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(200)
+  returns: Module(0) TypeId(201)
 }
-
-Module TypeId(206) => instanceof Module(0) TypeId(938)
 
 Module TypeId(207) => instanceof Module(0) TypeId(287)
 
@@ -13220,7 +6396,9 @@ Module TypeId(226) => instanceof Module(0) TypeId(915)
 
 Module TypeId(227) => instanceof Module(0) TypeId(287)
 
-Module TypeId(228) => sync Function {
+Module TypeId(228) => instanceof Module(0) TypeId(287)
+
+Module TypeId(229) => sync Function {
   accepts: {
     params: [
       required value: Module(0) TypeId(227) (bindings: value:Module(0) TypeId(227))
@@ -13229,8 +6407,6 @@ Module TypeId(228) => sync Function {
   }
   returns: Module(0) TypeId(9)
 }
-
-Module TypeId(229) => instanceof Module(0) TypeId(287)
 
 Module TypeId(230) => sync Function {
   accepts: {
@@ -13308,38 +6484,38 @@ Module TypeId(244) => instanceof Module(0) TypeId(977)
 
 Module TypeId(245) => instanceof Module(0) TypeId(977)
 
-Module TypeId(246) => sync Function {
+Module TypeId(246) => instanceof Module(0) TypeId(977)
+
+Module TypeId(247) => sync Function {
   accepts: {
     params: [
-      required pendingState: Module(0) TypeId(245) (bindings: pendingState:Module(0) TypeId(245))
+      required pendingState: Module(0) TypeId(246) (bindings: pendingState:Module(0) TypeId(246))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(245)
+  returns: Module(0) TypeId(246)
 }
 
-Module TypeId(247) => Module(0) TypeId(245) | Module(0) TypeId(246)
-
-Module TypeId(248) => instanceof Module(0) TypeId(977)
+Module TypeId(248) => Module(0) TypeId(246) | Module(0) TypeId(247)
 
 Module TypeId(249) => instanceof Module(0) TypeId(977)
 
-Module TypeId(250) => instanceof Module(0) TypeId(983)
+Module TypeId(250) => instanceof Module(0) TypeId(977)
 
-Module TypeId(251) => sync Function {
+Module TypeId(251) => instanceof Module(0) TypeId(983)
+
+Module TypeId(252) => instanceof Module(0) TypeId(983)
+
+Module TypeId(253) => sync Function {
   accepts: {
     params: [
       required state: Module(0) TypeId(249) (bindings: state:Module(0) TypeId(249))
-      required action: Module(0) TypeId(250) (bindings: action:Module(0) TypeId(250))
+      required action: Module(0) TypeId(252) (bindings: action:Module(0) TypeId(252))
     ]
     type_args: []
   }
   returns: Module(0) TypeId(249)
 }
-
-Module TypeId(252) => instanceof Module(0) TypeId(977)
-
-Module TypeId(253) => instanceof Module(0) TypeId(983)
 
 Module TypeId(254) => instanceof Module(0) TypeId(983)
 
@@ -13349,52 +6525,52 @@ Module TypeId(256) => instanceof Module(0) TypeId(990)<Module(0) TypeId(287)>
 
 Module TypeId(257) => instanceof Module(0) TypeId(977)
 
-Module TypeId(258) => instanceof unresolved reference "Awaited"<Module(0) TypeId(257)> (scope ID: 243)
+Module TypeId(258) => instanceof unresolved reference "Awaited"<Module(0) TypeId(257)> (scope ID: 244)
 
-Module TypeId(259) => instanceof Promise<Module(0) TypeId(257)>
+Module TypeId(259) => instanceof Module(0) TypeId(977)
 
-Module TypeId(260) => Module(0) TypeId(257) | Module(0) TypeId(259)
+Module TypeId(260) => instanceof unresolved reference "Awaited"<Module(0) TypeId(259)> (scope ID: 243)
 
-Module TypeId(261) => sync Function {
+Module TypeId(261) => instanceof Promise<Module(0) TypeId(259)>
+
+Module TypeId(262) => Module(0) TypeId(259) | Module(0) TypeId(261)
+
+Module TypeId(263) => sync Function {
   accepts: {
     params: [
-      required state: Module(0) TypeId(258) (bindings: state:Module(0) TypeId(258))
+      required state: Module(0) TypeId(260) (bindings: state:Module(0) TypeId(260))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(260)
+  returns: Module(0) TypeId(262)
 }
-
-Module TypeId(262) => instanceof Module(0) TypeId(977)
-
-Module TypeId(263) => instanceof unresolved reference "Awaited"<Module(0) TypeId(262)> (scope ID: 244)
 
 Module TypeId(264) => instanceof Module(0) TypeId(977)
 
-Module TypeId(265) => instanceof unresolved reference "Awaited"<Module(0) TypeId(264)> (scope ID: 246)
+Module TypeId(265) => instanceof unresolved reference "Awaited"<Module(0) TypeId(264)> (scope ID: 247)
 
 Module TypeId(266) => instanceof Module(0) TypeId(995)
 
-Module TypeId(267) => instanceof Promise<Module(0) TypeId(264)>
+Module TypeId(267) => instanceof Module(0) TypeId(977)
 
-Module TypeId(268) => Module(0) TypeId(264) | Module(0) TypeId(267)
+Module TypeId(268) => instanceof unresolved reference "Awaited"<Module(0) TypeId(267)> (scope ID: 246)
 
-Module TypeId(269) => sync Function {
+Module TypeId(269) => instanceof Module(0) TypeId(995)
+
+Module TypeId(270) => instanceof Promise<Module(0) TypeId(267)>
+
+Module TypeId(271) => Module(0) TypeId(267) | Module(0) TypeId(270)
+
+Module TypeId(272) => sync Function {
   accepts: {
     params: [
-      required state: Module(0) TypeId(265) (bindings: state:Module(0) TypeId(265))
-      required payload: Module(0) TypeId(266) (bindings: payload:Module(0) TypeId(266))
+      required state: Module(0) TypeId(268) (bindings: state:Module(0) TypeId(268))
+      required payload: Module(0) TypeId(269) (bindings: payload:Module(0) TypeId(269))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(268)
+  returns: Module(0) TypeId(271)
 }
-
-Module TypeId(270) => instanceof Module(0) TypeId(977)
-
-Module TypeId(271) => instanceof unresolved reference "Awaited"<Module(0) TypeId(270)> (scope ID: 247)
-
-Module TypeId(272) => instanceof Module(0) TypeId(995)
 
 Module TypeId(273) => instanceof Module(0) TypeId(995)
 
@@ -13480,7 +6656,7 @@ Module TypeId(297) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(298) => sync Function "forEach" {
@@ -13491,7 +6667,7 @@ Module TypeId(298) => sync Function "forEach" {
     ]
     type_args: [Module(0) TypeId(288)]
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(299) => sync Function "count" {
@@ -13520,7 +6696,7 @@ Module TypeId(302) => instanceof Array<Module(0) TypeId(301)>
 
 Module TypeId(303) => Module(0) TypeId(301) | Module(0) TypeId(302)
 
-Module TypeId(304) => Module(0) TypeId(171) | Module(0) TypeId(7) | Module(0) TypeId(85)
+Module TypeId(304) => Module(0) TypeId(173) | Module(0) TypeId(7) | Module(0) TypeId(85)
 
 Module TypeId(305) => instanceof unresolved reference "Exclude"<Module(0) TypeId(301), Module(0) TypeId(304)> (scope ID: 20)
 
@@ -13613,7 +6789,7 @@ Module TypeId(334) => value: true
 
 Module TypeId(335) => value: false
 
-Module TypeId(336) => Module(0) TypeId(171) | Module(0) TypeId(334) | Module(0) TypeId(335)
+Module TypeId(336) => Module(0) TypeId(173) | Module(0) TypeId(334) | Module(0) TypeId(335)
 
 Module TypeId(337) => value: anonymous
 
@@ -13633,9 +6809,9 @@ Module TypeId(344) => instanceof unresolved reference "Iterable"<Module(0) TypeI
 
 Module TypeId(345) => instanceof Module(0) TypeId(514)
 
-Module TypeId(346) => Module(0) TypeId(341) | string | number | Module(0) TypeId(342) | Module(0) TypeId(344) | Module(0) TypeId(345) | Module(0) TypeId(171) | Module(0) TypeId(7) | Module(0) TypeId(85) | Module(0) TypeId(295)
+Module TypeId(346) => Module(0) TypeId(341) | string | number | Module(0) TypeId(342) | Module(0) TypeId(344) | Module(0) TypeId(345) | Module(0) TypeId(173) | Module(0) TypeId(7) | Module(0) TypeId(85) | Module(0) TypeId(295)
 
-Module TypeId(347) => Module(0) TypeId(98) | Module(0) TypeId(84)
+Module TypeId(347) => Module(0) TypeId(99) | Module(0) TypeId(84)
 
 Module TypeId(348) => sync Function {
   accepts: {
@@ -15420,7 +8596,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(92),
+                Module(0) TypeId(93),
             ),
         },
         TypeMember {
@@ -15453,7 +8629,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(99),
+                Module(0) TypeId(100),
             ),
         },
         TypeMember {
@@ -16487,7 +9663,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(172),
+                Module(0) TypeId(174),
             ),
         },
         TypeMember {
@@ -16531,7 +9707,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(178),
+                Module(0) TypeId(181),
             ),
         },
         TypeMember {
@@ -16927,7 +10103,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(198),
+                Module(0) TypeId(199),
             ),
         },
         TypeMember {
@@ -16938,7 +10114,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(196),
+                Module(0) TypeId(197),
             ),
         },
         TypeMember {
@@ -16993,7 +10169,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(202),
+                Module(0) TypeId(203),
             ),
         },
         TypeMember {
@@ -17015,7 +10191,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(205),
+                Module(0) TypeId(206),
             ),
         },
         TypeMember {
@@ -17378,7 +10554,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(228),
+                Module(0) TypeId(229),
             ),
         },
         TypeMember {
@@ -17719,7 +10895,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(251),
+                Module(0) TypeId(253),
             ),
         },
         TypeMember {
@@ -17807,7 +10983,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(261),
+                Module(0) TypeId(263),
             ),
         },
         TypeMember {
@@ -17818,7 +10994,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(258),
+                Module(0) TypeId(260),
             ),
         },
         TypeMember {
@@ -17873,7 +11049,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(269),
+                Module(0) TypeId(272),
             ),
         },
         TypeMember {
@@ -17884,7 +11060,7 @@ Module TypeId(349) => Namespace {
             ),
             is_static: true,
             ty: Resolved(
-                Module(0) TypeId(265),
+                Module(0) TypeId(268),
             ),
         },
         TypeMember {
@@ -20971,7 +14147,7 @@ Module TypeId(520) => instanceof Module(0) TypeId(346)
 
 Module TypeId(521) => instanceof Promise<Module(0) TypeId(520)>
 
-Module TypeId(522) => Module(0) TypeId(516) | string | number | Module(0) TypeId(342) | Module(0) TypeId(518) | Module(0) TypeId(519) | Module(0) TypeId(171) | Module(0) TypeId(7) | Module(0) TypeId(85) | Module(0) TypeId(295) | Module(0) TypeId(521)
+Module TypeId(522) => Module(0) TypeId(516) | string | number | Module(0) TypeId(342) | Module(0) TypeId(518) | Module(0) TypeId(519) | Module(0) TypeId(173) | Module(0) TypeId(7) | Module(0) TypeId(85) | Module(0) TypeId(295) | Module(0) TypeId(521)
 
 Module TypeId(523) => instanceof Module(0) TypeId(522)
 
@@ -21464,7 +14640,7 @@ Module TypeId(658) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(659) => instanceof Module(0) TypeId(522)
@@ -21485,7 +14661,7 @@ Module TypeId(662) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(663) => interface "ProfilerProps" {
@@ -21551,14 +14727,14 @@ Module TypeId(682) => class "Component" {
 Module TypeId(683) => TypeOperatorType {
     operator: Keyof,
     ty: Resolved(
-        Module(0) TypeId(110),
+        Module(0) TypeId(114),
     ),
 }
 
 Module TypeId(684) => K extends Module(0) TypeId(683)
 
 Module TypeId(685) => class "PureComponent" {
-  extends: Module(0) TypeId(682)
+  extends: Module(0) TypeId(3)
   implements: []
   type_args: [
     Module(0) TypeId(369),
@@ -21581,7 +14757,7 @@ Module TypeId(689) => sync Function "replaceState" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(690) => sync Function "isMounted" {
@@ -21589,7 +14765,7 @@ Module TypeId(690) => sync Function "isMounted" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(691) => sync Function "getInitialState" {
@@ -21657,7 +14833,7 @@ Module TypeId(705) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(706) => instanceof Module(0) TypeId(382)
@@ -21897,7 +15073,7 @@ Module TypeId(751) => sync Function "componentDidMount" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(752) => Module(0) TypeId(751) | undefined
@@ -21915,7 +15091,7 @@ Module TypeId(755) => sync Function "shouldComponentUpdate" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(756) => Module(0) TypeId(755) | undefined
@@ -21925,7 +15101,7 @@ Module TypeId(757) => sync Function "componentWillUnmount" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(758) => Module(0) TypeId(757) | undefined
@@ -21942,7 +15118,7 @@ Module TypeId(761) => sync Function "componentDidCatch" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(762) => Module(0) TypeId(761) | undefined
@@ -22081,7 +15257,7 @@ Module TypeId(794) => sync Function "componentDidUpdate" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(795) => Module(0) TypeId(794) | undefined
@@ -22104,7 +15280,7 @@ Module TypeId(797) => sync Function "componentWillMount" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(798) => Module(0) TypeId(797) | undefined
@@ -22114,7 +15290,7 @@ Module TypeId(799) => sync Function "UNSAFE_componentWillMount" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(800) => Module(0) TypeId(799) | undefined
@@ -22131,7 +15307,7 @@ Module TypeId(803) => sync Function "componentWillReceiveProps" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(804) => Module(0) TypeId(803) | undefined
@@ -22144,7 +15320,7 @@ Module TypeId(805) => sync Function "UNSAFE_componentWillReceiveProps" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(806) => Module(0) TypeId(805) | undefined
@@ -22162,7 +15338,7 @@ Module TypeId(809) => sync Function "componentWillUpdate" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(810) => Module(0) TypeId(809) | undefined
@@ -22176,7 +15352,7 @@ Module TypeId(811) => sync Function "UNSAFE_componentWillUpdate" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(812) => Module(0) TypeId(811) | undefined
@@ -22362,7 +15538,7 @@ Module TypeId(868) => sync Function "memo" {
   accepts: {
     params: [
       required Component: Module(0) TypeId(169) (bindings: Component:Module(0) TypeId(169))
-      optional propsAreEqual: Module(0) TypeId(172) (bindings: propsAreEqual:Module(0) TypeId(172))
+      optional propsAreEqual: Module(0) TypeId(174) (bindings: propsAreEqual:Module(0) TypeId(174))
     ]
     type_args: [Module(0) TypeId(866)]
   }
@@ -22379,7 +15555,7 @@ Module TypeId(872) => sync Function "memo" {
   accepts: {
     params: [
       required Component: Module(0) TypeId(175) (bindings: Component:Module(0) TypeId(175))
-      optional propsAreEqual: Module(0) TypeId(178) (bindings: propsAreEqual:Module(0) TypeId(178))
+      optional propsAreEqual: Module(0) TypeId(181) (bindings: propsAreEqual:Module(0) TypeId(181))
     ]
     type_args: [Module(0) TypeId(870)]
   }
@@ -22443,7 +15619,7 @@ Module TypeId(888) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(889) => A
@@ -22455,7 +15631,7 @@ Module TypeId(890) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(891) => Tuple(
@@ -22484,7 +15660,7 @@ Module TypeId(895) => sync Function {
     params: [...(unnamed): Module(0) TypeId(894) (bindings: args:Module(0) TypeId(894))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(896) => instanceof Module(0) TypeId(893)
@@ -22496,7 +15672,7 @@ Module TypeId(898) => sync Function {
     params: [...(unnamed): Module(0) TypeId(894) (bindings: args:Module(0) TypeId(894))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(899) => instanceof Module(0) TypeId(897)
@@ -22506,7 +15682,7 @@ Module TypeId(900) => sync Function {
     params: [...(unnamed): Module(0) TypeId(899) (bindings: args:Module(0) TypeId(899))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(901) => instanceof Module(0) TypeId(893)
@@ -22518,7 +15694,7 @@ Module TypeId(903) => sync Function {
     params: [...(unnamed): Module(0) TypeId(899) (bindings: args:Module(0) TypeId(899))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(904) => instanceof Module(0) TypeId(674)
@@ -22601,7 +15777,7 @@ Module TypeId(916) => sync Function {
   returns: Module(0) TypeId(347)
 }
 
-Module TypeId(917) => Module(0) TypeId(98) | Module(0) TypeId(916)
+Module TypeId(917) => Module(0) TypeId(99) | Module(0) TypeId(916)
 
 Module TypeId(918) => sync Function {
   accepts: {
@@ -22638,7 +15814,7 @@ Module TypeId(923) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(924) => Tuple(
@@ -22687,7 +15863,7 @@ Module TypeId(930) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(931) => Tuple(
@@ -22728,14 +15904,14 @@ Module TypeId(935) => sync Function {
     params: [...(unnamed): Module(0) TypeId(894) (bindings: args:Module(0) TypeId(894))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(936) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(196),
+                Module(0) TypeId(197),
             ),
             name: None,
             is_optional: false,
@@ -22755,8 +15931,8 @@ Module TypeId(936) => Tuple(
 Module TypeId(937) => sync Function "useReducer" {
   accepts: {
     params: [
-      required reducer: Module(0) TypeId(198) (bindings: reducer:Module(0) TypeId(198))
-      required initialState: Module(0) TypeId(196) (bindings: initialState:Module(0) TypeId(196))
+      required reducer: Module(0) TypeId(199) (bindings: reducer:Module(0) TypeId(199))
+      required initialState: Module(0) TypeId(197) (bindings: initialState:Module(0) TypeId(197))
     ]
     type_args: [Module(0) TypeId(674), Module(0) TypeId(934)]
   }
@@ -22774,14 +15950,14 @@ Module TypeId(941) => sync Function {
     params: [...(unnamed): Module(0) TypeId(894) (bindings: args:Module(0) TypeId(894))]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(942) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(200),
+                Module(0) TypeId(201),
             ),
             name: None,
             is_optional: false,
@@ -22801,9 +15977,9 @@ Module TypeId(942) => Tuple(
 Module TypeId(943) => sync Function "useReducer" {
   accepts: {
     params: [
-      required reducer: Module(0) TypeId(202) (bindings: reducer:Module(0) TypeId(202))
+      required reducer: Module(0) TypeId(203) (bindings: reducer:Module(0) TypeId(203))
       required initialArg: Module(0) TypeId(204) (bindings: initialArg:Module(0) TypeId(204))
-      required init: Module(0) TypeId(205) (bindings: init:Module(0) TypeId(205))
+      required init: Module(0) TypeId(206) (bindings: init:Module(0) TypeId(206))
     ]
     type_args: [
       Module(0) TypeId(674),
@@ -22858,7 +16034,7 @@ Module TypeId(950) => sync Function "useLayoutEffect" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(951) => sync Function "useEffect" {
@@ -22869,7 +16045,7 @@ Module TypeId(951) => sync Function "useEffect" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(952) => R extends Module(0) TypeId(216)
@@ -22883,7 +16059,7 @@ Module TypeId(953) => sync Function "useImperativeHandle" {
     ]
     type_args: [Module(0) TypeId(287), Module(0) TypeId(952)]
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(954) => instanceof unresolved reference "Function" (scope ID: 211)
@@ -22916,11 +16092,11 @@ Module TypeId(958) => sync Function "useDebugValue" {
   accepts: {
     params: [
       required value: Module(0) TypeId(227) (bindings: value:Module(0) TypeId(227))
-      optional format: Module(0) TypeId(228) (bindings: format:Module(0) TypeId(228))
+      optional format: Module(0) TypeId(229) (bindings: format:Module(0) TypeId(229))
     ]
     type_args: [Module(0) TypeId(287)]
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(959) => instanceof Module(0) TypeId(347)
@@ -22952,7 +16128,7 @@ Module TypeId(964) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(965) => interface "TransitionStartFunction" {
@@ -22978,7 +16154,7 @@ Module TypeId(968) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(171),
+                Module(0) TypeId(173),
             ),
             name: None,
             is_optional: false,
@@ -23010,7 +16186,7 @@ Module TypeId(970) => sync Function "startTransition" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(971) => sync Function "act" {
@@ -23020,7 +16196,7 @@ Module TypeId(971) => sync Function "act" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(972) => sync Function "act" {
@@ -23049,7 +16225,7 @@ Module TypeId(974) => sync Function "useInsertionEffect" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(975) => Snapshot
@@ -23087,7 +16263,7 @@ Module TypeId(980) => sync Function {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(981) => Tuple(
@@ -23126,11 +16302,11 @@ Module TypeId(983) => Action
 Module TypeId(984) => sync Function {
   accepts: {
     params: [
-      required action: Module(0) TypeId(250) (bindings: action:Module(0) TypeId(250))
+      required action: Module(0) TypeId(252) (bindings: action:Module(0) TypeId(252))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(985) => Tuple(
@@ -23158,7 +16334,7 @@ Module TypeId(986) => sync Function "useOptimistic" {
   accepts: {
     params: [
       required passthrough: Module(0) TypeId(249) (bindings: passthrough:Module(0) TypeId(249))
-      required reducer: Module(0) TypeId(251) (bindings: reducer:Module(0) TypeId(251))
+      required reducer: Module(0) TypeId(253) (bindings: reducer:Module(0) TypeId(253))
     ]
     type_args: [Module(0) TypeId(977), Module(0) TypeId(983)]
   }
@@ -23189,7 +16365,7 @@ Module TypeId(993) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(258),
+                Module(0) TypeId(260),
             ),
             name: Some(
                 Borrowed(
@@ -23213,7 +16389,7 @@ Module TypeId(993) => Tuple(
         },
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(171),
+                Module(0) TypeId(173),
             ),
             name: Some(
                 Borrowed(
@@ -23229,8 +16405,8 @@ Module TypeId(993) => Tuple(
 Module TypeId(994) => sync Function "useActionState" {
   accepts: {
     params: [
-      required action: Module(0) TypeId(261) (bindings: action:Module(0) TypeId(261))
-      required initialState: Module(0) TypeId(258) (bindings: initialState:Module(0) TypeId(258))
+      required action: Module(0) TypeId(263) (bindings: action:Module(0) TypeId(263))
+      required initialState: Module(0) TypeId(260) (bindings: initialState:Module(0) TypeId(260))
       optional permalink: string (bindings: permalink:string)
     ]
     type_args: [Module(0) TypeId(977)]
@@ -23243,18 +16419,18 @@ Module TypeId(995) => Payload
 Module TypeId(996) => sync Function {
   accepts: {
     params: [
-      required payload: Module(0) TypeId(266) (bindings: payload:Module(0) TypeId(266))
+      required payload: Module(0) TypeId(269) (bindings: payload:Module(0) TypeId(269))
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(997) => Tuple(
     [
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(265),
+                Module(0) TypeId(268),
             ),
             name: Some(
                 Borrowed(
@@ -23278,7 +16454,7 @@ Module TypeId(997) => Tuple(
         },
         TupleElementType {
             ty: Resolved(
-                Module(0) TypeId(171),
+                Module(0) TypeId(173),
             ),
             name: Some(
                 Borrowed(
@@ -23294,8 +16470,8 @@ Module TypeId(997) => Tuple(
 Module TypeId(998) => sync Function "useActionState" {
   accepts: {
     params: [
-      required action: Module(0) TypeId(269) (bindings: action:Module(0) TypeId(269))
-      required initialState: Module(0) TypeId(265) (bindings: initialState:Module(0) TypeId(265))
+      required action: Module(0) TypeId(272) (bindings: action:Module(0) TypeId(272))
+      required initialState: Module(0) TypeId(268) (bindings: initialState:Module(0) TypeId(268))
       optional permalink: string (bindings: permalink:string)
     ]
     type_args: [Module(0) TypeId(977), Module(0) TypeId(995)]
@@ -23342,7 +16518,7 @@ Module TypeId(1009) => sync Function "preventDefault" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(1010) => sync Function "isDefaultPrevented" {
@@ -23350,7 +16526,7 @@ Module TypeId(1010) => sync Function "isDefaultPrevented" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(1011) => sync Function "stopPropagation" {
@@ -23358,7 +16534,7 @@ Module TypeId(1011) => sync Function "stopPropagation" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(1012) => sync Function "isPropagationStopped" {
@@ -23366,7 +16542,7 @@ Module TypeId(1012) => sync Function "isPropagationStopped" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(1013) => sync Function "persist" {
@@ -23374,7 +16550,7 @@ Module TypeId(1013) => sync Function "persist" {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(98)
+  returns: Module(0) TypeId(99)
 }
 
 Module TypeId(1014) => interface "BaseSyntheticEvent" {
@@ -23388,11 +16564,11 @@ Module TypeId(1014) => interface "BaseSyntheticEvent" {
     "nativeEvent": Module(0) TypeId(1006),
     "currentTarget": Module(0) TypeId(1007),
     "target": Module(0) TypeId(1008),
-    "bubbles": Module(0) TypeId(171),
-    "cancelable": Module(0) TypeId(171),
-    "defaultPrevented": Module(0) TypeId(171),
+    "bubbles": Module(0) TypeId(173),
+    "cancelable": Module(0) TypeId(173),
+    "defaultPrevented": Module(0) TypeId(173),
     "eventPhase": number,
-    "isTrusted": Module(0) TypeId(171),
+    "isTrusted": Module(0) TypeId(173),
     "preventDefault": Module(0) TypeId(1009),
     "isDefaultPrevented": Module(0) TypeId(1010),
     "stopPropagation": Module(0) TypeId(1011),
@@ -23519,7 +16695,7 @@ Module TypeId(1054) => interface "PointerEvent" {
     "width": number,
     "height": number,
     "pointerType": Module(0) TypeId(1053),
-    "isPrimary": Module(0) TypeId(171)
+    "isPrimary": Module(0) TypeId(173)
   ]
 }
 
@@ -23689,25 +16865,25 @@ Module TypeId(1107) => sync Function "getModifierState" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(1108) => interface "KeyboardEvent" {
   extends: [Module(0) TypeId(1105)]
   type_args: [Module(0) TypeId(1102)]
   members: [
-    "altKey": Module(0) TypeId(171),
+    "altKey": Module(0) TypeId(173),
     "charCode": number,
-    "ctrlKey": Module(0) TypeId(171),
+    "ctrlKey": Module(0) TypeId(173),
     "code": string,
     "getModifierState": Module(0) TypeId(1107),
     "key": string,
     "keyCode": number,
     "locale": string,
     "location": number,
-    "metaKey": Module(0) TypeId(171),
-    "repeat": Module(0) TypeId(171),
-    "shiftKey": Module(0) TypeId(171),
+    "metaKey": Module(0) TypeId(173),
+    "repeat": Module(0) TypeId(173),
+    "shiftKey": Module(0) TypeId(173),
     "which": number
   ]
 }
@@ -23735,7 +16911,7 @@ Module TypeId(1117) => sync Function "getModifierState" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(1118) => instanceof unresolved reference "EventTarget" (scope ID: 269)
@@ -23746,14 +16922,14 @@ Module TypeId(1120) => interface "MouseEvent" {
   extends: [Module(0) TypeId(1115)]
   type_args: [Module(0) TypeId(1110), Module(0) TypeId(1112)]
   members: [
-    "altKey": Module(0) TypeId(171),
+    "altKey": Module(0) TypeId(173),
     "button": number,
     "buttons": number,
     "clientX": number,
     "clientY": number,
-    "ctrlKey": Module(0) TypeId(171),
+    "ctrlKey": Module(0) TypeId(173),
     "getModifierState": Module(0) TypeId(1117),
-    "metaKey": Module(0) TypeId(171),
+    "metaKey": Module(0) TypeId(173),
     "movementX": number,
     "movementY": number,
     "pageX": number,
@@ -23761,7 +16937,7 @@ Module TypeId(1120) => interface "MouseEvent" {
     "relatedTarget": Module(0) TypeId(1119),
     "screenX": number,
     "screenY": number,
-    "shiftKey": Module(0) TypeId(171)
+    "shiftKey": Module(0) TypeId(173)
   ]
 }
 
@@ -23786,19 +16962,19 @@ Module TypeId(1128) => sync Function "getModifierState" {
     ]
     type_args: []
   }
-  returns: Module(0) TypeId(171)
+  returns: Module(0) TypeId(173)
 }
 
 Module TypeId(1129) => interface "TouchEvent" {
   extends: [Module(0) TypeId(1125)]
   type_args: [Module(0) TypeId(1122)]
   members: [
-    "altKey": Module(0) TypeId(171),
+    "altKey": Module(0) TypeId(173),
     "changedTouches": Module(0) TypeId(1126),
-    "ctrlKey": Module(0) TypeId(171),
+    "ctrlKey": Module(0) TypeId(173),
     "getModifierState": Module(0) TypeId(1128),
-    "metaKey": Module(0) TypeId(171),
-    "shiftKey": Module(0) TypeId(171),
+    "metaKey": Module(0) TypeId(173),
+    "shiftKey": Module(0) TypeId(173),
     "targetTouches": Module(0) TypeId(1126),
     "touches": Module(0) TypeId(1126)
   ]
@@ -24495,7 +17671,7 @@ Module TypeId(1352) => Module(0) TypeId(1351) | undefined
 
 Module TypeId(1353) => value: mixed
 
-Module TypeId(1354) => Module(0) TypeId(171) | Module(0) TypeId(335) | Module(0) TypeId(1353) | Module(0) TypeId(334) | Module(0) TypeId(85)
+Module TypeId(1354) => Module(0) TypeId(173) | Module(0) TypeId(335) | Module(0) TypeId(1353) | Module(0) TypeId(334) | Module(0) TypeId(85)
 
 Module TypeId(1355) => Module(0) TypeId(1354) | undefined
 
@@ -24513,7 +17689,7 @@ Module TypeId(1361) => value: date
 
 Module TypeId(1362) => value: time
 
-Module TypeId(1363) => Module(0) TypeId(171) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1358) | Module(0) TypeId(1359) | Module(0) TypeId(1360) | Module(0) TypeId(1361) | Module(0) TypeId(1362) | Module(0) TypeId(85)
+Module TypeId(1363) => Module(0) TypeId(173) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1358) | Module(0) TypeId(1359) | Module(0) TypeId(1360) | Module(0) TypeId(1361) | Module(0) TypeId(1362) | Module(0) TypeId(85)
 
 Module TypeId(1364) => Module(0) TypeId(1363) | undefined
 
@@ -24541,7 +17717,7 @@ Module TypeId(1375) => value: grid
 
 Module TypeId(1376) => value: dialog
 
-Module TypeId(1377) => Module(0) TypeId(171) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1372) | Module(0) TypeId(1373) | Module(0) TypeId(1374) | Module(0) TypeId(1375) | Module(0) TypeId(1376) | Module(0) TypeId(85)
+Module TypeId(1377) => Module(0) TypeId(173) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1372) | Module(0) TypeId(1373) | Module(0) TypeId(1374) | Module(0) TypeId(1375) | Module(0) TypeId(1376) | Module(0) TypeId(85)
 
 Module TypeId(1378) => Module(0) TypeId(1377) | undefined
 
@@ -24549,7 +17725,7 @@ Module TypeId(1379) => value: grammar
 
 Module TypeId(1380) => value: spelling
 
-Module TypeId(1381) => Module(0) TypeId(171) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1379) | Module(0) TypeId(1380) | Module(0) TypeId(85)
+Module TypeId(1381) => Module(0) TypeId(173) | Module(0) TypeId(335) | Module(0) TypeId(334) | Module(0) TypeId(1379) | Module(0) TypeId(1380) | Module(0) TypeId(85)
 
 Module TypeId(1382) => Module(0) TypeId(1381) | undefined
 
@@ -24806,7 +17982,7 @@ Module TypeId(1474) => instanceof Module(0) TypeId(287)
 
 Module TypeId(1475) => instanceof Module(0) TypeId(1340)
 
-Module TypeId(1476) => Module(0) TypeId(171) | Module(0) TypeId(85)
+Module TypeId(1476) => Module(0) TypeId(173) | Module(0) TypeId(85)
 
 Module TypeId(1477) => Module(0) TypeId(1476) | undefined
 
@@ -24995,9 +18171,9 @@ Module TypeId(1534) => instanceof Module(0) TypeId(1531)
 
 Module TypeId(1535) => instanceof unresolved reference "FormData" (scope ID: 307)
 
-Module TypeId(1536) => instanceof Promise<Module(0) TypeId(98)>
+Module TypeId(1536) => instanceof Promise<Module(0) TypeId(99)>
 
-Module TypeId(1537) => Module(0) TypeId(98) | Module(0) TypeId(1536)
+Module TypeId(1537) => Module(0) TypeId(99) | Module(0) TypeId(1536)
 
 Module TypeId(1538) => sync Function {
   accepts: {
@@ -25017,7 +18193,7 @@ Module TypeId(1541) => value: user
 
 Module TypeId(1542) => value: environment
 
-Module TypeId(1543) => Module(0) TypeId(171) | Module(0) TypeId(1541) | Module(0) TypeId(1542) | Module(0) TypeId(85)
+Module TypeId(1543) => Module(0) TypeId(173) | Module(0) TypeId(1541) | Module(0) TypeId(1542) | Module(0) TypeId(85)
 
 Module TypeId(1544) => Module(0) TypeId(1543) | undefined
 
@@ -25272,9 +18448,9 @@ Module TypeId(1593) => instanceof Module(0) TypeId(1531)
 
 Module TypeId(1594) => instanceof unresolved reference "FormData" (scope ID: 317)
 
-Module TypeId(1595) => instanceof Promise<Module(0) TypeId(98)>
+Module TypeId(1595) => instanceof Promise<Module(0) TypeId(99)>
 
-Module TypeId(1596) => Module(0) TypeId(98) | Module(0) TypeId(1595)
+Module TypeId(1596) => Module(0) TypeId(99) | Module(0) TypeId(1595)
 
 Module TypeId(1597) => sync Function {
   accepts: {
@@ -25456,9 +18632,9 @@ Module TypeId(1644) => instanceof Module(0) TypeId(1531)
 
 Module TypeId(1645) => instanceof unresolved reference "FormData" (scope ID: 328)
 
-Module TypeId(1646) => instanceof Promise<Module(0) TypeId(98)>
+Module TypeId(1646) => instanceof Promise<Module(0) TypeId(99)>
 
-Module TypeId(1647) => Module(0) TypeId(98) | Module(0) TypeId(1646)
+Module TypeId(1647) => Module(0) TypeId(99) | Module(0) TypeId(1646)
 
 Module TypeId(1648) => sync Function {
   accepts: {
@@ -25621,7 +18797,7 @@ Module TypeId(1691) => value: image
 
 Module TypeId(1692) => value: month
 
-Module TypeId(1693) => value: number
+Module TypeId(1693) => "number"
 
 Module TypeId(1694) => value: password
 
@@ -25785,9 +18961,9 @@ Module TypeId(1772) => Module(0) TypeId(1771) | undefined
 
 Module TypeId(1773) => instanceof unresolved reference "FormData" (scope ID: 348)
 
-Module TypeId(1774) => instanceof Promise<Module(0) TypeId(98)>
+Module TypeId(1774) => instanceof Promise<Module(0) TypeId(99)>
 
-Module TypeId(1775) => Module(0) TypeId(98) | Module(0) TypeId(1774)
+Module TypeId(1775) => Module(0) TypeId(99) | Module(0) TypeId(1774)
 
 Module TypeId(1776) => sync Function {
   accepts: {
@@ -27039,7 +20215,7 @@ Module TypeId(2073) => value: nav
 
 Module TypeId(2074) => value: noscript
 
-Module TypeId(2075) => value: object
+Module TypeId(2075) => "object"
 
 Module TypeId(2076) => value: ol
 
@@ -27221,7 +20397,7 @@ Module TypeId(2164) => value: stop
 
 Module TypeId(2165) => value: svg
 
-Module TypeId(2166) => value: symbol
+Module TypeId(2166) => "symbol"
 
 Module TypeId(2167) => value: textPath
 
@@ -28363,9 +21539,9 @@ Module TypeId(2521) => instanceof Promise<Module(0) TypeId(183)>
 
 Module TypeId(2522) => instanceof Promise<Module(0) TypeId(235)>
 
-Module TypeId(2523) => instanceof Promise<Module(0) TypeId(257)>
+Module TypeId(2523) => instanceof Promise<Module(0) TypeId(259)>
 
-Module TypeId(2524) => instanceof Promise<Module(0) TypeId(264)>
+Module TypeId(2524) => instanceof Promise<Module(0) TypeId(267)>
 
 Module TypeId(2525) => instanceof Array<Module(0) TypeId(289)>
 
@@ -28413,7 +21589,7 @@ Module TypeId(2546) => instanceof Promise<Module(0) TypeId(959)>
 
 Module TypeId(2547) => instanceof Array<string>
 
-Module TypeId(2548) => instanceof Promise<Module(0) TypeId(98)>
+Module TypeId(2548) => instanceof Promise<Module(0) TypeId(99)>
 ```
 
 # Scoped Type Resolver
@@ -28421,63 +21597,39 @@ Module TypeId(2548) => instanceof Promise<Module(0) TypeId(98)>
 ## Registered types
 
 ```
-Scope TypeId(0) => instanceof Promise
+Full TypeId(0) => Module(1) TypeId(956)
 
-Scope TypeId(1) => async Function {
+Full TypeId(1) => instanceof Promise
+
+Full TypeId(2) => async Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(1)
 }
 
-Scope TypeId(2) => async Function {
+Full TypeId(3) => async Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(0)
+  returns: Module(0) TypeId(1)
 }
 
-Scope TypeId(3) => sync Function "useCallback" {
-  accepts: {
-    params: [
-      required callback: Module(1) TypeId(222) (bindings: callback:Module(1) TypeId(222))
-      required deps: Module(1) TypeId(223) (bindings: deps:Module(1) TypeId(223))
-    ]
-    type_args: [Module(1) TypeId(955)]
-  }
-  returns: Module(1) TypeId(222)
-}
+Full TypeId(4) => Module(0) TypeId(3)
 
-Scope TypeId(4) => async Function {
+Full TypeId(5) => instanceof Promise
+
+Full TypeId(6) => Module(1) TypeId(956)
+
+Full TypeId(7) => async Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(4)
+  returns: Module(0) TypeId(1)
 }
 
-Scope TypeId(5) => instanceof Promise
-
-Scope TypeId(6) => async Function {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(0)
-}
-
-Scope TypeId(7) => sync Function "useCallback" {
-  accepts: {
-    params: [
-      required callback: Module(1) TypeId(222) (bindings: callback:Module(1) TypeId(222))
-      required deps: Module(1) TypeId(223) (bindings: deps:Module(1) TypeId(223))
-    ]
-    type_args: [Module(1) TypeId(955)]
-  }
-  returns: Module(1) TypeId(222)
-}
-
-Scope TypeId(8) => instanceof Promise
+Full TypeId(8) => instanceof Promise
 ```

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -14,7 +14,7 @@ use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_value::{JsonObject, JsonString};
 use biome_module_graph::JsExport;
 use biome_module_graph::{
-    ImportSymbol, JsImport, JsReexport, ModuleGraph, ResolvedPath, ScopedResolver,
+    ImportSymbol, JsImport, JsReexport, ModuleGraph, ModuleResolver, ResolvedPath,
 };
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
@@ -589,7 +589,7 @@ export const promise = makePromiseCb();
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let resolved_id = resolver
@@ -658,7 +658,7 @@ fn test_resolve_generic_return_value_with_multiple_modules() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let result_id = resolver
@@ -714,7 +714,7 @@ fn test_resolve_nested_function_call_with_namespace_in_return_type() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let result_id = resolver
@@ -1100,7 +1100,7 @@ fn test_resolve_react_types() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let use_callback_id = resolver
@@ -1207,7 +1207,7 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let resolved_id = resolver
@@ -1280,7 +1280,7 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ScopedResolver::from_global_scope(index_module, module_graph.clone());
+    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
     resolver.run_inference();
 
     let resolved_id = resolver

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -649,8 +649,7 @@ fn debug_type_info(
             // TODO: print correct type info
             Some(module_info) => {
                 let mut result = String::new();
-                let types = module_info.as_resolver().registered_types();
-                for ty in types {
+                for ty in module_info.types() {
                     result.push_str(format!("{ty}\n").as_str());
                 }
                 Ok(result)

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -9,7 +9,7 @@ use biome_diagnostics::termcolor::Buffer;
 use biome_diagnostics::{DiagnosticExt, Error, PrintDiagnostic};
 use biome_fs::{BiomePath, FileSystem, OsFileSystem};
 use biome_js_parser::{AnyJsRoot, JsFileSource, JsParserOptions};
-use biome_js_type_info::TypeResolver;
+use biome_js_type_info::{TypeData, TypeResolver};
 use biome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use biome_module_graph::ModuleGraph;
 use biome_package::PackageJson;
@@ -307,6 +307,21 @@ pub fn dump_registered_types(content: &mut String, resolver: &dyn TypeResolver) 
         content.push_str(&registered_types);
         content.push_str("```\n");
     }
+}
+
+pub fn dump_registered_module_types(content: &mut String, types: &[TypeData]) {
+    if types.is_empty() {
+        return;
+    }
+
+    content.push_str("## Registered types\n\n");
+    content.push_str("```");
+
+    for (i, ty) in types.iter().enumerate() {
+        content.push_str(&format!("\nModule TypeId({i}) => {ty}\n"));
+    }
+
+    content.push_str("```\n");
 }
 
 // Check that all red / green nodes have correctly been released on exit


### PR DESCRIPTION
## Summary

This PR inverts how expressions get resolved. Previously, an expression such as `a + b` would get inferred in three steps:

1. Infer `a + b`, this registered both the entire expression as well as its sub expressions.
2. Infer `a`, gets deduplicated because `a` was already registered.
3. Infer `b`, gets deduplicated because `b` was already registered.

Now the order has become:

1. Infer `a` and register it.
2. Infer `b` and register it.
3. Infer `a + b`, looking up the previously registered types for `a` and `b`.

This approach is actually necessarily for some parts of `noMisusedPromises`, because it will rely on the identity of certain references.

In addition, some more deduplication is performed to prevent types getting deep-cloned. This introduces additional references, which made it a little tough to get right, but so far it appears to work out well. And hopefully it gives a nice performance boost, since you can see the React snapshot has become significantly smaller.

Note I have also renamed the `ScopedResolver` to `ModuleResolver` because the name had become misleading. The `TypeResolverLevel` variants have been updated as well: `Scope` is now `Full` and `Module` is now `Thin`, corresponding to the level of inference performed by the resolvers. Some other simplifications have been done as well, most importantly that `JsModuleInfoInner` no longer implements `TypeResolver`.

## Test Plan

Snapshots updated.
