### PR TITLE
feat(linter): detect `Promise`-returning callbacks in `noMisusedPromises`

### DIFF
--- a/.changeset/muddy-mules-meander.md
+++ b/.changeset/muddy-mules-meander.md
@@ -16,6 +16,12 @@ if (promise) { /* ... */ }
 
 // Spreading a `Promise` has no effect:
 console.log({ foo: 42, ...promise });
+
+// This does not `await` the `Promise`s from the callbacks,
+// so it does not behave as you may expect:
+[1, 2, 3].forEach(async value => {
+  await fetch(`/${value}`);
+});
 ```
 
 ## Valid examples

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -262,6 +262,7 @@ fn find_misused_promise_returning_callback(
     let argument_ty = if let Some(call_expression) = argument_list
         .syntax()
         .ancestors()
+        .skip(1)
         .find_map(JsCallExpression::cast)
     {
         let callee_ty = ctx.type_of_expression(&call_expression.callee().ok()?);
@@ -270,6 +271,7 @@ fn find_misused_promise_returning_callback(
     } else if let Some(new_expression) = argument_list
         .syntax()
         .ancestors()
+        .skip(1)
         .find_map(JsNewExpression::cast)
     {
         let callee_ty = ctx.type_of_expression(&new_expression.callee().ok()?);

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -3,8 +3,12 @@ use biome_analyze::{
 };
 use biome_console::markup;
 use biome_js_factory::make;
-use biome_js_syntax::{AnyJsExpression, JsSyntaxKind};
-use biome_rowan::{AstNode, BatchMutationExt, TriviaPieceKind};
+use biome_js_syntax::{
+    AnyJsCallArgument, AnyJsExpression, JsCallArgumentList, JsCallExpression, JsNewExpression,
+    JsSyntaxKind,
+};
+use biome_js_type_info::{Type, TypeMemberKind};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TriviaPieceKind};
 
 use crate::{JsRuleAction, ast_utils::is_in_async_function, services::typed::Typed};
 
@@ -26,27 +30,36 @@ declare_lint_rule! {
     ///
     /// ```js
     /// const promise = Promise.resolve('value');
-    /// if (promise) { /* Do something */ }
+    /// if (promise) { /* This branch will always execute */ }
     /// ```
     ///
     /// ```js
     /// const promise = Promise.resolve('value');
-    /// const val = promise ? 123 : 456;
+    /// const val = promise ? 123 : 456; // Always evaluates to `123`.
     /// ```
     ///
     /// ```js
+    /// // The following filter has no effect:
     /// const promise = Promise.resolve('value');
     /// [1, 2, 3].filter(() => promise);
     /// ```
     ///
     /// ```js
     /// const promise = Promise.resolve('value');
-    /// while (promise) { /* Do something */ }
+    /// while (promise) { /* This is an endless loop */ }
     /// ```
     ///
     /// ```js
+    /// // Using a `Promise` as an iterable expands to nothing:
     /// const getData = () => fetch('/');
     /// console.log({ foo: 42, ...getData() });
+    /// ```
+    ///
+    /// ```js
+    /// // These `fetch`-es are not `await`-ed in order:
+    /// [1, 2, 3].forEach(async value => {
+    ///     await fetch(`/${value}`);
+    /// });
     /// ```
     ///
     /// ### Valid
