### PR TITLE
fix(lint): valid norwegian language tags

### DIFF
--- a/.changeset/long-hairs-guess.md
+++ b/.changeset/long-hairs-guess.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6341](https://github.com/biomejs/biome/issues/6341): Fixed an issue where Biome would throw an error for the language tags `nb` and `nn`.

--- a/crates/biome_aria_metadata/build.rs
+++ b/crates/biome_aria_metadata/build.rs
@@ -36,11 +36,11 @@ const ISO_LANGUAGES: &[&str] = &[
     "nl", "en", "eo", "et", "fo", "fa", "fj", "fi", "fr", "fy", "gl", "gd", "gv", "ka", "de", "el",
     "kl", "gn", "gu", "ht", "ha", "he", "iw", "hi", "hu", "is", "io", "id", "in", "ia", "ie", "iu",
     "ik", "ga", "it", "ja", "jv", "kn", "ks", "kk", "rw", "ky", "rn", "ko", "ku", "lo", "la", "lv",
-    "li", "ln", "lt", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mo", "mn", "na", "ne", "no", "oc",
-    "or", "om", "ps", "pl", "pt", "pa", "qu", "rm", "ro", "ru", "sm", "sg", "sa", "sr", "sh", "st",
-    "tn", "sn", "ii", "sd", "si", "ss", "sk", "sl", "so", "es", "su", "sw", "sv", "tl", "tg", "ta",
-    "tt", "te", "th", "bo", "ti", "to", "ts", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "vi", "vo",
-    "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
+    "li", "ln", "lt", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mo", "mn", "na", "ne", "no", "nb",
+    "nn", "oc", "or", "om", "ps", "pl", "pt", "pa", "qu", "rm", "ro", "ru", "sm", "sg", "sa", "sr",
+    "sh", "st", "tn", "sn", "ii", "sd", "si", "ss", "sk", "sl", "so", "es", "su", "sw", "sv", "tl",
+    "tg", "ta", "tt", "te", "th", "bo", "ti", "to", "ts", "tr", "tk", "tw", "ug", "uk", "ur", "uz",
+    "vi", "vo", "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
 ];
 
 #[derive(Debug, Default, biome_deserialize_macros::Merge, serde::Deserialize)]

--- a/crates/biome_aria_metadata/src/lib.rs
+++ b/crates/biome_aria_metadata/src/lib.rs
@@ -20,7 +20,7 @@ pub const ISO_COUNTRIES: [&str; 233] = [
     "UZ", "VU", "VE", "VN", "WF", "EH", "YE", "ZM", "ZW",
 ];
 
-pub const ISO_LANGUAGES: [&str; 150] = [
+pub const ISO_LANGUAGES: [&str; 152] = [
     "ab", "aa", "af", "sq", "am", "ar", "an", "hy", "as", "ay", "az", "ba", "eu", "bn", "dz", "bh",
     "bi", "br", "bg", "my", "be", "km", "ca", "zh", "zh-Hans", "zh-Hant", "co", "hr", "cs", "da",
     "nl", "en", "eo", "et", "fo", "fa", "fj", "fi", "fr", "fy", "gl", "gd", "gv", "ka", "de", "el",

--- a/crates/biome_aria_metadata/src/lib.rs
+++ b/crates/biome_aria_metadata/src/lib.rs
@@ -26,11 +26,11 @@ pub const ISO_LANGUAGES: [&str; 150] = [
     "nl", "en", "eo", "et", "fo", "fa", "fj", "fi", "fr", "fy", "gl", "gd", "gv", "ka", "de", "el",
     "kl", "gn", "gu", "ht", "ha", "he", "iw", "hi", "hu", "is", "io", "id", "in", "ia", "ie", "iu",
     "ik", "ga", "it", "ja", "jv", "kn", "ks", "kk", "rw", "ky", "rn", "ko", "ku", "lo", "la", "lv",
-    "li", "ln", "lt", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mo", "mn", "na", "ne", "no", "oc",
-    "or", "om", "ps", "pl", "pt", "pa", "qu", "rm", "ro", "ru", "sm", "sg", "sa", "sr", "sh", "st",
-    "tn", "sn", "ii", "sd", "si", "ss", "sk", "sl", "so", "es", "su", "sw", "sv", "tl", "tg", "ta",
-    "tt", "te", "th", "bo", "ti", "to", "ts", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "vi", "vo",
-    "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
+    "li", "ln", "lt", "mk", "mg", "ms", "ml", "mt", "mi", "mr", "mo", "mn", "na", "ne", "no", "nb",
+    "nn", "oc", "or", "om", "ps", "pl", "pt", "pa", "qu", "rm", "ro", "ru", "sm", "sg", "sa", "sr",
+    "sh", "st", "tn", "sn", "ii", "sd", "si", "ss", "sk", "sl", "so", "es", "su", "sw", "sv", "tl",
+    "tg", "ta", "tt", "te", "th", "bo", "ti", "to", "ts", "tr", "tk", "tw", "ug", "uk", "ur", "uz",
+    "vi", "vo", "wa", "cy", "wo", "xh", "yi", "ji", "yo", "zu",
 ];
 
 /// Returns a list of valid ISO countries

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidLang/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidLang/valid.jsx
@@ -3,3 +3,5 @@ let a = <Html lang="en-babab" />;
 let a = <html lang="en-US"></html>;
 let a = <html lang="en"></html>;
 let a = <html lang={lang}></html>;
+let a = <html lang="nb"></html>;
+let a = <html lang="nn"></html>;

--- a/crates/biome_js_analyze/tests/specs/a11y/useValidLang/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/a11y/useValidLang/valid.jsx.snap
@@ -9,5 +9,7 @@ let a = <Html lang="en-babab" />;
 let a = <html lang="en-US"></html>;
 let a = <html lang="en"></html>;
 let a = <html lang={lang}></html>;
+let a = <html lang="nb"></html>;
+let a = <html lang="nn"></html>;
 
 ```


### PR DESCRIPTION
Resolves #6341

Added `nb` and `nn` to the language list.