### PR TITLE
perf: use `TypeStore` in global resolver

### DIFF
--- a/crates/biome_js_type_info/src/type_store.rs
+++ b/crates/biome_js_type_info/src/type_store.rs
@@ -30,6 +30,23 @@ pub struct TypeStore {
 }
 
 impl TypeStore {
+    pub fn from_types(types: Vec<TypeData>) -> Self {
+        let mut table = HashTable::new();
+        for (i, data) in types.iter().enumerate() {
+            let mut hash = FxHasher::default();
+            data.hash(&mut hash);
+            let hash = hash.finish();
+
+            table.insert_unique(hash, i, |i| {
+                let mut hash = FxHasher::default();
+                types[*i].hash(&mut hash);
+                hash.finish()
+            });
+        }
+
+        Self { types, table }
+    }
+
     pub fn as_slice(&self) -> &[TypeData] {
         &self.types
     }


### PR DESCRIPTION
## Summary

Small performance improvement for type-aware rules, since we perform more regular lookups into the global resolver now.

In one of the Vercel repositories, this brings down the time for running `noMisusedPromises` from 16s to 15s. `noFloatingPromises` seems less affected and already took 15s.

## Test Plan

Everything should stay green.