@@ -61,6 +74,11 @@ declare_lint_rule! {
     ///
     /// const getData = () => fetch('/');
     /// console.log({ foo: 42, ...(await getData()) });
+    ///
+    /// // for-of puts `await` in outer context:
+    /// for (const value of [1, 2, 3]) {
+    ///     await doSomething(value);
+    /// }
     /// ```
     ///
     pub NoMisusedPromises {
@@ -76,6 +94,8 @@ declare_lint_rule! {
 
 pub enum NoMisusedPromisesState {
     Conditional,
+    ExpectedConditionalReturn,
+    ExpectedVoidReturn,
     Spread,
 }
 
@@ -87,26 +107,12 @@ impl Rule for NoMisusedPromises {
 
     fn run(ctx: &RuleContext<Self>) -> Self::Signals {
         let expression = ctx.query();
-
-        let parent = expression.syntax().parent()?;
-        let state = match parent.kind() {
-            JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => NoMisusedPromisesState::Conditional,
-            JsSyntaxKind::JS_DO_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
-            JsSyntaxKind::JS_IF_STATEMENT => NoMisusedPromisesState::Conditional,
-            JsSyntaxKind::JS_SPREAD => NoMisusedPromisesState::Spread,
-            JsSyntaxKind::JS_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
-            _ => return None,
-        };
-
         let ty = ctx.type_of_expression(expression);
-
-        // Uncomment the following line for debugging convenience:
-        //let printed = format!("type of {expression:?} = {ty:?}");
-        let should_signal = ty.is_promise_instance()
-            || matches!(state, NoMisusedPromisesState::Spread)
-                && ty.has_variant(|ty| ty.is_promise_instance());
-
-        should_signal.then_some(state)
+        if ty.is_function() {
+            find_misused_promise_returning_callback(ctx, expression, &ty)
+        } else {
+            find_misused_promise_expression(expression, &ty)
+        }
     }
 
     fn diagnostic(ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
@@ -127,6 +133,37 @@ impl Rule for NoMisusedPromises {
                     "You may have intended to `await` the Promise instead."
                 }),
             ),
+            NoMisusedPromisesState::ExpectedConditionalReturn => Some(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    node.range(),
+                    markup! {
+                        "This function returns a Promise where a conditional "
+                        "was expected."
+                    },
+                )
+                .note(markup! {
+                    "A Promise is always truthy, so this is most likely a mistake."
+                })
+                .note(markup! {
+                    "You may have intended to `await` the Promise, but this "
+                    "does not work inside a synchronous callback."
+                }),
+            ),
+            NoMisusedPromisesState::ExpectedVoidReturn => Some(
+                RuleDiagnostic::new(
+                    rule_category!(),
+                    node.range(),
+                    markup! {
+                        "This function returns a Promise, but no return value "
+                        "was expected."
+                    },
+                )
+                .note(markup! {
+                    "This may not have the desired result if you expect the "
+                    "Promise to be `await`-ed."
+                }),
+            ),
             NoMisusedPromisesState::Spread => Some(
                 RuleDiagnostic::new(
                     rule_category!(),
@@ -143,7 +180,12 @@ impl Rule for NoMisusedPromises {
         }
     }
 
-    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsRuleAction> {
+    fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
+        use NoMisusedPromisesState::*;
+        if matches!(state, ExpectedConditionalReturn | ExpectedVoidReturn) {
+            return None; // These cannot be automatically fixed.
+        }
+
         let expression = ctx.query();
 
         if !is_in_async_function(expression.syntax()) {
@@ -164,5 +206,90 @@ impl Rule for NoMisusedPromises {
             markup! { "Add await operator." }.to_owned(),
             mutation,
         ))
+    }
+}
+
+fn find_misused_promise_expression(
+    expression: &AnyJsExpression,
+    ty: &Type,
+) -> Option<NoMisusedPromisesState> {
+    let parent = expression.syntax().parent()?;
+    let state = match parent.kind() {
+        JsSyntaxKind::JS_CONDITIONAL_EXPRESSION => NoMisusedPromisesState::Conditional,
+        JsSyntaxKind::JS_DO_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
+        JsSyntaxKind::JS_IF_STATEMENT => NoMisusedPromisesState::Conditional,
+        JsSyntaxKind::JS_SPREAD => NoMisusedPromisesState::Spread,
+        JsSyntaxKind::JS_WHILE_STATEMENT => NoMisusedPromisesState::Conditional,
+        _ => return None,
+    };
+
+    // Uncomment the following line for debugging convenience:
+    //let printed = format!("type of {expression:?} = {ty:?}");
+    let is_promise = ty.is_promise_instance();
+    let is_maybe_promise = ty.has_variant(|ty| ty.is_promise_instance());
+    let should_signal =
+        // "maybe" promises could still be considered conditionals, so we
+        // don't signal those for the conditional variants
+        is_promise || (!matches!(state, NoMisusedPromisesState::Conditional) && is_maybe_promise);
+    should_signal.then_some(state)
+}
+
+fn find_misused_promise_returning_callback(
+    ctx: &RuleContext<NoMisusedPromises>,
+    expression: &AnyJsExpression,
+    ty: &Type,
+) -> Option<NoMisusedPromisesState> {
+    let callback = ty.as_function()?;
+
+    let return_ty = callback.return_type.as_type()?;
+    let return_ty = ty.resolve(return_ty)?;
+
+    let should_signal =
+        return_ty.is_promise_instance() || return_ty.has_variant(|ty| ty.is_promise_instance());
+    if !should_signal {
+        return None;
+    }
+
+    let argument = expression
+        .syntax()
+        .ancestors()
+        .find_map(AnyJsCallArgument::cast)?;
+    let argument_list = argument.parent::<JsCallArgumentList>()?;
+    let argument_index = argument_list
+        .iter()
+        .position(|arg| arg.is_ok_and(|arg| arg == argument))?;
+
+    let argument_ty = if let Some(call_expression) = argument_list
+        .syntax()
+        .ancestors()
+        .find_map(JsCallExpression::cast)
+    {
+        let callee_ty = ctx.type_of_expression(&call_expression.callee().ok()?);
+        let function = callee_ty.as_function()?;
+        callee_ty.resolve(&function.parameters.get(argument_index)?.ty)?
+    } else if let Some(new_expression) = argument_list
+        .syntax()
+        .ancestors()
+        .find_map(JsNewExpression::cast)
+    {
+        let callee_ty = ctx.type_of_expression(&new_expression.callee().ok()?);
+        let class = callee_ty.as_class()?;
+        let constructor = class
+            .members
+            .iter()
+            .find(|member| member.kind == TypeMemberKind::Constructor)?;
+        let constructor_ty = callee_ty.resolve(&constructor.ty)?;
+        let constructor = constructor_ty.as_function()?;
+        constructor_ty.resolve(&constructor.parameters.get(argument_index)?.ty)?
+    } else {
+        return None;
+    };
+
+    if argument_ty.is_function_with_return_type(|ty| ty.is_conditional()) {
+        Some(NoMisusedPromisesState::ExpectedConditionalReturn)
+    } else if argument_ty.is_function_with_return_type(|ty| ty.is_void()) {
+        Some(NoMisusedPromisesState::ExpectedVoidReturn)
+    } else {
+        None
     }
 }

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -2,8 +2,11 @@ use biome_analyze::{
     AddVisitor, FromServices, Phase, Phases, QueryKey, QueryMatch, Queryable, RuleDomain, RuleKey,
     RuleMetadata, ServiceBag, ServicesDiagnostic, SyntaxVisitor,
 };
-use biome_js_syntax::{AnyJsExpression, AnyJsRoot, JsLanguage, JsSyntaxNode};
-use biome_js_type_info::Type;
+use biome_js_syntax::{
+    AnyFunctionLike, AnyJsBinding, AnyJsClass, AnyJsClassMemberName, AnyJsExpression,
+    AnyJsFunction, AnyJsObjectMemberName, AnyJsRoot, JsLanguage, JsObjectExpression, JsSyntaxNode,
+};
+use biome_js_type_info::{Type, TypeData};
 use biome_module_graph::ModuleResolver;
 use biome_rowan::{AstNode, TextRange};
 use std::sync::Arc;
@@ -15,11 +18,109 @@ pub struct TypedService {
 }
 
 impl TypedService {
+    pub fn module_0_types(&self) -> &[TypeData] {
+        const EMPTY: &[TypeData] = &[];
+        self.resolver
+            .as_ref()
+            .map_or(EMPTY, |resolver| resolver.modules[0].types())
+    }
+
     pub fn type_of_expression(&self, expr: &AnyJsExpression) -> Type {
         self.resolver
             .as_ref()
             .map(|resolver| resolver.resolved_type_of_expression(expr))
             .unwrap_or_default()
+    }
+
+    pub fn type_of_function(&self, function: &AnyJsFunction) -> Type {
+        match function {
+            AnyJsFunction::JsArrowFunctionExpression(expr) => {
+                self.type_of_expression(&AnyJsExpression::JsArrowFunctionExpression(expr.clone()))
+            }
+            AnyJsFunction::JsFunctionDeclaration(decl) => decl
+                .id()
+                .ok()
+                .as_ref()
+                .and_then(AnyJsBinding::as_js_identifier_binding)
+                .and_then(|identifier| identifier.name_token().ok())
+                .and_then(|name| {
+                    self.resolver.as_ref().map(|resolver| {
+                        resolver.resolved_type_of_named_value(function.range(), name.text())
+                    })
+                })
+                .unwrap_or_default(),
+            AnyJsFunction::JsFunctionExportDefaultDeclaration(_decl) => self
+                .resolver
+                .as_ref()
+                .and_then(|resolver| resolver.resolved_type_of_default_export())
+                .unwrap_or_default(),
+            AnyJsFunction::JsFunctionExpression(expr) => {
+                self.type_of_expression(&AnyJsExpression::JsFunctionExpression(expr.clone()))
+            }
+        }
+    }
+
+    pub fn type_of_function_like(&self, function: &AnyFunctionLike) -> Option<Type> {
+        match function {
+            AnyFunctionLike::AnyJsFunction(function) => Some(self.type_of_function(function)),
+            AnyFunctionLike::JsMethodObjectMember(member) => {
+                let name = member
+                    .name()
+                    .ok()
+                    .as_ref()
+                    .and_then(AnyJsObjectMemberName::as_js_literal_member_name)
+                    .and_then(|name| name.value().ok())?;
+                let name = name.text_trimmed();
+
+                let object = member
+                    .syntax()
+                    .ancestors()
+                    .find_map(JsObjectExpression::cast)?;
+
+                let object_ty =
+                    self.type_of_expression(&AnyJsExpression::JsObjectExpression(object));
+                let member = object_ty
+                    .own_members()
+                    .find(|member| member.has_name(name))?;
+                self.resolver
+                    .as_ref()
+                    .map(|resolver| resolver.resolved_type_for_reference(&member.ty))
+            }
+            AnyFunctionLike::JsMethodClassMember(member) => {
+                let name = member
+                    .name()
+                    .ok()
+                    .as_ref()
+                    .and_then(AnyJsClassMemberName::as_js_literal_member_name)
+                    .and_then(|name| name.value().ok())?;
+                let name = name.text_trimmed();
+
+                let class = member.syntax().ancestors().find_map(AnyJsClass::cast)?;
+
+                let class_ty = match class {
+                    AnyJsClass::JsClassDeclaration(decl) => {
+                        let binding = decl.id().ok()?;
+                        let name = binding.as_js_identifier_binding()?.name_token().ok()?;
+                        self.resolver.as_ref().map(|resolver| {
+                            resolver.resolved_type_of_named_value(function.range(), name.text())
+                        })?
+                    }
+                    AnyJsClass::JsClassExportDefaultDeclaration(_decl) => self
+                        .resolver
+                        .as_ref()
+                        .and_then(|resolver| resolver.resolved_type_of_default_export())?,
+                    AnyJsClass::JsClassExpression(expr) => {
+                        self.type_of_expression(&AnyJsExpression::JsClassExpression(expr))
+                    }
+                };
+                let member = class_ty
+                    .own_members()
+                    .find(|member| member.has_name(name))?;
+                self.resolver
+                    .as_ref()
+                    .map(|resolver| resolver.resolved_type_for_reference(&member.ty))
+            }
+        }
     }
 }
 

--- a/crates/biome_js_analyze/src/services/typed.rs
+++ b/crates/biome_js_analyze/src/services/typed.rs
@@ -6,7 +6,7 @@ use biome_js_syntax::{
     AnyFunctionLike, AnyJsBinding, AnyJsClass, AnyJsClassMemberName, AnyJsExpression,
     AnyJsFunction, AnyJsObjectMemberName, AnyJsRoot, JsLanguage, JsObjectExpression, JsSyntaxNode,
 };
-use biome_js_type_info::{Type, TypeData};
+use biome_js_type_info::Type;
 use biome_module_graph::ModuleResolver;
 use biome_rowan::{AstNode, TextRange};
 use std::sync::Arc;
@@ -18,13 +18,6 @@ pub struct TypedService {
 }
 
 impl TypedService {
-    pub fn module_0_types(&self) -> &[TypeData] {
-        const EMPTY: &[TypeData] = &[];
-        self.resolver
-            .as_ref()
-            .map_or(EMPTY, |resolver| resolver.modules[0].types())
-    }
-
     pub fn type_of_expression(&self, expr: &AnyJsExpression) -> Type {
         self.resolver
             .as_ref()
@@ -75,6 +68,7 @@ impl TypedService {
                 let object = member
                     .syntax()
                     .ancestors()
+                    .skip(1)
                     .find_map(JsObjectExpression::cast)?;
 
                 let object_ty =
@@ -95,7 +89,11 @@ impl TypedService {
                     .and_then(|name| name.value().ok())?;
                 let name = name.text_trimmed();
 
-                let class = member.syntax().ancestors().find_map(AnyJsClass::cast)?;
+                let class = member
+                    .syntax()
+                    .ancestors()
+                    .skip(1)
+                    .find_map(AnyJsClass::cast)?;
 
                 let class_ty = match class {
                     AnyJsClass::JsClassDeclaration(decl) => {

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -26,11 +26,9 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"const promiseWithParentheses = new Promise((resolve, reject) =>
-	resolve("value")
-);
-promiseWithParentheses;
-"#;
+    const SOURCE: &str = r#"[1, 2, 3].forEach(async value => {
+  await fetch(`/${value}`);
+});"#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
@@ -41,7 +39,7 @@ promiseWithParentheses;
 
     let mut error_ranges: Vec<TextRange> = Vec::new();
     let options = AnalyzerOptions::default().with_file_path(file_path.clone());
-    let rule_filter = RuleFilter::Rule("nursery", "noFloatingPromises");
+    let rule_filter = RuleFilter::Rule("nursery", "noMisusedPromises");
 
     let mut dependencies = Dependencies::default();
     dependencies.add("buffer", "latest");

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsInvalid.ts
@@ -6,7 +6,6 @@ if (promise) {
 
 const val = promise ? 123 : 456;
 
-// FIXME: Not yet detected
 [1, 2, 3].filter(() => promise);
 
 while (promise) {

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsInvalid.ts.snap
@@ -12,7 +12,6 @@ if (promise) {
 
 const val = promise ? 123 : 456;
 
-// FIXME: Not yet detected
 [1, 2, 3].filter(() => promise);
 
 while (promise) {
@@ -51,7 +50,7 @@ checksConditionalsInvalid.ts:7:13 lint/nursery/noMisusedPromises ━━━━━
   > 7 │ const val = promise ? 123 : 456;
       │             ^^^^^^^
     8 │ 
-    9 │ // FIXME: Not yet detected
+    9 │ [1, 2, 3].filter(() => promise);
   
   i A Promise is always truthy, so this is most likely a mistake.
   
@@ -61,16 +60,35 @@ checksConditionalsInvalid.ts:7:13 lint/nursery/noMisusedPromises ━━━━━
 ```
 
 ```
-checksConditionalsInvalid.ts:12:8 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+checksConditionalsInvalid.ts:9:18 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise where a conditional was expected.
+  
+     7 │ const val = promise ? 123 : 456;
+     8 │ 
+   > 9 │ [1, 2, 3].filter(() => promise);
+       │                  ^^^^^^^^^^^^^
+    10 │ 
+    11 │ while (promise) {
+  
+  i A Promise is always truthy, so this is most likely a mistake.
+  
+  i You may have intended to `await` the Promise, but this does not work inside a synchronous callback.
+  
+
+```
+
+```
+checksConditionalsInvalid.ts:11:8 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A Promise was found where a conditional was expected.
   
-    10 │ [1, 2, 3].filter(() => promise);
-    11 │ 
-  > 12 │ while (promise) {
+     9 │ [1, 2, 3].filter(() => promise);
+    10 │ 
+  > 11 │ while (promise) {
        │        ^^^^^^^
-    13 │   // Do something
-    14 │ }
+    12 │   // Do something
+    13 │ }
   
   i A Promise is always truthy, so this is most likely a mistake.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksSpreadsInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksSpreadsInvalid.ts
@@ -1,6 +1,5 @@
 const getData = () => fetch('/');
 
-// FIXME: Not yet detected
 console.log({ foo: 42, ...getData() });
 
 const awaitData = async () => {

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksSpreadsInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksSpreadsInvalid.ts.snap
@@ -6,7 +6,6 @@ expression: checksSpreadsInvalid.ts
 ```ts
 const getData = () => fetch('/');
 
-// FIXME: Not yet detected
 console.log({ foo: 42, ...getData() });
 
 const awaitData = async () => {
@@ -19,15 +18,32 @@ console.log({ foo: 42, ...awaitData() });
 
 # Diagnostics
 ```
-checksSpreadsInvalid.ts:10:27 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+checksSpreadsInvalid.ts:3:27 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A Promise was found where an iterable was expected.
   
-     8 │ };
-     9 │ 
-  > 10 │ console.log({ foo: 42, ...awaitData() });
+    1 │ const getData = () => fetch('/');
+    2 │ 
+  > 3 │ console.log({ foo: 42, ...getData() });
+      │                           ^^^^^^^^^
+    4 │ 
+    5 │ const awaitData = async () => {
+  
+  i The spread syntax is used to expand an iterable, but a Promise needs to be `await`-ed to take its value.
+  
+
+```
+
+```
+checksSpreadsInvalid.ts:9:27 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A Promise was found where an iterable was expected.
+  
+     7 │ };
+     8 │ 
+   > 9 │ console.log({ foo: 42, ...awaitData() });
        │                           ^^^^^^^^^^^
-    11 │ 
+    10 │ 
   
   i The spread syntax is used to expand an iterable, but a Promise needs to be `await`-ed to take its value.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnInvalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnInvalid.ts
@@ -1,0 +1,8 @@
+[1, 2, 3].forEach(async value => {
+  await fetch(`/${value}`);
+});
+
+new Promise<void>(async (resolve, reject) => {
+  await fetch('/');
+  resolve();
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnInvalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnInvalid.ts.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: checksVoidReturnInvalid.ts
+---
+# Input
+```ts
+[1, 2, 3].forEach(async value => {
+  await fetch(`/${value}`);
+});
+
+new Promise<void>(async (resolve, reject) => {
+  await fetch('/');
+  resolve();
+});
+
+```
+
+# Diagnostics
+```
+checksVoidReturnInvalid.ts:1:19 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+  > 1 │ [1, 2, 3].forEach(async value => {
+      │                   ^^^^^^^^^^^^^^^^
+  > 2 │   await fetch(`/${value}`);
+  > 3 │ });
+      │ ^
+    4 │ 
+    5 │ new Promise<void>(async (resolve, reject) => {
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+
+```
+
+```
+checksVoidReturnInvalid.ts:5:19 lint/nursery/noMisusedPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This function returns a Promise, but no return value was expected.
+  
+    3 │ });
+    4 │ 
+  > 5 │ new Promise<void>(async (resolve, reject) => {
+      │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 6 │   await fetch('/');
+  > 7 │   resolve();
+  > 8 │ });
+      │ ^
+    9 │ 
+  
+  i This may not have the desired result if you expect the Promise to be `await`-ed.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnValid.ts
@@ -1,0 +1,22 @@
+/* should not generate diagnostics */
+
+// for-of puts `await` in outer context
+for (const value of [1, 2, 3]) {
+  await doSomething(value);
+}
+
+// If outer context is not `async`, handle error explicitly
+Promise.all(
+  [1, 2, 3].map(async value => {
+    await doSomething(value);
+  }),
+).catch(handleError);
+
+// Use an async IIFE wrapper
+new Promise((resolve, reject) => {
+  // combine with `void` keyword to tell `noFloatingPromises` rule to ignore unhandled rejection
+  void (async () => {
+    await doSomething();
+    resolve();
+  })();
+});

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksVoidReturnValid.ts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: checksVoidReturnValid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// for-of puts `await` in outer context
+for (const value of [1, 2, 3]) {
+  await doSomething(value);
+}
+
+// If outer context is not `async`, handle error explicitly
+Promise.all(
+  [1, 2, 3].map(async value => {
+    await doSomething(value);
+  }),
+).catch(handleError);
+
+// Use an async IIFE wrapper
+new Promise((resolve, reject) => {
+  // combine with `void` keyword to tell `noFloatingPromises` rule to ignore unhandled rejection
+  void (async () => {
+    await doSomething();
+    resolve();
+  })();
+});
+
+```

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -92,6 +92,7 @@ impl Format<FormatTypeContext> for TypeData {
             Self::String => write!(f, [text("string")]),
             Self::Symbol => write!(f, [text("symbol")]),
             Self::Undefined => write!(f, [text("undefined")]),
+            Self::Conditional => write!(f, [text("conditional")]),
             Self::Class(class) => write!(f, [&class.as_ref()]),
             Self::Constructor(ty) => write!(f, [FmtVerbatim(ty.as_ref())]),
             Self::Function(function) => write!(f, [&function.as_ref()]),

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -11,9 +11,9 @@ use biome_js_syntax::AnyJsExpression;
 use biome_rowan::Text;
 
 use crate::{
-    Class, Function, GenericTypeParameter, Literal, Resolvable, ResolvedTypeData, ResolvedTypeId,
-    ReturnType, ScopeId, TypeData, TypeId, TypeMember, TypeMemberKind, TypeReference,
-    TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
+    Class, Function, FunctionParameter, GenericTypeParameter, Literal, Resolvable,
+    ResolvedTypeData, ResolvedTypeId, ReturnType, ScopeId, TypeData, TypeId, TypeMember,
+    TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
 };
 
 const GLOBAL_LEVEL: TypeResolverLevel = TypeResolverLevel::Global;
@@ -34,42 +34,55 @@ pub static GLOBAL_TYPE_MEMBERS: LazyLock<Vec<TypeMember>> = LazyLock::new(|| {
 
 pub const UNKNOWN_ID: TypeId = TypeId::new(0);
 pub const UNDEFINED_ID: TypeId = TypeId::new(1);
-pub const ARRAY_ID: TypeId = TypeId::new(2);
-pub const GLOBAL_ID: TypeId = TypeId::new(3);
-pub const INSTANCEOF_PROMISE_ID: TypeId = TypeId::new(4);
-pub const NUMBER_ID: TypeId = TypeId::new(5);
-pub const PROMISE_ID: TypeId = TypeId::new(6);
-pub const PROMISE_CATCH_ID: TypeId = TypeId::new(7);
-pub const PROMISE_FINALLY_ID: TypeId = TypeId::new(8);
-pub const PROMISE_THEN_ID: TypeId = TypeId::new(9);
-pub const PROMISE_ALL_ID: TypeId = TypeId::new(10);
-pub const PROMISE_ALL_SETTLED_ID: TypeId = TypeId::new(11);
-pub const PROMISE_ANY_ID: TypeId = TypeId::new(12);
-pub const PROMISE_RACE_ID: TypeId = TypeId::new(13);
-pub const PROMISE_REJECT_ID: TypeId = TypeId::new(14);
-pub const PROMISE_RESOLVE_ID: TypeId = TypeId::new(15);
-pub const PROMISE_TRY_ID: TypeId = TypeId::new(16);
-pub const BIGINT_STRING_LITERAL_ID: TypeId = TypeId::new(17);
-pub const BOOLEAN_STRING_LITERAL_ID: TypeId = TypeId::new(18);
-pub const FUNCTION_STRING_LITERAL_ID: TypeId = TypeId::new(19);
-pub const NUMBER_STRING_LITERAL_ID: TypeId = TypeId::new(20);
-pub const OBJECT_STRING_LITERAL_ID: TypeId = TypeId::new(21);
-pub const STRING_STRING_LITERAL_ID: TypeId = TypeId::new(22);
-pub const SYMBOL_STRING_LITERAL_ID: TypeId = TypeId::new(23);
-pub const UNDEFINED_STRING_LITERAL_ID: TypeId = TypeId::new(24);
-pub const TYPEOF_OPERATOR_RETURN_UNION_ID: TypeId = TypeId::new(25);
-pub const STRING_ID: TypeId = TypeId::new(26);
-pub const T_ID: TypeId = TypeId::new(27);
-pub const NUM_PREDEFINED_TYPES: usize = 28; // Most be one more than the highest `TypeId` above.
+pub const VOID_ID: TypeId = TypeId::new(2);
+pub const CONDITIONAL_ID: TypeId = TypeId::new(3);
+pub const NUMBER_ID: TypeId = TypeId::new(4);
+pub const STRING_ID: TypeId = TypeId::new(5);
+pub const ARRAY_ID: TypeId = TypeId::new(6);
+pub const ARRAY_FILTER_ID: TypeId = TypeId::new(7);
+pub const ARRAY_FOREACH_ID: TypeId = TypeId::new(8);
+pub const GLOBAL_ID: TypeId = TypeId::new(9);
+pub const INSTANCEOF_PROMISE_ID: TypeId = TypeId::new(10);
+pub const PROMISE_ID: TypeId = TypeId::new(11);
+pub const PROMISE_CONSTRUCTOR_ID: TypeId = TypeId::new(12);
+pub const PROMISE_CATCH_ID: TypeId = TypeId::new(13);
+pub const PROMISE_FINALLY_ID: TypeId = TypeId::new(14);
+pub const PROMISE_THEN_ID: TypeId = TypeId::new(15);
+pub const PROMISE_ALL_ID: TypeId = TypeId::new(16);
+pub const PROMISE_ALL_SETTLED_ID: TypeId = TypeId::new(17);
+pub const PROMISE_ANY_ID: TypeId = TypeId::new(18);
+pub const PROMISE_RACE_ID: TypeId = TypeId::new(19);
+pub const PROMISE_REJECT_ID: TypeId = TypeId::new(20);
+pub const PROMISE_RESOLVE_ID: TypeId = TypeId::new(21);
+pub const PROMISE_TRY_ID: TypeId = TypeId::new(22);
+pub const BIGINT_STRING_LITERAL_ID: TypeId = TypeId::new(23);
+pub const BOOLEAN_STRING_LITERAL_ID: TypeId = TypeId::new(24);
+pub const FUNCTION_STRING_LITERAL_ID: TypeId = TypeId::new(25);
+pub const NUMBER_STRING_LITERAL_ID: TypeId = TypeId::new(26);
+pub const OBJECT_STRING_LITERAL_ID: TypeId = TypeId::new(27);
+pub const STRING_STRING_LITERAL_ID: TypeId = TypeId::new(28);
+pub const SYMBOL_STRING_LITERAL_ID: TypeId = TypeId::new(29);
+pub const UNDEFINED_STRING_LITERAL_ID: TypeId = TypeId::new(30);
+pub const TYPEOF_OPERATOR_RETURN_UNION_ID: TypeId = TypeId::new(31);
+pub const T_ID: TypeId = TypeId::new(32);
+pub const CONDITIONAL_CALLBACK_ID: TypeId = TypeId::new(33);
+pub const VOID_CALLBACK_ID: TypeId = TypeId::new(34);
+pub const FETCH_ID: TypeId = TypeId::new(35);
+pub const NUM_PREDEFINED_TYPES: usize = 36; // Most be one more than the highest `TypeId` above.
 
 pub const GLOBAL_UNKNOWN_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNKNOWN_ID);
 pub const GLOBAL_UNDEFINED_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNDEFINED_ID);
+pub const GLOBAL_VOID_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, VOID_ID);
+pub const GLOBAL_CONDITIONAL_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, CONDITIONAL_ID);
+pub const GLOBAL_NUMBER_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, NUMBER_ID);
+pub const GLOBAL_STRING_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, STRING_ID);
 pub const GLOBAL_ARRAY_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, ARRAY_ID);
 pub const GLOBAL_GLOBAL_ID /* :smirk: */: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, GLOBAL_ID);
 pub const GLOBAL_INSTANCEOF_PROMISE_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, INSTANCEOF_PROMISE_ID);
-pub const GLOBAL_NUMBER_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, NUMBER_ID);
 pub const GLOBAL_PROMISE_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, PROMISE_ID);
+pub const GLOBAL_PROMISE_CONSTRUCTOR_ID: ResolvedTypeId =
+    ResolvedTypeId::new(GLOBAL_LEVEL, PROMISE_CONSTRUCTOR_ID);
 pub const GLOBAL_BIGINT_STRING_LITERAL_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, BIGINT_STRING_LITERAL_ID);
 pub const GLOBAL_BOOLEAN_STRING_LITERAL_ID: ResolvedTypeId =
@@ -88,43 +101,51 @@ pub const GLOBAL_UNDEFINED_STRING_LITERAL_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, UNDEFINED_STRING_LITERAL_ID);
 pub const GLOBAL_TYPEOF_OPERATOR_RETURN_UNION_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, TYPEOF_OPERATOR_RETURN_UNION_ID);
-pub const GLOBAL_STRING_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, STRING_ID);
 pub const GLOBAL_T_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, T_ID);
