### PR TITLE
fix(core): infer method return types

### DIFF
--- a/.changeset/funky-functions-follow.md
+++ b/.changeset/funky-functions-follow.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Type inference can now infer the return types of functions and methods without
+annotations.
+
+## Example
+
+```ts
+const sneakyObject = {
+	doSomething() {
+		return Promise.resolve("This is a floating promise!");
+	},
+};
+
+// We can now detect that `doSomething()` returns a `Promise`.
+sneakyObject.doSomething();
+```

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -284,7 +284,6 @@ fn type_to_string(ty: &Type) -> String {
     match ty.deref() {
         TypeData::Literal(lit) => match lit.as_ref() {
             Literal::Boolean(b) => b.as_bool().to_string(),
-            Literal::Null => "null".to_string(),
             Literal::Number(n) => n.text().to_string(),
             Literal::String(s) => format!("\"{}\"", s.as_str()),
             _ => "unknown".to_string(),
@@ -305,7 +304,6 @@ fn type_to_expression(ty: &Type) -> Option<AnyJsExpression> {
                 }))
                 .into()
             }
-            Literal::Null => make::js_null_literal_expression(make::token(T![null])).into(),
             Literal::Number(n) => {
                 let text = n.text();
                 make::js_number_literal_expression(make::js_number_literal(text)).into()

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/09_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/09_invalid.ts
@@ -1,0 +1,6 @@
+const sneakyObject1 = {
+	doSomething() {
+		return Promise.resolve("This is a floating promise!");
+	},
+};
+sneakyObject1.doSomething();

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/09_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/09_invalid.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 09_invalid.ts
+---
+# Input
+```ts
+const sneakyObject1 = {
+	doSomething() {
+		return Promise.resolve("This is a floating promise!");
+	},
+};
+sneakyObject1.doSomething();
+
+```
+
+# Diagnostics
+```
+09_invalid.ts:6:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │ 	},
+    5 │ };
+  > 6 │ sneakyObject1.doSomething();
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -521,7 +521,7 @@ fn flattened_typeof_data(resolved: ResolvedTypeData) -> TypeData {
         TypeData::Literal(literal) => match literal.as_ref() {
             Literal::BigInt(_) => TypeData::reference(GLOBAL_BIGINT_STRING_LITERAL_ID),
             Literal::Boolean(_) => TypeData::reference(GLOBAL_BOOLEAN_STRING_LITERAL_ID),
-            Literal::Null | Literal::Object(_) | Literal::RegExp(_) => {
+            Literal::Object(_) | Literal::RegExp(_) => {
                 TypeData::reference(GLOBAL_OBJECT_STRING_LITERAL_ID)
             }
             Literal::Number(_) => TypeData::reference(GLOBAL_NUMBER_STRING_LITERAL_ID),
@@ -529,6 +529,7 @@ fn flattened_typeof_data(resolved: ResolvedTypeData) -> TypeData {
                 TypeData::reference(GLOBAL_STRING_STRING_LITERAL_ID)
             }
         },
+        TypeData::Null => TypeData::reference(GLOBAL_OBJECT_STRING_LITERAL_ID),
         TypeData::Number => TypeData::reference(GLOBAL_NUMBER_STRING_LITERAL_ID),
         TypeData::Object(_) | TypeData::Tuple(_) => {
             TypeData::reference(GLOBAL_OBJECT_STRING_LITERAL_ID)

--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -146,7 +146,6 @@ impl MergedType {
                 TypeData::Literal(literal) => match *literal {
                     Literal::BigInt(_)
                     | Literal::Boolean(_)
-                    | Literal::Null
                     | Literal::Number(_)
                     | Literal::String(_)
                     | Literal::Template(_) => MergedType::Primitive(TypeData::Literal(literal)),

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -696,7 +696,6 @@ impl Format<FormatTypeContext> for Literal {
                     TextSize::default()
                 )]
             ),
-            Self::Null => write!(f, [text("null")]),
             Self::Number(lit) => {
                 write!(f, [dynamic_text(lit.as_str(), TextSize::default())])
             }

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -1009,7 +1009,6 @@ impl TypeData {
             Self::Reference(GLOBAL_UNKNOWN_ID.into()),
             |name| match name.text() {
                 "globalThis" => Self::reference(GLOBAL_GLOBAL_ID),
-                "null" => Self::Null,
                 "undefined" => Self::Undefined,
                 _ => Self::reference(TypeReference::from_name(scope_id, name)),
             },

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -537,6 +537,7 @@ impl TypeData {
         match self {
             Self::BigInt
             | Self::Boolean
+            | Self::Null
             | Self::Number
             | Self::String
             | Self::Symbol

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -1125,10 +1125,17 @@ impl From<TypeImportQualifier> for TypeReference {
 }
 
 impl TypeReference {
+    /// Returns `true` if the reference references anything but `Unknown`.
     #[inline]
     pub fn is_known(&self) -> bool {
-        *self != Self::Unknown
+        match self {
+            Self::Import(_) => true,
+            Self::Qualifier(_) => true,
+            Self::Resolved(resolved_id) => *resolved_id != GLOBAL_UNKNOWN_ID,
+            Self::Unknown => false,
+        }
     }
+
     /// Merges the generic type parameters referenced by `incoming` into `base`.
     pub fn merge_parameters(base: &[Self], incoming: &[Self]) -> Box<[Self]> {
         base.iter()

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -176,6 +176,12 @@ impl Type {
         }
     }
 
+    /// Returns whether this type is the primitive `null`.
+    pub fn is_null(&self) -> bool {
+        self.as_raw_data()
+            .is_some_and(|ty| matches!(ty, TypeData::Null))
+    }
+
     /// Returns whether this type is a number or a literal number.
     pub fn is_number(&self) -> bool {
         self.id == GLOBAL_NUMBER_ID
@@ -207,6 +213,17 @@ impl Type {
             })
     }
 
+    /// Returns whether this type is a string with the given `value`.
+    pub fn is_string_literal(&self, value: &str) -> bool {
+        self.as_raw_data().is_some_and(|ty| match ty {
+            TypeData::Literal(literal) => match literal.as_ref() {
+                Literal::String(literal) => literal.as_str() == value,
+                _ => false,
+            },
+            _ => false,
+        })
+    }
+
     /// Returns whether this type indicates the `void` keyword.
     pub fn is_void(&self) -> bool {
         matches!(self.as_raw_data(), Some(TypeData::VoidKeyword))
@@ -224,7 +241,7 @@ impl Type {
     }
 
     #[inline]
-    fn resolved_data(&self) -> Option<ResolvedTypeData> {
+    pub fn resolved_data(&self) -> Option<ResolvedTypeData> {
         self.resolver.get_by_resolved_id(self.id)
     }
 
@@ -517,16 +534,16 @@ impl TypeData {
 
     /// Returns whether the given type is a primitive type.
     pub fn is_primitive(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::BigInt
-                | Self::Boolean
-                | Self::Null
-                | Self::Number
-                | Self::String
-                | Self::Symbol
-                | Self::Undefined
-        )
+            | Self::Boolean
+            | Self::Number
+            | Self::String
+            | Self::Symbol
+            | Self::Undefined => true,
+            Self::Literal(literal) => literal.is_primitive(),
+            _ => false,
+        }
     }
 
     pub fn reference(reference: impl Into<TypeReference>) -> Self {
@@ -723,12 +740,25 @@ impl Intersection {
 pub enum Literal {
     BigInt(Text),
     Boolean(BooleanLiteral),
-    Null,
     Number(NumberLiteral),
     Object(ObjectLiteral),
     RegExp(Text),
     String(StringLiteral),
     Template(Text), // TODO: Custom impl of PartialEq for template literals
+}
+
+impl Literal {
+    /// Returns whether the literal is a primitive type.
+    pub fn is_primitive(&self) -> bool {
+        matches!(
+            self,
+            Self::BigInt(_)
+                | Self::Boolean(_)
+                | Self::Number(_)
+                | Self::String(_)
+                | Self::Template(_)
+        )
+    }
 }
 
 /// A module definition.

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_chained_invocation_of_promise_returning_function.snap
@@ -34,12 +34,14 @@ Thin TypeId(1) => instanceof Promise<number>
 
 Thin TypeId(2) => Promise.prototype.then
 
-Thin TypeId(3) => sync Function {
+Thin TypeId(3) => void
+
+Thin TypeId(4) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(3)
 }
 
 Global TypeId(0) => instanceof Promise<number>

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -36,17 +36,19 @@ Thin TypeId(1) => instanceof Promise<number>
 
 Thin TypeId(2) => Promise.prototype.then
 
-Thin TypeId(3) => sync Function {
+Thin TypeId(3) => void
+
+Thin TypeId(4) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(3)
 }
 
-Thin TypeId(4) => instanceof Promise
+Thin TypeId(5) => instanceof Promise
 
-Thin TypeId(5) => Promise.prototype.finally
+Thin TypeId(6) => Promise.prototype.finally
 
 Global TypeId(0) => instanceof Promise<number>
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_interface_field.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_flattened_type_of_destructured_interface_field.snap
@@ -23,7 +23,7 @@ sync Function "bar" {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(3)
 }
 ```
 
@@ -45,6 +45,8 @@ Thin TypeId(2) => sync Function "foo" {
   }
   returns: string
 }
