### PR TITLE
ci: add step to dispatch event for automated codegen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  BIOME_WEBSITE_REPO: biomejs/website
+  BIOME_PUSH_ON_MAIN_EVENT_TYPE: biome-push-on-main-event
 
 jobs:
   changesets:
@@ -370,6 +372,15 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
 
+      - name: Dispatch event on release
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.BIOME_REPOSITORY_DISPATCH }}
+          repository: ${{ env.BIOME_WEBSITE_REPO }}
+          event-type: ${{ env.BIOME_PUSH_ON_MAIN_EVENT_TYPE }}
+          client-payload: |
+            '{ "sha": "${{ env.GITHUB_SHA }}", "tag": "@biomejs/biome@${{ needs.build-binaries.outputs.version }}", "version": "${{ needs.build-binaries.outputs.version }}" }'
+
   publish-js-api:
     name: Publish JS API
     runs-on: ubuntu-24.04
@@ -420,3 +431,5 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           make_latest: false # Keep the CLI release as latest
+
+


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new step after the publishing of the CLI.  The main idea is that once we dispatch this event, we will trigger a new workflow in `biomejs/website`, run the codege based on `client-payload`, and push them to `main`. 


This new step dispatches an event to `biomjes/website` with the following information:
- the SHA of the commit. It's probably not needed, but since we use SHA on the website, I want to keep it for now. The idea is to switch to git tags inside `Cargo.toml` and SHA commits for the playground
- the tag, to use inside `Cargo.toml`
- the version number, required when running the codegen

The dispatch event is copied from `repository_dispatch.yml`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Please proofread the `client-payload` and the environment variables. `BIOME_REPOSITORY_DISPATCH` is already available 



<!-- What demonstrates that your implementation is correct? -->
