### PR TITLE
perf: preallocate type store

### DIFF
--- a/crates/biome_js_analyze/src/lib.rs
+++ b/crates/biome_js_analyze/src/lib.rs
@@ -154,11 +154,7 @@ where
 
     let type_resolver = module_graph
         .module_info_for_path(file_path.as_ref())
-        .map(|module_info| {
-            let mut resolver = ModuleResolver::for_module(module_info, module_graph.clone());
-            resolver.run_inference();
-            resolver
-        })
+        .map(|module_info| ModuleResolver::for_module(module_info, module_graph.clone()))
         .map(Arc::new);
 
     services.insert_service(Arc::new(AriaRoles));

--- a/crates/biome_js_type_info/src/type_store.rs
+++ b/crates/biome_js_type_info/src/type_store.rs
@@ -42,6 +42,13 @@ impl TypeStore {
         Self { types, table }
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            types: Vec::with_capacity(capacity),
+            table: HashTable::with_capacity(capacity),
+        }
+    }
+
     pub fn as_slice(&self) -> &[TypeData] {
         &self.types
     }

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -76,21 +76,25 @@ pub struct ModuleResolver {
 
 impl ModuleResolver {
     pub fn for_module(module_info: JsModuleInfo, module_graph: Arc<ModuleGraph>) -> Self {
-        Self {
+        let num_initial_types = module_info.types.len();
+
+        let mut resolver = Self {
             module_graph,
             modules: vec![module_info],
             modules_by_path: Default::default(),
             expressions: Default::default(),
-            types: Default::default(),
+            types: TypeStore::with_capacity(num_initial_types),
             type_id_map: Default::default(),
-        }
+        };
+
+        resolver.run_inference();
+        resolver
     }
 
     /// Runs the resolver's inference.
     ///
-    /// This method must've been called before attempting to query the types of
-    /// functions or expressions.
-    pub fn run_inference(&mut self) {
+    /// This gets called once on construction of the resolver.
+    fn run_inference(&mut self) {
         self.resolve_imports_in_modules();
         self.resolve_all();
         self.flatten_all();

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -591,9 +591,10 @@ export const promise = makePromiseCb();
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let promise_id = resolver
         .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
@@ -648,9 +649,10 @@ fn test_resolve_generic_return_value_with_multiple_modules() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let result_id = resolver
         .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
@@ -694,9 +696,10 @@ fn test_resolve_import_as_namespace() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let result_id = resolver
         .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
@@ -737,8 +740,7 @@ fn test_resolve_nested_function_call_with_namespace_in_return_type() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
+    let resolver = ModuleResolver::for_module(index_module, module_graph.clone());
 
     let snapshot = ModuleGraphSnapshot::new(module_graph.as_ref(), &fs).with_resolver(&resolver);
     snapshot.assert_snapshot("test_resolve_nested_function_call_with_namespace_in_return_type");
@@ -1111,9 +1113,10 @@ fn test_resolve_react_types() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let use_callback_id = resolver
         .resolve_type_of(&Text::Static("useCallback"), ScopeId::GLOBAL)
@@ -1170,9 +1173,10 @@ fn test_resolve_single_reexport() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let result_id = resolver
         .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
@@ -1234,9 +1238,10 @@ fn test_resolve_multiple_reexports() {
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let result1_id = resolver
         .resolve_type_of(&Text::Static("result1"), ScopeId::GLOBAL)
@@ -1326,9 +1331,10 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let resolved_id = resolver
         .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
@@ -1389,9 +1395,10 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let resolved_id = resolver
         .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
@@ -1443,9 +1450,10 @@ const { mutate } = useSWRConfig();
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let use_swr_config_id = resolver
         .resolve_type_of(&Text::Static("useSWRConfig"), ScopeId::GLOBAL)
@@ -1502,9 +1510,10 @@ type Intersection = Foo & Bar;"#,
     let index_module = module_graph
         .module_info_for_path(Utf8Path::new("/src/index.ts"))
         .expect("module must exist");
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let intersection_id = resolver
         .resolve_type_of(&Text::Static("Intersection"), ScopeId::GLOBAL)
@@ -1593,9 +1602,10 @@ fn test_resolve_swr_types() {
         )))
     );
 
-    let mut resolver = ModuleResolver::for_module(index_module, module_graph.clone());
-    resolver.run_inference();
-    let resolver = Arc::new(resolver);
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
 
     let mutate_id = resolver
         .resolve_type_of(&Text::Static("mutate"), ScopeId::GLOBAL)


### PR DESCRIPTION
## Summary

A small optimisation to avoid unnecessary reallocations when running the inference on the module resolver.

Also made the `run_inference()` method itself private and run it directly upon construction. It is required to be called anyway, and may only be called once, so what better way to enforce that?

## Test Plan

Everything should stay green.
