### PR TITLE
feat(core): infer sequence operator and update operators

### DIFF
--- a/.changeset/consequtive_commas_collaborate.md
+++ b/.changeset/consequtive_commas_collaborate.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": minor
+---
+
+Type inference is now able to handle the sequence operator (`,`), as well as
+post- and pre-update operators: `++`.
+
+
+## Examples
+
+```ts
+let x = 5;
+
+// We now infer that `x++` resolves to a number, while the expression as a whole
+// becomes a Promise:
+x++, new Promise((resolve) => resolve('comma'));
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_invalid.ts
@@ -1,0 +1,5 @@
+// Promise in comma operator
+function pattern19() {
+	let _x = 5;
+	_x++, new Promise((resolve) => resolve('comma'));
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_invalid.ts.snap
@@ -1,0 +1,31 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 19_invalid.ts
+---
+# Input
+```ts
+// Promise in comma operator
+function pattern19() {
+	let _x = 5;
+	_x++, new Promise((resolve) => resolve('comma'));
+}
+
+```
+
+# Diagnostics
+```
+19_invalid.ts:4:2 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │ function pattern19() {
+    3 │ 	let _x = 5;
+  > 4 │ 	_x++, new Promise((resolve) => resolve('comma'));
+      │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ }
+    6 │ 
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_valid.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+
+// Promise in comma operator
+function pattern19() {
+	let _x = 5;
+	_x++ ?? new Promise((resolve) => resolve('comma'));
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/19_valid.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 19_valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// Promise in comma operator
+function pattern19() {
+	let _x = 5;
+	_x++ ?? new Promise((resolve) => resolve('comma'));
+}
+
+```

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -543,6 +543,12 @@ impl TypeData {
                 .expression()
                 .map(|expr| resolver.resolve_expression(scope_id, &expr).into_owned())
                 .unwrap_or_default(),
+            AnyJsExpression::JsPostUpdateExpression(_)
+            | AnyJsExpression::JsPreUpdateExpression(_) => Self::number(),
+            AnyJsExpression::JsSequenceExpression(expr) => expr
+                .right()
+                .map(|expr| resolver.resolve_expression(scope_id, &expr).into_owned())
+                .unwrap_or_default(),
             AnyJsExpression::JsStaticMemberExpression(expr) => match (expr.object(), expr.member())
             {
                 (Ok(object), Ok(member)) => text_from_any_js_name(member)


### PR DESCRIPTION
## Summary

Type inference is now able to handle the sequence operator (`,`), as well as post- and pre-update operators: `++`.

## Examples

```ts
let x = 5;

// We now infer that `x++` resolves to a number, while the expression as a whole
// becomes a Promise:
x++, new Promise((resolve) => resolve('comma'));
```

## Test Plan

Test cases added.
