### PR TITLE
fix(analyze/js): support special svelte store dereference syntax in semantic model

### DIFF
--- a/crates/biome_js_analyze/src/services/semantic.rs
+++ b/crates/biome_js_analyze/src/services/semantic.rs
@@ -3,7 +3,9 @@ use biome_analyze::{
     RuleMetadata, ServiceBag, ServicesDiagnostic, SyntaxVisitor, Visitor, VisitorContext,
     VisitorFinishContext,
 };
-use biome_js_semantic::{SemanticEventExtractor, SemanticModel, SemanticModelBuilder};
+use biome_js_semantic::{
+    SemanticEventExtractor, SemanticFlavor, SemanticModel, SemanticModelBuilder,
+};
 use biome_js_syntax::{AnyJsRoot, JsLanguage, JsSyntaxNode, TextRange, WalkEvent};
 use biome_rowan::AstNode;
 
@@ -95,9 +97,9 @@ pub struct SemanticModelBuilderVisitor {
 }
 
 impl SemanticModelBuilderVisitor {
-    pub(crate) fn new(root: &AnyJsRoot) -> Self {
+    pub(crate) fn new(root: &AnyJsRoot, flavor: SemanticFlavor) -> Self {
         Self {
-            extractor: SemanticEventExtractor::default(),
+            extractor: SemanticEventExtractor::default().with_flavor(flavor),
             builder: SemanticModelBuilder::new(root.clone()),
         }
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/svelte-store.svelte
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/svelte-store.svelte
@@ -1,0 +1,6 @@
+<script>
+/* should not generate diagnostics */
+import { writable } from "svelte";
+let foo = writable(0);
+$foo = 5;
+</script>

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/svelte-store.svelte.snap.new
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredVariables/svelte-store.svelte.snap.new
@@ -1,0 +1,33 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
+expression: svelte-store.svelte
+---
+# Input
+```js
+<script>
+import { writable } from "svelte";
+let foo = writable(0);
+$foo = 5;
+</script>
+
+```
+
+# Diagnostics
+```
+svelte-store.svelte:4:1 lint/correctness/noUndeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The $foo variable is undeclared.
+  
+    2 │ import { writable } from "svelte";
+    3 │ let foo = writable(0);
+  > 4 │ $foo = 5;
+      │ ^^^^
+    5 │ </script>
+    6 │ 
+  
+  i By default, Biome recognizes browser and Node.js globals.
+    You can ignore more globals using the javascript.globals configuration.
+  
+
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::mem;
 
-use crate::ScopeId;
+use crate::{ScopeId, SemanticFlavor};
 
 /// Events emitted by the [SemanticEventExtractor].
 /// These events are later made into the Semantic Model.
@@ -158,6 +158,21 @@ pub struct SemanticEventExtractor {
     /// Type parameters bound in a `infer T` clause.
     infers: Vec<TsTypeParameterName>,
     is_ambient_context: bool,
+    flavor: SemanticFlavor,
+}
+
+impl SemanticEventExtractor {
+    pub fn with_flavor(self, flavor: SemanticFlavor) -> Self {
+        Self {
+            stash: self.stash,
+            scopes: self.scopes,
+            scope_count: self.scope_count,
+            bindings: self.bindings,
+            infers: self.infers,
+            is_ambient_context: self.is_ambient_context,
+            flavor,
+        }
+    }
 }
 
 /// A binding name is either a type or a value.
@@ -715,6 +730,17 @@ impl SemanticEventExtractor {
             return;
         };
         let name = name_token.token_text_trimmed();
+        let (name, range) = if self.flavor == SemanticFlavor::Svelte {
+            // This is special Svelte syntax for dereferencing a store
+            if name.starts_with("$") {
+                let range = range.add_start(1.into());
+                (name.slice(range), range)
+            } else {
+                (name, range)
+            }
+        } else {
+            (name, range)
+        };
         match node {
             AnyJsIdentifierUsage::JsReferenceIdentifier(node) => {
                 let Some(parent) = node.syntax().parent() else {

--- a/crates/biome_js_semantic/src/semantic_model.rs
+++ b/crates/biome_js_semantic/src/semantic_model.rs
@@ -42,15 +42,24 @@ pub use scope::*;
 pub struct SemanticModelOptions {
     /// All the allowed globals names
     pub globals: FxHashSet<String>,
+    pub flavor: SemanticFlavor,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SemanticFlavor {
+    /// Regular JavaScript/Typescript
+    #[default]
+    Vanilla,
+    /// Allow the semantic model to account for Svelte specific features.
+    Svelte,
 }
 
 /// Build the complete [SemanticModel] of a parsed file.
 /// For a push based model to build the [SemanticModel], see [SemanticModelBuilder].
 pub fn semantic_model(root: &AnyJsRoot, options: SemanticModelOptions) -> SemanticModel {
-    let mut extractor = SemanticEventExtractor::default();
+    let SemanticModelOptions { globals, flavor } = options;
+    let mut extractor = SemanticEventExtractor::default().with_flavor(flavor);
     let mut builder = SemanticModelBuilder::new(root.clone());
-
-    let SemanticModelOptions { globals } = options;
 
     for global in globals {
         builder.push_global(global);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Svelte's compiler introduces special syntax for better dev ergonomics when interacting with "stores". Our semantic model currently can't resolve references that use this special syntax.

This PR aims to resolve this by introducing semantic model "flavors", and adds a flavor for Svelte, because this behavior is only relevant to Svelte.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #6316

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Will add tests.
