### PR TITLE
chore: print summary last

### DIFF
--- a/crates/biome_cli/src/reporter/terminal.rs
+++ b/crates/biome_cli/src/reporter/terminal.rs
@@ -26,10 +26,10 @@ pub(crate) struct ConsoleReporter {
 impl Reporter for ConsoleReporter {
     fn write(self, visitor: &mut dyn ReporterVisitor) -> io::Result<()> {
         visitor.report_diagnostics(&self.execution, self.diagnostics_payload, self.verbose)?;
-        visitor.report_summary(&self.execution, self.summary, self.verbose)?;
         if self.verbose {
             visitor.report_handled_paths(self.evaluated_paths, self.working_directory)?;
         }
+        visitor.report_summary(&self.execution, self.summary, self.verbose)?;
         Ok(())
     }
 }

--- a/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_diagnostics/max_diagnostics_verbose.snap
@@ -130,12 +130,6 @@ src/file.js format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -153,4 +147,10 @@ Found 1 error.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_from_cli_verbose.snap
@@ -40,11 +40,6 @@ package-lock.json project  VERBOSE  ━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 0 files in <TIME>. No fixes applied.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -62,4 +57,9 @@ Checked 0 files in <TIME>. No fixes applied.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 0 files in <TIME>. No fixes applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_file_linter_disabled_from_cli_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -47,12 +46,6 @@ other.json format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -70,4 +63,10 @@ Found 1 error.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_protected_files/not_process_ignored_file_from_cli_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -47,12 +46,6 @@ other.json format ━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -70,4 +63,10 @@ Found 1 error.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_command_verbose.snap
@@ -162,18 +162,6 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
-Diagnostics not shown: 60.
-```
-
-```block
-Scanned project folder in <TIME>.
-Checked 3 files in <TIME>. No fixes applied.
-Found 49 errors.
-Found 16 warnings.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -193,4 +181,16 @@ Found 16 warnings.
   ! The list is empty.
   
 
+```
+
+```block
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
+Diagnostics not shown: 60.
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 3 files in <TIME>. No fixes applied.
+Found 49 errors.
+Found 16 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_reporter_terminal/reports_diagnostics_check_write_command_verbose.snap
@@ -164,24 +164,6 @@ index.css format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Skipped 32 suggested fixes.
-If you wish to apply the suggested (unsafe) fixes, use the command biome check --write --unsafe
-
-```
-
-```block
-The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
-Diagnostics not shown: 56.
-```
-
-```block
-Scanned project folder in <TIME>.
-Checked 3 files in <TIME>. Fixed 2 files.
-Found 45 errors.
-Found 16 warnings.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -202,4 +184,22 @@ Found 16 warnings.
   - main.ts
   
 
+```
+
+```block
+Skipped 32 suggested fixes.
+If you wish to apply the suggested (unsafe) fixes, use the command biome check --write --unsafe
+
+```
+
+```block
+The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
+Diagnostics not shown: 56.
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 3 files in <TIME>. Fixed 2 files.
+Found 45 errors.
+Found 16 warnings.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_check_file_when_assist_is_disabled.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/doesnt_check_file_when_assist_is_disabled.snap
@@ -27,11 +27,6 @@ expression: redactor(content)
 # Emitted Messages
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -49,4 +44,9 @@ Checked 1 file in <TIME>. No fixes applied.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `check.js`
 
@@ -46,12 +45,6 @@ check.js format ━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 2 errors.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -69,4 +62,10 @@ Found 2 errors.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/print_verbose_write.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `check.js`
 
@@ -36,12 +35,6 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. Fixed 1 file.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -59,4 +52,10 @@ Found 1 error.
   - check.js
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. Fixed 1 file.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/unsupported_file_verbose.snap
@@ -41,12 +41,6 @@ check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 0 files in <TIME>. No fixes applied.
-Found 1 warning.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -64,4 +58,10 @@ Found 1 warning.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 0 files in <TIME>. No fixes applied.
+Found 1 warning.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/print_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `ci.js`
 
@@ -46,12 +45,6 @@ ci.js format ━━━━━━━━━━━━━━━━━━━━━━�
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 2 errors.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -69,4 +62,10 @@ Found 2 errors.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 2 errors.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/print_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `format.js`
 
@@ -35,12 +34,6 @@ format.js format ━━━━━━━━━━━━━━━━━━━━━
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -58,4 +51,10 @@ Found 1 error.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/print_verbose.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `check.js`
 
@@ -36,12 +35,6 @@ check.js:1:6 lint/correctness/noConstantCondition ━━━━━━━━━━
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 1 file in <TIME>. No fixes applied.
-Found 1 error.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -59,4 +52,10 @@ Found 1 error.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/unsupported_file_verbose.snap
@@ -41,12 +41,6 @@ check.txt files/missingHandler  VERBOSE  ━━━━━━━━━━━━━
 ```
 
 ```block
-Scanned project folder in <TIME>.
-Checked 0 files in <TIME>. No fixes applied.
-Found 1 warning.
-```
-
-```block
  VERBOSE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i Files processed:
@@ -64,4 +58,10 @@ Found 1 warning.
   ! The list is empty.
   
 
+```
+
+```block
+Scanned project folder in <TIME>.
+Checked 0 files in <TIME>. No fixes applied.
+Found 1 warning.
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

When doing some debugging and such, I always want to check the time first, and look at the files. This PR addresses that.

Plus, the `summary` reporter already does that, so this PR bring the terminal reporter in line.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Updated the snapshots 

<!-- What demonstrates that your implementation is correct? -->
