### PR TITLE
fix(lint/complexity/useDateNow): improve error message

### DIFF
--- a/.changeset/bumpy-pots-share.md
+++ b/.changeset/bumpy-pots-share.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Improve error message in `lint/complexity/useDateNow` rule
+Improved error message in [`useDateNow`](https://biomejs.dev/linter/rules/use-date-now/) rule.

--- a/.changeset/bumpy-pots-share.md
+++ b/.changeset/bumpy-pots-share.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improve error message in `lint/complexity/useDateNow` rule

--- a/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_date_now.rs
@@ -81,7 +81,7 @@ impl Rule for UseDateNow {
 
     fn diagnostic(_: &RuleContext<Self>, (node, kind): &Self::State) -> Option<RuleDiagnostic> {
         let message = match kind {
-            UseDateNowIssueKind::ReplaceMethod(method) => format!("new Date().{method}"),
+            UseDateNowIssueKind::ReplaceMethod(method) => format!("new Date().{method}()"),
             UseDateNowIssueKind::ReplaceConstructor => "new Date()".to_string(),
             UseDateNowIssueKind::ReplaceNumberConstructor => "Number(new Date())".to_string(),
         };

--- a/crates/biome_js_analyze/tests/specs/complexity/useDateNow/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useDateNow/invalid.js.snap
@@ -52,7 +52,7 @@ typeof+new Date();
 ```
 invalid.js:1:12 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().getTime.
+  ! Use Date.now() instead of new Date().getTime().
   
   > 1 │ const ts = new Date().getTime();
       │            ^^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ invalid.js:1:12 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:2:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().getTime.
+  ! Use Date.now() instead of new Date().getTime().
   
     1 │ const ts = new Date().getTime();
   > 2 │ const ts1 = (new Date()).getTime();
@@ -98,7 +98,7 @@ invalid.js:2:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:3:14 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().getTime.
+  ! Use Date.now() instead of new Date().getTime().
   
     1 │ const ts = new Date().getTime();
     2 │ const ts1 = (new Date()).getTime();
@@ -124,7 +124,7 @@ invalid.js:3:14 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:4:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().valueOf.
+  ! Use Date.now() instead of new Date().valueOf().
   
     2 │ const ts1 = (new Date()).getTime();
     3 │ const ts2 = (new Date().getTime());
@@ -150,7 +150,7 @@ invalid.js:4:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:5:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().valueOf.
+  ! Use Date.now() instead of new Date().valueOf().
   
     3 │ const ts2 = (new Date().getTime());
     4 │ const ts3 = new Date().valueOf();
@@ -176,7 +176,7 @@ invalid.js:5:13 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:6:14 lint/complexity/useDateNow  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ! Use Date.now() instead of new Date().valueOf.
+  ! Use Date.now() instead of new Date().valueOf().
   
     4 │ const ts3 = new Date().valueOf();
     5 │ const ts4 = (new Date()).valueOf();


### PR DESCRIPTION
## Summary

Previously, you would get an error like

```
Use Date.now() instead of new Date().getTime.
```

which wasn't technically correct. If you followed the error message literally, you'd end up with `Date.now()()` in your code.

## Test Plan

Updated snapshot tests