### PR TITLE
feat(core): support `export *` syntax

### DIFF
--- a/crates/biome_js_type_info/src/resolver.rs
+++ b/crates/biome_js_type_info/src/resolver.rs
@@ -273,7 +273,7 @@ impl TypeResolverLevel {
 }
 
 /// Identifier that indicates which module a type is defined in.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Resolvable)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Resolvable)]
 pub struct ModuleId(u32);
 
 impl ModuleId {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
@@ -1,0 +1,192 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/bar.ts` (Module 2)
+
+## Source
+
+```ts
+export function bar(): string {
+	return "bar";
+}
+```
+
+## Module Info
+
+```
+Exports {
+  "bar" => {
+    ExportOwnExport => JsOwnExport::Binding(0)
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: bar,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => value: bar
+
+Module TypeId(1) => sync Function "bar" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: string
+}
+```
+
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+import { foo } from "./reexports.ts";
+import * as reexports from "./reexports.ts";
+
+const result1 = foo();
+const result2 = reexports.bar();
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "foo" => {
+    Specifier: "./reexports.ts"
+    Resolved path: "/src/reexports.ts"
+    Import Symbol: foo
+  }
+  "reexports" => {
+    Specifier: "./reexports.ts"
+    Resolved path: "/src/reexports.ts"
+    Import Symbol: All
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => Import Symbol: foo from "/src/reexports.ts"
+
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
+
+Module TypeId(2) => Import Symbol: All from "/src/reexports.ts"
+
+Module TypeId(3) => Module(0) TypeId(2).bar
+
+Module TypeId(4) => Call Module(0) TypeId(3)(No parameters)
+```
+
+# `/src/foo.ts` (Module 3)
+
+## Source
+
+```ts
+export function foo(): number {
+	return 1;
+}
+```
+
+## Module Info
+
+```
+Exports {
+  "foo" => {
+    ExportOwnExport => JsOwnExport::Binding(0)
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: foo,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => value: 1
+
+Module TypeId(1) => sync Function "foo" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: number
+}
+```
+
+# `/src/reexports.ts` (Module 1)
+
+## Source
+
+```ts
+export * from "./foo.ts";
+export * from "./bar.ts";
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+
+# Scoped Type Resolver
+
+## Registered types
+
+```
+Full TypeId(0) => namespace for ModuleId(1)
+
+Full TypeId(1) => namespace for ModuleId(2)
+
+Full TypeId(2) => namespace for ModuleId(3)
+
+Full TypeId(3) => Module(3) TypeId(1)
+
+Full TypeId(4) => number
+
+Full TypeId(5) => Import TypeId(1)
+
+Full TypeId(6) => sync Function "bar" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: string
+}
+
+Full TypeId(7) => string
+```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_single_reexport.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_single_reexport.snap
@@ -1,0 +1,117 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/reexport.ts` (Module 1)
+
+## Source
+
+```ts
+export * from "./foo.ts";
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+import { foo } from "./reexport.ts";
+
+const result = foo();
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  "foo" => {
+    Specifier: "./reexport.ts"
+    Resolved path: "/src/reexport.ts"
+    Import Symbol: foo
+  }
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => Import Symbol: foo from "/src/reexport.ts"
+
+Module TypeId(1) => Call Module(0) TypeId(0)(No parameters)
+```
+
+# `/src/foo.ts` (Module 2)
+
+## Source
+
+```ts
+export function foo(): number {
+	return 1;
+}
+```
+
+## Module Info
+
+```
+Exports {
+  "foo" => {
+    ExportOwnExport => JsOwnExport::Binding(0)
+  }
+}
+Imports {
+  No imports
+}
+```
+
+## Exported Bindings
+
+```
+BindingId(0) => JsBindingData {
+  Name: foo,
+  Type: Module(0) TypeId(1),
+  Declaration kind: HoistedValue
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => value: 1
+
+Module TypeId(1) => sync Function "foo" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: number
+}
+```
+
+# Scoped Type Resolver
+
+## Registered types
+
+```
+Full TypeId(0) => namespace for ModuleId(1)
+
+Full TypeId(1) => namespace for ModuleId(2)
+
+Full TypeId(2) => Module(2) TypeId(1)
+
+Full TypeId(3) => number
+```


### PR DESCRIPTION
## Summary

Now we also support `export *` syntax.

I've unified a little how import namespaces and other imports are handled, so both kinds of import should play nicely together.

## Test Plan

Tests added.
