### PR TITLE
fix(stdin): keep stdin-file-path for well known files

### DIFF
--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -2,7 +2,7 @@
 //!
 use crate::diagnostics::StdinDiagnostic;
 use crate::execute::Execution;
-use crate::{CliDiagnostic, CliSession, TEMPORARY_INTERNAL_FILE_NAME, TraversalMode};
+use crate::{CliDiagnostic, CliSession, TraversalMode};
 use biome_analyze::RuleCategoriesBuilder;
 use biome_console::{ConsoleExt, markup};
 use biome_diagnostics::Diagnostic;
@@ -15,7 +15,6 @@ use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DropPatternParams, FeaturesBuilder, FileContent,
     FixFileParams, FormatFileParams, OpenFileParams, SupportsFeatureParams,
 };
-use camino::Utf8PathBuf;
 use std::borrow::Cow;
 
 pub(crate) fn run<'a>(
@@ -32,9 +31,7 @@ pub(crate) fn run<'a>(
 
     let std_in_file = biome_path
         .extension()
-        .map(|ext| {
-            BiomePath::new(Utf8PathBuf::from(TEMPORARY_INTERNAL_FILE_NAME).with_extension(ext))
-        })
+        .map(|_| biome_path.clone())
         .ok_or_else(|| CliDiagnostic::from(StdinDiagnostic::new_no_extension()))?;
 
     if mode.is_format() {

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -2298,6 +2298,37 @@ fn treat_known_json_files_as_jsonc_files() {
 }
 
 #[test]
+fn treat_known_json_files_as_jsonc_files_stdin() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    console.in_buffer.push(
+        r#"
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	"#
+        .to_string(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--stdin-file-path", "files/.eslintrc.json"].as_slice()),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "treat_known_json_files_as_jsonc_files_stdin",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn should_apply_different_formatting() {
     let mut fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files_stdin.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/treat_known_json_files_as_jsonc_files_stdin.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+# Input messages
+
+```block
+
+/*test*/ [
+
+/* some other comment*/1, 2, 3]
+	
+```
+
+# Emitted Messages
+
+```block
+/*test*/ [/* some other comment*/ 1, 2, 3]
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

This PR addresses an issue encountered while using `conform.nvim` in Neovim, specifically with formatting certain `json` files that are inherently `jsonc` (e.g., `tsconfig.json`, `jsconfig.json`).

Upon investigation of `conform.nvim`'s logs, it was observed that `stdin-file-path` was being used to pass the file name for formatting. This led to an analysis of the `biome` source code to understand why these well-known files were not being correctly formatted.

This PR aims to resolve that issue by keeping the path passed by user instead of renaming to internal name and avoiding to detect well-known files.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan
<!-- What demonstrates that your implementation is correct? -->
- Given this `tsconfig.json`:
  ```json
  {
  // Test Comment,
    // Hello
  "include": [],
  }
  ```
- When run `cat tsconfig.json | biome check --write stdin-file-path tsconfig.json`
- Then I see the Result:
  ```json
  {
  	// Test Comment,
  	// Hello
  	"include": []
  }
  ```
- When run `cat tsconfig.json | biome check --write stdin-file-path mytsconfig.json`
- Then I see the Result:
  ```
  format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                                                                                                               
  ✖ Code formatting aborted due to parsing errors. To format code with errors, enable the 'formatter.formatWithErrors' option.
  ```
