### PR TITLE
fix(lint): deduplicate missing dependencies in useExhaustiveDependencies

### DIFF
--- a/.changeset/shiny-groups-leave.md
+++ b/.changeset/shiny-groups-leave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6278](github.com/biomejs/biome/issues/6278): `useExhaustiveDependencies` no longer adds duplicated dependencies into the list.

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -974,7 +974,7 @@ impl Rule for UseExhaustiveDependencies {
                 let mut diag = RuleDiagnostic::new(
                     rule_category!(),
                     function_name_range,
-                    markup! {"This hook does not specify its dependency: "<Emphasis>{capture_text.as_ref()}</Emphasis>""},
+                    markup! {"This hook does not specify its dependency on "<Emphasis>{capture_text.as_ref()}</Emphasis>"."},
                 );
 
                 for range in captures_range {

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -974,13 +974,13 @@ impl Rule for UseExhaustiveDependencies {
                 let mut diag = RuleDiagnostic::new(
                     rule_category!(),
                     function_name_range,
-                    markup! {"This hook does not specify its dependencies: "<Emphasis>{capture_text.as_ref()}</Emphasis>""},
+                    markup! {"This hook does not specify its dependency: "<Emphasis>{capture_text.as_ref()}</Emphasis>""},
                 );
 
                 for range in captures_range {
                     diag = diag.detail(
                         range.text_trimmed_range(),
-                        "This dependency is being used here, but not specified in the hook dependency list.",
+                        "This dependency is being used here, but is not specified in the hook dependency list.",
                     );
                 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -974,22 +974,18 @@ impl Rule for UseExhaustiveDependencies {
                 let mut diag = RuleDiagnostic::new(
                     rule_category!(),
                     function_name_range,
-                    markup! {"This hook does not specify all of its dependencies: "{capture_text.as_ref()}""},
+                    markup! {"This hook does not specify its dependencies: "<Emphasis>{capture_text.as_ref()}</Emphasis>""},
                 );
 
                 for range in captures_range {
                     diag = diag.detail(
                         range.text_trimmed_range(),
-                        "This dependency is not specified in the hook dependency list.",
+                        "This dependency is being used here, but not specified in the hook dependency list.",
                     );
                 }
 
                 if dependencies_array.elements().len() == 0 {
-                    diag = if captures_range.len() == 1 {
-                        diag.note("Either include it or remove the dependency array")
-                    } else {
-                        diag.note("Either include them or remove the dependency array")
-                    }
+                    diag = diag.note("Either include it or remove the dependency array.");
                 }
 
                 Some(diag)
@@ -1077,19 +1073,21 @@ impl Rule for UseExhaustiveDependencies {
 
         let message = match state {
             Fix::AddDependency {
-                captures: (_, nodes),
+                captures: (_, captures),
                 dependencies_array,
                 ..
             } => {
+                let new_elements = captures.first().into_iter().filter_map(|node| {
+                    node.ancestors()
+                        .find_map(|node| node.cast::<AnyJsExpression>()?.trim_trivia())
+                        .map(AnyJsArrayElement::AnyJsExpression)
+                });
+
                 let elements = dependencies_array.elements();
                 let elements = elements
                     .elements()
                     .flat_map(|element| element.into_node())
-                    .chain(nodes.iter().filter_map(|node| {
-                        node.ancestors()
-                            .find_map(|node| node.cast::<AnyJsExpression>()?.trim_trivia())
-                            .map(AnyJsArrayElement::AnyJsExpression)
-                    }))
+                    .chain(new_elements)
                     .collect::<Vec<_>>();
 
                 mutation.replace_node(
@@ -1097,7 +1095,7 @@ impl Rule for UseExhaustiveDependencies {
                     recreate_array(dependencies_array, elements),
                 );
 
-                markup! { "Add the missing dependencies to the list." }
+                markup! { "Add the missing dependency to the list." }
             }
             Fix::RemoveDependency {
                 dependencies,

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
@@ -31,7 +31,7 @@ function MyComponent2() {
 ```
 checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     1 │ function MyComponent1() {
     2 │   let a = 1;
@@ -40,7 +40,7 @@ checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  F
     4 │       console.log(a);
     5 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     2 │   let a = 1;
     3 │   React.useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
@@ -31,7 +31,7 @@ function MyComponent2() {
 ```
 checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     1 │ function MyComponent1() {
     2 │   let a = 1;
@@ -40,7 +40,7 @@ checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  F
     4 │       console.log(a);
     5 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     2 │   let a = 1;
     3 │   React.useEffect(() => {
@@ -49,9 +49,9 @@ checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  F
     5 │   }, []);
     6 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     5 │ ··},·[a]);
       │       +   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/checkHooksImportedFromReact.js.snap
@@ -31,7 +31,7 @@ function MyComponent2() {
 ```
 checkHooksImportedFromReact.js:3:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     1 │ function MyComponent1() {
     2 │   let a = 1;

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
@@ -27,7 +27,7 @@ function MyComponent() {
 ```
 customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     3 │ function MyComponent() {
     4 │     let a = 1;
@@ -36,7 +36,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     6 │         console.log(a);
     7 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     4 │     let a = 1;
     5 │     useEffect(() => {
@@ -57,7 +57,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
 ```
 customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
      7 │     }, []);
      8 │ 
@@ -66,7 +66,7 @@ customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     10 │         console.log(a);
     11 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
      9 │     useMyEffect(() => {
   > 10 │         console.log(a);

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
@@ -27,7 +27,7 @@ function MyComponent() {
 ```
 customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     3 │ function MyComponent() {
     4 │     let a = 1;
@@ -57,7 +57,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
 ```
 customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
      7 │     }, []);
      8 │ 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/customHook.js.snap
@@ -27,7 +27,7 @@ function MyComponent() {
 ```
 customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     3 │ function MyComponent() {
     4 │     let a = 1;
@@ -36,7 +36,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     6 │         console.log(a);
     7 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     4 │     let a = 1;
     5 │     useEffect(() => {
@@ -45,9 +45,9 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     7 │     }, []);
     8 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     7 │ ····},·[a]);
       │         +   
@@ -57,7 +57,7 @@ customHook.js:5:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
 ```
 customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
      7 │     }, []);
      8 │ 
@@ -66,7 +66,7 @@ customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     10 │         console.log(a);
     11 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
      9 │     useMyEffect(() => {
   > 10 │         console.log(a);
@@ -74,9 +74,9 @@ customHook.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━
     11 │     }, []);
     12 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     11 │ ····},·[a]);
        │         +   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -176,7 +176,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: someObj
+  × This hook does not specify its dependency: someObj
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();
@@ -185,7 +185,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIX
     29 │       console.log(someObj)
     30 │   }, [someObj.id]);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     27 │   let someObj = getObj();
     28 │   useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -176,7 +176,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: someObj
+  × This hook does not specify its dependencies: someObj
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();
@@ -185,7 +185,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIX
     29 │       console.log(someObj)
     30 │   }, [someObj.id]);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     27 │   let someObj = getObj();
     28 │   useEffect(() => {
@@ -194,7 +194,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIX
     30 │   }, [someObj.id]);
     31 │ }
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     30 │ ··},·[someObj.id,·someObj]);
        │                 +++++++++   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/extraDependenciesInvalid.js.snap
@@ -176,7 +176,7 @@ extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies ━�
 ```
 extraDependenciesInvalid.js:28:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: someObj
+  × This hook does not specify its dependency on someObj.
   
     26 │ function MyComponent1() {
     27 │   let someObj = getObj();

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
@@ -31,7 +31,7 @@ function IgnoredDependencies2() {
 ```
 ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
      6 │     let b = 2;
      7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
@@ -40,7 +40,7 @@ ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  
      9 │         console.log(a + b);
     10 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
      7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
      8 │     useEffect(() => {
@@ -49,9 +49,9 @@ ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  
     10 │     }, []);
     11 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     10 │ ····},·[a]);
        │         +   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
@@ -31,7 +31,7 @@ function IgnoredDependencies2() {
 ```
 ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
      6 │     let b = 2;
      7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
@@ -40,7 +40,7 @@ ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  
      9 │         console.log(a + b);
     10 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
      7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`
      8 │     useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/ignoredDependencies.js.snap
@@ -31,7 +31,7 @@ function IgnoredDependencies2() {
 ```
 ignoredDependencies.js:8:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
      6 │     let b = 2;
      7 │     // biome-ignore lint/correctness/useExhaustiveDependencies(b): `b` is ignored, but there should still be a diagnostic for `a`

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
@@ -37,7 +37,7 @@ function MyComponent26() {
 ```
 issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: calc
+  × This hook does not specify its dependency: calc
   
      7 │     // they're imported from the "react" library. Explicitly configuring them
      8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
@@ -46,7 +46,7 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
     10 │         if (calc === 0) {
     11 │             setCalc(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
      8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
      9 │     useEffect(() => {
@@ -67,7 +67,7 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
 ```
 issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: calc
+  × This hook does not specify its dependency: calc
   
     19 │     // they're imported from the "react" library. Explicitly configuring them
     20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
@@ -76,7 +76,7 @@ issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     22 │         if (calc === 0) {
     23 │             setCalc(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
     21 │     ReactReexport.useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
@@ -37,7 +37,7 @@ function MyComponent26() {
 ```
 issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: calc
+  × This hook does not specify its dependency on calc.
   
      7 │     // they're imported from the "react" library. Explicitly configuring them
      8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
@@ -67,7 +67,7 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
 ```
 issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: calc
+  × This hook does not specify its dependency on calc.
   
     19 │     // they're imported from the "react" library. Explicitly configuring them
     20 │     // in the hooks array (as if they are user-provided hooks) overrides this.

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue1931.js.snap
@@ -37,7 +37,7 @@ function MyComponent26() {
 ```
 issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: calc
+  × This hook does not specify its dependencies: calc
   
      7 │     // they're imported from the "react" library. Explicitly configuring them
      8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
@@ -46,7 +46,7 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
     10 │         if (calc === 0) {
     11 │             setCalc(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
      8 │     // in the hooks array (as if they are user-provided hooks) overrides this.
      9 │     useEffect(() => {
@@ -55,9 +55,9 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
     11 │             setCalc(1);
     12 │         }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     13 │ ····},·[calc]);
        │         ++++   
@@ -67,7 +67,7 @@ issue1931.js:9:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
 ```
 issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: calc
+  × This hook does not specify its dependencies: calc
   
     19 │     // they're imported from the "react" library. Explicitly configuring them
     20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
@@ -76,7 +76,7 @@ issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     22 │         if (calc === 0) {
     23 │             setCalc(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     20 │     // in the hooks array (as if they are user-provided hooks) overrides this.
     21 │     ReactReexport.useEffect(() => {
@@ -85,9 +85,9 @@ issue1931.js:21:19 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     23 │             setCalc(1);
     24 │         }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     25 │ ····},·[calc]);
        │         ++++   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js
@@ -1,0 +1,8 @@
+import React from "react";
+
+const Comp = (myFn) => {
+	React.useCallback(() => {
+		myFn(true);
+		myFn(false);
+	}, []);
+};

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
@@ -19,7 +19,7 @@ const Comp = (myFn) => {
 ```
 issue6278.js:4:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: myFn
+  × This hook does not specify its dependency on myFn.
   
     3 │ const Comp = (myFn) => {
   > 4 │ 	React.useCallback(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
@@ -1,0 +1,55 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6278.js
+---
+# Input
+```js
+import React from "react";
+
+const Comp = (myFn) => {
+	React.useCallback(() => {
+		myFn(true);
+		myFn(false);
+	}, []);
+};
+
+```
+
+# Diagnostics
+```
+issue6278.js:4:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook does not specify its dependencies: myFn
+  
+    3 │ const Comp = (myFn) => {
+  > 4 │ 	React.useCallback(() => {
+      │ 	      ^^^^^^^^^^^
+    5 │ 		myFn(true);
+    6 │ 		myFn(false);
+  
+  i This dependency is being used here, but not specified in the hook dependency list.
+  
+    4 │ 	React.useCallback(() => {
+    5 │ 		myFn(true);
+  > 6 │ 		myFn(false);
+      │ 		^^^^
+    7 │ 	}, []);
+    8 │ };
+  
+  i This dependency is being used here, but not specified in the hook dependency list.
+  
+    3 │ const Comp = (myFn) => {
+    4 │ 	React.useCallback(() => {
+  > 5 │ 		myFn(true);
+      │ 		^^^^
+    6 │ 		myFn(false);
+    7 │ 	}, []);
+  
+  i Either include it or remove the dependency array.
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    7 │ → },·[myFn]);
+      │       ++++   
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6278.js.snap
@@ -19,7 +19,7 @@ const Comp = (myFn) => {
 ```
 issue6278.js:4:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: myFn
+  × This hook does not specify its dependency: myFn
   
     3 │ const Comp = (myFn) => {
   > 4 │ 	React.useCallback(() => {
@@ -27,7 +27,7 @@ issue6278.js:4:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
     5 │ 		myFn(true);
     6 │ 		myFn(false);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     4 │ 	React.useCallback(() => {
     5 │ 		myFn(true);
@@ -36,7 +36,7 @@ issue6278.js:4:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━�
     7 │ 	}, []);
     8 │ };
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     3 │ const Comp = (myFn) => {
     4 │ 	React.useCallback(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
@@ -200,7 +200,7 @@ function HoistedDeclarations() {
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -209,7 +209,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     19 │       console.log(a, b);
     20 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     17 │     const b = a + 1;
     18 │     useEffect(() => {
@@ -230,7 +230,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: b
+  × This hook does not specify its dependency: b
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -239,7 +239,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     19 │       console.log(a, b);
     20 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     17 │     const b = a + 1;
     18 │     useEffect(() => {
@@ -260,7 +260,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: deferredValue
+  × This hook does not specify its dependency: deferredValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -269,7 +269,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     39 │       console.log(memoizedCallback);
     40 │       console.log(memoizedValue);
@@ -290,7 +290,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: memoizedCallback
+  × This hook does not specify its dependency: memoizedCallback
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -299,7 +299,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     37 │       dispatch(1);
     38 │ 
@@ -320,7 +320,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: state
+  × This hook does not specify its dependency: state
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -329,7 +329,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     34 │       setName(1);
     35 │ 
@@ -350,7 +350,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: name
+  × This hook does not specify its dependency: name
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -359,7 +359,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     31 │   const [isPending, startTransition] = useTransition();
     32 │   useEffect(() => {
@@ -380,7 +380,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: isPending
+  × This hook does not specify its dependency: isPending
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -389,7 +389,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     41 │       console.log(deferredValue);
     42 │ 
@@ -410,7 +410,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: memoizedValue
+  × This hook does not specify its dependency: memoizedValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -419,7 +419,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     39 │       console.log(memoizedCallback);
   > 40 │       console.log(memoizedValue);
@@ -439,7 +439,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -448,7 +448,7 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -469,7 +469,7 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -478,7 +478,7 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -499,7 +499,7 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -508,7 +508,7 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -529,7 +529,7 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -538,7 +538,7 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
     56 │   useLayoutEffect(() => console.log(a), []);
     57 │   useInsertionEffect(() => console.log(a), []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -559,7 +559,7 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -568,7 +568,7 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
     57 │   useInsertionEffect(() => console.log(a), []);
     58 │ }
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -589,7 +589,7 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -598,7 +598,7 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
     58 │ }
     59 │ 
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -619,7 +619,7 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     62 │ function MyComponent4() {
     63 │   let a = 1;
@@ -628,7 +628,7 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
     65 │       return () => console.log(a)
     66 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     63 │   let a = 1;
     64 │   useEffect(() => {
@@ -649,7 +649,7 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     71 │ function MyComponent5() {
     72 │   let a = 1;
@@ -658,7 +658,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
     74 │     console.log(a);
     75 │     return () => console.log(a);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     72 │   let a = 1;
     73 │   useEffect(() => {
@@ -667,7 +667,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
     75 │     return () => console.log(a);
     76 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     73 │   useEffect(() => {
     74 │     console.log(a);
@@ -688,7 +688,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: someObj.name
+  × This hook does not specify its dependency: someObj.name
   
     81 │ function MyComponent6() {
     82 │   let someObj = getObj();
@@ -697,7 +697,7 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
     84 │       console.log(someObj.name)
     85 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     82 │   let someObj = getObj();
     83 │   useEffect(() => {
@@ -718,7 +718,7 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
   > 89 │   useEffect(() => {
@@ -726,7 +726,7 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
     90 │       console.log(a);
     91 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
     89 │   useEffect(() => {
@@ -747,7 +747,7 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
   > 95 │   useEffect(() => {
@@ -755,7 +755,7 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
     96 │       console.log(a);
     97 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
     95 │   useEffect(() => {
@@ -776,7 +776,7 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     101 │ export function MyComponent9() {
     102 │   let a = 1;
@@ -785,7 +785,7 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
     104 │       console.log(a);
     105 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     102 │   let a = 1;
     103 │   useEffect(() => {
@@ -806,7 +806,7 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     108 │ export default function MyComponent10() {
     109 │   let a = 1;
@@ -815,7 +815,7 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
     111 │       console.log(a);
     112 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     109 │   let a = 1;
     110 │   useEffect(() => {
@@ -836,7 +836,7 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     116 │ function MyComponent11() {
     117 │   let a = 1;
@@ -845,7 +845,7 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
     119 │       console.log(a);
     120 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     117 │   let a = 1;
     118 │   useEffect(function inner() {
@@ -866,7 +866,7 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     123 │ function MyComponent12() {
     124 │   let a = 1;
@@ -875,7 +875,7 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
     126 │       console.log(a);
     127 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     124 │   let a = 1;
     125 │   useEffect(async function inner() {
@@ -896,7 +896,7 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     131 │ function MyComponent13() {
     132 │   let a = 1;
@@ -905,7 +905,7 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
     134 │       console.log(a);
     135 │   }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     132 │   let a = 1;
     133 │   React.useEffect(() => {
@@ -926,7 +926,7 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: ref.current
+  × This hook does not specify its dependency: ref.current
   
     139 │ function MyComponent14() {
     140 │ 	const ref = useRef();
@@ -935,7 +935,7 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
     142 │ 			console.log(ref.current);
     143 │ 	}, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     140 │ 	const ref = useRef();
     141 │ 	useEffect(() => {
@@ -956,7 +956,7 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: ref.current
+  × This hook does not specify its dependency: ref.current
   
     150 │ 	}
     151 │ 	const ref = useRef();
@@ -965,7 +965,7 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
     153 │ 			console.log(ref.current);
     154 │ 	}, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     151 │ 	const ref = useRef();
     152 │ 	useEffect(() => {
@@ -986,7 +986,7 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: func
+  × This hook does not specify its dependency: func
   
     163 │   }
     164 │ 
@@ -995,7 +995,7 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
     166 │     func()
     167 │   }, [])
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     165 │   useEffect(() => {
   > 166 │     func()
@@ -1015,7 +1015,7 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     172 │ function HoistedDeclaration() {
   > 173 │ 	useEffect(() => {
@@ -1023,7 +1023,7 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
     174 │ 		console.log(a);
     175 │ 	}, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     172 │ function HoistedDeclaration() {
     173 │ 	useEffect(() => {
@@ -1044,7 +1044,7 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: a
+  × This hook does not specify its dependency: a
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {
@@ -1052,7 +1052,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     183 │ 		console.log(a, b);
     184 │ 	}, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     181 │ function HoistedDeclarations() {
     182 │ 	useEffect(() => {
@@ -1073,7 +1073,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependencies: b
+  × This hook does not specify its dependency: b
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {
@@ -1081,7 +1081,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     183 │ 		console.log(a, b);
     184 │ 	}, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     181 │ function HoistedDeclarations() {
     182 │ 	useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
@@ -200,7 +200,7 @@ function HoistedDeclarations() {
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -230,7 +230,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: b
+  × This hook does not specify its dependency on b.
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -260,7 +260,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: deferredValue
+  × This hook does not specify its dependency on deferredValue.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -290,7 +290,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: memoizedCallback
+  × This hook does not specify its dependency on memoizedCallback.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -320,7 +320,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: state
+  × This hook does not specify its dependency on state.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -350,7 +350,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: name
+  × This hook does not specify its dependency on name.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -380,7 +380,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: isPending
+  × This hook does not specify its dependency on isPending.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -410,7 +410,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: memoizedValue
+  × This hook does not specify its dependency on memoizedValue.
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -439,7 +439,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -469,7 +469,7 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -499,7 +499,7 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -529,7 +529,7 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -559,7 +559,7 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -589,7 +589,7 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -619,7 +619,7 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     62 │ function MyComponent4() {
     63 │   let a = 1;
@@ -649,7 +649,7 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     71 │ function MyComponent5() {
     72 │   let a = 1;
@@ -688,7 +688,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: someObj.name
+  × This hook does not specify its dependency on someObj.name.
   
     81 │ function MyComponent6() {
     82 │   let someObj = getObj();
@@ -718,7 +718,7 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
   > 89 │   useEffect(() => {
@@ -747,7 +747,7 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
   > 95 │   useEffect(() => {
@@ -776,7 +776,7 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     101 │ export function MyComponent9() {
     102 │   let a = 1;
@@ -806,7 +806,7 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     108 │ export default function MyComponent10() {
     109 │   let a = 1;
@@ -836,7 +836,7 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     116 │ function MyComponent11() {
     117 │   let a = 1;
@@ -866,7 +866,7 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     123 │ function MyComponent12() {
     124 │   let a = 1;
@@ -896,7 +896,7 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     131 │ function MyComponent13() {
     132 │   let a = 1;
@@ -926,7 +926,7 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: ref.current
+  × This hook does not specify its dependency on ref.current.
   
     139 │ function MyComponent14() {
     140 │ 	const ref = useRef();
@@ -956,7 +956,7 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: ref.current
+  × This hook does not specify its dependency on ref.current.
   
     150 │ 	}
     151 │ 	const ref = useRef();
@@ -986,7 +986,7 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: func
+  × This hook does not specify its dependency on func.
   
     163 │   }
     164 │ 
@@ -1015,7 +1015,7 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     172 │ function HoistedDeclaration() {
   > 173 │ 	useEffect(() => {
@@ -1044,7 +1044,7 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: a
+  × This hook does not specify its dependency on a.
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {
@@ -1073,7 +1073,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify its dependency: b
+  × This hook does not specify its dependency on b.
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/missingDependenciesInvalid.jsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 134
 expression: missingDependenciesInvalid.jsx
 ---
 # Input
@@ -201,7 +200,7 @@ function HoistedDeclarations() {
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -210,7 +209,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     19 │       console.log(a, b);
     20 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     17 │     const b = a + 1;
     18 │     useEffect(() => {
@@ -219,9 +218,9 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     20 │     }, []);
     21 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     20 │ ····},·[a]);
        │         +   
@@ -231,7 +230,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: b
+  × This hook does not specify its dependencies: b
   
     16 │     let a = 1;
     17 │     const b = a + 1;
@@ -240,7 +239,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     19 │       console.log(a, b);
     20 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     17 │     const b = a + 1;
     18 │     useEffect(() => {
@@ -249,9 +248,9 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
     20 │     }, []);
     21 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     20 │ ····},·[b]);
        │         +   
@@ -261,7 +260,7 @@ missingDependenciesInvalid.jsx:18:5 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: deferredValue
+  × This hook does not specify its dependencies: deferredValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -270,7 +269,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     39 │       console.log(memoizedCallback);
     40 │       console.log(memoizedValue);
@@ -279,9 +278,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     42 │ 
     43 │       console.log(isPending);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[deferredValue]);
        │       +++++++++++++   
@@ -291,7 +290,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: memoizedCallback
+  × This hook does not specify its dependencies: memoizedCallback
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -300,7 +299,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     37 │       dispatch(1);
     38 │ 
@@ -309,9 +308,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     40 │       console.log(memoizedValue);
     41 │       console.log(deferredValue);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[memoizedCallback]);
        │       ++++++++++++++++   
@@ -321,7 +320,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: state
+  × This hook does not specify its dependencies: state
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -330,7 +329,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     34 │       setName(1);
     35 │ 
@@ -339,9 +338,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     37 │       dispatch(1);
     38 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[state]);
        │       +++++   
@@ -351,7 +350,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: name
+  × This hook does not specify its dependencies: name
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -360,7 +359,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     31 │   const [isPending, startTransition] = useTransition();
     32 │   useEffect(() => {
@@ -369,9 +368,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     34 │       setName(1);
     35 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[name]);
        │       ++++   
@@ -381,7 +380,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: isPending
+  × This hook does not specify its dependencies: isPending
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -390,7 +389,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     41 │       console.log(deferredValue);
     42 │ 
@@ -399,9 +398,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     44 │       startTransition();
     45 │   }, []);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[isPending]);
        │       +++++++++   
@@ -411,7 +410,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: memoizedValue
+  × This hook does not specify its dependencies: memoizedValue
   
     30 │   const deferredValue = useDeferredValue(value);
     31 │   const [isPending, startTransition] = useTransition();
@@ -420,7 +419,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     33 │       console.log(name);
     34 │       setName(1);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     39 │       console.log(memoizedCallback);
   > 40 │       console.log(memoizedValue);
@@ -428,9 +427,9 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
     41 │       console.log(deferredValue);
     42 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     45 │ ··},·[memoizedValue]);
        │       +++++++++++++   
@@ -440,7 +439,7 @@ missingDependenciesInvalid.jsx:32:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -449,7 +448,7 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     50 │ function MyComponent3() {
     51 │   let a = 1;
@@ -458,9 +457,9 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     52 │ ··useEffect(()·=>·console.log(a),·[a]);
        │                                    +   
@@ -470,7 +469,7 @@ missingDependenciesInvalid.jsx:52:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -479,7 +478,7 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     51 │   let a = 1;
     52 │   useEffect(() => console.log(a), []);
@@ -488,9 +487,9 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     53 │ ··useCallback(()·=>·console.log(a),·[a]);
        │                                      +   
@@ -500,7 +499,7 @@ missingDependenciesInvalid.jsx:53:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -509,7 +508,7 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     52 │   useEffect(() => console.log(a), []);
     53 │   useCallback(() => console.log(a), []);
@@ -518,9 +517,9 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     54 │ ··useMemo(()·=>·console.log(a),·[a]);
        │                                  +   
@@ -530,7 +529,7 @@ missingDependenciesInvalid.jsx:54:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -539,7 +538,7 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
     56 │   useLayoutEffect(() => console.log(a), []);
     57 │   useInsertionEffect(() => console.log(a), []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     53 │   useCallback(() => console.log(a), []);
     54 │   useMemo(() => console.log(a), []);
@@ -548,9 +547,9 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
     56 │   useLayoutEffect(() => console.log(a), []);
     57 │   useInsertionEffect(() => console.log(a), []);
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     55 │ ··useImperativeHandle(ref,·()·=>·console.log(a),·[a]);
        │                                                   +   
@@ -560,7 +559,7 @@ missingDependenciesInvalid.jsx:55:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -569,7 +568,7 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
     57 │   useInsertionEffect(() => console.log(a), []);
     58 │ }
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     54 │   useMemo(() => console.log(a), []);
     55 │   useImperativeHandle(ref, () => console.log(a), []);
@@ -578,9 +577,9 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
     57 │   useInsertionEffect(() => console.log(a), []);
     58 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     56 │ ··useLayoutEffect(()·=>·console.log(a),·[a]);
        │                                          +   
@@ -590,7 +589,7 @@ missingDependenciesInvalid.jsx:56:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -599,7 +598,7 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
     58 │ }
     59 │ 
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     55 │   useImperativeHandle(ref, () => console.log(a), []);
     56 │   useLayoutEffect(() => console.log(a), []);
@@ -608,9 +607,9 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
     58 │ }
     59 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     57 │ ··useInsertionEffect(()·=>·console.log(a),·[a]);
        │                                             +   
@@ -620,7 +619,7 @@ missingDependenciesInvalid.jsx:57:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     62 │ function MyComponent4() {
     63 │   let a = 1;
@@ -629,7 +628,7 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
     65 │       return () => console.log(a)
     66 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     63 │   let a = 1;
     64 │   useEffect(() => {
@@ -638,9 +637,9 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
     66 │   }, []);
     67 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     66 │ ··},·[a]);
        │       +   
@@ -650,7 +649,7 @@ missingDependenciesInvalid.jsx:64:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     71 │ function MyComponent5() {
     72 │   let a = 1;
@@ -659,7 +658,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
     74 │     console.log(a);
     75 │     return () => console.log(a);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     72 │   let a = 1;
     73 │   useEffect(() => {
@@ -668,7 +667,7 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
     75 │     return () => console.log(a);
     76 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     73 │   useEffect(() => {
     74 │     console.log(a);
@@ -677,19 +676,19 @@ missingDependenciesInvalid.jsx:73:3 lint/correctness/useExhaustiveDependencies  
     76 │   }, []);
     77 │ }
   
-  i Either include them or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
-    76 │ ··},·[a,·a]);
-       │       ++++   
+    76 │ ··},·[a]);
+       │       +   
 
 ```
 
 ```
 missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: someObj.name
+  × This hook does not specify its dependencies: someObj.name
   
     81 │ function MyComponent6() {
     82 │   let someObj = getObj();
@@ -698,7 +697,7 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
     84 │       console.log(someObj.name)
     85 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     82 │   let someObj = getObj();
     83 │   useEffect(() => {
@@ -707,9 +706,9 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
     85 │   }, []);
     86 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     85 │ ··},·[someObj.name]);
        │       ++++++++++++   
@@ -719,7 +718,7 @@ missingDependenciesInvalid.jsx:83:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
   > 89 │   useEffect(() => {
@@ -727,7 +726,7 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
     90 │       console.log(a);
     91 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     88 │ const MyComponent7 = React.memo(function ({ a }) {
     89 │   useEffect(() => {
@@ -736,9 +735,9 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
     91 │   }, []);
     92 │ });
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     91 │ ··},·[a]);
        │       +   
@@ -748,7 +747,7 @@ missingDependenciesInvalid.jsx:89:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
   > 95 │   useEffect(() => {
@@ -756,7 +755,7 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
     96 │       console.log(a);
     97 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     94 │ const MyComponent8 = React.memo(({ a }) => {
     95 │   useEffect(() => {
@@ -765,9 +764,9 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
     97 │   }, []);
     98 │ });
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     97 │ ··},·[a]);
        │       +   
@@ -777,7 +776,7 @@ missingDependenciesInvalid.jsx:95:3 lint/correctness/useExhaustiveDependencies  
 ```
 missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     101 │ export function MyComponent9() {
     102 │   let a = 1;
@@ -786,7 +785,7 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
     104 │       console.log(a);
     105 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     102 │   let a = 1;
     103 │   useEffect(() => {
@@ -795,9 +794,9 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
     105 │   }, []);
     106 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     105 │ ··},·[a]);
         │       +   
@@ -807,7 +806,7 @@ missingDependenciesInvalid.jsx:103:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     108 │ export default function MyComponent10() {
     109 │   let a = 1;
@@ -816,7 +815,7 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
     111 │       console.log(a);
     112 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     109 │   let a = 1;
     110 │   useEffect(() => {
@@ -825,9 +824,9 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
     112 │   }, []);
     113 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     112 │ ··},·[a]);
         │       +   
@@ -837,7 +836,7 @@ missingDependenciesInvalid.jsx:110:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     116 │ function MyComponent11() {
     117 │   let a = 1;
@@ -846,7 +845,7 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
     119 │       console.log(a);
     120 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     117 │   let a = 1;
     118 │   useEffect(function inner() {
@@ -855,9 +854,9 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
     120 │   }, []);
     121 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     120 │ ··},·[a]);
         │       +   
@@ -867,7 +866,7 @@ missingDependenciesInvalid.jsx:118:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     123 │ function MyComponent12() {
     124 │   let a = 1;
@@ -876,7 +875,7 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
     126 │       console.log(a);
     127 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     124 │   let a = 1;
     125 │   useEffect(async function inner() {
@@ -885,9 +884,9 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
     127 │   }, []);
     128 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     127 │ ··},·[a]);
         │       +   
@@ -897,7 +896,7 @@ missingDependenciesInvalid.jsx:125:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     131 │ function MyComponent13() {
     132 │   let a = 1;
@@ -906,7 +905,7 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
     134 │       console.log(a);
     135 │   }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     132 │   let a = 1;
     133 │   React.useEffect(() => {
@@ -915,9 +914,9 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
     135 │   }, []);
     136 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     135 │ ··},·[a]);
         │       +   
@@ -927,7 +926,7 @@ missingDependenciesInvalid.jsx:133:9 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: ref.current
+  × This hook does not specify its dependencies: ref.current
   
     139 │ function MyComponent14() {
     140 │ 	const ref = useRef();
@@ -936,7 +935,7 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
     142 │ 			console.log(ref.current);
     143 │ 	}, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     140 │ 	const ref = useRef();
     141 │ 	useEffect(() => {
@@ -945,9 +944,9 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
     143 │ 	}, []);
     144 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     143 │ → },·[ref.current]);
         │       +++++++++++   
@@ -957,7 +956,7 @@ missingDependenciesInvalid.jsx:141:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: ref.current
+  × This hook does not specify its dependencies: ref.current
   
     150 │ 	}
     151 │ 	const ref = useRef();
@@ -966,7 +965,7 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
     153 │ 			console.log(ref.current);
     154 │ 	}, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     151 │ 	const ref = useRef();
     152 │ 	useEffect(() => {
@@ -975,9 +974,9 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
     154 │ 	}, []);
     155 │ }
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     154 │ → },·[ref.current]);
         │       +++++++++++   
@@ -987,7 +986,7 @@ missingDependenciesInvalid.jsx:152:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: func
+  × This hook does not specify its dependencies: func
   
     163 │   }
     164 │ 
@@ -996,7 +995,7 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
     166 │     func()
     167 │   }, [])
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     165 │   useEffect(() => {
   > 166 │     func()
@@ -1004,9 +1003,9 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
     167 │   }, [])
     168 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     167 │ ··},·[func])
         │       ++++  
@@ -1016,7 +1015,7 @@ missingDependenciesInvalid.jsx:165:3 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     172 │ function HoistedDeclaration() {
   > 173 │ 	useEffect(() => {
@@ -1024,7 +1023,7 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
     174 │ 		console.log(a);
     175 │ 	}, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     172 │ function HoistedDeclaration() {
     173 │ 	useEffect(() => {
@@ -1033,9 +1032,9 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
     175 │ 	}, []);
     176 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     175 │ → },·[a]);
         │       +   
@@ -1045,7 +1044,7 @@ missingDependenciesInvalid.jsx:173:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: a
+  × This hook does not specify its dependencies: a
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {
@@ -1053,7 +1052,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     183 │ 		console.log(a, b);
     184 │ 	}, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     181 │ function HoistedDeclarations() {
     182 │ 	useEffect(() => {
@@ -1062,9 +1061,9 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     184 │ 	}, []);
     185 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     184 │ → },·[a]);
         │       +   
@@ -1074,7 +1073,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
 ```
 missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: b
+  × This hook does not specify its dependencies: b
   
     181 │ function HoistedDeclarations() {
   > 182 │ 	useEffect(() => {
@@ -1082,7 +1081,7 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     183 │ 		console.log(a, b);
     184 │ 	}, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     181 │ function HoistedDeclarations() {
     182 │ 	useEffect(() => {
@@ -1091,9 +1090,9 @@ missingDependenciesInvalid.jsx:182:2 lint/correctness/useExhaustiveDependencies 
     184 │ 	}, []);
     185 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     184 │ → },·[b]);
         │       +   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
@@ -21,7 +21,7 @@ function useCounter() {
 ```
 preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: value
+  × This hook does not specify its dependency on value.
   
     4 │ function useCounter() {
     5 │     const [value, setValue] = useState(0);

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
@@ -21,7 +21,7 @@ function useCounter() {
 ```
 preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: value
+  × This hook does not specify its dependencies: value
   
     4 │ function useCounter() {
     5 │     const [value, setValue] = useState(0);
@@ -30,7 +30,7 @@ preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     7 │         setValue(value + 1);
     8 │     }, []);
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     5 │     const [value, setValue] = useState(0);
     6 │     const increment = useCallback(() => {
@@ -39,9 +39,9 @@ preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     8 │     }, []);
     9 │     return { value, increment };
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     8 │ ····},·[value]);
       │         +++++   

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/preactHooks.js.snap
@@ -21,7 +21,7 @@ function useCounter() {
 ```
 preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: value
+  × This hook does not specify its dependency: value
   
     4 │ function useCounter() {
     5 │     const [value, setValue] = useState(0);
@@ -30,7 +30,7 @@ preactHooks.js:6:23 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━�
     7 │         setValue(value + 1);
     8 │     }, []);
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     5 │     const [value, setValue] = useState(0);
     6 │     const increment = useCallback(() => {

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
@@ -18,7 +18,7 @@ function MyComponent25() {
 ```
 stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependencies: dispatch
+  × This hook does not specify its dependency: dispatch
   
     4 │ function MyComponent25() {
     5 │     const dispatch = useDispatch();
@@ -27,7 +27,7 @@ stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE 
     7 │ }
     8 │ 
   
-  i This dependency is being used here, but not specified in the hook dependency list.
+  i This dependency is being used here, but is not specified in the hook dependency list.
   
     4 │ function MyComponent25() {
     5 │     const dispatch = useDispatch();

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
@@ -18,7 +18,7 @@ function MyComponent25() {
 ```
 stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify its dependency: dispatch
+  × This hook does not specify its dependency on dispatch.
   
     4 │ function MyComponent25() {
     5 │     const dispatch = useDispatch();

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalid.js.snap
@@ -18,7 +18,7 @@ function MyComponent25() {
 ```
 stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━
 
-  × This hook does not specify all of its dependencies: dispatch
+  × This hook does not specify its dependencies: dispatch
   
     4 │ function MyComponent25() {
     5 │     const dispatch = useDispatch();
@@ -27,7 +27,7 @@ stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE 
     7 │ }
     8 │ 
   
-  i This dependency is not specified in the hook dependency list.
+  i This dependency is being used here, but not specified in the hook dependency list.
   
     4 │ function MyComponent25() {
     5 │     const dispatch = useDispatch();
@@ -36,9 +36,9 @@ stableResultInvalid.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE 
     7 │ }
     8 │ 
   
-  i Either include it or remove the dependency array
+  i Either include it or remove the dependency array.
   
-  i Unsafe fix: Add the missing dependencies to the list.
+  i Unsafe fix: Add the missing dependency to the list.
   
     6 │ ····const·doAction·=·useCallback(()·=>·dispatch(someAction()),·[dispatch]);
       │                                                                 ++++++++   


### PR DESCRIPTION
## Summary

Fixes #6278 

The missing dependency was duplicated in the code fix if it is used multiple times in the hook. A single diagnostic of the rule is only for **one** dependency to add, so we should add only one instance of it.

I also improved the diagnostics slightly.

## Test Plan

Snapshot updated.