### PR TITLE
fix(lint/useHookAtTopLevel): don't flag Vitest function calls that look like hooks

### DIFF
--- a/crates/biome_js_analyze/src/react/hooks.rs
+++ b/crates/biome_js_analyze/src/react/hooks.rs
@@ -148,7 +148,7 @@ pub(crate) fn is_react_hook_call(call: &JsCallExpression) -> bool {
         return false;
     };
 
-    // HACK: jest has some functions that start with `use` and are not hooks
+    // HACK: Jest/Vitest have some functions that start with `use` and are not hooks
     if let Some(expr) = call
         .callee()
         .ok()
@@ -158,7 +158,8 @@ pub(crate) fn is_react_hook_call(call: &JsCallExpression) -> bool {
         .and_then(|ident| ident.name().ok())
         .and_then(|name| name.value_token().ok())
     {
-        if expr.text_trimmed() == "jest" {
+        let exprTrimmed = expr.text_trimmed();
+        if exprTrimmed == "jest" || exprTrimmed == "vi" {
             return false;
         }
     }

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js
@@ -130,7 +130,12 @@ test('c', () => {
 describe("foo", () => {
   beforeEach(() => jest.useFakeTimers('legacy'));
   afterEach(() => jest.useRealTimers());
-})
+});
+
+describe("bar", () => {
+  beforeEach(() => vi.useFakeTimers('legacy'));
+  afterEach(() => vi.useRealTimers());
+});
 
 class DemoMethod {
     useHook() {

--- a/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useHookAtTopLevel/valid.js.snap
@@ -136,7 +136,12 @@ test('c', () => {
 describe("foo", () => {
   beforeEach(() => jest.useFakeTimers('legacy'));
   afterEach(() => jest.useRealTimers());
-})
+});
+
+describe("bar", () => {
+  beforeEach(() => vi.useFakeTimers('legacy'));
+  afterEach(() => vi.useRealTimers());
+});
 
 class DemoMethod {
     useHook() {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes #6396

Extension of #3415

Vitest has some functions that our heuristics flag as a React hook. This PR makes it so Biome doesn't flag `vi.useFakeTimers` and `vi.useRealTimers` as React hooks.

## Test Plan

See valid.js
