### PR TITLE
chore(editorconfig): remove max_line_length comment

### DIFF
--- a/crates/biome_configuration/src/editorconfig.rs
+++ b/crates/biome_configuration/src/editorconfig.rs
@@ -7,7 +7,6 @@
 //! | indent_style         | indent_style |
 //! | indent_size          | indent_width |
 //! | end_of_line          | line_ending  |
-//! | max_line_length      | line_width   |
 
 use crate::{
     Configuration, FormatterConfiguration, OverrideFormatterConfiguration, OverrideGlobs,


### PR DESCRIPTION
## Summary

This change just updates the `editorconfig.rs`'s comment. This aligns the comments with the actual implementation.

See https://github.com/biomejs/biome/pull/4894

## Test Plan

No tests are necessary for this comment-only change.
