### PR TITLE
feat(linter): handle arrays of Promises in `noFloatingPromises`

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -94,9 +94,9 @@ declare_lint_rule! {
 
 pub enum NoMisusedPromisesState {
     Conditional,
-    ExpectedConditionalReturn,
-    ExpectedVoidReturn,
+    ConditionalReturn,
     Spread,
+    VoidReturn,
 }
 
 impl Rule for NoMisusedPromises {
@@ -133,7 +133,7 @@ impl Rule for NoMisusedPromises {
                     "You may have intended to `await` the Promise instead."
                 }),
             ),
-            NoMisusedPromisesState::ExpectedConditionalReturn => Some(
+            NoMisusedPromisesState::ConditionalReturn => Some(
                 RuleDiagnostic::new(
                     rule_category!(),
                     node.range(),
@@ -150,7 +150,7 @@ impl Rule for NoMisusedPromises {
                     "does not work inside a synchronous callback."
                 }),
             ),
-            NoMisusedPromisesState::ExpectedVoidReturn => Some(
+            NoMisusedPromisesState::VoidReturn => Some(
                 RuleDiagnostic::new(
                     rule_category!(),
                     node.range(),
@@ -182,7 +182,7 @@ impl Rule for NoMisusedPromises {
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         use NoMisusedPromisesState::*;
-        if matches!(state, ExpectedConditionalReturn | ExpectedVoidReturn) {
+        if matches!(state, ConditionalReturn | VoidReturn) {
             return None; // These cannot be automatically fixed.
         }
 
@@ -296,9 +296,9 @@ fn find_misused_promise_returning_callback(
     };
 
     if argument_ty.is_function_with_return_type(|ty| ty.is_conditional()) {
-        Some(NoMisusedPromisesState::ExpectedConditionalReturn)
+        Some(NoMisusedPromisesState::ConditionalReturn)
     } else if argument_ty.is_function_with_return_type(|ty| ty.is_void()) {
-        Some(NoMisusedPromisesState::ExpectedVoidReturn)
+        Some(NoMisusedPromisesState::VoidReturn)
     } else {
         None
     }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -345,3 +345,9 @@ function returnMaybePromise(): Promise<void> | undefined {
 }
 
 returnMaybePromise();
+
+[1, 2, 3].map(async (x) => x + 1);
+
+async function floatingArray() {
+	[1, 2, 3].map((x) => Promise.resolve(x + 1));
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -352,6 +352,12 @@ function returnMaybePromise(): Promise<void> | undefined {
 
 returnMaybePromise();
 
+[1, 2, 3].map(async (x) => x + 1);
+
+async function floatingArray() {
+	[1, 2, 3].map((x) => Promise.resolve(x + 1));
+}
+
 ```
 
 # Diagnostics
@@ -1631,8 +1637,46 @@ invalid.ts:347:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
   > 347 │ returnMaybePromise();
         │ ^^^^^^^^^^^^^^^^^^^^^
     348 │ 
+    349 │ [1, 2, 3].map(async (x) => x + 1);
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
+
+```
+
+```
+invalid.ts:349:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    347 │ returnMaybePromise();
+    348 │ 
+  > 349 │ [1, 2, 3].map(async (x) => x + 1);
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    350 │ 
+    351 │ async function floatingArray() {
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:352:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i An array of Promises was found, meaning they are not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    351 │ async function floatingArray() {
+  > 352 │ 	[1, 2, 3].map((x) => Promise.resolve(x + 1));
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    353 │ }
+    354 │ 
+  
+  i This happens when an array of Promises is not wrapped with Promise.all() or a similar method, and is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Wrap in Promise.all() and add await operator.
+  
+    352 │ → await·Promise.all([1,·2,·3].map((x)·=>·Promise.resolve(x·+·1)));
+        │   ++++++++++++++++++                                            + 
 
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts
@@ -248,3 +248,9 @@ async function testDestructuringAndCallingReturnsPromiseFromRest({
 }: Props) {
   rest.returnsPromise().catch(() => {}).finally(() => {});
 }
+
+void [1, 2, 3].map(async (x) => x + 1);
+
+async function floatingArray() {
+  await Promise.all([1, 2, 3].map((x) => Promise.resolve(x + 1)));
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/valid.ts.snap
@@ -255,4 +255,10 @@ async function testDestructuringAndCallingReturnsPromiseFromRest({
   rest.returnsPromise().catch(() => {}).finally(() => {});
 }
 
+void [1, 2, 3].map(async (x) => x + 1);
+
+async function floatingArray() {
+  await Promise.all([1, 2, 3].map((x) => Promise.resolve(x + 1)));
+}
+
 ```

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -12,9 +12,9 @@ use biome_rowan::Text;
 
 use crate::{
     Class, Function, FunctionParameter, GenericTypeParameter, Literal, Resolvable,
-    ResolvedTypeData, ResolvedTypeId, ReturnType, ScopeId, TypeData, TypeId, TypeMember,
-    TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolver, TypeResolverLevel,
-    TypeStore, flattening::MAX_FLATTEN_DEPTH,
+    ResolvedTypeData, ResolvedTypeId, ReturnType, ScopeId, TypeData, TypeId, TypeInstance,
+    TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolver,
+    TypeResolverLevel, TypeStore, flattening::MAX_FLATTEN_DEPTH,
 };
 
 const GLOBAL_LEVEL: TypeResolverLevel = TypeResolverLevel::Global;
@@ -39,37 +39,42 @@ pub const VOID_ID: TypeId = TypeId::new(2);
 pub const CONDITIONAL_ID: TypeId = TypeId::new(3);
 pub const NUMBER_ID: TypeId = TypeId::new(4);
 pub const STRING_ID: TypeId = TypeId::new(5);
-pub const ARRAY_ID: TypeId = TypeId::new(6);
-pub const ARRAY_FILTER_ID: TypeId = TypeId::new(7);
-pub const ARRAY_FOREACH_ID: TypeId = TypeId::new(8);
-pub const GLOBAL_ID: TypeId = TypeId::new(9);
-pub const INSTANCEOF_PROMISE_ID: TypeId = TypeId::new(10);
-pub const PROMISE_ID: TypeId = TypeId::new(11);
-pub const PROMISE_CONSTRUCTOR_ID: TypeId = TypeId::new(12);
-pub const PROMISE_CATCH_ID: TypeId = TypeId::new(13);
-pub const PROMISE_FINALLY_ID: TypeId = TypeId::new(14);
-pub const PROMISE_THEN_ID: TypeId = TypeId::new(15);
-pub const PROMISE_ALL_ID: TypeId = TypeId::new(16);
-pub const PROMISE_ALL_SETTLED_ID: TypeId = TypeId::new(17);
-pub const PROMISE_ANY_ID: TypeId = TypeId::new(18);
-pub const PROMISE_RACE_ID: TypeId = TypeId::new(19);
-pub const PROMISE_REJECT_ID: TypeId = TypeId::new(20);
-pub const PROMISE_RESOLVE_ID: TypeId = TypeId::new(21);
-pub const PROMISE_TRY_ID: TypeId = TypeId::new(22);
-pub const BIGINT_STRING_LITERAL_ID: TypeId = TypeId::new(23);
-pub const BOOLEAN_STRING_LITERAL_ID: TypeId = TypeId::new(24);
-pub const FUNCTION_STRING_LITERAL_ID: TypeId = TypeId::new(25);
-pub const NUMBER_STRING_LITERAL_ID: TypeId = TypeId::new(26);
-pub const OBJECT_STRING_LITERAL_ID: TypeId = TypeId::new(27);
-pub const STRING_STRING_LITERAL_ID: TypeId = TypeId::new(28);
-pub const SYMBOL_STRING_LITERAL_ID: TypeId = TypeId::new(29);
-pub const UNDEFINED_STRING_LITERAL_ID: TypeId = TypeId::new(30);
-pub const TYPEOF_OPERATOR_RETURN_UNION_ID: TypeId = TypeId::new(31);
-pub const T_ID: TypeId = TypeId::new(32);
-pub const CONDITIONAL_CALLBACK_ID: TypeId = TypeId::new(33);
-pub const VOID_CALLBACK_ID: TypeId = TypeId::new(34);
-pub const FETCH_ID: TypeId = TypeId::new(35);
-pub const NUM_PREDEFINED_TYPES: usize = 36; // Most be one more than the highest `TypeId` above.
+pub const INSTANCEOF_ARRAY_T_ID: TypeId = TypeId::new(6);
+pub const INSTANCEOF_ARRAY_U_ID: TypeId = TypeId::new(7);
+pub const ARRAY_ID: TypeId = TypeId::new(8);
+pub const ARRAY_FILTER_ID: TypeId = TypeId::new(9);
+pub const ARRAY_FOREACH_ID: TypeId = TypeId::new(10);
+pub const ARRAY_MAP_ID: TypeId = TypeId::new(11);
+pub const GLOBAL_ID: TypeId = TypeId::new(12);
+pub const INSTANCEOF_PROMISE_ID: TypeId = TypeId::new(13);
+pub const PROMISE_ID: TypeId = TypeId::new(14);
+pub const PROMISE_CONSTRUCTOR_ID: TypeId = TypeId::new(15);
+pub const PROMISE_CATCH_ID: TypeId = TypeId::new(16);
+pub const PROMISE_FINALLY_ID: TypeId = TypeId::new(17);
+pub const PROMISE_THEN_ID: TypeId = TypeId::new(18);
+pub const PROMISE_ALL_ID: TypeId = TypeId::new(19);
+pub const PROMISE_ALL_SETTLED_ID: TypeId = TypeId::new(20);
+pub const PROMISE_ANY_ID: TypeId = TypeId::new(21);
+pub const PROMISE_RACE_ID: TypeId = TypeId::new(22);
+pub const PROMISE_REJECT_ID: TypeId = TypeId::new(23);
+pub const PROMISE_RESOLVE_ID: TypeId = TypeId::new(24);
+pub const PROMISE_TRY_ID: TypeId = TypeId::new(25);
+pub const BIGINT_STRING_LITERAL_ID: TypeId = TypeId::new(26);
+pub const BOOLEAN_STRING_LITERAL_ID: TypeId = TypeId::new(27);
+pub const FUNCTION_STRING_LITERAL_ID: TypeId = TypeId::new(28);
+pub const NUMBER_STRING_LITERAL_ID: TypeId = TypeId::new(29);
+pub const OBJECT_STRING_LITERAL_ID: TypeId = TypeId::new(30);
+pub const STRING_STRING_LITERAL_ID: TypeId = TypeId::new(31);
+pub const SYMBOL_STRING_LITERAL_ID: TypeId = TypeId::new(32);
+pub const UNDEFINED_STRING_LITERAL_ID: TypeId = TypeId::new(33);
+pub const TYPEOF_OPERATOR_RETURN_UNION_ID: TypeId = TypeId::new(34);
+pub const T_ID: TypeId = TypeId::new(35);
+pub const U_ID: TypeId = TypeId::new(36);
+pub const CONDITIONAL_CALLBACK_ID: TypeId = TypeId::new(37);
+pub const MAP_CALLBACK_ID: TypeId = TypeId::new(38);
+pub const VOID_CALLBACK_ID: TypeId = TypeId::new(39);
+pub const FETCH_ID: TypeId = TypeId::new(40);
+pub const NUM_PREDEFINED_TYPES: usize = 41; // Must be one more than the highest `TypeId` above.
 
 pub const GLOBAL_UNKNOWN_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNKNOWN_ID);
 pub const GLOBAL_UNDEFINED_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, UNDEFINED_ID);
@@ -103,6 +108,7 @@ pub const GLOBAL_UNDEFINED_STRING_LITERAL_ID: ResolvedTypeId =
 pub const GLOBAL_TYPEOF_OPERATOR_RETURN_UNION_ID: ResolvedTypeId =
     ResolvedTypeId::new(GLOBAL_LEVEL, TYPEOF_OPERATOR_RETURN_UNION_ID);
 pub const GLOBAL_T_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, T_ID);
+pub const GLOBAL_U_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, U_ID);
 pub const GLOBAL_FETCH_ID: ResolvedTypeId = ResolvedTypeId::new(GLOBAL_LEVEL, FETCH_ID);
 
 /// Returns a string for formatting global IDs in test snapshots.
@@ -114,39 +120,44 @@ pub fn global_type_name(id: TypeId) -> &'static str {
         3 => "conditional",
         4 => "number",
         5 => "string",
-        6 => "Array",
-        7 => "Array.prototype.filter",
-        8 => "Array.prototype.forEach",
-        9 => "globalThis",
-        10 => "instanceof Promise",
-        11 => "Promise",
-        12 => "Promise.constructor",
-        13 => "Promise.prototype.catch",
-        14 => "Promise.prototype.finally",
-        15 => "Promise.prototype.then",
-        16 => "Promise.all",
-        17 => "Promise.allSettled",
-        18 => "Promise.any",
-        19 => "Promise.race",
-        20 => "Promise.reject",
-        21 => "Promise.resolve",
-        22 => "Promise.try",
-        23 => "\"bigint\"",
-        24 => "\"boolean\"",
-        25 => "\"function\"",
-        26 => "\"number\"",
-        27 => "\"object\"",
-        28 => "\"string\"",
-        29 => "\"symbol\"",
-        30 => "\"undefined\"",
-        31 => {
+        6 => "instanceof Array<T>",
+        7 => "instanceof Array<U>",
+        8 => "Array",
+        9 => "Array.prototype.filter",
+        10 => "Array.prototype.forEach",
+        11 => "Array.prototype.map",
+        12 => "globalThis",
+        13 => "instanceof Promise",
+        14 => "Promise",
+        15 => "Promise.constructor",
+        16 => "Promise.prototype.catch",
+        17 => "Promise.prototype.finally",
+        18 => "Promise.prototype.then",
+        19 => "Promise.all",
+        20 => "Promise.allSettled",
+        21 => "Promise.any",
+        22 => "Promise.race",
+        23 => "Promise.reject",
+        24 => "Promise.resolve",
+        25 => "Promise.try",
+        26 => "\"bigint\"",
+        27 => "\"boolean\"",
+        28 => "\"function\"",
+        29 => "\"number\"",
+        30 => "\"object\"",
+        31 => "\"string\"",
+        32 => "\"symbol\"",
+        33 => "\"undefined\"",
+        34 => {
             "\"bigint\" | \"boolean\" | \"function\" | \"number\" | \"object\" \
                 | \"string\" | \"symbol\" | \"undefined\""
         }
-        32 => "T",
-        33 => "() => conditional",
-        34 => "() => void",
-        35 => "fetch",
+        35 => "T",
+        36 => "U",
+        37 => "() => conditional",
+        38 => "<U>(item: T) => U",
+        39 => "() => void",
+        40 => "fetch",
         _ => "inferred type",
     }
 }
@@ -175,10 +186,13 @@ impl Default for GlobalsResolver {
         };
 
         let array_method_definition =
-            |id: TypeId, param_type_id: TypeId, return_type_id: TypeId| {
+            |id: TypeId,
+             param_type_id: TypeId,
+             return_type_id: TypeId,
+             type_parameters: Box<[TypeReference]>| {
                 TypeData::from(Function {
                     is_async: false,
-                    type_parameters: Default::default(),
+                    type_parameters,
                     name: Some(Text::Static(global_type_name(id))),
                     parameters: [FunctionParameter {
                         name: None,
@@ -215,6 +229,11 @@ impl Default for GlobalsResolver {
             TypeData::Conditional,
             TypeData::Number,
             TypeData::String,
+            TypeData::instance_of(TypeReference::from(GLOBAL_ARRAY_ID)),
+            TypeData::instance_of(TypeInstance {
+                ty: TypeReference::from(GLOBAL_ARRAY_ID),
+                type_parameters: [GLOBAL_U_ID.into()].into(),
+            }),
             TypeData::Class(Box::new(Class {
                 name: Some(Text::Static("Array")),
                 type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
@@ -223,6 +242,7 @@ impl Default for GlobalsResolver {
                 members: Box::new([
                     method("filter", ARRAY_FILTER_ID),
                     method("forEach", ARRAY_FOREACH_ID),
+                    method("map", ARRAY_MAP_ID),
                     TypeMember {
                         kind: TypeMemberKind::Named(Text::Static("length")),
                         is_static: false,
@@ -230,8 +250,24 @@ impl Default for GlobalsResolver {
                     },
                 ]),
             })),
-            array_method_definition(ARRAY_FILTER_ID, CONDITIONAL_CALLBACK_ID, ARRAY_ID),
-            array_method_definition(ARRAY_FOREACH_ID, VOID_CALLBACK_ID, VOID_ID),
+            array_method_definition(
+                ARRAY_FILTER_ID,
+                CONDITIONAL_CALLBACK_ID,
+                INSTANCEOF_ARRAY_T_ID,
+                Default::default(),
+            ),
+            array_method_definition(
+                ARRAY_FOREACH_ID,
+                VOID_CALLBACK_ID,
+                VOID_ID,
+                Default::default(),
+            ),
+            array_method_definition(
+                ARRAY_MAP_ID,
+                MAP_CALLBACK_ID,
+                INSTANCEOF_ARRAY_U_ID,
+                [GLOBAL_U_ID.into()].into(),
+            ),
             TypeData::Global,
             TypeData::instance_of(TypeReference::from(GLOBAL_PROMISE_ID)),
             TypeData::Class(Box::new(Class {
@@ -304,12 +340,31 @@ impl Default for GlobalsResolver {
                 constraint: TypeReference::Unknown,
                 default: TypeReference::Unknown,
             }),
+            TypeData::from(GenericTypeParameter {
+                name: Text::Static("U"),
+                constraint: TypeReference::Unknown,
+                default: TypeReference::Unknown,
+            }),
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
                 name: Some(Text::Static(global_type_name(CONDITIONAL_CALLBACK_ID))),
                 parameters: Default::default(),
                 return_type: ReturnType::Type(GLOBAL_CONDITIONAL_ID.into()),
+            }),
+            TypeData::from(Function {
+                is_async: false,
+                type_parameters: Default::default(),
+                name: Some(Text::Static(global_type_name(MAP_CALLBACK_ID))),
+                parameters: [FunctionParameter {
+                    name: None,
+                    ty: GLOBAL_U_ID.into(),
+                    bindings: Default::default(),
+                    is_optional: false,
+                    is_rest: false,
+                }]
+                .into(),
+                return_type: ReturnType::Type(GLOBAL_U_ID.into()),
             }),
             TypeData::from(Function {
                 is_async: false,

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -20,7 +20,9 @@ use biome_js_type_info_macros::Resolvable;
 use biome_resolver::ResolvedPath;
 use biome_rowan::Text;
 
-use crate::globals::{GLOBAL_NUMBER_ID, GLOBAL_PROMISE_ID, GLOBAL_STRING_ID, GLOBAL_UNKNOWN_ID};
+use crate::globals::{
+    GLOBAL_ARRAY_ID, GLOBAL_NUMBER_ID, GLOBAL_PROMISE_ID, GLOBAL_STRING_ID, GLOBAL_UNKNOWN_ID,
+};
 use crate::type_info::literal::{BooleanLiteral, NumberLiteral, StringLiteral};
 use crate::{
     GLOBAL_RESOLVER, ModuleId, Resolvable, ResolvedTypeData, ResolvedTypeId, ResolvedTypeMember,
@@ -102,6 +104,22 @@ impl Type {
                 .iter()
                 .filter_map(|ty| self.resolve(ty))
                 .any(predicate),
+            _ => false,
+        }
+    }
+
+    /// Returns whether if this type is an instance of a type matching the given
+    /// `predicate`.
+    pub fn is_array_of(&self, predicate: impl Fn(Self) -> bool) -> bool {
+        match self.as_raw_data() {
+            Some(TypeData::InstanceOf(instance)) => {
+                instance.ty == GLOBAL_ARRAY_ID.into()
+                    && instance
+                        .type_parameters
+                        .first()
+                        .and_then(|type_param| self.resolve(type_param))
+                        .is_some_and(predicate)
+            }
             _ => false,
         }
     }

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_generic_mapped_value.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_generic_mapped_value.snap
@@ -1,0 +1,142 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/index.ts` (Not imported by resolver)
+
+## Source
+
+```ts
+const mapped = [1, 2, 3].map(async (x) => x + 1);
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => value: 1
+
+Module TypeId(1) => value: 2
+
+Module TypeId(2) => value: 3
+
+Module TypeId(3) => Tuple(
+    [
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(0),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(1),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(2),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+    ],
+)
+
+Module TypeId(4) => Array.prototype.map
+
+Module TypeId(5) => unknown
+
+Module TypeId(6) => Module(0) TypeId(5)
+
+Module TypeId(7) => instanceof Promise
+
+Module TypeId(8) => async Function {
+  accepts: {
+    params: [
+      required x: Module(0) TypeId(5) (bindings: x:Module(0) TypeId(5))
+    ]
+    type_args: []
+  }
+  returns: Module(0) TypeId(7)
+}
+
+Module TypeId(9) => instanceof Array<Module(0) TypeId(7)>
+```
+
+# Module Resolver
+
+## Registered types
+
+```
+Full TypeId(0) => value: 1
+
+Full TypeId(1) => value: 2
+
+Full TypeId(2) => value: 3
+
+Full TypeId(3) => Tuple(
+    [
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(0),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(1),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+        TupleElementType {
+            ty: Resolved(
+                Module(0) TypeId(2),
+            ),
+            name: None,
+            is_optional: false,
+            is_rest: false,
+        },
+    ],
+)
+
+Full TypeId(4) => Array.prototype.map
+
+Full TypeId(5) => unknown
+
+Full TypeId(6) => Module(0) TypeId(5)
+
+Full TypeId(7) => instanceof Promise
+
+Full TypeId(8) => async Function {
+  accepts: {
+    params: [
+      required x: Module(0) TypeId(5) (bindings: x:Module(0) TypeId(5))
+    ]
+    type_args: []
+  }
+  returns: Module(0) TypeId(7)
+}
+
+Full TypeId(9) => instanceof Array<Module(0) TypeId(7)>
+```


### PR DESCRIPTION
## Summary

Implements handling of arrays with Promises in `noFloatingPromises`. While this involves some extension of the rule itself, with specialised diagnostics and fixer in case an array of Promises is detected, the tricky part was in the detection of such arrays itself. Specifically, we want to detect cases where we take an array and call `.map()` with a callback that returns a Promise, which involved handling of slightly more advanced generics cases than we'd seen so far.

## Test Plan

Test cases added.
