### PR TITLE
perf: optimise ignore checking

### DIFF
--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -33,7 +33,9 @@ pub(crate) struct ScanResult {
     /// Duration of the full scan.
     pub duration: Duration,
 
-    /// List of additional configuration files found inside the project (it doesn't contain the current one)
+    /// List of nested configuration files found inside the project.
+    ///
+    /// The root configuration is not included in this.
     pub configuration_files: Vec<BiomePath>,
 }
 


### PR DESCRIPTION
## Summary

While investigating #6509, I noticed that we do quite a bit of unnecessary cloning and Papaya lookups while checking if a file is ignored or not. Given that the scanner calls this for every file and folder it can find, it makes sense to make this as lightweight as we can, so I made a little effort optimising this further.

## Test Plan

Everything should stay green.
