### PR TITLE
chore: update contribution guide to include vladimir ivanov as a maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -493,7 +493,7 @@ Members are listed in alphabetical order. Members are free to use the full name,
 - [Dani Guardiola @DaniGuardiola](https://github.com/DaniGuardiola)
 - [Justinas Delinda @minht11](https://github.com/minht11)
 - [Madeline Gurriarán @SuperchupuDev](https://github.com/SuperchupuDev)
-- [Vladimir Ivanov@vlad](https://github.com/vladimir-ivanov)
+- [Vladimir Ivanov_@vlad](https://github.com/vladimir-ivanov)
 - [Vo Hoang Long @vohoanglong0107](https://github.com/vohoanglong0107)
 - [Yoshiaki Togami @togami2864](https://github.com/togami2864)
 - [Yusuke Abe @chansuke](https://github.com/chansuke)


### PR DESCRIPTION
## Summary

update contribution guide to include vladimir ivanov as a maintainer