### PR TITLE
feat(biome_js_analyze): allow specifying stable object keys in `useExhaustiveDependencies` configuration

### DIFF
--- a/.changeset/thick-seas-draw.md
+++ b/.changeset/thick-seas-draw.md
@@ -1,0 +1,28 @@
+---
+"@biomejs/biome": minor
+---
+
+Added support for tracking stable results in user-provided React hooks that return objects to [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) to compliment existing support for array return values. For example:
+
+```json
+"useExhaustiveDependencies": {
+    "level": "error",
+    "options": {
+        "hooks": [{
+            "name": "useCustomHook",
+            "stableResult": [
+                "setMyState"
+            ]
+        }]
+    }
+}
+```
+
+This will allow the following to be validated:
+
+```js
+const {myState, setMyState} = useCustomHook();
+const toggleMyState = useCallback(() => {
+  setMyState(!myState);
+}, [myState]); // Only `myState` needs to be specified here.
+```

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -209,7 +209,7 @@ declare_lint_rule! {
     /// hook always have the same identity and should be omitted as such.
     ///
     /// You can configure custom hooks that return stable results in one of
-    /// three ways:
+    /// four ways:
     ///
     /// * `"stableResult": true` -- marks the return value as stable. An example
     ///   of a React hook that would be configured like this is `useRef()`.
@@ -217,6 +217,8 @@ declare_lint_rule! {
     ///   marks the given index or indices to be stable. An example of a React
     ///   hook that would be configured like this is `useState()`.
     /// * `"stableResult": 1` -- shorthand for `"stableResult": [1]`.
+    /// * `"stableResult": ["setValue"]` -- expects the return value to be an
+    ///   object and marks the given property or properties to be stable.
     ///
     /// #### Example
     ///
@@ -624,7 +626,7 @@ fn into_member_iter(node: &JsSyntaxNode) -> impl Iterator<Item = String> + use<>
         }
     }
 