+pub const GLOBAL_FETCH_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, FETCH_ID);
 
 /// Returns a string for formatting global IDs in test snapshots.
 pub fn global_type_name(id: TypeId) -> &'static str {
     match id.index() {
         0 => "unknown",
         1 => "undefined",
-        2 => "Array",
-        3 => "globalThis",
-        4 => "instanceof Promise",
-        5 => "number",
-        6 => "Promise",
-        7 => "Promise.prototype.catch",
-        8 => "Promise.prototype.finally",
-        9 => "Promise.prototype.then",
-        10 => "Promise.all",
-        11 => "Promise.allSettled",
-        12 => "Promise.any",
-        13 => "Promise.race",
-        14 => "Promise.reject",
-        15 => "Promise.resolve",
-        16 => "Promise.try",
-        17 => "\"bigint\"",
-        18 => "\"boolean\"",
-        19 => "\"function\"",
-        20 => "\"number\"",
-        21 => "\"object\"",
-        22 => "\"string\"",
-        23 => "\"symbol\"",
-        24 => "\"undefined\"",
-        25 => {
+        2 => "void",
+        3 => "conditional",
+        4 => "number",
+        5 => "string",
+        6 => "Array",
+        7 => "Array.prototype.filter",
+        8 => "Array.prototype.forEach",
+        9 => "globalThis",
+        10 => "instanceof Promise",
+        11 => "Promise",
+        12 => "Promise.constructor",
+        13 => "Promise.prototype.catch",
+        14 => "Promise.prototype.finally",
+        15 => "Promise.prototype.then",
+        16 => "Promise.all",
+        17 => "Promise.allSettled",
+        18 => "Promise.any",
+        19 => "Promise.race",
+        20 => "Promise.reject",
+        21 => "Promise.resolve",
+        22 => "Promise.try",
+        23 => "\"bigint\"",
+        24 => "\"boolean\"",
+        25 => "\"function\"",
+        26 => "\"number\"",
+        27 => "\"object\"",
+        28 => "\"string\"",
+        29 => "\"symbol\"",
+        30 => "\"undefined\"",
+        31 => {
             "\"bigint\" | \"boolean\" | \"function\" | \"number\" | \"object\" \
                 | \"string\" | \"symbol\" | \"undefined\""
         }
-        26 => "string",
-        27 => "T",
+        32 => "T",
+        33 => "() => conditional",
+        34 => "() => void",
+        35 => "fetch",
         _ => "inferred type",
     }
 }
