### PR TITLE
fix(lint/noUselessEscapeInRegex): don't report `\k` as useless

### DIFF
--- a/.changeset/beige-otters-divide.md
+++ b/.changeset/beige-otters-divide.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a false positive of `noUselessEscapeInRegex` where `\k` was reported as useless in non-Unicode regular expressions.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_escape_in_regex.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_escape_in_regex.rs
@@ -86,11 +86,13 @@ impl Rule for NoUselessEscapeInRegex {
                         | b'*' | b'+' | b'?' | b'{' | b'}'
                         // Backreferences
                         | b'1'..=b'9'
+                        // Named backreferences
+                        | b'k'
                         // Groups
                         | b'(' | b')'
                         // Alternation
                         | b'|' => {}
-                        b'p' | b'P' | b'k' | b'q' if is_unicode_aware => {}
+                        b'p' | b'P' | b'q' if is_unicode_aware => {}
                         _ => {
                             return Some(State {
                                 backslash_index: index as u16,

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/invalid.js.snap
@@ -987,26 +987,6 @@ invalid.js:46:4 lint/complexity/noUselessEscapeInRegex  FIXABLE  ━━━━━
 ```
 
 ```
-invalid.js:49:8 lint/complexity/noUselessEscapeInRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i The character doesn't need to be escaped.
-  
-    48 │ // Unlike ESLint, we report `\k` when it is not in a unicode-aware regex
-  > 49 │ /(?<a>)\k<a>/;
-       │        ^^
-    50 │ 
-    51 │ // A test with unicode characters that take more than one byte
-  
-  i The escape sequence is only useful if the regular expression is unicode-aware. To be unicode-aware, the `u` or `v` flag should be used.
-  
-  i Safe fix: Unescape the character.
-  
-    49 │ /(?<a>)\k<a>/;
-       │        -      
-
-```
-
-```
 invalid.js:52:3 lint/complexity/noUselessEscapeInRegex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The character doesn't need to be escaped.

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/valid.js
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/valid.js
@@ -15,6 +15,9 @@
 /vi/m;
 /\B/;
 
+// https://github.com/biomejs/biome/issues/6331
+/(?<a>)\k<a>/;
+
 // https://github.com/eslint/eslint/issues/7472
 /\0/; // null character
 /\1/; // \x01 character (octal literal)

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessEscapeInRegex/valid.js.snap
@@ -21,6 +21,9 @@ expression: valid.js
 /vi/m;
 /\B/;
 
+// https://github.com/biomejs/biome/issues/6331
+/(?<a>)\k<a>/;
+
 // https://github.com/eslint/eslint/issues/7472
 /\0/; // null character
 /\1/; // \x01 character (octal literal)


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/issues/6331

## Test Plan

I updated the tests.
