### PR TITLE
fix(biome_parser): trivia placement for zero-width tokens

### DIFF
--- a/crates/biome_parser/src/token_source.rs
+++ b/crates/biome_parser/src/token_source.rs
@@ -38,6 +38,11 @@ impl Trivia {
         self.range.start()
     }
 
+    /// Returns the byte offset of the end of the trivia in the source text
+    pub fn end_offset(&self) -> TextSize {
+        self.range.end()
+    }
+
     /// Returns `true` if this is the trailing trivia of a non-trivia token or false otherwise.
     pub fn trailing(&self) -> bool {
         self.trailing


### PR DESCRIPTION
## Summary

The current trivia attachment logic in TreeSink tries to attach a trivia as soon as when the current text position match the trivia's offset. This leads to problem when a trivia is attached as leading trivia to a token precedes it. For example, given this token set:
```
SEQUENCE_START@0:0
DASH@0:1
WHITESPACE@1:2
PLAIN_LITERAL@2:9
SEQUENCE_END@9:9
NEWLINE@9:10
EOF@10:10
```

which corresponds to 
```yaml
- literal
```

The TreeSink will attempt to attach `NEWLINE` token as `SEQUENCE_END`'s leading trivia, which in turns caused a whole host of problem with rowan.

This PR tries to fix this by adding a new condition to the trivia check, which checks for the end offset of the current token and the trivia to determine if this trivia is really this token's leading trivia

## Test Plan

All tests should still be green.
