### PR TITLE
chore: add `syntax` parser directive to Dockerfile

### DIFF
--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM rust:1.87.0@sha256:251cec8da4689d180f124ef00024c2f83f79d9bf984e43c180a598119e326b84
 WORKDIR /usr/src/
 


### PR DESCRIPTION
## Summary

Add [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to the first line of the [Dockerfile](https://docs.docker.com/reference/dockerfile/).

## Why?

To declare the Dockerfile syntax version to use for the build.
If unspecified, [BuildKit](https://docs.docker.com/build/buildkit/) uses a bundled version of the Dockerfile frontend.