### PR TITLE
fix(core): fix extending configs with root field

### DIFF
--- a/.changeset/rebellious-roots-respect.md
+++ b/.changeset/rebellious-roots-respect.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6616](https://github.com/biomejs/biome/issues/6616): Fixed an issue with
+extending configurations that contained an explicit `root` field while the
+configuration in the project did not.

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -4078,3 +4078,161 @@ bar();"#
         result,
     ));
 }
+
+#[test]
+fn should_apply_root_settings_with_stdin_file_path() {
+    let mut fs = TemporaryFs::new("should_apply_root_settings_with_stdin_file_path");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single",
+            "semicolons": "always",
+        }
+    }
+}"#,
+    );
+
+    let mut console = BufferConsole::default();
+    console.in_buffer.push("let a = \"a\"".into());
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["check", "--stdin-file-path=file.js", "--write", "--unsafe"].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_apply_root_settings_with_stdin_file_path",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_apply_root_settings_with_stdin_file_path_and_extended_config() {
+    let mut fs =
+        TemporaryFs::new("should_apply_root_settings_with_stdin_file_path_and_extended_config");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "extends": ["base-config/biome"],
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single",
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "node_modules/base-config/package.json",
+        r#"{
+  "exports": {
+    "./biome": "./configs/biome.jsonc"
+  }
+}"#,
+    );
+
+    fs.create_file(
+        "node_modules/base-config/configs/biome.jsonc",
+        r#"{
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 3,
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+        }
+    }
+}"#,
+    );
+
+    let mut console = BufferConsole::default();
+    console
+        .in_buffer
+        .push("let a = \"a\"; if (true) { a = \"b\" }".into());
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["check", "--stdin-file-path=file.js", "--write", "--unsafe"].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_apply_root_settings_with_stdin_file_path_and_extended_config",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_apply_root_settings_with_stdin_file_path_and_extended_non_root_config() {
+    let mut fs = TemporaryFs::new(
+        "should_apply_root_settings_with_stdin_file_path_and_extended_non_root_config",
+    );
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "extends": ["base-config/biome"],
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single",
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "node_modules/base-config/package.json",
+        r#"{
+  "exports": {
+    "./biome": "./configs/biome.jsonc"
+  }
+}"#,
+    );
+
+    fs.create_file(
+        "node_modules/base-config/configs/biome.jsonc",
+        r#"{
+    "root": false,
+    "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 3,
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+        }
+    }
+}"#,
+    );
+
+    let mut console = BufferConsole::default();
+    console
+        .in_buffer
+        .push("let a = \"a\"; if (true) { a = \"b\" }".into());
+
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["check", "--stdin-file-path=file.js", "--write", "--unsafe"].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_apply_root_settings_with_stdin_file_path_and_extended_non_root_config",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.jsonc`
+
+```json
+{
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}
+```
+
+# Input messages
+
+```block
+let a = "a"
+```
+
+# Emitted Messages
+
+```block
+const _a = 'a';
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_broken_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_broken_config.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `node_modules/base-config/configs/biome.jsonc`
+
+```json
+{
+  "root": false,
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 3
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "extends": ["base-config/biome"],
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}
+```
+
+## `node_modules/base-config/package.json`
+
+```json
+{
+  "exports": {
+    "./biome": "./configs/biome.jsonc"
+  }
+}
+```
+
+# Input messages
+
+```block
+let a = "a"; if (true) { a = "b" }
+```
+
+# Emitted Messages
+
+```block
+let _a = 'a';
+if (true) {
+   _a = 'b';
+}
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_config.snap
@@ -1,0 +1,58 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `node_modules/base-config/configs/biome.jsonc`
+
+```json
+{
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 3
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "extends": ["base-config/biome"],
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}
+```
+
+## `node_modules/base-config/package.json`
+
+```json
+{
+  "exports": {
+    "./biome": "./configs/biome.jsonc"
+  }
+}
+```
+
+# Input messages
+
+```block
+let a = "a"; if (true) { a = "b" }
+```
+
+# Emitted Messages
+
+```block
+let _a = 'a';
+if (true) {
+   _a = 'b';
+}
+
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_non_root_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_apply_root_settings_with_stdin_file_path_and_extended_non_root_config.snap
@@ -1,0 +1,59 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `node_modules/base-config/configs/biome.jsonc`
+
+```json
+{
+  "root": false,
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 3
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "extends": ["base-config/biome"],
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  }
+}
+```
+
+## `node_modules/base-config/package.json`
+
+```json
+{
+  "exports": {
+    "./biome": "./configs/biome.jsonc"
+  }
+}
+```
+
+# Input messages
+
+```block
+let a = "a"; if (true) { a = "b" }
+```
+
+# Emitted Messages
+
+```block
+let _a = 'a';
+if (true) {
+   _a = 'b';
+}
+
+```


### PR DESCRIPTION
## Summary

If a configuration that did not contain an explicit `root` field extended another configuration that _did_ contain a `root` field, the `root` field was inherited. This is never what we want, and it tripped up configuration loading pretty badly, although it only manifested when checking a file from `stdin`.

Fixes #6616.

## Test Plan

Added several test cases to show that `--stdin-file-path` works correctly in various use cases.
