### PR TITLE
feat(core): handle logical operators

### DIFF
--- a/.changeset/boolean-bananas-bounce.md
+++ b/.changeset/boolean-bananas-bounce.md
@@ -1,0 +1,34 @@
+---
+"@biomejs/biome": patch
+---
+
+Type inference is now able to handle logical expressions: `&&`, `||`, and `??`.
+
+
+## Examples
+
+```ts
+// We can now infer that because `true` is truthy, the entire expression
+// evaluates to a `Promise`.
+true && Promise.reject("logical operator bypass");
+
+// And we know that this doesn't:
+false && Promise.reject("logical operator bypass");
+
+// Truthiness, falsiness, and non-nullishness can all be determined on more
+// complex expressions as well. So the following also works:
+type Nullish = null | undefined;
+
+type Params = {
+    booleanOption: boolean | Nullish;
+    falsyOption: false | Nullish;
+};
+
+function foo({ booleanOption, falsyOption }: Params) {
+    // This may be a Promise:
+    booleanOption ?? Promise.reject("logical operator bypass");
+    
+    // But this never is:
+    falsyOption && Promise.reject("logical operator bypass");
+}
+```

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -297,7 +297,7 @@ fn find_misused_promise_returning_callback(
 
     if argument_ty.is_function_with_return_type(|ty| ty.is_conditional()) {
         Some(NoMisusedPromisesState::ConditionalReturn)
-    } else if argument_ty.is_function_with_return_type(|ty| ty.is_void()) {
+    } else if argument_ty.is_function_with_return_type(|ty| ty.is_void_keyword()) {
         Some(NoMisusedPromisesState::VoidReturn)
     } else {
         None

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts
@@ -1,0 +1,32 @@
+true && Promise.reject("logical operator bypass");
+false || Promise.reject("logical operator bypass");
+null ?? Promise.reject("logical operator bypass");
+"one" && 1 && Promise.reject("logical operator bypass");
+"" || 0 || Promise.reject("logical operator bypass");
+null ?? undefined ?? Promise.reject("logical operator bypass");
+
+type Truthy = 1 | "one";
+let truthy: Truthy = 1;
+truthy && Promise.reject("logical operator bypass");
+
+type Nullish = null | undefined;
+let nullish: Nullish = null;
+nullish || Promise.reject("logical operator bypass");
+nullish ?? Promise.reject("logical operator bypass");
+
+let either: Truthy | Nullish = 1;
+either && Promise.reject("logical operator bypass");
+either || Promise.reject("logical operator bypass");
+either ?? Promise.reject("logical operator bypass");
+
+interface Foo {}
+let foo: Foo;
+foo && Promise.reject("logical operator bypass");
+foo || Promise.reject("logical operator bypass");
+
+class C {}
+let c = new C;
+c && Promise.reject("logical operator bypass");
+
+let o: object;
+o && Promise.reject("logical operator bypass");

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts
@@ -30,3 +30,11 @@ c && Promise.reject("logical operator bypass");
 
 let o: object;
 o && Promise.reject("logical operator bypass");
+
+type Params = {
+    option: boolean | Nullish;
+};
+
+function functionWithParams({ option }: Params) {
+    option ?? Promise.reject("logical operator bypass");
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts.snap
@@ -37,6 +37,14 @@ c && Promise.reject("logical operator bypass");
 let o: object;
 o && Promise.reject("logical operator bypass");
 
+type Params = {
+    option: boolean | Nullish;
+};
+
+function functionWithParams({ option }: Params) {
+    option ?? Promise.reject("logical operator bypass");
+}
+
 ```
 
 # Diagnostics
@@ -300,6 +308,23 @@ o && Promise.reject("logical operator bypass");
   > 32 │ o && Promise.reject("logical operator bypass");
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     33 │ 
+    34 │ type Params = {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:39:5 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    38 │ function functionWithParams({ option }: Params) {
+  > 39 │     option ?? Promise.reject("logical operator bypass");
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    40 │ }
+    41 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_invalid.ts.snap
@@ -1,0 +1,307 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 13_invalid.ts
+---
+# Input
+```ts
+true && Promise.reject("logical operator bypass");
+false || Promise.reject("logical operator bypass");
+null ?? Promise.reject("logical operator bypass");
+"one" && 1 && Promise.reject("logical operator bypass");
+"" || 0 || Promise.reject("logical operator bypass");
+null ?? undefined ?? Promise.reject("logical operator bypass");
+
+type Truthy = 1 | "one";
+let truthy: Truthy = 1;
+truthy && Promise.reject("logical operator bypass");
+
+type Nullish = null | undefined;
+let nullish: Nullish = null;
+nullish || Promise.reject("logical operator bypass");
+nullish ?? Promise.reject("logical operator bypass");
+
+let either: Truthy | Nullish = 1;
+either && Promise.reject("logical operator bypass");
+either || Promise.reject("logical operator bypass");
+either ?? Promise.reject("logical operator bypass");
+
+interface Foo {}
+let foo: Foo;
+foo && Promise.reject("logical operator bypass");
+foo || Promise.reject("logical operator bypass");
+
+class C {}
+let c = new C;
+c && Promise.reject("logical operator bypass");
+
+let o: object;
+o && Promise.reject("logical operator bypass");
+
+```
+
+# Diagnostics
+```
+13_invalid.ts:1:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+  > 1 │ true && Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    2 │ false || Promise.reject("logical operator bypass");
+    3 │ null ?? Promise.reject("logical operator bypass");
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:2:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    1 │ true && Promise.reject("logical operator bypass");
+  > 2 │ false || Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ null ?? Promise.reject("logical operator bypass");
+    4 │ "one" && 1 && Promise.reject("logical operator bypass");
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:3:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    1 │ true && Promise.reject("logical operator bypass");
+    2 │ false || Promise.reject("logical operator bypass");
+  > 3 │ null ?? Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ "one" && 1 && Promise.reject("logical operator bypass");
+    5 │ "" || 0 || Promise.reject("logical operator bypass");
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:4:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │ false || Promise.reject("logical operator bypass");
+    3 │ null ?? Promise.reject("logical operator bypass");
+  > 4 │ "one" && 1 && Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ "" || 0 || Promise.reject("logical operator bypass");
+    6 │ null ?? undefined ?? Promise.reject("logical operator bypass");
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ null ?? Promise.reject("logical operator bypass");
+    4 │ "one" && 1 && Promise.reject("logical operator bypass");
+  > 5 │ "" || 0 || Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ null ?? undefined ?? Promise.reject("logical operator bypass");
+    7 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:6:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │ "one" && 1 && Promise.reject("logical operator bypass");
+    5 │ "" || 0 || Promise.reject("logical operator bypass");
+  > 6 │ null ?? undefined ?? Promise.reject("logical operator bypass");
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    7 │ 
+    8 │ type Truthy = 1 | "one";
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:10:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+     8 │ type Truthy = 1 | "one";
+     9 │ let truthy: Truthy = 1;
+  > 10 │ truthy && Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ type Nullish = null | undefined;
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:14:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    12 │ type Nullish = null | undefined;
+    13 │ let nullish: Nullish = null;
+  > 14 │ nullish || Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ nullish ?? Promise.reject("logical operator bypass");
+    16 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:15:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    13 │ let nullish: Nullish = null;
+    14 │ nullish || Promise.reject("logical operator bypass");
+  > 15 │ nullish ?? Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    16 │ 
+    17 │ let either: Truthy | Nullish = 1;
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:18:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    17 │ let either: Truthy | Nullish = 1;
+  > 18 │ either && Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    19 │ either || Promise.reject("logical operator bypass");
+    20 │ either ?? Promise.reject("logical operator bypass");
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:19:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    17 │ let either: Truthy | Nullish = 1;
+    18 │ either && Promise.reject("logical operator bypass");
+  > 19 │ either || Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    20 │ either ?? Promise.reject("logical operator bypass");
+    21 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:20:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    18 │ either && Promise.reject("logical operator bypass");
+    19 │ either || Promise.reject("logical operator bypass");
+  > 20 │ either ?? Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ 
+    22 │ interface Foo {}
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:24:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    22 │ interface Foo {}
+    23 │ let foo: Foo;
+  > 24 │ foo && Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    25 │ foo || Promise.reject("logical operator bypass");
+    26 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:25:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    23 │ let foo: Foo;
+    24 │ foo && Promise.reject("logical operator bypass");
+  > 25 │ foo || Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    26 │ 
+    27 │ class C {}
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:29:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    27 │ class C {}
+    28 │ let c = new C;
+  > 29 │ c && Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    30 │ 
+    31 │ let o: object;
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+13_invalid.ts:32:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    31 │ let o: object;
+  > 32 │ o && Promise.reject("logical operator bypass");
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    33 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
@@ -1,0 +1,33 @@
+/* should not generate diagnostics */
+
+false && Promise.reject("logical operator bypass");
+true || Promise.reject("logical operator bypass");
+({}) ?? Promise.reject("logical operator bypass");
+"one" && 0 && Promise.reject("logical operator bypass");
+"" || 1 || Promise.reject("logical operator bypass");
+null ?? (() => true) ?? Promise.reject("logical operator bypass");
+
+type Truthy = 1 | "one";
+let truthy: Truthy = 1;
+truthy || Promise.reject("logical operator bypass");
+truthy ?? Promise.reject("logical operator bypass");
+
+type Nullish = null | undefined;
+let nullish: Nullish = null;
+nullish && Promise.reject("logical operator bypass");
+
+let falsy: Nullish | false;
+falsy && Promise.reject("logical operator bypass");
+
+interface Foo {}
+let foo: Foo;
+foo ?? Promise.reject("logical operator bypass");
+
+class C {}
+let c = new C;
+c || Promise.reject("logical operator bypass");
+c ?? Promise.reject("logical operator bypass");
+
+let o: object;
+o || Promise.reject("logical operator bypass");
+o ?? Promise.reject("logical operator bypass");

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
@@ -31,3 +31,11 @@ c ?? Promise.reject("logical operator bypass");
 let o: object;
 o || Promise.reject("logical operator bypass");
 o ?? Promise.reject("logical operator bypass");
+
+type Params = {
+    option: false | Nullish;
+};
+
+function functionWithParams({ option }: Params) {
+    option && Promise.reject("logical operator bypass");
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
@@ -38,4 +38,12 @@ let o: object;
 o || Promise.reject("logical operator bypass");
 o ?? Promise.reject("logical operator bypass");
 
+type Params = {
+    option: false | Nullish;
+};
+
+function functionWithParams({ option }: Params) {
+    option && Promise.reject("logical operator bypass");
+}
+
 ```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
@@ -1,0 +1,41 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 13_valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+false && Promise.reject("logical operator bypass");
+true || Promise.reject("logical operator bypass");
+({}) ?? Promise.reject("logical operator bypass");
+"one" && 0 && Promise.reject("logical operator bypass");
+"" || 1 || Promise.reject("logical operator bypass");
+null ?? (() => true) ?? Promise.reject("logical operator bypass");
+
+type Truthy = 1 | "one";
+let truthy: Truthy = 1;
+truthy || Promise.reject("logical operator bypass");
+truthy ?? Promise.reject("logical operator bypass");
+
+type Nullish = null | undefined;
+let nullish: Nullish = null;
+nullish && Promise.reject("logical operator bypass");
+
+let falsy: Nullish | false;
+falsy && Promise.reject("logical operator bypass");
+
+interface Foo {}
+let foo: Foo;
+foo ?? Promise.reject("logical operator bypass");
+
+class C {}
+let c = new C;
+c || Promise.reject("logical operator bypass");
+c ?? Promise.reject("logical operator bypass");
+
+let o: object;
+o || Promise.reject("logical operator bypass");
+o ?? Promise.reject("logical operator bypass");
+
+```

--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -286,7 +286,7 @@ fn function_intersection(f1: Function, f2: Function, resolver: &mut dyn TypeReso
         return_type: match (f1.return_type, f2.return_type) {
             (ReturnType::Type(r1), ReturnType::Type(r2)) => ReturnType::Type(
                 resolver
-                    .register_and_resolve(TypeData::union_of(vec![r1, r2]))
+                    .register_and_resolve(TypeData::union_of(resolver, vec![r1, r2]))
                     .into(),
             ),
             // TODO: We could be smarter about merging other return types.
@@ -311,7 +311,7 @@ fn member_intersection(
                 if member.ty != merged_member.ty {
                     let ty = std::mem::take(&mut merged_member.ty);
                     merged_member.ty = resolver
-                        .register_and_resolve(TypeData::union_of(vec![member.ty, ty]))
+                        .register_and_resolve(TypeData::union_of(resolver, vec![member.ty, ty]))
                         .into()
                 }
             }

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -416,8 +416,44 @@ impl Format<FormatTypeContext> for TypeofExpression {
                     )
                 }
             },
+            Self::LogicalAnd(expr) => {
+                write!(
+                    f,
+                    [&format_args![
+                        &expr.left,
+                        space(),
+                        text("&&"),
+                        space(),
+                        &expr.right
+                    ]]
+                )
+            }
+            Self::LogicalOr(expr) => {
+                write!(
+                    f,
+                    [&format_args![
+                        &expr.left,
+                        space(),
+                        text("||"),
+                        space(),
+                        &expr.right
+                    ]]
+                )
+            }
             Self::New(expr) => {
                 write!(f, [&format_args![text("new"), space(), &expr.callee]])
+            }
+            Self::NullishCoalescing(expr) => {
+                write!(
+                    f,
+                    [&format_args![
+                        &expr.left,
+                        space(),
+                        text("??"),
+                        space(),
+                        &expr.right
+                    ]]
+                )
             }
             Self::StaticMember(expr) => {
                 write!(f, [&format_args![&expr.object, text("."), &expr.member]])

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -14,7 +14,7 @@ use crate::{
     Class, Function, FunctionParameter, GenericTypeParameter, Literal, Resolvable,
     ResolvedTypeData, ResolvedTypeId, ReturnType, ScopeId, TypeData, TypeId, TypeInstance,
     TypeMember, TypeMemberKind, TypeReference, TypeReferenceQualifier, TypeResolver,
-    TypeResolverLevel, TypeStore, flattening::MAX_FLATTEN_DEPTH,
+    TypeResolverLevel, TypeStore, Union, flattening::MAX_FLATTEN_DEPTH,
 };
 
 const GLOBAL_LEVEL: TypeResolverLevel = TypeResolverLevel::Global;
@@ -320,7 +320,7 @@ impl Default for GlobalsResolver {
             string_literal("string"),
             string_literal("symbol"),
             string_literal("undefined"),
-            TypeData::union_of(vec![
+            TypeData::Union(Box::new(Union(Box::new([
                 GLOBAL_BIGINT_STRING_LITERAL_ID.into(),
                 GLOBAL_BOOLEAN_STRING_LITERAL_ID.into(),
                 GLOBAL_FUNCTION_STRING_LITERAL_ID.into(),
@@ -329,7 +329,7 @@ impl Default for GlobalsResolver {
                 GLOBAL_STRING_STRING_LITERAL_ID.into(),
                 GLOBAL_SYMBOL_STRING_LITERAL_ID.into(),
                 GLOBAL_UNDEFINED_STRING_LITERAL_ID.into(),
-            ]),
+            ])))),
             TypeData::from(GenericTypeParameter {
                 name: Text::Static("T"),
                 constraint: TypeReference::Unknown,

--- a/crates/biome_js_type_info/src/helpers.rs
+++ b/crates/biome_js_type_info/src/helpers.rs
@@ -1,9 +1,11 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, cmp::Ordering};
+
+use biome_rowan::Text;
 
 use crate::{
-    BindingId, Class, Interface, Module, Namespace, Object, Resolvable, ResolvedTypeData,
-    ResolvedTypeId, ResolvedTypeMember, ResolverId, TypeData, TypeInstance, TypeMember,
-    TypeReference, TypeResolver,
+    BindingId, Class, Interface, Literal, MAX_FLATTEN_DEPTH, Module, Namespace, Object, Resolvable,
+    ResolvedTypeData, ResolvedTypeId, ResolvedTypeMember, ResolverId, Type, TypeData, TypeInstance,
+    TypeMember, TypeReference, TypeResolver, Union,
     globals::{GLOBAL_ARRAY_ID, GLOBAL_PROMISE_ID, GLOBAL_TYPE_MEMBERS},
 };
 
@@ -56,16 +58,9 @@ impl<'a> ResolvedTypeData<'a> {
         TypeMemberOwner::from_type_data(self.as_raw_data()).is_some()
     }
 
-    pub fn is_class(self) -> bool {
-        matches!(self.as_raw_data(), TypeData::Class(_))
-    }
-
-    pub fn is_expression(self) -> bool {
-        matches!(self.as_raw_data(), TypeData::TypeofExpression(_))
-    }
-
-    pub fn is_generic(self) -> bool {
-        matches!(self.as_raw_data(), TypeData::Generic(_))
+    #[inline]
+    pub fn is_inferred(self) -> bool {
+        self.as_raw_data().is_inferred()
     }
 
     /// Returns whether this type data is an instance of a type matching the
@@ -133,12 +128,6 @@ impl<'a> ResolvedTypeData<'a> {
     /// Returns whether this type is an instance of a `Promise`.
     pub fn is_promise_instance(self, resolver: &dyn TypeResolver) -> bool {
         self.is_instance_of(resolver, GLOBAL_PROMISE_ID)
-    }
-
-    /// Returns whether this type is a reference to another type.
-    #[inline]
-    pub fn is_reference(self) -> bool {
-        matches!(self.as_raw_data(), TypeData::Reference(_))
     }
 
     /// Returns a reference to the type's prototype, if any.
@@ -229,6 +218,207 @@ impl TypeData {
         }
     }
 
+    /// Returns whether this data is known to have a falsy value.
+    pub fn is_falsy(&self, resolver: &dyn TypeResolver) -> bool {
+        fn is_falsy(ty: &TypeData, resolver: &dyn TypeResolver, mut depth: usize) -> bool {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return false;
+            }
+
+            let is_falsy_reference = |reference: &TypeReference| -> bool {
+                resolver
+                    .resolve_and_get(reference)
+                    .is_some_and(|ty| is_falsy(&ty.to_data(), resolver, depth))
+            };
+
+            match ty {
+                TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword => true,
+                TypeData::AnyKeyword
+                | TypeData::BigInt
+                | TypeData::Boolean
+                | TypeData::Class(_)
+                | TypeData::Conditional
+                | TypeData::Constructor(_)
+                | TypeData::Function(_)
+                | TypeData::Generic(_)
+                | TypeData::Global
+                | TypeData::Module(_)
+                | TypeData::Namespace(_)
+                | TypeData::ImportNamespace(_)
+                | TypeData::Interface(_)
+                | TypeData::NeverKeyword
+                | TypeData::Number
+                | TypeData::ObjectKeyword
+                | TypeData::Object(_)
+                | TypeData::String
+                | TypeData::Symbol
+                | TypeData::ThisKeyword
+                | TypeData::Tuple(_)
+                | TypeData::TypeOperator(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::TypeofType(_)
+                | TypeData::TypeofValue(_)
+                | TypeData::Unknown
+                | TypeData::UnknownKeyword => false,
+                TypeData::Literal(literal) => match literal.as_ref() {
+                    Literal::BigInt(text) => text.text() == "0n" || text.text() == "-0n",
+                    Literal::Boolean(boolean) => !boolean.as_bool(),
+                    Literal::Number(number) => {
+                        number.to_f64().is_some_and(|n| n == 0. || n.is_nan())
+                    }
+                    Literal::String(string) => string.as_str().is_empty(),
+                    Literal::Object(_) | Literal::RegExp(_) | Literal::Template(_) => false,
+                },
+                TypeData::InstanceOf(instance) => is_falsy_reference(&instance.ty),
+                TypeData::Intersection(intersection) => {
+                    intersection.types().iter().all(is_falsy_reference)
+                }
+                TypeData::MergedReference(reference) => {
+                    reference.ty.as_ref().is_none_or(is_falsy_reference)
+                        && reference.ty.as_ref().is_none_or(is_falsy_reference)
+                        && reference.ty.as_ref().is_none_or(is_falsy_reference)
+                }
+                TypeData::Reference(reference) => is_falsy_reference(reference),
+                TypeData::Union(union) => union.types().iter().all(is_falsy_reference),
+            }
+        }
+        is_falsy(self, resolver, 0)
+    }
+
+    /// Returns whether this data is known to be neither `null` nor `undefined`.
+    pub fn is_non_nullish(&self, resolver: &dyn TypeResolver) -> bool {
+        fn is_non_nullish(ty: &TypeData, resolver: &dyn TypeResolver, mut depth: usize) -> bool {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return false;
+            }
+
+            let is_non_nullish_reference = |reference: &TypeReference| -> bool {
+                resolver
+                    .resolve_and_get(reference)
+                    .is_some_and(|ty| is_non_nullish(&ty.to_data(), resolver, depth))
+            };
+
+            match ty {
+                TypeData::BigInt
+                | TypeData::Boolean
+                | TypeData::Global
+                | TypeData::Number
+                | TypeData::String
+                | TypeData::Symbol
+                | TypeData::ImportNamespace(_)
+                | TypeData::Class(_)
+                | TypeData::Constructor(_)
+                | TypeData::Function(_)
+                | TypeData::Interface(_)
+                | TypeData::Module(_)
+                | TypeData::Namespace(_)
+                | TypeData::Object(_)
+                | TypeData::Tuple(_)
+                | TypeData::Literal(_)
+                | TypeData::ObjectKeyword
+                | TypeData::ThisKeyword => true,
+                TypeData::AnyKeyword
+                | TypeData::Conditional
+                | TypeData::Generic(_)
+                | TypeData::NeverKeyword
+                | TypeData::Null
+                | TypeData::TypeOperator(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::TypeofType(_)
+                | TypeData::TypeofValue(_)
+                | TypeData::Undefined
+                | TypeData::Unknown
+                | TypeData::UnknownKeyword
+                | TypeData::VoidKeyword => false,
+                TypeData::InstanceOf(instance) => is_non_nullish_reference(&instance.ty),
+                TypeData::Intersection(intersection) => {
+                    intersection.types().iter().all(is_non_nullish_reference)
+                }
+                TypeData::MergedReference(reference) => {
+                    reference.ty.as_ref().is_none_or(is_non_nullish_reference)
+                        && reference.ty.as_ref().is_none_or(is_non_nullish_reference)
+                        && reference.ty.as_ref().is_none_or(is_non_nullish_reference)
+                }
+                TypeData::Reference(reference) => is_non_nullish_reference(reference),
+                TypeData::Union(union) => union.types().iter().all(is_non_nullish_reference),
+            }
+        }
+        is_non_nullish(self, resolver, 0)
+    }
+
+    /// Returns whether this data is known to have a truthy value.
+    pub fn is_truthy(&self, resolver: &dyn TypeResolver) -> bool {
+        fn is_truthy(ty: &TypeData, resolver: &dyn TypeResolver, mut depth: usize) -> bool {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return false;
+            }
+
+            let is_truthy_reference = |reference: &TypeReference| -> bool {
+                resolver
+                    .resolve_and_get(reference)
+                    .is_some_and(|ty| is_truthy(&ty.to_data(), resolver, depth))
+            };
+
+            match ty {
+                TypeData::Global
+                | TypeData::Symbol
+                | TypeData::ImportNamespace(_)
+                | TypeData::Class(_)
+                | TypeData::Constructor(_)
+                | TypeData::Function(_)
+                | TypeData::Module(_)
+                | TypeData::Namespace(_)
+                | TypeData::Object(_)
+                | TypeData::Tuple(_)
+                | TypeData::ObjectKeyword
+                | TypeData::ThisKeyword => true,
+                TypeData::AnyKeyword
+                | TypeData::BigInt
+                | TypeData::Boolean
+                | TypeData::Conditional
+                | TypeData::Generic(_)
+                | TypeData::Interface(_)
+                | TypeData::NeverKeyword
+                | TypeData::Null
+                | TypeData::Number
+                | TypeData::String
+                | TypeData::TypeOperator(_)
+                | TypeData::TypeofExpression(_)
+                | TypeData::TypeofType(_)
+                | TypeData::TypeofValue(_)
+                | TypeData::Undefined
+                | TypeData::Unknown
+                | TypeData::UnknownKeyword
+                | TypeData::VoidKeyword => false,
+                TypeData::Literal(literal) => match literal.as_ref() {
+                    Literal::BigInt(text) => text.text() != "0n" && text.text() != "-0n",
+                    Literal::Boolean(boolean) => boolean.as_bool(),
+                    Literal::Number(number) => {
+                        number.to_f64().is_some_and(|n| n != 0. && !n.is_nan())
+                    }
+                    Literal::Object(_) | Literal::RegExp(_) => true,
+                    Literal::String(string) => !string.as_str().is_empty(),
+                    Literal::Template(_) => false,
+                },
+                TypeData::InstanceOf(instance) => is_truthy_reference(&instance.ty),
+                TypeData::Intersection(intersection) => {
+                    intersection.types().iter().all(is_truthy_reference)
+                }
+                TypeData::MergedReference(reference) => {
+                    reference.ty.as_ref().is_none_or(is_truthy_reference)
+                        && reference.ty.as_ref().is_none_or(is_truthy_reference)
+                        && reference.ty.as_ref().is_none_or(is_truthy_reference)
+                }
+                TypeData::Reference(reference) => is_truthy_reference(reference),
+                TypeData::Union(union) => union.types().iter().all(is_truthy_reference),
+            }
+        }
+        is_truthy(self, resolver, 0)
+    }
+
     /// Iterates own member fields.
     ///
     /// This iterator does not return members of [`TypeData::InstanceOf`] or
@@ -238,6 +428,217 @@ impl TypeData {
         OwnTypeMemberIterator {
             owner: TypeMemberOwner::from_type_data(self),
             index: 0,
+        }
+    }
+
+    /// Converts the type data to a value that is falsy.
+    ///
+    /// If the data itself may hold both truthy and falsy values, new data may
+    /// be returned that can be falsy only.
+    ///
+    /// Returns `None` if the value is known to be always truthy.
+    pub fn to_falsy_value(self, resolver: &mut dyn TypeResolver) -> Option<Self> {
+        fn to_falsy_value(
+            ty: TypeData,
+            resolver: &mut dyn TypeResolver,
+            mut depth: usize,
+        ) -> Option<TypeData> {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return Some(ty);
+            }
+
+            let new_ty = match &ty {
+                TypeData::BigInt => Literal::BigInt(Text::Static("0n")).into(),
+                TypeData::Boolean => Literal::Boolean(false.into()).into(),
+                TypeData::Conditional => TypeData::Unknown,
+                TypeData::Literal(literal) => match literal.as_ref() {
+                    Literal::BigInt(text) => match text.text() {
+                        "0n" | "-0n" => ty,
+                        _ => return None,
+                    },
+                    Literal::Boolean(boolean) => match boolean.as_bool() {
+                        false => ty,
+                        true => return None,
+                    },
+                    Literal::Number(number) => match number.to_f64() {
+                        Some(0.) => ty,
+                        Some(n) if n.is_nan() => ty,
+                        _ => return None,
+                    },
+                    Literal::Object(_) | Literal::RegExp(_) => return None,
+                    Literal::String(string) => match string.as_str() {
+                        "" => ty,
+                        _ => return None,
+                    },
+                    Literal::Template(_) => ty,
+                },
+                TypeData::String => Literal::String(Text::Static("").into()).into(),
+                TypeData::Union(union) => {
+                    let types = union
+                        .types()
+                        .iter()
+                        .filter_map(|reference| {
+                            let ty = resolver
+                                .resolve_and_get(reference)
+                                .map(ResolvedTypeData::to_data)
+                                .and_then(|ty| to_falsy_value(ty, resolver, depth))?;
+                            Some(resolver.reference_to_owned_data(ty))
+                        })
+                        .collect();
+                    TypeData::union_of(resolver, types)
+                }
+                TypeData::Class(_)
+                | TypeData::Constructor(_)
+                | TypeData::Function(_)
+                | TypeData::Global
+                | TypeData::ImportNamespace(_)
+                | TypeData::Module(_)
+                | TypeData::Namespace(_)
+                | TypeData::Object(_)
+                | TypeData::Symbol
+                | TypeData::Tuple(_) => return None,
+                _unchanged => ty,
+            };
+
+            Some(new_ty)
+        }
+
+        to_falsy_value(self, resolver, 0)
+    }
+
+    /// Converts the type data to a value that is not `null` or `undefined`.
+    ///
+    /// If the data itself may be either nullish or non-nullish, new data may be
+    /// returned that can be non-nullish only.
+    ///
+    /// Returns `None` if the value is known to be always nullish.
+    pub fn to_non_nullish_value(self, resolver: &mut dyn TypeResolver) -> Option<Self> {
+        fn to_non_nullish_value(
+            ty: TypeData,
+            resolver: &mut dyn TypeResolver,
+            mut depth: usize,
+        ) -> Option<TypeData> {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return Some(ty);
+            }
+
+            let new_ty = match &ty {
+                TypeData::Null | TypeData::Undefined => return None,
+                TypeData::Union(union) => {
+                    let types = union
+                        .types()
+                        .iter()
+                        .filter_map(|reference| {
+                            let ty = resolver
+                                .resolve_and_get(reference)
+                                .map(ResolvedTypeData::to_data)
+                                .and_then(|ty| to_non_nullish_value(ty, resolver, depth))?;
+                            Some(resolver.reference_to_owned_data(ty))
+                        })
+                        .collect();
+                    TypeData::union_of(resolver, types)
+                }
+                _unchanged => ty,
+            };
+
+            Some(new_ty)
+        }
+
+        to_non_nullish_value(self, resolver, 0)
+    }
+
+    /// Converts the type data to a value that is truthy.
+    ///
+    /// If the data itself may hold both truthy and falsy values, new data may
+    /// be returned that can be truthy only.
+    ///
+    /// Returns `None` if the value is known to be always falsy.
+    pub fn to_truthy_value(self, resolver: &mut dyn TypeResolver) -> Option<Self> {
+        fn to_truthy_value(
+            ty: TypeData,
+            resolver: &mut dyn TypeResolver,
+            mut depth: usize,
+        ) -> Option<TypeData> {
+            depth += 1;
+            if depth == MAX_FLATTEN_DEPTH {
+                return Some(ty);
+            }
+
+            let new_data = match &ty {
+                TypeData::Boolean => Literal::Boolean(true.into()).into(),
+                TypeData::Conditional => TypeData::Unknown,
+                TypeData::Literal(literal) => match literal.as_ref() {
+                    Literal::BigInt(text) => match text.text() {
+                        "0n" | "-0n" => return None,
+                        _ => ty,
+                    },
+                    Literal::Boolean(boolean) => match boolean.as_bool() {
+                        false => return None,
+                        true => ty,
+                    },
+                    Literal::Number(number) => match number.to_f64() {
+                        Some(0.) => return None,
+                        Some(n) if n.is_nan() => return None,
+                        _ => ty,
+                    },
+                    Literal::Object(_) | Literal::RegExp(_) => return None,
+                    Literal::String(string) => match string.as_str() {
+                        "" => return None,
+                        _ => ty,
+                    },
+                    Literal::Template(_) => ty,
+                },
+                TypeData::Null | TypeData::Undefined | TypeData::VoidKeyword => return None,
+                TypeData::Union(union) => {
+                    let types = union
+                        .types()
+                        .iter()
+                        .filter_map(|reference| {
+                            let ty = resolver
+                                .resolve_and_get(reference)
+                                .map(ResolvedTypeData::to_data)
+                                .and_then(|ty| to_truthy_value(ty, resolver, depth))?;
+                            Some(resolver.reference_to_owned_data(ty))
+                        })
+                        .collect();
+                    TypeData::union_of(resolver, types)
+                }
+                _unchanged => ty,
+            };
+
+            Some(new_data)
+        }
+
+        to_truthy_value(self, resolver, 0)
+    }
+
+    /// Creates a union of type references.
+    ///
+    /// References are automatically deduplicated. If only a single type
+    /// remains, an instance of `Self::Reference` is returned instead of
+    /// `Self::Union`.
+    pub fn union_of(resolver: &dyn TypeResolver, mut types: Vec<TypeReference>) -> Self {
+        types.dedup();
+
+        for ty in &types {
+            if let Some(resolved) = resolver.resolve_and_get(ty) {
+                if resolved.is_any_keyword() {
+                    return Self::AnyKeyword;
+                }
+            }
+        }
+
+        types.retain(|ty| match resolver.resolve_and_get(ty) {
+            Some(resolved) => !resolved.is_never_keyword(),
+            None => true,
+        });
+
+        match types.len().cmp(&1) {
+            Ordering::Greater => Self::Union(Box::new(Union(types.into()))),
+            Ordering::Equal => Self::reference(types.remove(0)),
+            Ordering::Less => Self::NeverKeyword,
         }
     }
 }
@@ -452,3 +853,61 @@ impl<'a> TypeMemberOwner<'a> {
         }
     }
 }
+
+macro_rules! generate_resolved_matcher {
+    ($name:ident) => {
+        impl ResolvedTypeData<'_> {
+            #[inline]
+            pub fn $name(self) -> bool {
+                self.as_raw_data().$name()
+            }
+        }
+    };
+}
+macro_rules! generate_type_matcher {
+    ($name:ident) => {
+        impl Type {
+            #[inline]
+            pub fn $name(&self) -> bool {
+                self.as_raw_data().is_some_and(TypeData::$name)
+            }
+        }
+    };
+}
+macro_rules! generate_matcher {
+    ($name:ident, $variant:ident) => {
+        impl TypeData {
+            #[inline]
+            pub fn $name(&self) -> bool {
+                matches!(self, Self::$variant)
+            }
+        }
+
+        generate_resolved_matcher!($name);
+        generate_type_matcher!($name);
+    };
+    ($name:ident, $variant:ident, $data:pat) => {
+        impl TypeData {
+            #[inline]
+            pub fn $name(&self) -> bool {
+                matches!(self, Self::$variant($data))
+            }
+        }
+
+        generate_resolved_matcher!($name);
+        generate_type_matcher!($name);
+    };
+}
+
+generate_matcher!(is_any_keyword, AnyKeyword);
+generate_matcher!(is_class, Class, _);
+generate_matcher!(is_conditional, Conditional);
+generate_matcher!(is_expression, TypeofExpression, _);
+generate_matcher!(is_function, Function, _);
+generate_matcher!(is_generic, Generic, _);
+generate_matcher!(is_interface, Interface, _);
+generate_matcher!(is_null, Null);
+generate_matcher!(is_reference, Reference, _);
+generate_matcher!(is_never_keyword, NeverKeyword);
+generate_matcher!(is_unknown_keyword, UnknownKeyword);
+generate_matcher!(is_void_keyword, VoidKeyword);

--- a/crates/biome_js_type_info/src/type_info/literal.rs
+++ b/crates/biome_js_type_info/src/type_info/literal.rs
@@ -60,6 +60,7 @@ impl NumberLiteral {
                 Some("0b" | "0B") => Some(u64::from_str_radix(&s[2..], 2).ok()? as f64),
                 Some("0o" | "0O") => Some(u64::from_str_radix(&s[2..], 8).ok()? as f64),
                 Some("0x" | "0X") => Some(u64::from_str_radix(&s[2..], 16).ok()? as f64),
+                Some("Na") => (s == "NaN").then_some(f64::NAN),
                 Some(prefix)
                     if prefix.starts_with('0')
                         && !prefix.ends_with(['e', 'E'])


### PR DESCRIPTION
## Summary

Type inference is now able to handle logical expressions: `&&`, `||`, and `??`.

## Examples

```ts
// We can now infer that because `true` is truthy, the entire expression
// evaluates to a `Promise`.
true && Promise.reject("logical operator bypass");

// And we know that this doesn't:
false && Promise.reject("logical operator bypass");

// Truthiness, falsiness, and non-nullishness can all be determined on more
// complex expressions as well. So the following also works:
type Nullish = null | undefined;

type Params = {
    booleanOption: boolean | Nullish;
    falsyOption: false | Nullish;
};

function foo({ booleanOption, falsyOption }: Params) {
    // This may be a Promise:
    booleanOption ?? Promise.reject("logical operator bypass");
    
    // But this never is:
    falsyOption && Promise.reject("logical operator bypass");
}
```

## Test Plan

Tests added.
