### PR TITLE
fix(lint): false positive on noSelfCompare for additional arguments

### DIFF
--- a/.changeset/quick-nails-sniff.md
+++ b/.changeset/quick-nails-sniff.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6377](https://github.com/biomejs/biome/issues/6377): The rule [noSelfCompare](https://biomejs.dev/linter/rules/no-self-compare/) now correctly compares two function calls with different arguments.

--- a/crates/biome_js_analyze/src/utils.rs
+++ b/crates/biome_js_analyze/src/utils.rs
@@ -14,8 +14,10 @@ pub(crate) fn is_node_equal(a_node: &JsSyntaxNode, b_node: &JsSyntaxNode) -> boo
     let a_tree = a_node.preorder_with_tokens(Direction::Next);
     let b_tree = b_node.preorder_with_tokens(Direction::Next);
     for (a_event, b_event) in iter::zip(a_tree, b_tree) {
-        let (WalkEvent::Enter(a_child), WalkEvent::Enter(b_child)) = (a_event, b_event) else {
-            continue;
+        let (a_child, b_child) = match (a_event, b_event) {
+            (WalkEvent::Enter(a), WalkEvent::Enter(b)) => (a, b),
+            (WalkEvent::Leave(_), WalkEvent::Leave(_)) => continue,
+            _ => return false,
         };
         if a_child.kind() != b_child.kind() {
             return false;

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSelfCompare/issue6377.js
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSelfCompare/issue6377.js
@@ -1,0 +1,19 @@
+function sum(...args) {
+	let result = 0;
+	for (const value of args) {
+		result += value;
+	}
+	return result;
+}
+
+// False positive ❌
+sum(1) === sum(1, 2);
+sum(1) !== sum(1, 2);
+
+// True positives ✅
+sum(1) === sum(1);
+sum(1) !== sum(1);
+
+// True negatives ✅
+sum(1) === sum(2);
+sum(1) !== sum(2);

--- a/crates/biome_js_analyze/tests/specs/suspicious/noSelfCompare/issue6377.js.snap
+++ b/crates/biome_js_analyze/tests/specs/suspicious/noSelfCompare/issue6377.js.snap
@@ -1,0 +1,57 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6377.js
+---
+# Input
+```js
+function sum(...args) {
+	let result = 0;
+	for (const value of args) {
+		result += value;
+	}
+	return result;
+}
+
+// False positive ❌
+sum(1) === sum(1, 2);
+sum(1) !== sum(1, 2);
+
+// True positives ✅
+sum(1) === sum(1);
+sum(1) !== sum(1);
+
+// True negatives ✅
+sum(1) === sum(2);
+sum(1) !== sum(2);
+
+```
+
+# Diagnostics
+```
+issue6377.js:14:1 lint/suspicious/noSelfCompare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Comparing to itself is potentially pointless.
+  
+    13 │ // True positives ✅
+  > 14 │ sum(1) === sum(1);
+       │ ^^^^^^^^^^^^^^^^^
+    15 │ sum(1) !== sum(1);
+    16 │ 
+  
+
+```
+
+```
+issue6377.js:15:1 lint/suspicious/noSelfCompare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Comparing to itself is potentially pointless.
+  
+    13 │ // True positives ✅
+    14 │ sum(1) === sum(1);
+  > 15 │ sum(1) !== sum(1);
+       │ ^^^^^^^^^^^^^^^^^
+    16 │ 
+    17 │ // True negatives ✅
+  
+
+```


### PR DESCRIPTION
## Summary

Fixes #6377 

Fixed that `biome_js_analyze::utils::is_node_equal` didn't compare two nodes when these have a common part at the start in a syntax node.

## Test Plan

Added snapshot tests.
