### PR TITLE
impl PartialEq and Eq for SendNode

### DIFF
--- a/crates/biome_rowan/src/syntax/node.rs
+++ b/crates/biome_rowan/src/syntax/node.rs
@@ -817,7 +817,7 @@ impl<L: Language> From<cursor::SyntaxNode> for SyntaxNode<L> {
 
 /// Language-agnostic representation of the root node of a syntax tree, can be
 /// sent or shared between threads
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SendNode {
     language: TypeId,
     green: GreenNode,


### PR DESCRIPTION
## Summary

- It's nice to have `SendNode` as `PartialEq` so that it can be used in [salsa](https://github.com/salsa-rs/salsa) queries, also all of it's fields are already `PartialEq` anyways :smile: 

## Test Plan

- Just automatically deriving the traits