+
+Thin TypeId(3) => void
 
 Global TypeId(0) => sync Function "foo" {
   accepts: {

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_chained_invocation_of_promise_returning_function.snap
@@ -16,7 +16,7 @@ returnsPromise().then(() => {});
 ## Result
 
 ```
-Call Module(0) TypeId(2)(Module(0) TypeId(3))
+Call Module(0) TypeId(2)(Module(0) TypeId(4))
 ```
 
 ## Registered types
@@ -34,12 +34,14 @@ Thin TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
 Thin TypeId(2) => Module(0) TypeId(1).then
 
-Thin TypeId(3) => sync Function {
+Thin TypeId(3) => void
+
+Thin TypeId(4) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(3)
 }
 
 Global TypeId(0) => instanceof Global TypeId(1)

--- a/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_resolved_type_from_double_chained_invocation_of_promise_returning_function.snap
@@ -18,7 +18,7 @@ returnsPromise()
 ## Result
 
 ```
-Call Module(0) TypeId(5)(Module(0) TypeId(3))
+Call Module(0) TypeId(6)(Module(0) TypeId(4))
 ```
 
 ## Registered types
@@ -36,17 +36,19 @@ Thin TypeId(1) => Call Module(0) TypeId(0)(No parameters)
 
 Thin TypeId(2) => Module(0) TypeId(1).then
 
-Thin TypeId(3) => sync Function {
+Thin TypeId(3) => void
+
+Thin TypeId(4) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(3)
 }
 
-Thin TypeId(4) => Call Module(0) TypeId(2)(Module(0) TypeId(3))
+Thin TypeId(5) => Call Module(0) TypeId(2)(Module(0) TypeId(4))
 
-Thin TypeId(5) => Module(0) TypeId(4).finally
+Thin TypeId(6) => Module(0) TypeId(5).finally
 
 Global TypeId(0) => instanceof Global TypeId(1)
 

--- a/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
+++ b/crates/biome_js_type_info/tests/snapshots/infer_type_of_function_with_destructured_arguments.snap
@@ -25,7 +25,7 @@ sync Function "destruct" {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: void
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_referenced_function.snap
@@ -33,7 +33,7 @@ Imports {
 ```
 BindingId(0) => JsBindingData {
   Name: foo,
-  Type: Module(0) TypeId(0),
+  Type: Module(0) TypeId(1),
   JSDoc comment: JsDoc(
     @returns {string}
   ),
@@ -44,11 +44,13 @@ BindingId(0) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "foo" {
+Module TypeId(0) => void
+
+Module TypeId(1) => sync Function "foo" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(0)
 }
 ```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -102,7 +102,7 @@ Module TypeId(8) => sync Function "giveMeABiggerAnswer" {
     ]
     type_args: []
   }
-  returns: unknown reference
+  returns: unknown
 }
 
 Module TypeId(9) => unknown

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -118,7 +118,7 @@ Imports {
 ```
 BindingId(0) => JsBindingData {
   Name: foo,
-  Type: Module(0) TypeId(9),
+  Type: Module(0) TypeId(10),
   JSDoc comment: JsDoc(
     @returns {string}
   ),
@@ -127,7 +127,7 @@ BindingId(0) => JsBindingData {
 
 BindingId(1) => JsBindingData {
   Name: bar,
-  Type: Module(0) TypeId(10),
+  Type: Module(0) TypeId(11),
   JSDoc comment: JsDoc(
     @package
   ),
@@ -145,7 +145,7 @@ BindingId(2) => JsBindingData {
 
 BindingId(3) => JsBindingData {
   Name: baz,
-  Type: Module(0) TypeId(12),
+  Type: Module(0) TypeId(13),
   Declaration kind: HoistedValue
 }
 
@@ -181,7 +181,7 @@ BindingId(8) => JsBindingData {
 
 BindingId(11) => JsBindingData {
   Name: Component,
-  Type: Module(0) TypeId(16),
+  Type: Module(0) TypeId(17),
   JSDoc comment: JsDoc(
     @public
     @returns {JSX.Element}
@@ -200,7 +200,7 @@ Module TypeId(0) => Object {
 
 Module TypeId(1) => value: 1
 
-Module TypeId(2) => Module(0) TypeId(14)
+Module TypeId(2) => Module(0) TypeId(15)
 
 Module TypeId(3) => Object {
   prototype: No prototype
@@ -242,37 +242,39 @@ Module TypeId(6) => Tuple(
 
 Module TypeId(7) => boolean
 
-Module TypeId(8) => Module(0) TypeId(7) | Module(0) TypeId(13)
+Module TypeId(8) => Module(0) TypeId(7) | Module(0) TypeId(14)
 
-Module TypeId(9) => sync Function "foo" {
+Module TypeId(9) => void
+
+Module TypeId(10) => sync Function "foo" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(9)
 }
 
-Module TypeId(10) => sync Function "bar" {
+Module TypeId(11) => sync Function "bar" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(9)
 }
 
-Module TypeId(11) => instanceof Promise
+Module TypeId(12) => instanceof Promise<Module(0) TypeId(9)>
 
-Module TypeId(12) => async Function "baz" {
+Module TypeId(13) => async Function "baz" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(11)
+  returns: Module(0) TypeId(12)
 }
 
-Module TypeId(13) => undefined
+Module TypeId(14) => undefined
 
-Module TypeId(14) => sync Function "getObject" {
+Module TypeId(15) => sync Function "getObject" {
   accepts: {
     params: []
     type_args: []
@@ -280,19 +282,19 @@ Module TypeId(14) => sync Function "getObject" {
   returns: Module(0) TypeId(3)
 }
 
-Module TypeId(15) => unknown
+Module TypeId(16) => unknown
 
-Module TypeId(16) => sync Function "Component" {
+Module TypeId(17) => sync Function "Component" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(15)
+  returns: Module(0) TypeId(16)
 }
 
-Module TypeId(17) => Module(0) TypeId(7)
+Module TypeId(18) => Module(0) TypeId(7)
 
-Module TypeId(18) => Module(0) TypeId(8)
+Module TypeId(19) => Module(0) TypeId(8)
 ```
 
 # `/src/renamed-reexports.ts`
@@ -321,7 +323,7 @@ Imports {
 ```
 BindingId(0) => JsBindingData {
   Name: ohNo,
-  Type: Module(0) TypeId(0),
+  Type: Module(0) TypeId(1),
   Declaration kind: HoistedValue
 }
 ```
@@ -329,12 +331,14 @@ BindingId(0) => JsBindingData {
 ## Registered types
 
 ```
-Module TypeId(0) => sync Function "ohNo" {
+Module TypeId(0) => void
+
+Module TypeId(1) => sync Function "ohNo" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: unknown reference
+  returns: Module(0) TypeId(0)
 }
 ```
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_promise_export.snap
@@ -44,7 +44,7 @@ Module TypeId(0) => value: value
 
 Module TypeId(1) => Module(0) TypeId(3)
 
-Module TypeId(2) => instanceof Promise
+Module TypeId(2) => instanceof Promise<Module(0) TypeId(0)>
 
 Module TypeId(3) => async Function "returnsPromise" {
   accepts: {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -259,7 +259,7 @@ Module TypeId(12) => instanceof Module(0) TypeId(11)
 
 Module TypeId(13) => instanceof Module(0) TypeId(8)
 
-Module TypeId(14) => value: null
+Module TypeId(14) => null
 
 Module TypeId(15) => Module(0) TypeId(13) | Module(0) TypeId(14)
 


### PR DESCRIPTION
## Summary

Type inference can now infer the return types of functions and methods without
annotations.

## Example

```ts
const sneakyObject = {
	doSomething() {
		return Promise.resolve("This is a floating promise!");
	},
};

// We can now detect that `doSomething()` returns a `Promise`.
sneakyObject.doSomething();
```

As part of this, we also explicitly track functions that return `void`.

## Test Plan

Test added, snapshots updated.
