### PR TITLE
fix(formatter): don't insert an empty line before semicolon with leading comments

### DIFF
--- a/.changeset/yellow-hornets-lose.md
+++ b/.changeset/yellow-hornets-lose.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6375](https://github.com/biomejs/biome/issues/6375): The formatter no longer inserts an extra empty line before a semicolon when it has leading comments.

--- a/crates/biome_js_formatter/src/js/statements/expression_statement.rs
+++ b/crates/biome_js_formatter/src/js/statements/expression_statement.rs
@@ -30,7 +30,10 @@ impl FormatNodeRule<JsExpressionStatement> for FormatJsExpressionStatement {
             .prev_sibling()
             .and_then(|sibling| sibling.last_token())
         {
-            if token.kind() == T![;] && get_lines_before_token(&token) > 1 {
+            if token.kind() == T![;]
+                && !token.has_leading_comments()
+                && get_lines_before_token(&token) > 1
+            {
                 write!(f, [empty_line()])?;
             }
         }

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue6375.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue6375.js
@@ -1,0 +1,7 @@
+const Transport = {}
+const newRequest = {}
+
+/**
+ * SAFETY: monkey patching and getting around the provided type definitions.
+ */
+;(Transport.prototype as any).request = newRequest

--- a/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue6375.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/no-semi/issue6375.js.snap
@@ -1,0 +1,79 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: js/module/no-semi/issue6375.js
+---
+# Input
+
+```js
+const Transport = {}
+const newRequest = {}
+
+/**
+ * SAFETY: monkey patching and getting around the provided type definitions.
+ */
+;(Transport.prototype as any).request = newRequest
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Expand lists: Auto
+-----
+
+```js
+const Transport = {};
+const newRequest = {};
+
+/**
+ * SAFETY: monkey patching and getting around the provided type definitions.
+ */
+(Transport.prototype as any).request = newRequest;
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: As needed
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Expand lists: Auto
+-----
+
+```js
+const Transport = {}
+const newRequest = {}
+
+/**
+ * SAFETY: monkey patching and getting around the provided type definitions.
+ */
+;(Transport.prototype as any).request = newRequest
+```


### PR DESCRIPTION
## Summary

Fixes #6375 

Fixed a regression introduced by #6048. The leading semicolon shouldn't have an empty line when it has some leading comments.

## Test Plan

Added a snapshot test.