### PR TITLE
docs: fix JS API example

### DIFF
--- a/packages/@biomejs/js-api/README.md
+++ b/packages/@biomejs/js-api/README.md
@@ -26,7 +26,7 @@ const biome = await Biome.create({
 	distribution: Distribution.NODE, // Or BUNDLER / WEB depending on the distribution package you've installed
 });
 
-const projectKey = biome.openProject("path/to/project/dir");
+const { projectKey } = biome.openProject("path/to/project/dir");
 
 // Optionally apply a Biome configuration (instead of biome.json)
 biome.applyConfiguration(projectKey, {...});


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fix the JavaScript API example. The `openProject()` method returns an `OpenProjectResult`: `{ projectKey: 2, scanKind: "none" }`. But the `formatContent()` and `lintContent()` methods only take the `projectKey` as a parameter.

```
/home/regseb/testcase/node_modules/@biomejs/js-api/dist/wasm.js:94
        return new WasmError(e);
               ^

WasmError
    at WasmError.fromError (/home/regseb/testcase/node_modules/@biomejs/js-api/dist/wasm.js:94:16)
    at wrapError (/home/regseb/testcase/node_modules/@biomejs/js-api/dist/wasm.js:103:22)
    at Biome.applyConfiguration (/home/regseb/testcase/node_modules/@biomejs/js-api/dist/index.js:50:40)
    at file:///home/regseb/testcase/index.js:11:7 {
  stackTrace: Error: Error: invalid type: JsValue(Object({"projectKey":2,"scanKind":"none"})), expected a nonzero usize
      at module.exports.__wbg_new_c68d7209be747379 (/home/regseb/testcase/node_modules/@biomejs/wasm-nodejs/biome_wasm.js:703:17)
      at wasm://wasm/04a71e9a:wasm-function[15331]:0xf5f503
      at wasm://wasm/04a71e9a:wasm-function[10207]:0xe399e5
      at wasm://wasm/04a71e9a:wasm-function[13594]:0xf2c55c
      at Workspace.updateSettings (/home/regseb/testcase/node_modules/@biomejs/wasm-nodejs/biome_wasm.js:297:26)
      at Biome.applyConfiguration (/home/regseb/testcase/node_modules/@biomejs/js-api/dist/index.js:43:28)
      at file:///home/regseb/testcase/index.js:11:7
}

Node.js v22.15.0
```

## Test Plan

[Message in Discord](https://discord.com/channels/1132231889290285117/1384819089360293928/1384822601372663908)