### PR TITLE
fix(biome_js_analyze): add JsExport to be walked by JsDocTypeCollectorVisitior

### DIFF
--- a/.changeset/large-showers-leave.md
+++ b/.changeset/large-showers-leave.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [4677](https://github.com/biomejs/biome/issues/4677). Now the rule `noUnusedImports` rule won't produce diagnostics for types used in comment of JS_EXPORT
+Fixed [#4677](https://github.com/biomejs/biome/issues/4677): Now the `noUnusedImports` rule won't produce diagnostics for types used in JSDoc comment of exports.

--- a/.changeset/large-showers-leave.md
+++ b/.changeset/large-showers-leave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [4677](https://github.com/biomejs/biome/issues/4677). Now the rule `noUnusedImports` rule won't produce diagnostics for types used in comment of JS_EXPORT

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -17,8 +17,8 @@ use biome_js_factory::make::{js_identifier_binding, js_module, js_module_item_li
 use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
     AnyJsBinding, AnyJsClassMember, AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsImportClause,
-    AnyJsNamedImportSpecifier, AnyTsTypeMember, JsLanguage, JsNamedImportSpecifiers, JsSyntaxNode,
-    T, TsEnumMember,
+    AnyJsNamedImportSpecifier, AnyTsTypeMember, JsExport, JsLanguage, JsNamedImportSpecifiers,
+    JsSyntaxNode, T, TsEnumMember,
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::{
@@ -124,7 +124,7 @@ struct JsDocTypeCollectorVisitior {
 }
 
 declare_node_union! {
-    pub AnyJsWithTypeReferencingJsDoc = AnyJsDeclaration | AnyJsClassMember | AnyTsTypeMember | TsEnumMember
+    pub AnyJsWithTypeReferencingJsDoc = AnyJsDeclaration | AnyJsClassMember | AnyTsTypeMember | TsEnumMember | JsExport
 }
 
 impl Visitor for JsDocTypeCollectorVisitior {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js
@@ -8,6 +8,7 @@ import TypeOnClassField from "mod";
 import TypeOnGlobalVariable from "mod";
 import TypeOnFunctionVariable from "mod";
 import TypeOnTypeDef from "mod";
+import TypeOnExportedFunction from "mod";
 
 /**
  * @typedef {TypeOnTypeDef} TestTypeOnTypeDef 
@@ -17,6 +18,11 @@ import TypeOnTypeDef from "mod";
  * @param {TypeOnFunctionParam} param
  */
 function testTypeOnFunction(param) {}
+
+/**
+ * @param {TypeOnExportedFunction} param
+ */
+export function testTypeOnExportedFunction(param) {}
 
 class TestTypeOnClassMethodParam {
 	/**

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js.snap
@@ -14,6 +14,7 @@ import TypeOnClassField from "mod";
 import TypeOnGlobalVariable from "mod";
 import TypeOnFunctionVariable from "mod";
 import TypeOnTypeDef from "mod";
+import TypeOnExportedFunction from "mod";
 
 /**
  * @typedef {TypeOnTypeDef} TestTypeOnTypeDef 
@@ -23,6 +24,11 @@ import TypeOnTypeDef from "mod";
  * @param {TypeOnFunctionParam} param
  */
 function testTypeOnFunction(param) {}
+
+/**
+ * @param {TypeOnExportedFunction} param
+ */
+export function testTypeOnExportedFunction(param) {}
 
 class TestTypeOnClassMethodParam {
 	/**


### PR DESCRIPTION
https://github.com/biomejs/biome/pull/5698 fixed the majority of https://github.com/biomejs/biome/issues/4677.

An unhandled edge case is exported function.

```
// Some comment
export function exportedFunction {}
```

In this case, the comment belongs to `JsExport` instead of `AnyJsDeclaration`. This PR fixes the edge case.