### PR TITLE
ci: unify release and use changeset publish for tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,5 +329,5 @@ jobs:
 
       - name: Upload assets to the latest tag
         run: |
-          files=$(ls cli-* | tr '\n' ' ')
+          files=$(ls biome-* | tr '\n' ' ')
           gh release upload @biomejs/biome@${{ needs.build-binaries.outputs.version }} $files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,13 +292,14 @@ jobs:
 
   # Publishing jobs
 
-  publish-cli:
+  publish:
     name: Publish
     runs-on: ubuntu-24.04
     needs:
       - build-binaries
       - build-binaries-gnu
       - build-wasm
+      - build-js-api
     environment: npm-publish
     permissions:
       contents: write
@@ -317,49 +318,16 @@ jobs:
           pattern: wasm-*
           merge-multiple: true
           path: packages/@biomejs
-
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Generate npm packages
-        run: node packages/@biomejs/biome/scripts/generate-packages.mjs
-
       - name: Publish npm packages as latest
-        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ]; then npm publish $package --tag latest --access public --provenance; fi; done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish
 
       - name: Upload assets to the latest tag
         run: |
-          files=$(ls biome-* | tr '\n' ' ')
+          files=$(ls cli-* | tr '\n' ' ')
           gh release upload @biomejs/biome@${{ needs.build-binaries.outputs.version }} $files
-
-  publish-js-api:
-    name: Publish
-    runs-on: ubuntu-24.04
-    needs: build-js-api
-    environment: npm-publish
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Download package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: js-api
-          path: packages/@biomejs/js-api/dist
-
-      - name: Install Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish npm package as latest
-        run: npm publish packages/@biomejs/js-api --tag latest --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/crates/biome_formatter_test/src/prettier/package.json
+++ b/crates/biome_formatter_test/src/prettier/package.json
@@ -5,5 +5,6 @@
 	},
 	"dependencies": {
 		"prettier": "3.5.3"
-	}
+	},
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "check:write": "cargo biome-cli-dev check --write --unsafe",
     "check": "cargo biome-cli-dev check",
     "ci": "cargo biome-cli-dev ci",
-    "version": "changeset version && pnpm install --no-frozen-lockfile"
+    "version": "changeset version && pnpm install --no-frozen-lockfile",
+    "publish": "changeset publish"
   },
   "keywords": [],
   "author": "Biome Developers and Contributors",

--- a/packages/@biomejs/cli-darwin-arm64/package.json
+++ b/packages/@biomejs/cli-darwin-arm64/package.json
@@ -16,5 +16,8 @@
   ],
   "cpu": [
     "arm64"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-darwin-x64/package.json
+++ b/packages/@biomejs/cli-darwin-x64/package.json
@@ -16,5 +16,8 @@
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-linux-arm64-musl/package.json
+++ b/packages/@biomejs/cli-linux-arm64-musl/package.json
@@ -19,5 +19,8 @@
   ],
   "libc": [
     "musl"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-linux-arm64/package.json
+++ b/packages/@biomejs/cli-linux-arm64/package.json
@@ -19,5 +19,8 @@
   ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-linux-x64-musl/package.json
+++ b/packages/@biomejs/cli-linux-x64-musl/package.json
@@ -19,5 +19,8 @@
   ],
   "libc": [
     "musl"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-linux-x64/package.json
+++ b/packages/@biomejs/cli-linux-x64/package.json
@@ -19,5 +19,8 @@
   ],
   "libc": [
     "glibc"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-win32-arm64/package.json
+++ b/packages/@biomejs/cli-win32-arm64/package.json
@@ -16,5 +16,8 @@
   ],
   "cpu": [
     "arm64"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/cli-win32-x64/package.json
+++ b/packages/@biomejs/cli-win32-x64/package.json
@@ -16,5 +16,8 @@
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/js-api/package.json
+++ b/packages/@biomejs/js-api/package.json
@@ -68,5 +68,8 @@
     "@biomejs/wasm-web": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/@biomejs/wasm-bundler/package.json
+++ b/packages/@biomejs/wasm-bundler/package.json
@@ -29,5 +29,8 @@
     "linter",
     "formatter",
     "wasm"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/wasm-nodejs/package.json
+++ b/packages/@biomejs/wasm-nodejs/package.json
@@ -23,5 +23,8 @@
     "linter",
     "formatter",
     "wasm"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/@biomejs/wasm-web/package.json
+++ b/packages/@biomejs/wasm-web/package.json
@@ -27,5 +27,8 @@
     "linter",
     "formatter",
     "wasm"
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- merged the two jobs into one
- the publish command is done by `changeset publish` (tested it locally, and it works as expected)
- fixed the manual upload of the artefacts, where it was using `biome-` instead of `cli-`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tested only the publish part. For uploading the artefacts, we should trigger a new release. It will need a new changeset

<!-- What demonstrates that your implementation is correct? -->