@@ -141,17 +162,37 @@ pub struct GlobalsResolver {
 
 impl Default for GlobalsResolver {
     fn default() -> Self {
-        let promise_method = |name: &'static str, id: TypeId| TypeMember {
+        let method = |name: &'static str, id: TypeId| TypeMember {
             kind: TypeMemberKind::Named(Text::Static(name)),
             is_static: false,
             ty: ResolvedTypeId::new(TypeResolverLevel::Global, id).into(),
         };
 
-        let static_promise_method = |name: &'static str, id: TypeId| TypeMember {
+        let static_method = |name: &'static str, id: TypeId| TypeMember {
             kind: TypeMemberKind::Named(Text::Static(name)),
             is_static: true,
             ty: ResolvedTypeId::new(TypeResolverLevel::Global, id).into(),
         };
+
+        let array_method_definition =
+            |id: TypeId, param_type_id: TypeId, return_type_id: TypeId| {
+                TypeData::from(Function {
+                    is_async: false,
+                    type_parameters: Default::default(),
+                    name: Some(Text::Static(global_type_name(id))),
+                    parameters: [FunctionParameter {
+                        name: None,
+                        bindings: Default::default(),
+                        is_optional: false,
+                        is_rest: false,
+                        ty: ResolvedTypeId::new(TypeResolverLevel::Global, param_type_id).into(),
+                    }]
+                    .into(),
+                    return_type: ReturnType::Type(
+                        ResolvedTypeId::new(TypeResolverLevel::Global, return_type_id).into(),
+                    ),
+                })
+            };
 
         let promise_method_definition = |id: TypeId| {
             TypeData::from(Function {
@@ -170,38 +211,66 @@ impl Default for GlobalsResolver {
         let types = vec![
             TypeData::Unknown,
             TypeData::Undefined,
+            TypeData::VoidKeyword,
+            TypeData::Conditional,
+            TypeData::Number,
+            TypeData::String,
             TypeData::Class(Box::new(Class {
                 name: Some(Text::Static("Array")),
                 type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
                 extends: None,
                 implements: [].into(),
-                members: Box::new([TypeMember {
-                    kind: TypeMemberKind::Named(Text::Static("length")),
-                    is_static: false,
-                    ty: GLOBAL_NUMBER_ID.into(),
-                }]),
+                members: Box::new([
+                    method("filter", ARRAY_FILTER_ID),
+                    method("forEach", ARRAY_FOREACH_ID),
+                    TypeMember {
+                        kind: TypeMemberKind::Named(Text::Static("length")),
+                        is_static: false,
+                        ty: GLOBAL_NUMBER_ID.into(),
+                    },
+                ]),
             })),
+            array_method_definition(ARRAY_FILTER_ID, CONDITIONAL_CALLBACK_ID, ARRAY_ID),
+            array_method_definition(ARRAY_FOREACH_ID, VOID_CALLBACK_ID, VOID_ID),
             TypeData::Global,
             TypeData::instance_of(TypeReference::from(GLOBAL_PROMISE_ID)),
-            TypeData::Number,
             TypeData::Class(Box::new(Class {
                 name: Some(Text::Static("Promise")),
                 type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
                 extends: None,
                 implements: [].into(),
                 members: Box::new([
-                    promise_method("catch", PROMISE_CATCH_ID),
-                    promise_method("finally", PROMISE_FINALLY_ID),
-                    promise_method("then", PROMISE_THEN_ID),
-                    static_promise_method("all", PROMISE_ALL_ID),
-                    static_promise_method("allSettled", PROMISE_ALL_SETTLED_ID),
-                    static_promise_method("any", PROMISE_ANY_ID),
-                    static_promise_method("race", PROMISE_RACE_ID),
-                    static_promise_method("reject", PROMISE_REJECT_ID),
-                    static_promise_method("resolve", PROMISE_RESOLVE_ID),
-                    static_promise_method("try", PROMISE_TRY_ID),
+                    TypeMember {
+                        kind: TypeMemberKind::Constructor,
+                        is_static: true,
+                        ty: GLOBAL_PROMISE_CONSTRUCTOR_ID.into(),
+                    },
+                    method("catch", PROMISE_CATCH_ID),
+                    method("finally", PROMISE_FINALLY_ID),
+                    method("then", PROMISE_THEN_ID),
+                    static_method("all", PROMISE_ALL_ID),
+                    static_method("allSettled", PROMISE_ALL_SETTLED_ID),
+                    static_method("any", PROMISE_ANY_ID),
+                    static_method("race", PROMISE_RACE_ID),
+                    static_method("reject", PROMISE_REJECT_ID),
+                    static_method("resolve", PROMISE_RESOLVE_ID),
+                    static_method("try", PROMISE_TRY_ID),
                 ]),
             })),
+            TypeData::from(Function {
+                is_async: false,
+                type_parameters: Default::default(),
+                name: Some(Text::Static(global_type_name(PROMISE_CONSTRUCTOR_ID))),
+                parameters: [FunctionParameter {
+                    name: None,
+                    bindings: Default::default(),
+                    is_optional: false,
+                    is_rest: false,
+                    ty: ResolvedTypeId::new(GLOBAL_LEVEL, VOID_CALLBACK_ID).into(),
+                }]
+                .into(),
+                return_type: ReturnType::Type(GLOBAL_VOID_ID.into()),
+            }),
             promise_method_definition(PROMISE_CATCH_ID),
             promise_method_definition(PROMISE_FINALLY_ID),
             promise_method_definition(PROMISE_THEN_ID),
@@ -230,11 +299,31 @@ impl Default for GlobalsResolver {
                 GLOBAL_SYMBOL_STRING_LITERAL_ID.into(),
                 GLOBAL_UNDEFINED_STRING_LITERAL_ID.into(),
             ]),
-            TypeData::String,
             TypeData::from(GenericTypeParameter {
                 name: Text::Static("T"),
                 constraint: TypeReference::Unknown,
                 default: TypeReference::Unknown,
+            }),
+            TypeData::from(Function {
+                is_async: false,
+                type_parameters: Default::default(),
+                name: Some(Text::Static(global_type_name(CONDITIONAL_CALLBACK_ID))),
+                parameters: Default::default(),
+                return_type: ReturnType::Type(GLOBAL_CONDITIONAL_ID.into()),
+            }),
+            TypeData::from(Function {
+                is_async: false,
+                type_parameters: Default::default(),
+                name: Some(Text::Static(global_type_name(VOID_CALLBACK_ID))),
+                parameters: Default::default(),
+                return_type: ReturnType::Type(GLOBAL_VOID_ID.into()),
+            }),
+            TypeData::from(Function {
+                is_async: false,
+                type_parameters: Default::default(),
+                name: Some(Text::Static(global_type_name(FETCH_ID))),
+                parameters: Default::default(),
+                return_type: ReturnType::Type(GLOBAL_INSTANCEOF_PROMISE_ID.into()),
             }),
         ];
 
@@ -331,6 +420,7 @@ impl TypeResolver for GlobalsResolver {
 
     fn resolve_type_of(&self, identifier: &Text, _scope_id: ScopeId) -> Option<ResolvedTypeId> {
         match identifier.text() {
+            "fetch" => Some(GLOBAL_FETCH_ID),
             "globalThis" | "window" => Some(GLOBAL_GLOBAL_ID),
             _ => None,
         }

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_direct_promise_instance.snap
@@ -18,13 +18,17 @@ instanceof Promise
 ## Registered types
 
 ```
-Global TypeId(0) => sync Function {
+Global TypeId(0) => value: value
+
+Global TypeId(1) => Call unresolved reference "resolve" (scope ID: 0)(Global TypeId(0))
+
+Global TypeId(2) => sync Function {
   accepts: {
     params: [
       required resolve: unknown (bindings: resolve:unknown)
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Global TypeId(1)
 }
 ```

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_direct_promise_instance.snap
@@ -18,13 +18,17 @@ new Promise
 ## Registered types
 
 ```
-Global TypeId(0) => sync Function {
+Global TypeId(0) => value: value
+
+Global TypeId(1) => Call unresolved reference "resolve" (scope ID: 0)(Global TypeId(0))
+
+Global TypeId(2) => sync Function {
   accepts: {
     params: [
       required resolve: unknown (bindings: resolve:unknown)
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Global TypeId(1)
 }
 ```

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -629,17 +629,17 @@ impl TypeResolver for JsModuleInfoCollector {
     fn get_by_resolved_id(&self, id: ResolvedTypeId) -> Option<ResolvedTypeData> {
         let mut id = id;
         loop {
-            let resolved_id: ResolvedTypeData = match id.level() {
+            let resolved_data: ResolvedTypeData = match id.level() {
                 TypeResolverLevel::Thin => (id, self.get_by_id(id.id())).into(),
                 TypeResolverLevel::Global => (id, GLOBAL_RESOLVER.get_by_id(id.id())).into(),
                 TypeResolverLevel::Full | TypeResolverLevel::Import => break None,
             };
 
-            match resolved_id.as_raw_data() {
+            match resolved_data.as_raw_data() {
                 TypeData::Reference(TypeReference::Resolved(resolved_id)) if id != *resolved_id => {
                     id = *resolved_id;
                 }
-                _ => break Some(resolved_id),
+                _ => break Some(resolved_data),
             }
         }
     }

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -55,7 +55,7 @@ pub struct ModuleResolver {
     /// "Module 0" derives its name from being stored at the first index of this
     /// vector. Other modules are those imported by module 0, either directly
     /// or transitively.
-    pub modules: Vec<JsModuleInfo>,
+    modules: Vec<JsModuleInfo>,
 
     /// Map of module IDs keyed by their resolved paths.
     ///

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::{BTreeMap, btree_map::Entry},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -54,7 +55,7 @@ pub struct ModuleResolver {
     /// "Module 0" derives its name from being stored at the first index of this
     /// vector. Other modules are those imported by module 0, either directly
     /// or transitively.
-    modules: Vec<JsModuleInfo>,
+    pub modules: Vec<JsModuleInfo>,
 
     /// Map of module IDs keyed by their resolved paths.
     ///
@@ -85,6 +86,8 @@ impl ModuleResolver {
         }
     }
 
+    /// Runs the resolver's inference.
+    ///
     /// This method must've been called before attempting to query the types of
     /// functions or expressions.
     pub fn run_inference(&mut self) {
@@ -94,9 +97,16 @@ impl ModuleResolver {
     }
 
     /// Creates a [`Type`] instance for the given `resolved_id`.
+    ///
+    /// If `resolved_id` points to a reference, this automatically dereferences
+    /// the type.
     #[inline]
     pub fn resolved_type_for_id(self: &Arc<Self>, resolved_id: ResolvedTypeId) -> Type {
-        Type::from_id(self.clone(), resolved_id)
+        let ty = Type::from_id(self.clone(), resolved_id);
+        match ty.deref() {
+            TypeData::Reference(reference) => self.resolved_type_for_reference(reference),
+            _ => ty,
+        }
     }
 
     /// Returns the resolved type for the given `reference`.

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_type_referencing_imported_type.snap
@@ -66,7 +66,7 @@ Module TypeId(5) => sync Function {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(4)
 }
 
 Module TypeId(6) => instanceof Module(0) TypeId(0)

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -149,7 +149,7 @@ Module TypeId(5) => sync Function {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(4)
 }
 
 Module TypeId(6) => instanceof Module(0) TypeId(0)

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -175,7 +175,7 @@ Module TypeId(5) => sync Function {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(4)
 }
 
 Module TypeId(6) => instanceof Module(0) TypeId(0)


### PR DESCRIPTION
## Summary

This adds the detection of callbacks that return `Promise`s in places where conditional-returning or `void`-returning callback was expected. This gives us rough parity with ESLint's `typescript-eslint`.

Fixes #5541.

## Test Plan

Tests added and snapshots updated.
