### PR TITLE
fix(lint): add missing known pseudo classes and elements

### DIFF
--- a/.changeset/common-melons-see.md
+++ b/.changeset/common-melons-see.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6360](https://github.com/biomejs/biome/issues/6360): The following pseudo classes and elements are no longer reported by `noUnknownPseudoClass` or `noUnknownPseudoElement` rules.
+
+- `:open`
+- `::details-content`
+- `::prefix`
+- `::search-text`
+- `::suffix`

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -848,19 +848,23 @@ pub const VENDOR_SPECIFIC_PSEUDO_ELEMENTS: [&str; 66] = [
 
 pub const SHADOW_TREE_PSEUDO_ELEMENTS: [&str; 1] = ["part"];
 
-pub const OTHER_PSEUDO_ELEMENTS: [&str; 18] = [
+pub const OTHER_PSEUDO_ELEMENTS: [&str; 22] = [
     "backdrop",
     "content",
     "cue",
+    "details-content",
     "file-selector-button",
     "grammar-error",
     "highlight",
     "marker",
     "placeholder",
+    "prefix",
+    "search-text",
     "selection",
     "shadow",
     "slotted",
     "spelling-error",
+    "suffix",
     "target-text",
     "view-transition",
     "view-transition-group",
@@ -923,7 +927,7 @@ pub const RESOURCE_STATE_PSEUDO_CLASSES: [&str; 7] = [
     "volume-locked",
 ];
 
-pub const OTHER_PSEUDO_CLASSES: [&str; 50] = [
+pub const OTHER_PSEUDO_CLASSES: [&str; 51] = [
     "active",
     "any-link",
     "autofill",
@@ -955,6 +959,7 @@ pub const OTHER_PSEUDO_CLASSES: [&str; 50] = [
     "modal",
     "only-child",
     "only-of-type",
+    "open",
     "optional",
     "out-of-range",
     "past",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css
@@ -37,3 +37,4 @@ a:defined { }
 :popover-open {}
 :seeking, :stalled, :buffering, :volume-locked, :muted {}
 ::-webkit-scrollbar-button:hover {}
+dialog:open {}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoClass/valid.css.snap
@@ -43,4 +43,6 @@ a:defined { }
 :popover-open {}
 :seeking, :stalled, :buffering, :volume-locked, :muted {}
 ::-webkit-scrollbar-button:hover {}
+dialog:open {}
+
 ```

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.css
@@ -35,3 +35,4 @@ a::part(shadow-part) { }
 ::view-transition-new(*) {
 	position: absolute;
 }
+details::details-content {}

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownPseudoElement/valid.css.snap
@@ -41,5 +41,6 @@ a::part(shadow-part) { }
 ::view-transition-new(*) {
 	position: absolute;
 }
+details::details-content {}
 
 ```


### PR DESCRIPTION
## Summary

Fixes #6360 

Added the following pseudo classes and elements:

- `:open`
- `::details-content`
- `::prefix`
- `::search-text`
- `::suffix`

ref: https://drafts.csswg.org/css-pseudo-4/
ref: https://drafts.csswg.org/selectors/

## Test Plan

Updated snapshot tests.
