### PR TITLE
ci: update lockfile in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "check:write": "cargo biome-cli-dev check --write --unsafe",
     "check": "cargo biome-cli-dev check",
     "ci": "cargo biome-cli-dev ci",
-    "version": "changeset version",
+    "//": "when we create the release PR, we need to update the lock file with the new versions",
+    "version": "changeset version && pnpm i --no-lock-file",
     "publish": "changeset publish"
   },
   "keywords": [],


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I think we really need to lock file in `ci: release` 

The latest failure shows that:

```

  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 8 dependencies are mismatched:
  - @biomejs/cli-darwin-arm64 (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-darwin-x64 (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-linux-arm64 (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-linux-arm64-musl (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-linux-x64 (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-linux-x64-musl (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-win32-arm64 (lockfile: 2.0.0, manifest: 2.0.1)
  - @biomejs/cli-win32-x64 (lockfile: 2.0.0, manifest: 2.0.1)
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Another release? 

<!-- What demonstrates that your implementation is correct? -->