-    // elemnsts are inserted in reverse, thus we have to reverse the iteration.
+    // elements are inserted in reverse, thus we have to reverse the iteration.
     vec.into_iter().rev()
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.js
@@ -1,0 +1,7 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.js.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
+expression: stableResultInvalidKeysIndices.js
+---
+# Input
+```js
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function MyComponent25() {
+    const dispatch = useDispatch();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}
+
+```
+
+# Diagnostics
+```
+stableResultInvalidKeysIndices.options:12:49 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected either property key names or array indices, not a combination of both
+  
+    10 │                             {
+    11 │                                 "name": "otherCustomHook",
+  > 12 │                                 "stableResult": ["key", 1]
+       │                                                 ^^^^^^^^^^
+    13 │                             }
+    14 │                         ]
+  
+
+```
+
+```
+stableResultInvalidKeysIndices.js:6:22 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━
+
+  × This hook does not specify its dependency on dispatch.
+  
+    4 │ function MyComponent25() {
+    5 │     const dispatch = useDispatch();
+  > 6 │     const doAction = useCallback(() => dispatch(someAction()), []);
+      │                      ^^^^^^^^^^^
+    7 │ }
+    8 │ 
+  
+  i This dependency is being used here, but is not specified in the hook dependency list.
+  
+    4 │ function MyComponent25() {
+    5 │     const dispatch = useDispatch();
+  > 6 │     const doAction = useCallback(() => dispatch(someAction()), []);
+      │                                        ^^^^^^^^
+    7 │ }
+    8 │ 
+  
+  i Either include it or remove the dependency array.
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    6 │ ····const·doAction·=·useCallback(()·=>·dispatch(someAction()),·[dispatch]);
+      │                                                                 ++++++++   
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultInvalidKeysIndices.options.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "rules": {
+            "correctness": {
+                "useExhaustiveDependencies": {
+                    "level": "error",
+                    "options": {
+                        "hooks": [
+                            {
+                                "name": "otherCustomHook",
+                                "stableResult": ["key", 1]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.js
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function useCustomHook() {
+    const dispatch = useDispatch();
+    return { dispatch }
+}
+
+function MyComponent27() {
+    const { dispatch } = useCustomHook();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.js.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 134
+expression: stableResultKeys.js
+---
+# Input
+```js
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+
+function useCustomHook() {
+    const dispatch = useDispatch();
+    return { dispatch }
+}
+
+function MyComponent27() {
+    const { dispatch } = useCustomHook();
+    const doAction = useCallback(() => dispatch(someAction()), []);
+}
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/stableResultKeys.options.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+    "linter": {
+        "rules": {
+            "correctness": {
+                "useExhaustiveDependencies": {
+                    "level": "error",
+                    "options": {
+                        "hooks": [
+                            {
+                                "name": "useCustomHook",
+                                "stableResult": ["dispatch"]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8025,7 +8025,7 @@ export type Regex = string;
  */
 export type Style2 = "auto" | "inlineType" | "separatedType";
 export type GroupMatcher = ImportMatcher | SourceMatcher;
-export type StableHookResult = boolean | number[];
+export type StableHookResult = boolean | number[] | string[];
 export type Formats = Format[];
 export interface Selector {
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -11465,6 +11465,12 @@
 						"minimum": 0.0
 					},
 					"minItems": 1
+				},
+				{
+					"description": "Used to indicate the hook returns an object and some of its properties have stable identities.",
+					"type": "array",
+					"items": { "type": "string" },
+					"minItems": 1
 				}
 			]
 		},


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #6386

Currently Biome supports specifying that React hook results are stable when hook returns either a single value or an array. This PR adds support for specifying stable object keys inside a hook return value as well.

For example, this hook returns a stable `setMyState` function:

```ts
const useCustomHook = () => {
  const [myState, setMyState] = useState(false)
  return {myState, setMyState}
}

const Component = () => {
  const {myState, setMyState} = useCustomHook()
  const toggleMyState = useCallback(() => {
    setMyState(!myState);
  }, [myState]);

  return <button onClick={toggleMyState}>button</button>
}
```

but when linting with Biome the following error is generated:

```
file.tsx:26:25 lint/correctness/useExhaustiveDependencies  FIXABLE  
  ✖ This hook does not specify all of its dependencies: setMyState
  
    24 │ const Component = () => {
    25 │   const {myState, setMyState} = useCustomHook()
  > 26 │   const toggleMyState = useCallback(() => {
       │                         ^^^^^^^^^^^
    27 │     setMyState(!myState);
    28 │   }, [myState]);
  
  ℹ This dependency is not specified in the hook dependency list.
  
    25 │   const {myState, setMyState} = useCustomHook()
    26 │   const toggleMyState = useCallback(() => {
  > 27 │     setMyState(!myState);
       │     ^^^^^^^^^^
    28 │   }, [myState]);
    29 │ 
  
  ℹ Unsafe fix: Add the missing dependencies to the list.
  
    28 │ ··},·[myState,·setMyState]);
       │              ++++++++++++
```

with no ability to specify that this value is stable without suppressing the rule.

This PR adds a new option which allows specifying that such object properties are stable:

```json
"useExhaustiveDependencies": {
    "level": "error",
    "options": {
        "hooks": [{
            "name": "useCustomHook",
            "stableResult": [
                "setMyState"
            ]
        }]
    }
}
```

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Added two tests:
- [stableResultKeys](https://github.com/biomejs/biome/compare/main...josh-:use-exhaustive-dependencies-stable-object-keys?expand=1#diff-45fcb627b2957a628e1fb75cccec111da4e5b4c863ffb5602736ad165858c9db) validates the new configuration option
- [stableResultInvalidKeysIndices](https://github.com/biomejs/biome/compare/main...josh-:use-exhaustive-dependencies-stable-object-keys?expand=1#diff-0a102400268c21c327ece09dcab8892b37261b628039b37c994d7a00f71ec078) validates the new error throw when mixing array indices and object property keys in the configtaiton