### PR TITLE
fix(cli): replace `files.ignore` with `files.includes` in the error message

### DIFF
--- a/.changeset/plenty-bananas-throw.md
+++ b/.changeset/plenty-bananas-throw.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6559](https://github.com/biomejs/biome/issues/6559): the error message on detected a large file was outdated and referred a removed configuration option `files.ignore`.

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_max_file_size/overrides_files_max_size_too_large_limit_check.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_max_file_size/overrides_files_max_size_too_large_limit_check.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 432
 expression: redactor(content)
 ---
 ## `biome.json`
@@ -49,7 +48,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 test.js check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 13 B, which exceeds the configured maximum of 1 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_max_file_size/overrides_files_max_size_too_large_limit_format.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_max_file_size/overrides_files_max_size_too_large_limit_format.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 432
 expression: redactor(content)
 ---
 ## `biome.json`
@@ -49,7 +48,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 test.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 13 B, which exceeds the configured maximum of 1 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large.snap
@@ -25,7 +25,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 check.js check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 1.0 MiB, which exceeds the configured maximum of 1.0 MiB for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_cli_limit.snap
@@ -32,7 +32,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 check.js check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/file_too_large_config_limit.snap
@@ -42,7 +42,7 @@ check ━━━━━━━━━━━━━━━━━━━━━━━━�
 check.js check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large.snap
@@ -25,7 +25,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ci.js ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 1.0 MiB, which exceeds the configured maximum of 1.0 MiB for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_cli_limit.snap
@@ -32,7 +32,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ci.js ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/file_too_large_config_limit.snap
@@ -42,7 +42,7 @@ ci ━━━━━━━━━━━━━━━━━━━━━━━━━�
 ci.js ci ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large.snap
@@ -25,7 +25,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 1.0 MiB, which exceeds the configured maximum of 1.0 MiB for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_cli_limit.snap
@@ -32,7 +32,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/file_too_large_config_limit.snap
@@ -42,7 +42,7 @@ format ━━━━━━━━━━━━━━━━━━━━━━━━�
 format.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large.snap
@@ -25,7 +25,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 1.0 MiB, which exceeds the configured maximum of 1.0 MiB for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_cli_limit.snap
@@ -32,7 +32,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/file_too_large_config_limit.snap
@@ -42,7 +42,7 @@ lint ━━━━━━━━━━━━━━━━━━━━━━━━━
 check.js lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i The size of the file is 27 B, which exceeds the configured maximum of 16 B for this project.
-    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file.
+    Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file.
   
 
 ```

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -309,7 +309,7 @@ impl Diagnostic for FileTooLarge {
         fmt.write_markup(
             markup!{
                 "The size of the file is "{Bytes(self.size)}", which exceeds the configured maximum of "{Bytes(self.limit)}" for this project.
-Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.ignore` to ignore the file."
+Use the `files.maxSize` configuration to change the maximum size of files processed, or `files.includes` to ignore the file."
             }
         )
     }


### PR DESCRIPTION
## Summary

Fixes #6559 

When a file is larger than the limit, the CLI emits a diagnostic. The error message there was outdated, and referred the missing option `files.ignore` that was removed in 2.0.

## Test Plan

Updated snapshots.