### PR TITLE
fix(linter): prevent false positives in `noMisusedPromises`

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsValid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsValid.ts
@@ -15,3 +15,5 @@ const returnVal = await promise;
 while (await promise) {
   // Do something
 }
+
+const maybePromise = 1 == 2 ? promise : undefined;

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsValid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/checksConditionalsValid.ts.snap
@@ -22,4 +22,6 @@ while (await promise) {
   // Do something
 }
 
+const maybePromise = 1 == 2 ? promise : undefined;
+
 ```


### PR DESCRIPTION
## Summary

Make sure `noMisusedPromises` doesn't signal false positives when a `Promise` expression is in one of the branches of a ternary expression.

## Test Plan

Test case added.
