### PR TITLE
fix(linter): prevent squashed inline comments from being "promoted" to cover the whole rule category.

### DIFF
--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -291,6 +291,11 @@ where
         }
 
         for suppression in suppressions.line_suppressions {
+            // TODO: `did_suppress_signal` is set after any single match. If a
+            // comment suppresses multiple rules, any unused parts of it will not
+            // be reported. This can be solved by tracking every rule match separately,
+            // but that would essentially duplicate the logic of handling separate rules.
+            // We'd better stop merging them altogether.
             if suppression.did_suppress_signal {
                 continue;
             }

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -402,13 +402,14 @@ impl<'analyzer> Suppressions<'analyzer> {
         filter: Option<RuleFilter<'static>>,
         plugin_name: Option<String>,
         instance: Option<String>,
-        current_range: TextRange,
+        comment_range: TextRange,
         already_suppressed: Option<TextRange>,
         rule_category: RuleCategory,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
         if let Some(suppression) = self.line_suppressions.last_mut() {
             if suppression.line_index == self.line_index {
                 suppression.already_suppressed = already_suppressed;
+                suppression.comment_span = suppression.comment_span.cover(comment_range);
 
                 match filter {
                     None => {
@@ -442,8 +443,8 @@ impl<'analyzer> Suppressions<'analyzer> {
         }
 
         let mut suppression = LineSuppression {
-            comment_span: current_range,
-            text_range: current_range,
+            comment_span: comment_range,
+            text_range: comment_range,
             line_index: self.line_index,
             already_suppressed,
             ..Default::default()

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -126,8 +126,7 @@ pub(crate) struct LineSuppression {
     pub(crate) comment_span: TextRange,
     /// Range of source text this comment is suppressing lint rules for
     pub(crate) text_range: TextRange,
-    /// Set to true if this comment has set the `suppress_all` flag to true
-    /// (must be restored to false on expiration)
+    /// All rules from groups included here are ignored.
     pub(crate) suppressed_categories: RuleCategories,
     /// List of all the rules this comment has started suppressing (must be
     /// removed from the suppressed set on expiration)
@@ -408,7 +407,7 @@ impl<'analyzer> Suppressions<'analyzer> {
         rule_category: RuleCategory,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
         if let Some(suppression) = self.line_suppressions.last_mut() {
-            if (suppression.line_index) == (self.line_index) {
+            if suppression.line_index == self.line_index {
                 suppression.already_suppressed = already_suppressed;
 
                 match filter {
@@ -436,7 +435,6 @@ impl<'analyzer> Suppressions<'analyzer> {
                         if let Some(instance) = instance {
                             suppression.suppressed_instances.insert(instance, filter);
                         }
-                        suppression.suppressed_categories.insert(rule_category);
                     }
                 }
                 return Ok(());

--- a/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx
+++ b/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx
@@ -41,6 +41,19 @@ function bothDisabled() {
   )
 }
 
+function bothDisabledFarAway() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    // biome-ignore lint/a11y/noRedundantAlt: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
 function unused1() {
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: ...
@@ -67,6 +80,50 @@ function unused3() {
   return (
     // biome-ignore lint/style/noImplicitBoolean: ...
     // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function wideThenNarrow() {
+  return (
+    // biome-ignore lint: ...
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function wideThenNarrowUnused() {
+  return (
+    // biome-ignore lint: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function narrowThenWide() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function narrowUnusedThenWide() {
+  return (
+    // biome-ignore lint/security/noBlankTarget: ...
+    // biome-ignore lint: ...
     <span
       role="button"
       onClick={()=>null}

--- a/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx
+++ b/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx
@@ -1,0 +1,75 @@
+///! lint/a11y/useKeyWithClickEvents
+///! lint/a11y/useSemanticElements
+
+function bothFailing() {
+  return (
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function firstDisabled() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function secondDisabled() {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function bothDisabled() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused1() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/noRedundantAlt: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused2() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused3() {
+  return (
+    // biome-ignore lint/style/noImplicitBoolean: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}

--- a/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
+++ b/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
@@ -396,8 +396,10 @@ suppressions.jsx:68:5 suppressions/unused ━━━━━━━━━━━━�
     67 │   return (
   > 68 │     // biome-ignore lint/style/noImplicitBoolean: ...
        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    69 │     // biome-ignore lint/security/noBlankTarget: ...
+  > 69 │     // biome-ignore lint/security/noBlankTarget: ...
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     70 │     <span
+    71 │       role="button"
   
 
 ```

--- a/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
+++ b/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
@@ -1,0 +1,403 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: suppressions.jsx
+---
+# Input
+```jsx
+///! lint/a11y/useKeyWithClickEvents
+///! lint/a11y/useSemanticElements
+
+function bothFailing() {
+  return (
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function firstDisabled() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function secondDisabled() {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function bothDisabled() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused1() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/noRedundantAlt: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused2() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function unused3() {
+  return (
+    // biome-ignore lint/style/noImplicitBoolean: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+```
+
+# Diagnostics
+```
+suppressions.jsx:6:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event.
+  
+     4 │ function bothFailing() {
+     5 │   return (
+   > 6 │     <span
+       │     ^^^^^
+   > 7 │       role="button"
+   > 8 │       onClick={()=>null}
+   > 9 │     >Some text</span>
+       │     ^
+    10 │   )
+    11 │ }
+  
+  i Actions triggered using mouse events should have corresponding keyboard events to account for keyboard-only navigation.
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
+  
+     4  4 │   function bothFailing() {
+     5  5 │     return (
+     6    │ - ····<span
+        6 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+        7 │ + <span
+     7  8 │         role="button"
+     8  9 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:7:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The elements with this role can be changed to the following elements:
+    <button>
+  
+    5 │   return (
+    6 │     <span
+  > 7 │       role="button"
+      │       ^^^^^^^^^^^^^
+    8 │       onClick={()=>null}
+    9 │     >Some text</span>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
+  
+     4  4 │   function bothFailing() {
+     5  5 │     return (
+     6    │ - ····<span
+        6 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+        7 │ + <span
+     7  8 │         role="button"
+     8  9 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:17:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The elements with this role can be changed to the following elements:
+    <button>
+  
+    15 │     // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    16 │     <span
+  > 17 │       role="button"
+       │       ^^^^^^^^^^^^^
+    18 │       onClick={()=>null}
+    19 │     >Some text</span>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
+  
+    14 14 │     return (
+    15 15 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    16    │ - ····<span
+       16 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+       17 │ + <span
+    17 18 │         role="button"
+    18 19 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:26:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event.
+  
+    24 │   return (
+    25 │     // biome-ignore lint/a11y/useSemanticElements: ...
+  > 26 │     <span
+       │     ^^^^^
+  > 27 │       role="button"
+  > 28 │       onClick={()=>null}
+  > 29 │     >Some text</span>
+       │     ^
+    30 │   )
+    31 │ }
+  
+  i Actions triggered using mouse events should have corresponding keyboard events to account for keyboard-only navigation.
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
+  
+    24 24 │     return (
+    25 25 │       // biome-ignore lint/a11y/useSemanticElements: ...
+    26    │ - ····<span
+       26 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+       27 │ + <span
+    27 28 │         role="button"
+    28 29 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:49:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The elements with this role can be changed to the following elements:
+    <button>
+  
+    47 │     // biome-ignore lint/a11y/noRedundantAlt: ...
+    48 │     <span
+  > 49 │       role="button"
+       │       ^^^^^^^^^^^^^
+    50 │       onClick={()=>null}
+    51 │     >Some text</span>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
+  
+    46 46 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    47 47 │       // biome-ignore lint/a11y/noRedundantAlt: ...
+    48    │ - ····<span
+       48 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+       49 │ + <span
+    49 50 │         role="button"
+    50 51 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:60:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The elements with this role can be changed to the following elements:
+    <button>
+  
+    58 │     // biome-ignore lint/security/noBlankTarget: ...
+    59 │     <span
+  > 60 │       role="button"
+       │       ^^^^^^^^^^^^^
+    61 │       onClick={()=>null}
+    62 │     >Some text</span>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
+  
+    57 57 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    58 58 │       // biome-ignore lint/security/noBlankTarget: ...
+    59    │ - ····<span
+       59 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+       60 │ + <span
+    60 61 │         role="button"
+    61 62 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:70:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event.
+  
+    68 │     // biome-ignore lint/style/noImplicitBoolean: ...
+    69 │     // biome-ignore lint/security/noBlankTarget: ...
+  > 70 │     <span
+       │     ^^^^^
+  > 71 │       role="button"
+  > 72 │       onClick={()=>null}
+  > 73 │     >Some text</span>
+       │     ^
+    74 │   )
+    75 │ }
+  
+  i Actions triggered using mouse events should have corresponding keyboard events to account for keyboard-only navigation.
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
+  
+    68 68 │       // biome-ignore lint/style/noImplicitBoolean: ...
+    69 69 │       // biome-ignore lint/security/noBlankTarget: ...
+    70    │ - ····<span
+       70 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+       71 │ + <span
+    71 72 │         role="button"
+    72 73 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:71:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × The elements with this role can be changed to the following elements:
+    <button>
+  
+    69 │     // biome-ignore lint/security/noBlankTarget: ...
+    70 │     <span
+  > 71 │       role="button"
+       │       ^^^^^^^^^^^^^
+    72 │       onClick={()=>null}
+    73 │     >Some text</span>
+  
+  i For examples and more information, see WAI-ARIA Roles
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
+  
+    68 68 │       // biome-ignore lint/style/noImplicitBoolean: ...
+    69 69 │       // biome-ignore lint/security/noBlankTarget: ...
+    70    │ - ····<span
+       70 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+       71 │ + <span
+    71 72 │         role="button"
+    72 73 │         onClick={()=>null}
+  
+  i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
+  
+     1  1 │   ///! lint/a11y/useKeyWithClickEvents
+     2    │ - ///!·lint/a11y/useSemanticElements
+        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+        3 │ + ///!·lint/a11y/useSemanticElements
+     3  4 │   
+     4  5 │   function bothFailing() {
+  
+
+```
+
+```
+suppressions.jsx:68:5 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
+  
+    66 │ function unused3() {
+    67 │   return (
+  > 68 │     // biome-ignore lint/style/noImplicitBoolean: ...
+       │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    69 │     // biome-ignore lint/security/noBlankTarget: ...
+    70 │     <span
+  
+
+```

--- a/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
+++ b/crates/biome_js_analyze/tests/multiple_rules/suppressions.jsx.snap
@@ -47,6 +47,19 @@ function bothDisabled() {
   )
 }
 
+function bothDisabledFarAway() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint/a11y/useSemanticElements: ...
+    // biome-ignore lint/a11y/noRedundantAlt: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
 function unused1() {
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: ...
@@ -79,6 +92,51 @@ function unused3() {
     >Some text</span>
   )
 }
+
+function wideThenNarrow() {
+  return (
+    // biome-ignore lint: ...
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function wideThenNarrowUnused() {
+  return (
+    // biome-ignore lint: ...
+    // biome-ignore lint/security/noBlankTarget: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function narrowThenWide() {
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+    // biome-ignore lint: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
+function narrowUnusedThenWide() {
+  return (
+    // biome-ignore lint/security/noBlankTarget: ...
+    // biome-ignore lint: ...
+    <span
+      role="button"
+      onClick={()=>null}
+    >Some text</span>
+  )
+}
+
 ```
 
 # Diagnostics
@@ -102,22 +160,22 @@ suppressions.jsx:6:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━�
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
   
-     4  4 │   function bothFailing() {
-     5  5 │     return (
-     6    │ - ····<span
-        6 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
-        7 │ + <span
-     7  8 │         role="button"
-     8  9 │         onClick={()=>null}
+      4   4 │   function bothFailing() {
+      5   5 │     return (
+      6     │ - ····<span
+          6 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+          7 │ + <span
+      7   8 │         role="button"
+      8   9 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
@@ -139,22 +197,22 @@ suppressions.jsx:7:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━�
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
   
-     4  4 │   function bothFailing() {
-     5  5 │     return (
-     6    │ - ····<span
-        6 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
-        7 │ + <span
-     7  8 │         role="button"
-     8  9 │         onClick={()=>null}
+      4   4 │   function bothFailing() {
+      5   5 │     return (
+      6     │ - ····<span
+          6 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+          7 │ + <span
+      7   8 │         role="button"
+      8   9 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
@@ -176,22 +234,22 @@ suppressions.jsx:17:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
   
-    14 14 │     return (
-    15 15 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
-    16    │ - ····<span
-       16 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
-       17 │ + <span
-    17 18 │         role="button"
-    18 19 │         onClick={()=>null}
+     14  14 │     return (
+     15  15 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+     16     │ - ····<span
+         16 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+         17 │ + <span
+     17  18 │         role="button"
+     18  19 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
@@ -216,190 +274,190 @@ suppressions.jsx:26:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━�
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
   
-    24 24 │     return (
-    25 25 │       // biome-ignore lint/a11y/useSemanticElements: ...
-    26    │ - ····<span
-       26 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
-       27 │ + <span
-    27 28 │         role="button"
-    28 29 │         onClick={()=>null}
+     24  24 │     return (
+     25  25 │       // biome-ignore lint/a11y/useSemanticElements: ...
+     26     │ - ····<span
+         26 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+         27 │ + <span
+     27  28 │         role="button"
+     28  29 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
 
 ```
-suppressions.jsx:49:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+suppressions.jsx:62:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The elements with this role can be changed to the following elements:
     <button>
   
-    47 │     // biome-ignore lint/a11y/noRedundantAlt: ...
-    48 │     <span
-  > 49 │       role="button"
+    60 │     // biome-ignore lint/a11y/noRedundantAlt: ...
+    61 │     <span
+  > 62 │       role="button"
        │       ^^^^^^^^^^^^^
-    50 │       onClick={()=>null}
-    51 │     >Some text</span>
+    63 │       onClick={()=>null}
+    64 │     >Some text</span>
   
   i For examples and more information, see WAI-ARIA Roles
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
   
-    46 46 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
-    47 47 │       // biome-ignore lint/a11y/noRedundantAlt: ...
-    48    │ - ····<span
-       48 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
-       49 │ + <span
-    49 50 │         role="button"
-    50 51 │         onClick={()=>null}
+     59  59 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+     60  60 │       // biome-ignore lint/a11y/noRedundantAlt: ...
+     61     │ - ····<span
+         61 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+         62 │ + <span
+     62  63 │         role="button"
+     63  64 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
 
 ```
-suppressions.jsx:60:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+suppressions.jsx:73:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The elements with this role can be changed to the following elements:
     <button>
   
-    58 │     // biome-ignore lint/security/noBlankTarget: ...
-    59 │     <span
-  > 60 │       role="button"
+    71 │     // biome-ignore lint/security/noBlankTarget: ...
+    72 │     <span
+  > 73 │       role="button"
        │       ^^^^^^^^^^^^^
-    61 │       onClick={()=>null}
-    62 │     >Some text</span>
+    74 │       onClick={()=>null}
+    75 │     >Some text</span>
   
   i For examples and more information, see WAI-ARIA Roles
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
   
-    57 57 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
-    58 58 │       // biome-ignore lint/security/noBlankTarget: ...
-    59    │ - ····<span
-       59 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
-       60 │ + <span
-    60 61 │         role="button"
-    61 62 │         onClick={()=>null}
+     70  70 │       // biome-ignore lint/a11y/useKeyWithClickEvents: ...
+     71  71 │       // biome-ignore lint/security/noBlankTarget: ...
+     72     │ - ····<span
+         72 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+         73 │ + <span
+     73  74 │         role="button"
+     74  75 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
 
 ```
-suppressions.jsx:70:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+suppressions.jsx:83:5 lint/a11y/useKeyWithClickEvents  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Enforce to have the onClick mouse event with the onKeyUp, the onKeyDown, or the onKeyPress keyboard event.
   
-    68 │     // biome-ignore lint/style/noImplicitBoolean: ...
-    69 │     // biome-ignore lint/security/noBlankTarget: ...
-  > 70 │     <span
+    81 │     // biome-ignore lint/style/noImplicitBoolean: ...
+    82 │     // biome-ignore lint/security/noBlankTarget: ...
+  > 83 │     <span
        │     ^^^^^
-  > 71 │       role="button"
-  > 72 │       onClick={()=>null}
-  > 73 │     >Some text</span>
+  > 84 │       role="button"
+  > 85 │       onClick={()=>null}
+  > 86 │     >Some text</span>
        │     ^
-    74 │   )
-    75 │ }
+    87 │   )
+    88 │ }
   
   i Actions triggered using mouse events should have corresponding keyboard events to account for keyboard-only navigation.
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for this line.
   
-    68 68 │       // biome-ignore lint/style/noImplicitBoolean: ...
-    69 69 │       // biome-ignore lint/security/noBlankTarget: ...
-    70    │ - ····<span
-       70 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
-       71 │ + <span
-    71 72 │         role="button"
-    72 73 │         onClick={()=>null}
+     81  81 │       // biome-ignore lint/style/noImplicitBoolean: ...
+     82  82 │       // biome-ignore lint/security/noBlankTarget: ...
+     83     │ - ····<span
+         83 │ + ····//·biome-ignore·lint/a11y/useKeyWithClickEvents:·<explanation>
+         84 │ + <span
+     84  85 │         role="button"
+     85  86 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useKeyWithClickEvents for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useKeyWithClickEvents:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
 
 ```
-suppressions.jsx:71:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+suppressions.jsx:84:7 lint/a11y/useSemanticElements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × The elements with this role can be changed to the following elements:
     <button>
   
-    69 │     // biome-ignore lint/security/noBlankTarget: ...
-    70 │     <span
-  > 71 │       role="button"
+    82 │     // biome-ignore lint/security/noBlankTarget: ...
+    83 │     <span
+  > 84 │       role="button"
        │       ^^^^^^^^^^^^^
-    72 │       onClick={()=>null}
-    73 │     >Some text</span>
+    85 │       onClick={()=>null}
+    86 │     >Some text</span>
   
   i For examples and more information, see WAI-ARIA Roles
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for this line.
   
-    68 68 │       // biome-ignore lint/style/noImplicitBoolean: ...
-    69 69 │       // biome-ignore lint/security/noBlankTarget: ...
-    70    │ - ····<span
-       70 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
-       71 │ + <span
-    71 72 │         role="button"
-    72 73 │         onClick={()=>null}
+     81  81 │       // biome-ignore lint/style/noImplicitBoolean: ...
+     82  82 │       // biome-ignore lint/security/noBlankTarget: ...
+     83     │ - ····<span
+         83 │ + ····//·biome-ignore·lint/a11y/useSemanticElements:·<explanation>
+         84 │ + <span
+     84  85 │         role="button"
+     85  86 │         onClick={()=>null}
   
   i Safe fix: Suppress rule lint/a11y/useSemanticElements for the whole file.
   
-     1  1 │   ///! lint/a11y/useKeyWithClickEvents
-     2    │ - ///!·lint/a11y/useSemanticElements
-        2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
-        3 │ + ///!·lint/a11y/useSemanticElements
-     3  4 │   
-     4  5 │   function bothFailing() {
+      1   1 │   ///! lint/a11y/useKeyWithClickEvents
+      2     │ - ///!·lint/a11y/useSemanticElements
+          2 │ + /**·biome-ignore-all·lint/a11y/useSemanticElements:·<explanation>·*/
+          3 │ + ///!·lint/a11y/useSemanticElements
+      3   4 │   
+      4   5 │   function bothFailing() {
   
 
 ```
 
 ```
-suppressions.jsx:68:5 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+suppressions.jsx:81:5 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
   
-    66 │ function unused3() {
-    67 │   return (
-  > 68 │     // biome-ignore lint/style/noImplicitBoolean: ...
+    79 │ function unused3() {
+    80 │   return (
+  > 81 │     // biome-ignore lint/style/noImplicitBoolean: ...
        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 69 │     // biome-ignore lint/security/noBlankTarget: ...
+  > 82 │     // biome-ignore lint/security/noBlankTarget: ...
        │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    70 │     <span
-    71 │       role="button"
+    83 │     <span
+    84 │       role="button"
   
 
 ```

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use std::{fs::read_to_string, slice};
 
 tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
-tests_macros::gen_tests! {"tests/suppression/**/*.{js,ts,cjs,cjs,mjs,mts,jsx,tsx}", crate::run_suppression_test, "module"}
-tests_macros::gen_tests! {"tests/multiple_rules/**/*.{js,ts,cjs,cjs,mjs,mts,jsx,tsx}", crate::run_multi_rule_test, "module"}
+tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/multiple_rules/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_multi_rule_test, "module"}
 tests_macros::gen_tests! {"tests/plugin/*.grit", crate::run_plugin_test, "module"}
 
 /// Checks if any of the enabled rules is in the project domain and requires the module graph.

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -374,7 +374,7 @@ pub(crate) fn run_multi_rule_test(input: &'static str, _: &str, _: &str, _: &str
     let rule_filters: Vec<_> = input_code
         .lines()
         .take_while(|line| line.is_empty() || line.starts_with("///!"))
-        .flat_map(|line| {
+        .filter_map(|line| {
             if line.is_empty() {
                 return None;
             }
@@ -382,7 +382,7 @@ pub(crate) fn run_multi_rule_test(input: &'static str, _: &str, _: &str, _: &str
             if !line.starts_with(prefix) {
                 panic!("Rule enabling comments must be of shape `{prefix}{{group}}/{{rule}}");
             }
-            let mut parts = line.trim_start_matches(prefix).split("/");
+            let mut parts = line.trim_start_matches(prefix).split('*');
             let group = parts.next().expect("Missing rule part in enable comment");
             let rule = parts.next().expect("Missing rule part in enable comment");
             if let Some(unused) = parts.next() {

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -22,8 +22,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::{fs::read_to_string, slice};
 
-tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
-tests_macros::gen_tests! {"tests/suppression/**/*.{cjs,cts,js,jsx,tsx,ts,json,jsonc,svelte}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/specs/**/*.{cjs,cts,js,mjs,jsx,tsx,ts,json,jsonc,svelte}", crate::run_test, "module"}
+tests_macros::gen_tests! {"tests/suppression/**/*.{js,ts,cjs,cjs,mjs,mts,jsx,tsx}", crate::run_suppression_test, "module"}
+tests_macros::gen_tests! {"tests/multiple_rules/**/*.{js,ts,cjs,cjs,mjs,mts,jsx,tsx}", crate::run_multi_rule_test, "module"}
 tests_macros::gen_tests! {"tests/plugin/*.grit", crate::run_plugin_test, "module"}
 
 /// Checks if any of the enabled rules is in the project domain and requires the module graph.
@@ -328,6 +329,81 @@ pub(crate) fn run_suppression_test(input: &'static str, _: &str, _: &str, _: &st
     let rule_filter = RuleFilter::Rule(group, rule);
     let filter = AnalysisFilter {
         enabled_rules: Some(slice::from_ref(&rule_filter)),
+        ..AnalysisFilter::default()
+    };
+
+    let mut snapshot = String::new();
+    analyze_and_snap(
+        &mut snapshot,
+        &input_code,
+        source_type,
+        filter,
+        file_name,
+        input_file,
+        CheckActionType::Suppression,
+        JsParserOptions::default(),
+        &[],
+    );
+
+    insta::with_settings!({
+        prepend_module_to_snapshot => false,
+        snapshot_path => input_file.parent().unwrap(),
+    }, {
+        insta::assert_snapshot!(file_name, snapshot, file_name);
+    });
+}
+
+pub(crate) fn run_multi_rule_test(input: &'static str, _: &str, _: &str, _: &str) {
+    register_leak_checker();
+
+    let input_file = Utf8Path::new(input);
+    let file_name = input_file.file_name().unwrap();
+    let source_type = match input_file.extension() {
+        Some("js" | "mjs" | "jsx") => JsFileSource::jsx(),
+        Some("cjs") => JsFileSource::js_script(),
+        Some("ts") => JsFileSource::ts(),
+        Some("mts" | "cts") => JsFileSource::ts_restricted(),
+        Some("tsx") => JsFileSource::tsx(),
+        _ => {
+            panic!("Unknown file extension: {:?}", input_file.extension());
+        }
+    };
+    let input_code = read_to_string(input_file)
+        .unwrap_or_else(|err| panic!("failed to read {input_file:?}: {err:?}"));
+
+    let rule_filters: Vec<_> = input_code
+        .lines()
+        .take_while(|line| line.is_empty() || line.starts_with("///!"))
+        .flat_map(|line| {
+            if line.is_empty() {
+                return None;
+            }
+            let prefix = "///! lint/";
+            if !line.starts_with(prefix) {
+                panic!("Rule enabling comments must be of shape `{prefix}{{group}}/{{rule}}");
+            }
+            let mut parts = line.trim_start_matches(prefix).split("/");
+            let group = parts.next().expect("Missing rule part in enable comment");
+            let rule = parts.next().expect("Missing rule part in enable comment");
+            if let Some(unused) = parts.next() {
+                panic!("Unrecognized enable comment suffix: {unused}");
+            }
+            if biome_js_analyze::METADATA
+                .deref()
+                .find_rule(group, rule)
+                .is_none()
+            {
+                panic!("could not find rule {group}/{rule}");
+            }
+            Some(RuleFilter::Rule(group, rule))
+        })
+        .collect();
+    if rule_filters.is_empty() {
+        panic!("At least one rule must be enabled with `///! lint/{{group}}/{{rule}}` comment");
+    }
+
+    let filter = AnalysisFilter {
+        enabled_rules: Some(&rule_filters),
         ..AnalysisFilter::default()
     };
 

--- a/crates/biome_js_analyze/tests/spec_tests.rs
+++ b/crates/biome_js_analyze/tests/spec_tests.rs
@@ -382,7 +382,7 @@ pub(crate) fn run_multi_rule_test(input: &'static str, _: &str, _: &str, _: &str
             if !line.starts_with(prefix) {
                 panic!("Rule enabling comments must be of shape `{prefix}{{group}}/{{rule}}");
             }
-            let mut parts = line.trim_start_matches(prefix).split('*');
+            let mut parts = line.trim_start_matches(prefix).split('/');
             let group = parts.next().expect("Missing rule part in enable comment");
             let rule = parts.next().expect("Missing rule part in enable comment");
             if let Some(unused) = parts.next() {


### PR DESCRIPTION
## Summary

Fixes #6621

Prevent squashed inline comments from being "promoted" to cover the whole rule category.

This PR might be superseded by #6650 if that aligns with the maintainers opinion - please take a look!

## Test Plan

Added a new test category that supports enabling multiple rules inline. Such tests must start with one or more lines of the shape

```
///! lint/{group}/{rule}
```

Added a testfile with multiple inline suppression comments. If the core idea of this PR is approved, I'll add more testcases covering non-jsx sources (that probably shouldn't matter, but there are too few tests for ignore comments, let's add more).