### PR TITLE
fix(core): infer types of properties with getters

### DIFF
--- a/.changeset/getters-get-good.md
+++ b/.changeset/getters-get-good.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+Biome's type inference now detects the type of properties with getters.
+
+## Example
+
+```ts
+const sneakyObject2 = {
+	get something() {
+		return new Promise((_, reject) => reject("This is a floating promise!"));
+	},
+};
+// We now detect this is a Promise:
+sneakyObject2.something;
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/11_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/11_invalid.ts
@@ -1,0 +1,6 @@
+const sneakyObject2 = {
+	get something() {
+		return new Promise((_, reject) => reject("This is a floating promise!"));
+	},
+};
+sneakyObject2.something;

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/11_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/11_invalid.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 11_invalid.ts
+---
+# Input
+```ts
+const sneakyObject2 = {
+	get something() {
+		return new Promise((_, reject) => reject("This is a floating promise!"));
+	},
+};
+sneakyObject2.something;
+
+```
+
+# Diagnostics
+```
+11_invalid.ts:6:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │ 	},
+    5 │ };
+  > 6 │ sneakyObject2.something;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -90,7 +90,7 @@ pub(super) fn flattened_expression(
                                     !member.is_static() && member.has_name(name.text())
                                 })
                             })
-                            .and_then(|member| resolver.resolve_and_get(&member.ty()))
+                            .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))
                             .map(ResolvedTypeData::to_data)
                     }
                     (
@@ -132,7 +132,7 @@ pub(super) fn flattened_expression(
                             .all_members(resolver)
                             .find(|member| !member.is_static() && member.has_name(name.text()))?;
                         resolver
-                            .resolve_and_get(&member.ty())
+                            .resolve_and_get(&member.deref_ty(resolver))
                             .map(ResolvedTypeData::to_data)
                     }
                     (TypeData::Object(_), DestructureField::RestExcept(names)) => {
@@ -297,7 +297,7 @@ pub(super) fn flattened_expression(
                             !member.is_static()
                         }
                 });
-                member.map(|member| TypeData::reference(member.ty().into_owned()))
+                member.map(|member| TypeData::reference(member.deref_ty(resolver).into_owned()))
             } else {
                 None
             }
@@ -354,7 +354,7 @@ fn flattened_call(
                             .find(|member| member.kind().is_call_signature())
                     })
                     .map(ResolvedTypeMember::to_member)
-                    .and_then(|member| resolver.resolve_and_get(&member.ty))?
+                    .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
                     .to_data();
             }
             TypeData::Object(_) => {
@@ -363,7 +363,7 @@ fn flattened_call(
                         .all_members(resolver)
                         .find(|member| member.kind().is_call_signature())
                         .map(ResolvedTypeMember::to_member)
-                        .and_then(|member| resolver.resolve_and_get(&member.ty))?
+                        .and_then(|member| resolver.resolve_and_get(&member.deref_ty(resolver)))?
                         .to_data();
             }
             _ => break,

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -323,6 +323,10 @@ impl Format<FormatTypeContext> for TypeMemberKind {
         match self {
             Self::CallSignature => write!(f, [text("()")]),
             Self::Constructor => write!(f, [text("constructor")]),
+            Self::Getter(name) => {
+                let quoted = std::format!("get \"{name}\"");
+                write!(f, [dynamic_text(&quoted, TextSize::default())])
+            }
             Self::Named(name) => {
                 let quoted = std::format!("\"{name}\"");
                 write!(f, [dynamic_text(&quoted, TextSize::default())])

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_property_with_getter.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_property_with_getter.snap
@@ -1,0 +1,70 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+expression: content
+---
+# `/src/index.ts`
+
+## Source
+
+```ts
+class Foo {
+	get foo() {
+		if (!this.initialised) {
+			this.initialise();
+			return "foo";
+		}
+
+		return "foo";
+	}
+}
+
+const fooness = new Foo();
+const foo = fooness.foo;
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => Module(0) TypeId(2).initialised
+
+Module TypeId(1) => boolean
+
+Module TypeId(2) => instanceof Module(0) TypeId(10)
+
+Module TypeId(3) => Module(0) TypeId(2).initialise
+
+Module TypeId(4) => Call Module(0) TypeId(3)(No parameters)
+
+Module TypeId(5) => value: foo
+
+Module TypeId(6) => Module(0) TypeId(10)
+
+Module TypeId(7) => instanceof Module(0) TypeId(6)
+
+Module TypeId(8) => Module(0) TypeId(5)
+
+Module TypeId(9) => sync Function "foo" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(5)
+}
+
+Module TypeId(10) => class "Foo" {
+  extends: none
+  implements: []
+  type_args: []
+}
+```


### PR DESCRIPTION
## Summary

Biome's type inference now detects the type of properties with getters.

## Example

```ts
const sneakyObject2 = {
	get something() {
		return new Promise((_, reject) => reject("This is a floating promise!"));
	},
};
// We now detect this is a Promise:
sneakyObject2.something;
```

## Test Plan

Tests added.
