### PR TITLE
fix(lint): noUselessFragments should ignore fragments with untrimmed whitespaces

### DIFF
--- a/.changeset/chubby-carrots-divide.md
+++ b/.changeset/chubby-carrots-divide.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6391](https://github.com/biomejs/biome/issues/6391): the rule [`noUselessFragments`](https://biomejs.dev/linter/rules/no-useless-fragments/) no longer reports a fragment that contains whitespaces which aren't trimmed by the runtime.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -218,16 +218,21 @@ impl Rule for NoUselessFragments {
                                 // We need to whitespaces and newlines from the original string.
                                 // Since in the JSX newlines aren't trivia, we require to allocate a string to trim from those characters.
                                 let original_text = child.to_trimmed_text();
-                                let child_text = original_text.text().trim();
+                                let trimmed_text = original_text.text().trim();
 
                                 if (in_jsx_expr || in_js_logical_expr)
-                                    && contains_html_character_references(child_text)
+                                    && contains_html_character_references(trimmed_text)
                                 {
                                     children_where_fragments_must_preserved = true;
                                     break;
                                 }
 
-                                if !child_text.is_empty() {
+                                // Test whether a node is a padding spaces trimmed by the React runtime.
+                                let is_only_whitespace = trimmed_text.is_empty();
+                                let is_padding_spaces =
+                                    is_only_whitespace && original_text.contains('\n');
+
+                                if !is_padding_spaces {
                                     significant_children += 1;
                                     if first_significant_child.is_none() {
                                         first_significant_child = Some(child);

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx
@@ -1,0 +1,1 @@
+appendToLastRow(rows, <> {character.leftBracket}</>);

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue_6391.jsx
+---
+# Input
+```jsx
+appendToLastRow(rows, <> {character.leftBracket}</>);
+
+```


### PR DESCRIPTION
## Summary

Fixes #6391

React trims a "padding" whitespaces inside a element when it contains **at least one line break**; whitespaces without line breaks will never be trimmed and should be considered as a valid text node.

For example, the following code:

```jsx
<> </>
```

is equivalent to:

```jsx
<>{" "}</>
```

There is the same logic in `react/jsx-no-unnecessary-fragment`: https://github.com/jsx-eslint/eslint-plugin-react/blob/f2869fd6dc76ceb863c5e2aeea8bf4d392508775/lib/rules/jsx-no-useless-fragment.js#L116-L125

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
