### PR TITLE
fix(biome_js_analyze): fix JsDocTypeCollectorVisitior to also walk on JsStaticMemberAssignment

### DIFF
--- a/.changeset/modern-turtles-exist.md
+++ b/.changeset/modern-turtles-exist.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4677](https://github.com/biomejs/biome/issues/4677): Now the `noUnusedImports` rule won't produce diagnostics for types used in comments of static members.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -18,7 +18,7 @@ use biome_js_semantic::{ReferencesExtensions, SemanticModel};
 use biome_js_syntax::{
     AnyJsBinding, AnyJsClassMember, AnyJsCombinedSpecifier, AnyJsDeclaration, AnyJsImportClause,
     AnyJsNamedImportSpecifier, AnyTsTypeMember, JsExport, JsLanguage, JsNamedImportSpecifiers,
-    JsSyntaxNode, T, TsEnumMember,
+    JsStaticMemberAssignment, JsSyntaxNode, T, TsEnumMember,
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::{
@@ -124,7 +124,7 @@ struct JsDocTypeCollectorVisitior {
 }
 
 declare_node_union! {
-    pub AnyJsWithTypeReferencingJsDoc = AnyJsDeclaration | AnyJsClassMember | AnyTsTypeMember | TsEnumMember | JsExport
+    pub AnyJsWithTypeReferencingJsDoc = AnyJsDeclaration | AnyJsClassMember | AnyTsTypeMember | TsEnumMember | JsExport | JsStaticMemberAssignment
 }
 
 impl Visitor for JsDocTypeCollectorVisitior {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js
@@ -58,5 +58,3 @@ function testTypeOnFunctionVariable() {
 	 */
 	let testTypeOnFunctionVariable;
 }
-
-

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedImports/issue_4677_jsdoc.js.snap
@@ -65,32 +65,4 @@ function testTypeOnFunctionVariable() {
 	let testTypeOnFunctionVariable;
 }
 
-
-
-```
-
-# Diagnostics
-```
-issue_4677_jsdoc.js:7:8 lint/correctness/noUnusedImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This import is unused.
-  
-    5 │ import TypeOnClassMethodParam from "mod";
-    6 │ import TypeOnClassConstructorParam from "mod";
-  > 7 │ import TypeOnClassField from "mod";
-      │        ^^^^^^^^^^^^^^^^
-    8 │ import TypeOnGlobalVariable from "mod";
-    9 │ import TypeOnFunctionVariable from "mod";
-  
-  i Unused imports might be the result of an incomplete refactoring.
-  
-  i Unsafe fix: Remove the unused imports.
-  
-     5  5 │   import TypeOnClassMethodParam from "mod";
-     6  6 │   import TypeOnClassConstructorParam from "mod";
-     7    │ - import·TypeOnClassField·from·"mod";
-     8  7 │   import TypeOnGlobalVariable from "mod";
-     9  8 │   import TypeOnFunctionVariable from "mod";
-  
-
 ```


### PR DESCRIPTION
This PR fixed the edge case mentioned by @arendjr in https://github.com/biomejs/biome/pull/6565#pullrequestreview-2965088544.

The biome playground was very helpful in identifying the missing js syntax.