### PR TITLE
fix(core): fix inference for boolean that must be truthy

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts
@@ -44,3 +44,7 @@ function functionWithParams({ option }: Params) {
 let maybeString: string | undefined;
 const definitelyString = maybeString ?? "string";
 definitelyString ?? Promise.reject("logical operator bypass");
+
+let bool: boolean;
+const definitelyTruthy = bool || "string";
+definitelyTruthy || Promise.reject("logical operator bypass");

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/13_valid.ts.snap
@@ -51,4 +51,8 @@ let maybeString: string | undefined;
 const definitelyString = maybeString ?? "string";
 definitelyString ?? Promise.reject("logical operator bypass");
 
+let bool: boolean;
+const definitelyTruthy = bool || "string";
+definitelyTruthy || Promise.reject("logical operator bypass");
+
 ```

--- a/crates/biome_js_type_info/src/flattening/conditionals.rs
+++ b/crates/biome_js_type_info/src/flattening/conditionals.rs
@@ -318,12 +318,16 @@ pub fn reference_to_truthy_subset_of(
     ty: &TypeData,
     resolver: &mut dyn TypeResolver,
 ) -> Option<TypeReference> {
-    let filter = |ty: &TypeData| {
-        if ConditionalType::from_data_shallow(ty).is_none_or(|conditional| !conditional.is_falsy())
-        {
-            FilteredData::Retained
-        } else {
-            FilteredData::Stripped
+    let filter = |ty: &TypeData| match ty {
+        TypeData::Boolean => FilteredData::Mapped(Literal::Boolean(true.into()).into()),
+        other => {
+            if ConditionalType::from_data_shallow(other)
+                .is_none_or(|conditional| !conditional.is_falsy())
+            {
+                FilteredData::Retained
+            } else {
+                FilteredData::Stripped
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

Tiny fix for infering truthiness of booleans in derived types.

Didn't add a changelog, because the functionality itself was only introduced in `next`.

## Test Plan

Test added.
