### PR TITLE
chore(lint): fix document of the `noMagicNumbers` rule that produces invalid MDX

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
@@ -16,34 +16,34 @@ use biome_rowan::{AstNode, declare_node_union};
 
 declare_lint_rule! {
     /// Reports usage of "magic numbers" — numbers used directly instead of being assigned to named constants.
-   ///
-   /// Its goal is to improve code maintainability and readability by encouraging developers to extract such numbers into named constants, making their purpose explicit.
-   ///
-   /// It ignores:
-   /// - non-magic values (like 0, 1, 2, 10, 24, 60, and their negative or bigint forms) found anywhere, including arithmetic expressions, fn calls etc.
-   /// - Array indices
-   /// - Enum values
-   /// - Initial values in variable or class property declarations
-   /// - Default values in function parameters or destructuring patterns
-   /// - Arguments to JSON.stringify and parseInt (e.g., JSON.stringify(22), parseInt("123", 8))
-   /// - Operands in bitwise operations (e.g., a & 7, a | 7)
-   /// - Values in JSX expressions (e.g., <div>{1}</div>)
-   /// - Object property values (e.g., { tax: 0.25 })
-   ///
-   /// ## Examples
-   ///
-   /// ### Invalid
-   ///
-   /// ```js,expect_diagnostic
-   /// let total = price * 1.23; // Magic number for tax rate
-   /// ```
-   ///
-   /// ### Valid
-   ///
-   /// ```js
-   /// const TAX_RATE = 1.23;
-   /// let total = price * TAX_RATE;
-   /// ```
+    ///
+    /// Its goal is to improve code maintainability and readability by encouraging developers to extract such numbers into named constants, making their purpose explicit.
+    ///
+    /// It ignores:
+    /// - non-magic values (like 0, 1, 2, 10, 24, 60, and their negative or bigint forms) found anywhere, including arithmetic expressions, fn calls etc.
+    /// - Array indices
+    /// - Enum values
+    /// - Initial values in variable or class property declarations
+    /// - Default values in function parameters or destructuring patterns
+    /// - Arguments to JSON.stringify and parseInt (e.g., `JSON.stringify(22)`, `parseInt("123", 8)`)
+    /// - Operands in bitwise operations (e.g., `a & 7`, `a | 7`)
+    /// - Values in JSX expressions (e.g., `<div>{1}</div>`)
+    /// - Object property values (e.g., `{ tax: 0.25 }`)
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```js,expect_diagnostic
+    /// let total = price * 1.23; // Magic number for tax rate
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```js
+    /// const TAX_RATE = 1.23;
+    /// let total = price * TAX_RATE;
+    /// ```
     pub NoMagicNumbers {
         version: "next",
         name: "noMagicNumbers",


### PR DESCRIPTION
## Summary

Currently website builds are failing as the doc comment of the `noMagicNumbers` rule has some code inside and it produces invalid MDX. This pull request resolves it by wrapping them with backquotes.

Deploy log: https://app.netlify.com/projects/biomejs/deploys/685eb8e91d147700080c8945

cc @vladimir-ivanov 

## Test Plan

Website builds should back green.
