### PR TITLE
feat(analyze): add rule domains for Vue

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -373,6 +373,10 @@ pub enum RuleDomain {
     Solid,
     /// Next.js framework rules
     Next,
+    /// Vue.js 2 & 3 framework rules
+    Vue,
+    /// Vue.js 3 framework rules
+    Vue3,
     /// For rules that require querying multiple files inside a project
     Project,
 }
@@ -385,6 +389,8 @@ impl Display for RuleDomain {
             Self::Test => fmt.write_str("test"),
             Self::Solid => fmt.write_str("solid"),
             Self::Next => fmt.write_str("next"),
+            Self::Vue => fmt.write_str("vue"),
+            Self::Vue3 => fmt.write_str("vue3"),
             Self::Project => fmt.write_str("project"),
         }
     }
@@ -418,6 +424,8 @@ impl RuleDomain {
             ],
             Self::Solid => &[&("solid", ">=1.0.0")],
             Self::Next => &[&("next", ">=14.0.0")],
+            Self::Vue => &[&("vue", ">=2.0.0")],
+            Self::Vue3 => &[&("vue", ">=3.0.0")],
             Self::Project => &[],
         }
     }
@@ -440,6 +448,8 @@ impl RuleDomain {
             ],
             Self::Solid => &[],
             Self::Next => &[],
+            Self::Vue => &[],
+            Self::Vue3 => &[],
             Self::Project => &[],
         }
     }

--- a/crates/biome_configuration/tests/invalid/domains.json.snap
+++ b/crates/biome_configuration/tests/invalid/domains.json.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_configuration/tests/spec_tests.rs
 expression: domains.json
-snapshot_kind: text
 ---
 domains.json:4:7 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -20,6 +19,8 @@ domains.json:4:7 deserialize ━━━━━━━━━━━━━━━━━
   - test
   - solid
   - next
+  - vue
+  - vue3
   - project
   
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -890,7 +890,14 @@ export type TrailingCommas2 = "none" | "all";
 /**
  * Rule domains
  */
-export type RuleDomain = "react" | "test" | "solid" | "next" | "project";
+export type RuleDomain =
+	| "react"
+	| "test"
+	| "solid"
+	| "next"
+	| "vue"
+	| "vue3"
+	| "project";
 export type RuleDomainValue = "all" | "none" | "recommended";
 export type SeverityOrGroup_for_A11y = GroupPlainConfiguration | A11y;
 export type SeverityOrGroup_for_Complexity =

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3439,6 +3439,16 @@
 					"enum": ["next"]
 				},
 				{
+					"description": "Vue.js 2 & 3 framework rules",
+					"type": "string",
+					"enum": ["vue"]
+				},
+				{
+					"description": "Vue.js 3 framework rules",
+					"type": "string",
+					"enum": ["vue3"]
+				},
+				{
 					"description": "For rules that require querying multiple files inside a project",
 					"type": "string",
 					"enum": ["project"]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
There are some Vue-specific rules that can be implemented today, even with our partial support. This adds 2 new domains for Vue rules: 1 for rules that apply to both Vue 2 and 3, and 1 for rules that apply to just Vue 3. The rules that are Vue 2 specific are all deprecated.

See also: https://eslint.vuejs.org/rules/

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
CI should stay green.
