### PR TITLE
Detect json import attribute with trimmed text value instead of plain text value

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_json_import_attribute.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_json_import_attribute.rs
@@ -86,9 +86,9 @@ impl Rule for UseJsonImportAttribute {
             for entry in assertions.into_iter().flatten() {
                 if let AnyJsImportAssertionEntry::JsImportAssertionEntry(entry) = entry {
                     if let Ok(key) = entry.key() {
-                        if key.text() == "type" {
+                        if key.text_trimmed() == "type" {
                             if let Ok(value) = entry.value_token() {
-                                if value.text() == "json" {
+                                if value.text_trimmed() == "json" {
                                     found_type_json = true;
                                     break;
                                 } else {

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsonImportAttribute/valid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsonImportAttribute/valid.js
@@ -3,3 +3,7 @@
 import foo from 'bar.json' with { type: 'json' };
 
 import bar from 'baz.json' with { other: 'value', type: 'json' }
+
+import hoge from 'hoge.json' with {
+    type: 'json'
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useJsonImportAttribute/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useJsonImportAttribute/valid.js.snap
@@ -10,4 +10,8 @@ import foo from 'bar.json' with { type: 'json' };
 
 import bar from 'baz.json' with { other: 'value', type: 'json' }
 
+import hoge from 'hoge.json' with {
+    type: 'json'
+}
+
 ```

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js
@@ -5,3 +5,6 @@ import {test} from "foo.json" with { for: "for" }
 import foo_json from "foo.json" with { type: "json", hasOwnProperty: "true" };
 import "x" with
 { type: "json" }
+import foo from "foo.json" with {
+    type: "json"
+}

--- a/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/ok/import_attribute.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_parser/tests/spec_test.rs
 expression: snapshot
-snapshot_kind: text
 ---
 ## Input
 
@@ -13,6 +12,9 @@ import {test} from "foo.json" with { for: "for" }
 import foo_json from "foo.json" with { type: "json", hasOwnProperty: "true" };
 import "x" with
 { type: "json" }
+import foo from "foo.json" with {
+    type: "json"
+}
 
 ```
 
@@ -185,19 +187,47 @@ JsModule {
             },
             semicolon_token: missing (optional),
         },
+        JsImport {
+            import_token: IMPORT_KW@282..290 "import" [Newline("\n")] [Whitespace(" ")],
+            import_clause: JsImportDefaultClause {
+                type_token: missing (optional),
+                default_specifier: JsDefaultImportSpecifier {
+                    local_name: JsIdentifierBinding {
+                        name_token: IDENT@290..294 "foo" [] [Whitespace(" ")],
+                    },
+                },
+                from_token: FROM_KW@294..299 "from" [] [Whitespace(" ")],
+                source: JsModuleSource {
+                    value_token: JS_STRING_LITERAL@299..310 "\"foo.json\"" [] [Whitespace(" ")],
+                },
+                assertion: JsImportAssertion {
+                    with_token: WITH_KW@310..315 "with" [] [Whitespace(" ")],
+                    l_curly_token: L_CURLY@315..316 "{" [] [],
+                    assertions: JsImportAssertionEntryList [
+                        JsImportAssertionEntry {
+                            key: IDENT@316..325 "type" [Newline("\n"), Whitespace("    ")] [],
+                            colon_token: COLON@325..327 ":" [] [Whitespace(" ")],
+                            value_token: JS_STRING_LITERAL@327..333 "\"json\"" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@333..335 "}" [Newline("\n")] [],
+                },
+            },
+            semicolon_token: missing (optional),
+        },
     ],
-    eof_token: EOF@282..283 "" [Newline("\n")] [],
+    eof_token: EOF@335..336 "" [Newline("\n")] [],
 }
 ```
 
 ## CST
 
 ```
-0: JS_MODULE@0..283
+0: JS_MODULE@0..336
   0: (empty)
   1: (empty)
   2: JS_DIRECTIVE_LIST@0..0
-  3: JS_MODULE_ITEM_LIST@0..282
+  3: JS_MODULE_ITEM_LIST@0..335
     0: JS_IMPORT@0..32
       0: IMPORT_KW@0..7 "import" [] [Whitespace(" ")]
       1: JS_IMPORT_BARE_CLAUSE@7..32
@@ -313,6 +343,26 @@ JsModule {
               2: JS_STRING_LITERAL@274..281 "\"json\"" [] [Whitespace(" ")]
           3: R_CURLY@281..282 "}" [] []
       2: (empty)
-  4: EOF@282..283 "" [Newline("\n")] []
+    6: JS_IMPORT@282..335
+      0: IMPORT_KW@282..290 "import" [Newline("\n")] [Whitespace(" ")]
+      1: JS_IMPORT_DEFAULT_CLAUSE@290..335
+        0: (empty)
+        1: JS_DEFAULT_IMPORT_SPECIFIER@290..294
+          0: JS_IDENTIFIER_BINDING@290..294
+            0: IDENT@290..294 "foo" [] [Whitespace(" ")]
+        2: FROM_KW@294..299 "from" [] [Whitespace(" ")]
+        3: JS_MODULE_SOURCE@299..310
+          0: JS_STRING_LITERAL@299..310 "\"foo.json\"" [] [Whitespace(" ")]
+        4: JS_IMPORT_ASSERTION@310..335
+          0: WITH_KW@310..315 "with" [] [Whitespace(" ")]
+          1: L_CURLY@315..316 "{" [] []
+          2: JS_IMPORT_ASSERTION_ENTRY_LIST@316..333
+            0: JS_IMPORT_ASSERTION_ENTRY@316..333
+              0: IDENT@316..325 "type" [Newline("\n"), Whitespace("    ")] []
+              1: COLON@325..327 ":" [] [Whitespace(" ")]
+              2: JS_STRING_LITERAL@327..333 "\"json\"" [] []
+          3: R_CURLY@333..335 "}" [Newline("\n")] []
+      2: (empty)
+  4: EOF@335..336 "" [Newline("\n")] []
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Fixes: #6610


When detecting JSON import attributes, we were previously using text(). However, text() includes newlines and other whitespace, leading to issues like https://github.com/biomejs/biome/issues/6610. To resolve this, we will now detect JSON import attributes by referring to the trimmed text value instead.

This is my first pull request to biome, so Please feel free to point out anything I might have missed!

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

I believe added test cases covers that
