### PR TITLE
feat(core): targeted file scanner

### DIFF
--- a/.changeset/targeted-tigers-tango.md
+++ b/.changeset/targeted-tigers-tango.md
@@ -17,5 +17,5 @@ a path, as well as those where project rules are enabled, are not expected to
 see performance benefits from this.
 
 Implemented [#6234](https://github.com/biomejs/biome/issues/6234), and fixed
-[#6484](https://github.com/biomejs/biome/issues/6483) and
+[#6483](https://github.com/biomejs/biome/issues/6483) and
 [#6563](https://github.com/biomejs/biome/issues/6563).

--- a/.changeset/targeted-tigers-tango.md
+++ b/.changeset/targeted-tigers-tango.md
@@ -1,0 +1,21 @@
+---
+"@biomejs/biome": minor
+---
+
+We have implemented a more targeted version of the scanner, which ensures that
+if you provide file paths to handle on the CLI, the scanner will exclude
+directories that are not relevant to those paths.
+
+Note that for many commands, such as `biome check` and `biome format`, the file
+paths to handle are implicitly set to the current working directory if you do
+not provide any path explicitly. The targeted scanner also works with such
+implicit paths, which means that if you run Biome from a subfolder, other
+folders that are part of the project are automatically exempted.
+
+Use cases where you invoke Biome from the root of the project without providing
+a path, as well as those where project rules are enabled, are not expected to
+see performance benefits from this.
+
+Implemented [#6234](https://github.com/biomejs/biome/issues/6234), and fixed
+[#6484](https://github.com/biomejs/biome/issues/6483) and
+[#6563](https://github.com/biomejs/biome/issues/6563).

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -148,9 +148,15 @@ pub enum BiomeCommand {
         configuration: Option<Configuration>,
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
-        /// Use this option when you want to format code piped from `stdin`, and print the output to `stdout`.
+        /// Use this option when you want to format code piped from `stdin`, and
+        /// print the output to `stdout`.
         ///
-        /// The file doesn't need to exist on disk, what matters is the extension of the file. Based on the extension, Biome knows how to check the code.
+        /// The file doesn't need to exist on disk, what matters is the
+        /// extension of the file. Based on the extension, Biome knows how to
+        /// check the code.
+        ///
+        /// Also, if you have overrides configured and/or nested configurations,
+        /// the path may determine the settings being applied.
         ///
         /// Example:
         /// ```shell

--- a/crates/biome_cli/src/commands/scan_kind.rs
+++ b/crates/biome_cli/src/commands/scan_kind.rs
@@ -1,35 +1,44 @@
 use crate::{Execution, TraversalMode};
-use biome_configuration::Configuration;
+use biome_fs::BiomePath;
 use biome_service::workspace::ScanKind;
+use camino::Utf8Path;
 
 /// Returns a forced scan kind based on the given `execution`.
 ///
 /// Rules:
-/// - Returns [ScanKind::NoScanner] when processing from `stdin`. When using `stdin`,
-///   we don't know the input's real path, so we can't match nested configs or
-///   resolve import paths, meaning there's no use for the scanner.
+/// - When processing from `stdin`, we return [ScanKind::NoScanner] if the stdin
+///   file path is in the directory of the root configuration, and
+///   [ScanKind::TargetedKnownFiles] otherwise.
 /// - Returns [ScanKind::KnownFiles] for `biome format`, `biome migrate`, and
-///   `biome search` when the configuration is at the root of a Biome project,
-///   because we know there is no use for project analysis with these commands.
+///   `biome search`, because we know there is no use for project analysis with
+///   these commands.
 /// - Returns `None` otherwise.
 pub(crate) fn get_forced_scan_kind(
     execution: &Execution,
-    configuration: &Configuration,
+    root_configuration_dir: &Utf8Path,
+    working_dir: &Utf8Path,
 ) -> Option<ScanKind> {
-    if execution.is_stdin() {
-        return Some(ScanKind::NoScanner);
+    if let Some(stdin) = execution.stdin() {
+        let path = stdin.as_path();
+        if path
+            .parent()
+            .is_some_and(|dir| dir == root_configuration_dir)
+        {
+            return Some(ScanKind::NoScanner);
+        } else {
+            return Some(ScanKind::TargetedKnownFiles {
+                target_paths: vec![BiomePath::new(working_dir.join(path))],
+                descend_from_targets: false,
+            });
+        }
     }
+
     // We want to keep the `match`, so if we add new traversal modes,
     // the compiler will error, and we will need to handle the new variant
     match execution.traversal_mode() {
-        TraversalMode::Migrate { .. } => Some(ScanKind::KnownFiles),
-        TraversalMode::Format { .. } | TraversalMode::Search { .. } => {
-            if configuration.is_root() {
-                Some(ScanKind::KnownFiles)
-            } else {
-                None
-            }
-        }
+        TraversalMode::Format { .. }
+        | TraversalMode::Migrate { .. }
+        | TraversalMode::Search { .. } => Some(ScanKind::KnownFiles),
         // These traversals might enable lint rules that require project rules,
         // so we need to return `None` so we can use the `ScanKind` returned by the workspace
         TraversalMode::Lint { .. } | TraversalMode::Check { .. } | TraversalMode::CI { .. } => None,
@@ -56,10 +65,8 @@ mod tests {
             skip_parse_errors: false,
         });
 
-        assert_eq!(
-            get_forced_scan_kind(&execution, &Configuration::default()),
-            None
-        );
+        let root_dir = Utf8Path::new("/");
+        assert_eq!(get_forced_scan_kind(&execution, root_dir, root_dir), None);
     }
 
     #[test]
@@ -71,8 +78,9 @@ mod tests {
             vcs_targeted: VcsTargeted::default(),
         });
 
+        let root_dir = Utf8Path::new("/");
         assert_eq!(
-            get_forced_scan_kind(&execution, &Configuration::default()),
+            get_forced_scan_kind(&execution, root_dir, root_dir),
             Some(ScanKind::KnownFiles)
         );
     }

--- a/crates/biome_cli/src/commands/scan_kind.rs
+++ b/crates/biome_cli/src/commands/scan_kind.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_forced_scan_kind(
     root_configuration_dir: &Utf8Path,
     working_dir: &Utf8Path,
 ) -> Option<ScanKind> {
-    if let Some(stdin) = execution.stdin() {
+    if let Some(stdin) = execution.as_stdin_file() {
         let path = stdin.as_path();
         if path
             .parent()

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -360,17 +360,6 @@ impl Execution {
         matches!(self.traversal_mode, TraversalMode::Lint { .. })
     }
 
-    pub(crate) fn stdin(&self) -> Option<&Stdin> {
-        match &self.traversal_mode {
-            TraversalMode::Check { stdin, .. } => stdin.as_ref(),
-            TraversalMode::Lint { stdin, .. } => stdin.as_ref(),
-            TraversalMode::CI { .. } => None,
-            TraversalMode::Format { stdin, .. } => stdin.as_ref(),
-            TraversalMode::Migrate { .. } => None,
-            TraversalMode::Search { stdin, .. } => stdin.as_ref(),
-        }
-    }
-
     #[instrument(level = "debug", skip(self), fields(result))]
     pub(crate) fn is_safe_fixes_enabled(&self) -> bool {
         let result = match self.traversal_mode {

--- a/crates/biome_cli/tests/cases/monorepo.rs
+++ b/crates/biome_cli/tests/cases/monorepo.rs
@@ -385,3 +385,200 @@ fn should_not_lint_when_root_is_disabled_but_nested_is_enabled() {
         result,
     ));
 }
+
+#[test]
+fn should_find_settings_when_run_from_nested_dir() {
+    let mut console = BufferConsole::default();
+    let mut fs = TemporaryFs::new("should_find_settings_when_run_from_nested_dir");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "off" },
+            "suspicious": { "noDebugger": "off" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/lib/biome.jsonc",
+        r#"{
+    "extends": "//",
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "error" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file("file.js", "let a; debugger");
+
+    fs.create_file("packages/lib/file.js", "let a; debugger");
+
+    fs.append_to_working_directory("packages/lib");
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint", fs.cli_path()].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_find_settings_when_run_from_nested_dir",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_find_settings_when_targeting_file_in_nested_dir() {
+    let mut fs = TemporaryFs::new("should_find_settings_when_targeting_file_in_nested_dir");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "linter": {
+        "includes": ["**/*.js"],
+        "rules": {
+            "correctness": { "noUnusedVariables": "off" },
+            "suspicious": { "noDebugger": "off" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/lib/biome.jsonc",
+        r#"{
+    "extends": "//",
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "error" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file("file.js", "let a; debugger");
+
+    fs.create_file("packages/lib/file.js", "let a; debugger");
+
+    let mut console = BufferConsole::default();
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint", &format!("{}/packages/lib/file.js", fs.cli_path())].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_find_settings_when_targeting_file_in_nested_dir",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_find_settings_when_targeting_nested_dir() {
+    let mut fs = TemporaryFs::new("should_find_settings_when_targeting_nested_dir");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "linter": {
+        "includes": ["**/*.js"],
+        "rules": {
+            "correctness": { "noUnusedVariables": "off" },
+            "suspicious": { "noDebugger": "off" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/lib/biome.jsonc",
+        r#"{
+    "extends": "//",
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "error" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file("file.js", "let a; debugger");
+
+    fs.create_file("packages/lib/file.js", "let a; debugger");
+
+    let mut console = BufferConsole::default();
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint", &format!("{}/packages/lib", fs.cli_path())].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_find_settings_when_targeting_nested_dir",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_find_settings_when_targeting_parent_of_nested_dir() {
+    let mut fs = TemporaryFs::new("should_find_settings_when_targeting_parent_of_nested_dir");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "linter": {
+        "includes": ["**/*.js"],
+        "rules": {
+            "correctness": { "noUnusedVariables": "off" },
+            "suspicious": { "noDebugger": "off" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "packages/lib/biome.jsonc",
+        r#"{
+    "extends": "//",
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "error" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file("file.js", "let a; debugger");
+
+    fs.create_file("packages/lib/file.js", "let a; debugger");
+
+    let mut console = BufferConsole::default();
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint", &format!("{}/packages", fs.cli_path())].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_find_settings_when_targeting_parent_of_nested_dir",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_root_when_run_from_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_root_when_run_from_nested_dir.snap
@@ -1,0 +1,78 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `packages/lib/biome.jsonc`
+
+```json
+{
+  "extends": "//",
+  "root": false,
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `packages/lib/file.js`
+
+```js
+let a; debugger
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable a is unused.
+  
+  > 1 │ let a; debugger
+      │     ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - let·a;·debugger
+  + let·_a;·debugger
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_run_from_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_run_from_nested_dir.snap
@@ -1,0 +1,77 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `packages/lib/biome.jsonc`
+
+```json
+{
+  "extends": "//",
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `packages/lib/file.js`
+
+```js
+let a; debugger
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable a is unused.
+  
+  > 1 │ let a; debugger
+      │     ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - let·a;·debugger
+  + let·_a;·debugger
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_file_in_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_file_in_nested_dir.snap
@@ -1,0 +1,78 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `packages/lib/biome.jsonc`
+
+```json
+{
+  "extends": "//",
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "linter": {
+    "includes": ["**/*.js"],
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `packages/lib/file.js`
+
+```js
+let a; debugger
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+packages/lib/file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable a is unused.
+  
+  > 1 │ let a; debugger
+      │     ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - let·a;·debugger
+  + let·_a;·debugger
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_nested_dir.snap
@@ -1,0 +1,78 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `packages/lib/biome.jsonc`
+
+```json
+{
+  "extends": "//",
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "linter": {
+    "includes": ["**/*.js"],
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `packages/lib/file.js`
+
+```js
+let a; debugger
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+packages/lib/file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable a is unused.
+  
+  > 1 │ let a; debugger
+      │     ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - let·a;·debugger
+  + let·_a;·debugger
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_parent_of_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_parent_of_nested_dir.snap
@@ -1,0 +1,78 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `packages/lib/biome.jsonc`
+
+```json
+{
+  "extends": "//",
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "linter": {
+    "includes": ["**/*.js"],
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `packages/lib/file.js`
+
+```js
+let a; debugger
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+packages/lib/file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This variable a is unused.
+  
+  > 1 │ let a; debugger
+      │     ^
+  
+  i Unused variables are often the result of an incomplete refactoring, typos, or other sources of bugs.
+  
+  i Unsafe fix: If this is intentional, prepend a with an underscore.
+  
+  - let·a;·debugger
+  + let·_a;·debugger
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -234,6 +234,8 @@ Available options:
                               The file doesn't need to exist on disk, what matters is the extension
                               of the file. Based on the extension, Biome knows how to check the
                               code.
+                              Also, if you have overrides configured and/or nested configurations,
+                              the path may determine the settings being applied.
                               Example: ```shell echo 'let a;' | biome check
                               --stdin-file-path=file.js --write ```
         --staged              When set to true, only the files that have been staged (the ones

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -19,6 +19,7 @@ use biome_plugin_loader::PluginDiagnostic;
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
+use std::ffi::OsString;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::process::{ExitCode, Termination};
@@ -26,43 +27,70 @@ use std::process::{ExitCode, Termination};
 /// Generic errors thrown during biome operations
 #[derive(Deserialize, Diagnostic, Serialize)]
 pub enum WorkspaceError {
-    /// The file does not exist in the [crate::Workspace]
-    NotFound(NotFound),
-    /// A file is not supported. It contains the language and path of the file
-    /// Use this error if Biome is trying to process a file that Biome can't understand
-    SourceFileNotSupported(SourceFileNotSupported),
-    /// The formatter encountered an error while formatting the file
-    FormatError(FormatError),
-    /// The formatter encountered an error while formatting the file
-    PrintError(PrintError),
-    /// The file could not be formatted since it has syntax errors and `format_with_errors` is disabled
-    FormatWithErrorsDisabled(FormatWithErrorsDisabled),
-    /// The file could not be analyzed because a rule caused an error.
-    RuleError(RuleError),
-    /// Thrown when Biome can't read a generic file
+    /// Thrown when Biome can't read a generic file.
     CantReadFile(CantReadFile),
-    /// Error thrown when validating the configuration. Once deserialized, further checks have to be done.
+
+    /// Error thrown when validating the configuration. Once deserialized,
+    /// further checks have to be done.
     Configuration(ConfigurationDiagnostic),
-    /// An operation is attempted on the registered project, but there is no registered project.
-    NoProject(NoProject),
-    /// Thrown when the workspace attempts to register a nested project, but no working directory was provided
-    NoWorkspaceDirectory(NoWorkspaceDirectory),
-    /// Error thrown when Biome cannot rename a symbol.
-    RenameError(RenameError),
-    /// Error emitted by the underlying transport layer for a remote Workspace
-    TransportError(TransportError),
-    /// Emitted when the file is ignored and should not be processed
+
+    /// Emitted when the file is ignored and should not be processed.
     FileIgnored(FileIgnored),
-    /// Diagnostics emitted when querying the file system
+
+    /// Diagnostics emitted when querying the file system.
     FileSystem(FileSystemDiagnostic),
-    /// Raised when there's an issue around the VCS integration
-    Vcs(VcsDiagnostic),
+
+    /// The formatter encountered an error while formatting the file.
+    FormatError(FormatError),
+
+    /// The file could not be formatted since it has syntax errors and
+    /// `format_with_errors` is disabled.
+    FormatWithErrorsDisabled(FormatWithErrorsDisabled),
+
+    /// An operation is attempted on the registered project, but there is no
+    /// registered project.
+    NoProject(NoProject),
+
+    /// Thrown when the workspace attempts to register a nested project, but no
+    /// working directory was provided.
+    NoWorkspaceDirectory(NoWorkspaceDirectory),
+
+    /// Path contained a non-UTF8 character.
+    NonUtf8Path(NonUtf8Path),
+
+    /// The file does not exist in the [crate::Workspace].
+    NotFound(NotFound),
+
     /// One or more errors occurred during plugin loading.
     PluginErrors(PluginErrors),
+
+    /// The formatter encountered an error while formatting the file.
+    PrintError(PrintError),
+
     /// Diagnostic raised when a file is protected.
     ProtectedFile(ProtectedFile),
+
+    /// Error thrown when Biome cannot rename a symbol.
+    RenameError(RenameError),
+
+    /// The file could not be analyzed because a rule caused an error.
+    RuleError(RuleError),
+
     /// Error when searching for a pattern
     SearchError(SearchError),
+
+    /// A file is not supported. Contains the language and path of the file.
+    ///
+    /// Use this error if Biome is trying to process a file that Biome can't
+    /// understand.
+    SourceFileNotSupported(SourceFileNotSupported),
+
+    /// Error emitted by the underlying transport layer for a remote Workspace.
+    TransportError(TransportError),
+
+    /// Raised when there's an issue around the VCS integration.
+    Vcs(VcsDiagnostic),
+
     /// Error in the workspace watcher.
     WatchError(WatchError),
 }
@@ -78,6 +106,10 @@ impl WorkspaceError {
 
     pub fn invalid_pattern() -> Self {
         Self::SearchError(SearchError::InvalidPattern(InvalidPattern))
+    }
+
+    pub fn non_utf8_path(path: OsString) -> Self {
+        Self::NonUtf8Path(NonUtf8Path { path })
     }
 
     pub fn not_found() -> Self {
@@ -202,6 +234,36 @@ impl From<CantResolve> for WorkspaceError {
 impl From<WorkspaceError> for biome_diagnostics::serde::Diagnostic {
     fn from(error: WorkspaceError) -> Self {
         Self::new(error)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NonUtf8Path {
+    path: OsString,
+}
+
+impl Diagnostic for NonUtf8Path {
+    fn category(&self) -> Option<&'static Category> {
+        Some(category!("internalError/fs"))
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Error
+    }
+
+    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            fmt,
+            "Biome does not support non-UTF8 characters in path: {}",
+            self.path.display()
+        )
+    }
+
+    fn message(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
+        fmt.write_markup(markup! {
+            "Biome does not support non-UTF8 characters in path: "
+            <Emphasis>{self.path.display().to_string()}</Emphasis>
+        })
     }
 }
 

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -109,7 +109,7 @@ impl WorkspaceError {
     }
 
     pub fn non_utf8_path(path: OsString) -> Self {
-        Self::NonUtf8Path(NonUtf8Path { path })
+        Self::NonUtf8Path(NonUtf8Path { path: path.display().to_string() })
     }
 
     pub fn not_found() -> Self {
@@ -237,34 +237,17 @@ impl From<WorkspaceError> for biome_diagnostics::serde::Diagnostic {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Diagnostic, Serialize)]
+#[diagnostic( 
+     category = "internalError/fs", 
+     severity = Error, 
+     message( 
+         description = "Biome does not support non-UTF8 characters in path: {path}", 
+         message("Biome does not support non-UTF8 characters in path: "<Emphasis>{self.path}</Emphasis>) 
+     ), 
+ )] 
 pub struct NonUtf8Path {
-    path: OsString,
-}
-
-impl Diagnostic for NonUtf8Path {
-    fn category(&self) -> Option<&'static Category> {
-        Some(category!("internalError/fs"))
-    }
-
-    fn severity(&self) -> Severity {
-        Severity::Error
-    }
-
-    fn description(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            fmt,
-            "Biome does not support non-UTF8 characters in path: {}",
-            self.path.display()
-        )
-    }
-
-    fn message(&self, fmt: &mut biome_console::fmt::Formatter<'_>) -> std::io::Result<()> {
-        fmt.write_markup(markup! {
-            "Biome does not support non-UTF8 characters in path: "
-            <Emphasis>{self.path.display().to_string()}</Emphasis>
-        })
-    }
+    path: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Diagnostic)]

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -109,7 +109,9 @@ impl WorkspaceError {
     }
 
     pub fn non_utf8_path(path: OsString) -> Self {
-        Self::NonUtf8Path(NonUtf8Path { path: path.display().to_string() })
+        Self::NonUtf8Path(NonUtf8Path {
+            path: path.display().to_string(),
+        })
     }
 
     pub fn not_found() -> Self {
@@ -238,14 +240,14 @@ impl From<WorkspaceError> for biome_diagnostics::serde::Diagnostic {
 }
 
 #[derive(Debug, Deserialize, Diagnostic, Serialize)]
-#[diagnostic( 
-     category = "internalError/fs", 
-     severity = Error, 
-     message( 
-         description = "Biome does not support non-UTF8 characters in path: {path}", 
-         message("Biome does not support non-UTF8 characters in path: "<Emphasis>{self.path}</Emphasis>) 
-     ), 
- )] 
+#[diagnostic(
+     category = "internalError/fs",
+     severity = Error,
+     message(
+         description = "Biome does not support non-UTF8 characters in path: {path}",
+         message("Biome does not support non-UTF8 characters in path: "<Emphasis>{self.path}</Emphasis>)
+     ),
+ )]
 pub struct NonUtf8Path {
     path: String,
 }

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -230,8 +230,7 @@ pub enum ScanKind {
     TargetedKnownFiles {
         /// The paths to target by the scanner.
         ///
-        /// If a target path indicates a folder, all files and folders within
-        /// are scanned as well.
+        /// If a target path indicates a folder, all files within are scanned as well.
         ///
         /// Target paths must be absolute.
         target_paths: Vec<BiomePath>,

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -217,28 +217,43 @@ pub(crate) struct ScanContext<'app> {
     scan_kind: ScanKind,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum ScanKind {
-    /// The scanner should not be triggered
+    /// The scanner should not be triggered.
     NoScanner,
-    /// It targets specific files
+    /// Scans for limited, known files across the repository.
     KnownFiles,
-    /// It targets the project, so it attempts to open all the files in the project.
+    /// Scans for limited, knows files, but only within a set of predefined
+    /// paths.
+    TargetedKnownFiles {
+        /// The paths to target by the scanner.
+        ///
+        /// If a target path indicates a folder, all files and folders within
+        /// are scanned as well.
+        ///
+        /// Target paths must be absolute.
+        target_paths: Vec<BiomePath>,
+
+        /// Determines whether the file scanner should descend into
+        /// subdirectories of the target paths.
+        descend_from_targets: bool,
+    },
+    /// Scans the entire repository, indexing all files to enable project rules.
     Project,
 }
 
 impl ScanKind {
-    pub const fn is_project(self) -> bool {
+    pub const fn is_project(&self) -> bool {
         matches!(self, Self::Project)
     }
 
-    pub const fn is_known_files(self) -> bool {
+    pub const fn is_known_files(&self) -> bool {
         matches!(self, Self::KnownFiles)
     }
 
-    pub const fn is_none(self) -> bool {
+    pub const fn is_none(&self) -> bool {
         matches!(self, Self::NoScanner)
     }
 }
@@ -277,27 +292,45 @@ impl TraversalContext for ScanContext<'_> {
 
         match self.workspace.fs().symlink_path_kind(path) {
             Ok(PathKind::Directory { .. }) => {
-                if self.scan_kind.is_project() && path.is_dependency() {
-                    // In project mode, the scanner always scans dependencies
-                    // because they're a valuable source of type information.
-                    true
-                } else if !path.is_dependency() {
-                    !self
-                        .workspace
-                        .is_path_ignored(IsPathIgnoredParams {
-                            project_key: self.project_key,
-                            path: path.clone(),
-                            // The scanner only cares about the top-level
-                            // `files.includes`
-                            features: FeaturesBuilder::new().build(),
-                        })
-                        .unwrap_or_default()
-                } else {
-                    false
+                if path.is_dependency() {
+                    // Only project mode cares about dependencies, because they
+                    // are a valuable source of type information.
+                    return self.scan_kind.is_project();
                 }
+
+                if self
+                    .workspace
+                    .is_path_ignored(IsPathIgnoredParams {
+                        project_key: self.project_key,
+                        path: path.clone(),
+                        // The scanner only cares about the top-level
+                        // `files.includes`
+                        features: FeaturesBuilder::new().build(),
+                    })
+                    .unwrap_or_default()
+                {
+                    return false; // Nobody cares about ignored paths.
+                }
+
+                if let ScanKind::TargetedKnownFiles {
+                    target_paths,
+                    descend_from_targets,
+                } = &self.scan_kind
+                {
+                    if !target_paths.iter().any(|target_path| {
+                        target_path.starts_with(path.as_path())
+                            || (*descend_from_targets && path.starts_with(target_path.as_path()))
+                    }) {
+                        return false; // Path is not being targeted.
+                    }
+                }
+
+                true
             }
-            Ok(PathKind::File { .. }) => match self.scan_kind {
-                ScanKind::KnownFiles => path.is_required_during_scan() && !path.is_dependency(),
+            Ok(PathKind::File { .. }) => match &self.scan_kind {
+                ScanKind::KnownFiles | ScanKind::TargetedKnownFiles { .. } => {
+                    path.is_required_during_scan() && !path.is_dependency()
+                }
                 ScanKind::Project => {
                     if path.is_dependency() {
                         path.is_package_json() || path.is_type_declaration()

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -601,15 +601,18 @@ impl WorkspaceServer {
         }
     }
 
-    /// It updates the nested settings of the project assigned to the `project_key`.
+    /// Updates the nested settings of the project assigned to the
+    /// `project_key`.
     ///
-    /// If a configuration file contains errors, it's not processed and the project isn't updated.
+    /// If a configuration file contains errors, it's not processed and the
+    /// project isn't updated.
     ///
-    /// It's the responsibility of the client to process the diagnostics and handle the errors emitted by the configuration.
+    /// It's the responsibility of the client to process the diagnostics and
+    /// handle the errors emitted by the configuration.
     ///
     /// ## Errors
     ///
-    /// - A nested configuration file si a root
+    /// - A nested configuration file is a root
     /// - Biome can't read the file
     pub(super) fn update_project_config_files(
         &self,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3952,7 +3952,26 @@ export interface OpenProjectResult {
 	 */
 	scanKind: ScanKind;
 }
-export type ScanKind = "noScanner" | "knownFiles" | "project";
+export type ScanKind =
+	| "noScanner"
+	| "knownFiles"
+	| {
+			targetedKnownFiles: {
+				/**
+				 * Determines whether the file scanner should descend into subdirectories of the target paths.
+				 */
+				descend_from_targets: boolean;
+				/**
+	* The paths to target by the scanner.
+
+If a target path indicates a folder, all files and folders within are scanned as well.
+
+Target paths must be absolute. 
+	 */
+				target_paths: BiomePath[];
+			};
+	  }
+	| "project";
 export interface OpenFileParams {
 	content: FileContent;
 	documentFileSource?: DocumentFileSource;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -3964,7 +3964,7 @@ export type ScanKind =
 				/**
 	* The paths to target by the scanner.
 
-If a target path indicates a folder, all files and folders within are scanned as well.
+If a target path indicates a folder, all files within are scanned as well.
 
 Target paths must be absolute. 
 	 */


### PR DESCRIPTION
## Summary

Implemented a more targeted version of the scanner, which ensures that if you provide file paths to handle on the CLI, the scanner will exclude directories that are not relevant to those paths.

Note that for many commands, such as `biome check` and `biome format`, the file paths to handle are implicitly set to the current working directory if you do not provide any path explicitly. The targeted scanner also works with such implicit paths, which means that if you run Biome from a subfolder, other folders that are part of the project are automatically exempted.

Use cases where you invoke Biome from the root of the project without providing a path, as well as those where project rules are enabled, are not expected to see performance benefits from this.

Fixed #6234.
Fixed #6483.
Fixed #6563.

## Test Plan

I have added a bunch of automated tests, but could use a little bit of extra verification from others as well.

Even though we could technically push this as a patch release, there may be subtle behavioral changes. I don't expect any issues, but just in case I would prefer to push this as a minor instead.
