### PR TITLE
fix(lsp): require config and code actions

### DIFF
--- a/.changeset/busy-zebras-smash.md
+++ b/.changeset/busy-zebras-smash.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where Biome LSP didn't provide all the available code actions when requrested by the editor.

--- a/.changeset/busy-zebras-smash.md
+++ b/.changeset/busy-zebras-smash.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed a bug where Biome LSP didn't provide all the available code actions when requrested by the editor.
+Fixed a bug where Biome didn't provide all the available code actions when requested by the editor.

--- a/.changeset/hot-dragons-count.md
+++ b/.changeset/hot-dragons-count.md
@@ -2,5 +2,5 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6287](https://github.com/biomejs/biome/issues/6287) where the Biome LSP didn't adhere to the `settings.requireConfiguration` option when pulling diagnostics and code actions.
+Fixed [#6287](https://github.com/biomejs/biome/issues/6287) where Biome Language Server didn't adhere to the `settings.requireConfiguration` option when pulling diagnostics and code actions.
 Note that for this configuration be correctly applied, your editor must support dynamic registration capabilities.

--- a/.changeset/hot-dragons-count.md
+++ b/.changeset/hot-dragons-count.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6287](https://github.com/biomejs/biome/issues/6287) where the Biome LSP didn't adhere to the `settings.requireConfiguration` option when pulling diagnostics and code actions.
+Note that for this configuration be correctly applied, your editor must support dynamic registration capabilities.

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -82,11 +82,6 @@ impl Projects {
         let projects = self.0.pin();
         let data = projects.get(&project_key)?;
 
-        debug!(
-            "Get settings for {} {}",
-            file_path.as_str(),
-            data.nested_settings.len()
-        );
         for (project_path, settings) in &data.nested_settings {
             if file_path.starts_with(project_path) {
                 return Some(settings.clone());


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR closes two bugs.

Closes https://github.com/biomejs/biome/issues/6287

To fix this bug, I had to apply the following changes:
- when loading the configuration, now we check if the configuration folder is empty. If it is empty, and the editor require the configuration, when we return early with `ConfigurationStatus::Missed`.
- the language server request `textDocument/codeAction` must be registered dynamically. We already do so with formatting requests too.

The second bug was related to how we compute the code actions to provide to the editors. I must admit that there was a lot of confusion on my part (and possibly others') in understanding the feature and correctly applying it to the code.

When the client requests `textDocument/codeAction`, we simply need to provide the code actions available to a diagnostic. Those code actions are the ones that belong to the choices that the editor provides when clicking <kbd>Cmd</kbd> + <kbd>.</kbd>. This means that we need to provide **ALL** code actions: the safe fix, the inline suppression and the top-level suppression. The user will choose what they want. 

When configuring `codeActionsOnSave` / `code_actions_on_format`, the user chooses which ones should be applied **among** the ones listed. 

Given the previous statements, I adjusted the code, and I also added and fixed some checks: we now check both assist and linter.

> [!IMPORTANT]
> There's still a small bug where we provide suppressions regardless of whether the action is a lint rule or an assist action. This requires some refactoring that I prefer to tackle in a different PR.


I also updated the label of the `fixAll` action. This is how it looks like:

<img width="504" alt="Screenshot 2025-06-26 at 11 18 49" src="https://github.com/user-attachments/assets/0473122c-4dfb-4dcf-b616-6e3ba01390df" />


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

I did manual testing in Zed and VSCode and made sure they behave the same.
Updated the tests, and removed one test that doesn't make sense anymore.

<!-- What demonstrates that your implementation is correct? -->
