### PR TITLE
fix(linter): don't flag imports from dependencies

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -228,9 +228,9 @@ impl Rule for NoPrivateImports {
             .is_static_import()
             .then(|| node.inner_string_text())
             .flatten()
-            .filter(|specifier| !BiomePath::new(specifier.text()).is_dependency())
             .and_then(|specifier| module_info.static_import_paths.get(specifier.text()))
             .and_then(ResolvedPath::as_path)
+            .filter(|path| !BiomePath::new(path).is_dependency())
         else {
             return Vec::new();
         };

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/.gitignore
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/node_modules/external-package/index.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/node_modules/external-package/index.js
@@ -1,0 +1,5 @@
+/**
+ * @private
+ * This should be ignored because we're inside `node_modules`.
+ */
+export function privateExport() {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/node_modules/external-package/index.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/node_modules/external-package/index.js.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: index.js
+---
+# Input
+```js
+/**
+ * @private
+ * This should be ignored because we're inside `node_modules`.
+ */
+export function privateExport() {}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/package.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "no-private-imports",
+    "dependencies": {
+        "external-package": "0.0.1"
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js
@@ -1,6 +1,6 @@
 /* should not generate diagnostics */
 
-import { unknown } from "external-package";
+import { privateExport } from "external-package";
 
 // Importing a package-private symbol within the same package is allowed.
 import { fooPackageVariable } from "./foo.js";

--- a/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noPrivateImports/valid.js.snap
@@ -6,7 +6,7 @@ expression: valid.js
 ```js
 /* should not generate diagnostics */
 
-import { unknown } from "external-package";
+import { privateExport } from "external-package";
 
 // Importing a package-private symbol within the same package is allowed.
 import { fooPackageVariable } from "./foo.js";


### PR DESCRIPTION
## Summary

Really fix #6214.

## Test Plan

Added fixture data so the test case really resolves to a dependency. Double-checked that reverting the fix fails the test.
