### PR TITLE
ci: restore the pnpm install step in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           corepack enable
           pnpm --version
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Create Release Pull Request
         id: changesets-action
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3


### PR DESCRIPTION
## Summary

Follow-up of #6416 

The removed pnpm install step was necessary to install the changeset CLI.

## Test Plan

The release workflow on main should back green
