### PR TITLE
perf: resolve and map types in single pass

### DIFF
--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_return_value_with_multiple_modules.snap
@@ -196,7 +196,5 @@ Full TypeId(9) => Object {
 
 Full TypeId(10) => Module(1) TypeId(0)
 
-Full TypeId(11) => Module(2) TypeId(3)
-
-Full TypeId(12) => value: bar
+Full TypeId(11) => value: bar
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_nested_function_call_with_namespace_in_return_type.snap
@@ -99,7 +99,5 @@ Full TypeId(3) => instanceof unknown reference
 
 Full TypeId(4) => Call Module(0) TypeId(0)(Module(0) TypeId(2))
 
-Full TypeId(5) => Module(1) TypeId(1)
-
-Full TypeId(6) => instanceof unknown reference
+Full TypeId(5) => instanceof unknown reference
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_imported_promise_type.snap
@@ -188,7 +188,5 @@ Full TypeId(2) => Module(1) TypeId(8)
 
 Full TypeId(3) => instanceof Promise<Module(2) TypeId(3)>
 
-Full TypeId(4) => Module(1) TypeId(8)
-
-Full TypeId(5) => instanceof Promise<Module(2) TypeId(3)>
+Full TypeId(4) => instanceof Promise<Module(2) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_from_imported_function_returning_reexported_promise_type.snap
@@ -216,7 +216,5 @@ Full TypeId(3) => Module(1) TypeId(8)
 
 Full TypeId(4) => instanceof Promise<Module(3) TypeId(3)>
 
-Full TypeId(5) => Module(1) TypeId(8)
-
-Full TypeId(6) => instanceof Promise<Module(3) TypeId(3)>
+Full TypeId(5) => instanceof Promise<Module(3) TypeId(3)>
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_react_types.snap
@@ -21623,9 +21623,7 @@ Full TypeId(5) => Module(0) TypeId(3)
 
 Full TypeId(6) => instanceof Promise
 
-Full TypeId(7) => Module(1) TypeId(956)
-
-Full TypeId(8) => async Function {
+Full TypeId(7) => async Function {
   accepts: {
     params: []
     type_args: []
@@ -21633,5 +21631,5 @@ Full TypeId(8) => async Function {
   returns: Module(0) TypeId(1)
 }
 
-Full TypeId(9) => instanceof Promise
+Full TypeId(8) => instanceof Promise
 ```


### PR DESCRIPTION
## Summary

In the module resolver, instead of first registering types from module 0 and then resolving them, we now do it in a single pass. This should be faster and we save a few unnecessary indirections from getting registered.

Unfortunately, I didn't see a significant reduction in total running time, but it still seems a small but worthwhile improvement.

## Test Plan

Everything should stay green.
