### PR TITLE
fix(linter): don't enable nursery rules in domains

### DIFF
--- a/.changeset/khaki-paths-cry.md
+++ b/.changeset/khaki-paths-cry.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6482](https://github.com/biomejs/biome/issues/6482) where nursery rules that belonged to a domain were incorrectly enabled.

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1011,6 +1011,12 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
         L: biome_rowan::Language,
         R: Rule<Query: Queryable<Language = L, Output: Clone>> + 'static,
     {
+        let group = <R::Group as RuleGroup>::NAME;
+        // Nursery rules must be enabled only when they are enabled from the group
+        if group == "nursery" {
+            return;
+        }
+
         let path = self.path.expect("File path");
 
         let recommended_enabled = self
@@ -1057,7 +1063,11 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
         R: Rule<Query: Queryable<Language = L, Output: Clone>> + 'static,
     {
         let no_only = self.only.is_some_and(|only| only.is_empty());
-
+        let group = <R::Group as RuleGroup>::NAME;
+        // Nursery rules must be enabled only when they are enabled from the group
+        if group == "nursery" {
+            return;
+        }
         if !no_only {
             return;
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes #6482

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

 I thought about creating two tests, but they would fail once the nursery rule gets promoted. I tested locally using the user reproduction. I also tested it against 

```json
{
	"linter": {
		"domains": {
			"react": "all"
		}
	}
}
```

<!-- What demonstrates that your implementation is correct? -->
