### PR TITLE
fix(core): ignore nested configs

### DIFF
--- a/.changeset/nested-nettles-neglect.md
+++ b/.changeset/nested-nettles-neglect.md
@@ -1,0 +1,11 @@
+---
+"@biomejs/biome": patch
+---
+
+If a nested configuration file is ignored by the root configuration, it will now
+actually be ignored.
+
+Biome has an exception in place for configuration files so they cannot be
+ignored, because the configuration files are vital to Biome itself. But this
+exception was incorrectly applied to nested configurations as well. Now only the
+root configuration is exempt from being ignored.

--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -153,40 +153,13 @@ pub(crate) fn process_file(ctx: &TraversalOptions, biome_path: &BiomePath) -> Fi
     // then we pick the specific features for this file
     let unsupported_reason = match ctx.execution.traversal_mode() {
         TraversalMode::Check { .. } | TraversalMode::CI { .. } => file_features
-            .support_kind_for(&FeatureKind::Lint)
-            .and_then(|support_kind| {
-                if support_kind.is_not_enabled() {
-                    Some(support_kind)
-                } else {
-                    None
-                }
-            })
-            .and(
-                file_features
-                    .support_kind_for(&FeatureKind::Format)
-                    .and_then(|support_kind| {
-                        if support_kind.is_not_enabled() {
-                            Some(support_kind)
-                        } else {
-                            None
-                        }
-                    }),
-            )
-            .and(
-                file_features
-                    .support_kind_for(&FeatureKind::Assist)
-                    .and_then(|support_kind| {
-                        if support_kind.is_not_enabled() {
-                            Some(support_kind)
-                        } else {
-                            None
-                        }
-                    }),
-            ),
-        TraversalMode::Format { .. } => file_features.support_kind_for(&FeatureKind::Format),
-        TraversalMode::Lint { .. } => file_features.support_kind_for(&FeatureKind::Lint),
+            .support_kind_if_not_enabled(FeatureKind::Lint)
+            .and(file_features.support_kind_if_not_enabled(FeatureKind::Format))
+            .and(file_features.support_kind_if_not_enabled(FeatureKind::Assist)),
+        TraversalMode::Format { .. } => Some(file_features.support_kind_for(FeatureKind::Format)),
+        TraversalMode::Lint { .. } => Some(file_features.support_kind_for(FeatureKind::Lint)),
         TraversalMode::Migrate { .. } => None,
-        TraversalMode::Search { .. } => file_features.support_kind_for(&FeatureKind::Search),
+        TraversalMode::Search { .. } => Some(file_features.support_kind_for(FeatureKind::Search)),
     };
 
     if let Some(reason) = unsupported_reason {
@@ -229,7 +202,7 @@ pub(crate) fn process_file(ctx: &TraversalOptions, biome_path: &BiomePath) -> Fi
             format(shared_context, biome_path.clone())
         }
         TraversalMode::Check { .. } | TraversalMode::CI { .. } => {
-            check_file(shared_context, biome_path.clone(), &file_features)
+            check_file(shared_context, biome_path.clone(), file_features)
         }
         TraversalMode::Migrate { .. } => {
             unreachable!("The migration should not be called for this file")

--- a/crates/biome_cli/src/execute/process_file/check.rs
+++ b/crates/biome_cli/src/execute/process_file/check.rs
@@ -11,7 +11,7 @@ use biome_service::workspace::FileFeaturesResult;
 pub(crate) fn check_file<'ctx>(
     ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
     path: BiomePath,
-    file_features: &'ctx FileFeaturesResult,
+    file_features: FileFeaturesResult,
 ) -> FileResult {
     let mut has_failures = false;
     let mut workspace_file = WorkspaceFile::new(ctx, path)?;

--- a/crates/biome_cli/tests/cases/monorepo.rs
+++ b/crates/biome_cli/tests/cases/monorepo.rs
@@ -582,3 +582,54 @@ fn should_find_settings_when_targeting_parent_of_nested_dir() {
         result,
     ));
 }
+
+#[test]
+fn should_ignore_nested_configuration_in_ignored_directory() {
+    let mut fs = TemporaryFs::new("should_ignore_nested_configuration_in_ignored_directory");
+
+    fs.create_file(
+        "biome.jsonc",
+        r#"{
+    "files": {
+        "includes": ["**/*.js", "!vendor/**"],
+    },
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "off" },
+            "suspicious": { "noDebugger": "off" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file(
+        "vendor/biome.jsonc",
+        r#"{
+    "root": true,
+    "linter": {
+        "rules": {
+            "correctness": { "noUnusedVariables": "error" }
+        }
+    }
+}"#,
+    );
+
+    fs.create_file("file.js", "let a; debugger");
+
+    fs.create_file("vendor/foo/file.js", "let a; debugger");
+
+    let mut console = BufferConsole::default();
+    let result = run_cli_with_dyn_fs(
+        Box::new(fs.create_os()),
+        &mut console,
+        Args::from(["lint"].as_slice()),
+    );
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_ignore_nested_configuration_in_ignored_directory",
+        fs.create_mem(),
+        console,
+        result,
+    ));
+}

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_nested_dir.snap
@@ -73,6 +73,6 @@ packages/lib/file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes applied.
+Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_parent_of_nested_dir.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_find_settings_when_targeting_parent_of_nested_dir.snap
@@ -73,6 +73,6 @@ packages/lib/file.js:1:5 lint/correctness/noUnusedVariables  FIXABLE  ━━━�
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes applied.
+Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_ignore_nested_configuration_in_ignored_directory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_monorepo/should_ignore_nested_configuration_in_ignored_directory.snap
@@ -1,0 +1,50 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `vendor/biome.jsonc`
+
+```json
+{
+  "root": true,
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "error" }
+    }
+  }
+}
+```
+
+## `biome.jsonc`
+
+```json
+{
+  "files": {
+    "includes": ["**/*.js", "!vendor/**"]
+  },
+  "linter": {
+    "rules": {
+      "correctness": { "noUnusedVariables": "off" },
+      "suspicious": { "noDebugger": "off" }
+    }
+  }
+}
+```
+
+## `file.js`
+
+```js
+let a; debugger
+```
+
+## `vendor/foo/file.js`
+
+```js
+let a; debugger
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/include_files_in_symlinked_subdir.snap
@@ -64,7 +64,7 @@ symlinked/file.js:2:1 lint/suspicious/noDebugger  FIXABLE  ━━━━━━━
 ```
 
 ```block
-Checked 2 files in <TIME>. No fixes applied.
+Checked 1 file in <TIME>. No fixes applied.
 Found 1 error.
 Found 1 warning.
 ```

--- a/crates/biome_css_formatter/tests/language.rs
+++ b/crates/biome_css_formatter/tests/language.rs
@@ -35,9 +35,9 @@ impl TestFormatLanguage for CssTestFormatLanguage {
     ) -> Self::FormatLanguage {
         let language_settings = &settings.languages.css.formatter;
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(language_settings),
+            &settings.formatter,
+            &settings.override_settings,
+            language_settings,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -166,6 +166,7 @@ impl BiomePath {
     }
 
     /// Returns `true` if the path is inside `node_modules`
+    #[inline(always)]
     pub fn is_dependency(&self) -> bool {
         self.path
             .components()

--- a/crates/biome_graphql_formatter/tests/language.rs
+++ b/crates/biome_graphql_formatter/tests/language.rs
@@ -33,9 +33,9 @@ impl TestFormatLanguage for GraphqlTestFormatLanguage {
     ) -> Self::FormatLanguage {
         let language_settings = &settings.languages.graphql.formatter;
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(language_settings),
+            &settings.formatter,
+            &settings.override_settings,
+            language_settings,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_grit_formatter/tests/language.rs
+++ b/crates/biome_grit_formatter/tests/language.rs
@@ -24,9 +24,9 @@ impl TestFormatLanguage for GritTestFormatLanguage {
     ) -> Self::FormatLanguage {
         let language_settings = &settings.languages.grit.formatter;
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(language_settings),
+            &settings.formatter,
+            &settings.override_settings,
+            language_settings,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_html_formatter/tests/language.rs
+++ b/crates/biome_html_formatter/tests/language.rs
@@ -36,9 +36,9 @@ impl TestFormatLanguage for HtmlTestFormatLanguage {
         file_source: &DocumentFileSource,
     ) -> Self::FormatLanguage {
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(&settings.languages.html.formatter),
+            &settings.formatter,
+            &settings.override_settings,
+            &settings.languages.html.formatter,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_js_formatter/tests/language.rs
+++ b/crates/biome_js_formatter/tests/language.rs
@@ -38,9 +38,9 @@ impl TestFormatLanguage for JsTestFormatLanguage {
     ) -> Self::FormatLanguage {
         let language_settings = &settings.languages.javascript.formatter;
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(language_settings),
+            &settings.formatter,
+            &settings.override_settings,
+            language_settings,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_json_formatter/tests/language.rs
+++ b/crates/biome_json_formatter/tests/language.rs
@@ -31,9 +31,9 @@ impl TestFormatLanguage for JsonTestFormatLanguage {
     ) -> Self::FormatLanguage {
         let language_settings = &settings.languages.json.formatter;
         let options = Self::ServiceLanguage::resolve_format_options(
-            Some(&settings.formatter),
-            Some(&settings.override_settings),
-            Some(language_settings),
+            &settings.formatter,
+            &settings.override_settings,
+            language_settings,
             &BiomePath::new(""),
             file_source,
         );

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -118,6 +118,7 @@ impl WorkspaceError {
         Self::NotFound(NotFound)
     }
 
+    #[inline]
     pub fn no_project() -> Self {
         Self::NoProject(NoProject)
     }

--- a/crates/biome_service/src/file_handlers/astro.rs
+++ b/crates/biome_service/src/file_handlers/astro.rs
@@ -4,7 +4,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities, javascript,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::Settings;
 use crate::workspace::{DocumentFileSource, FixFileResult, PullActionsResult};
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
@@ -105,7 +105,7 @@ fn parse(
     _rome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let frontmatter = AstroFileHandler::input(text);
@@ -129,7 +129,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -137,7 +137,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -147,7 +147,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -11,7 +11,7 @@ use crate::file_handlers::{
 };
 use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
-    Settings, WorkspaceSettingsHandle, check_feature_activity, check_override_feature_activity,
+    Settings, check_feature_activity, check_override_feature_activity,
 };
 use crate::workspace::{
     CodeAction, DocumentFileSource, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
@@ -142,28 +142,28 @@ impl ServiceLanguage for CssLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&FormatSettings>,
-        overrides: Option<&OverrideSettings>,
-        language: Option<&Self::FormatterSettings>,
+        global: &FormatSettings,
+        overrides: &OverrideSettings,
+        language: &Self::FormatterSettings,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> Self::FormatOptions {
         let indent_style = language
-            .and_then(|l| l.indent_style)
-            .or(global.and_then(|g| g.indent_style))
+            .indent_style
+            .or(global.indent_style)
             .unwrap_or_default();
         let line_width = language
-            .and_then(|l| l.line_width)
-            .or(global.and_then(|g| g.line_width))
+            .line_width
+            .or(global.line_width)
             .unwrap_or_default();
         let indent_width = language
-            .and_then(|l| l.indent_width)
-            .or(global.and_then(|g| g.indent_width))
+            .indent_width
+            .or(global.indent_width)
             .unwrap_or_default();
 
         let line_ending = language
-            .and_then(|l| l.line_ending)
-            .or(global.and_then(|g| g.line_ending))
+            .line_ending
+            .or(global.line_ending)
             .unwrap_or_default();
 
         let options = CssFormatOptions::new(
@@ -175,55 +175,43 @@ impl ServiceLanguage for CssLanguage {
         .with_indent_width(indent_width)
         .with_line_width(line_width)
         .with_line_ending(line_ending)
-        .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default());
-        if let Some(overrides) = overrides {
-            overrides.to_override_css_format_options(path, options)
-        } else {
-            options
-        }
+        .with_quote_style(language.quote_style.unwrap_or_default());
+        overrides.to_override_css_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        global: Option<&Settings>,
-        _language: Option<&Self::LinterSettings>,
+        global: &Settings,
+        _language: &Self::LinterSettings,
         _environment: Option<&Self::EnvironmentSettings>,
-
         file_path: &BiomePath,
         _file_source: &DocumentFileSource,
         suppression_reason: Option<&str>,
     ) -> AnalyzerOptions {
         let preferred_quote = global
-            .and_then(|global| {
-                global
-                    .languages
-                    .css
-                    .formatter
-                    .quote_style
-                    .map(|quote_style: QuoteStyle| {
-                        if quote_style == QuoteStyle::Single {
-                            PreferredQuote::Single
-                        } else {
-                            PreferredQuote::Double
-                        }
-                    })
+            .languages
+            .css
+            .formatter
+            .quote_style
+            .map(|quote_style: QuoteStyle| {
+                if quote_style == QuoteStyle::Single {
+                    PreferredQuote::Single
+                } else {
+                    PreferredQuote::Double
+                }
             })
             .unwrap_or_default();
 
         let configuration = AnalyzerConfiguration::default()
-            .with_rules(
-                global
-                    .map(|g| to_analyzer_rules(g, file_path.as_path()))
-                    .unwrap_or_default(),
-            )
+            .with_rules(to_analyzer_rules(global, file_path.as_path()))
             .with_preferred_quote(preferred_quote)
-            .with_css_modules(global.is_some_and(|global| {
+            .with_css_modules(
                 global
                     .languages
                     .css
                     .parser
                     .css_modules_enabled
-                    .is_some_and(|css_modules_enabled| css_modules_enabled.into())
-            }));
+                    .is_some_and(|css_modules_enabled| css_modules_enabled.into()),
+            );
 
         AnalyzerOptions::default()
             .with_file_path(file_path.as_path())
@@ -231,94 +219,88 @@ impl ServiceLanguage for CssLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.css.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.css.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn assist_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.css.assist.enabled,
+                        pattern.assist.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.css.assist.enabled,
+                settings.assist.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.css.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn linter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.css.linter.enabled,
+                        pattern.linter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.css.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.css.linter.enabled,
+                settings.linter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn resolve_environment(_settings: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
+    fn resolve_environment(_settings: &Settings) -> Option<&Self::EnvironmentSettings> {
         None
     }
 }
@@ -362,19 +344,19 @@ impl ExtensionHandler for CssFileHandler {
     }
 }
 
-fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<CssLanguage>(path)
+fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<CssLanguage>(path)
 }
 
-fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<CssLanguage>(path)
+fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<CssLanguage>(path)
 }
 
-fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<CssLanguage>(path)
+fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<CssLanguage>(path)
 }
 
-fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -382,26 +364,29 @@ fn parse(
     biome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    handle: WorkspaceSettingsHandle,
+    settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let settings = handle.settings();
     let mut options = CssParserOptions {
         allow_wrong_line_comments: settings
-            .and_then(|s| s.languages.css.parser.allow_wrong_line_comments)
+            .languages
+            .css
+            .parser
+            .allow_wrong_line_comments
             .unwrap_or_default()
             .into(),
         css_modules: settings
-            .and_then(|s| s.languages.css.parser.css_modules_enabled)
+            .languages
+            .css
+            .parser
+            .css_modules_enabled
             .unwrap_or_default()
             .into(),
         grit_metavariables: false,
     };
-    if let Some(settings) = settings {
-        options = settings
-            .override_settings
-            .to_override_css_parser_options(biome_path, options);
-    }
+    options = settings
+        .override_settings
+        .to_override_css_parser_options(biome_path, options);
     let parse = biome_css_parser::parse_css_with_cache(text, cache, options);
     ParseResult {
         any_parse: parse.into(),
@@ -422,7 +407,7 @@ fn debug_formatter_ir(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
 
@@ -438,7 +423,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
 
@@ -455,7 +440,7 @@ fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
@@ -469,7 +454,7 @@ fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<CssLanguage>(biome_path, document_file_source);
@@ -505,8 +490,8 @@ fn format_on_type(
 fn lint(params: LintParams) -> LintResults {
     let _ =
         debug_span!("Linting CSS file", path =? params.path, language =? params.language).entered();
-    let workspace_settings = &params.workspace;
-    let analyzer_options = workspace_settings.analyzer_options::<CssLanguage>(
+    let settings = &params.settings;
+    let analyzer_options = settings.analyzer_options::<CssLanguage>(
         params.path,
         &params.language,
         params.suppression_reason.as_deref(),
@@ -514,7 +499,7 @@ fn lint(params: LintParams) -> LintResults {
     let tree = params.parse.tree();
 
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
@@ -547,7 +532,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     let CodeActionsParams {
         parse,
         range,
-        workspace,
+        settings,
         path,
         module_graph: _,
         project_layout,
@@ -570,10 +555,10 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     };
 
     let analyzer_options =
-        workspace.analyzer_options::<CssLanguage>(path, &language, suppression_reason.as_deref());
+        settings.analyzer_options::<CssLanguage>(path, &language, suppression_reason.as_deref());
     let mut actions = Vec::new();
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(settings, analyzer_options)
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
@@ -607,27 +592,19 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     PullActionsResult { actions }
 }
 
-/// If applies all the safe fixes to the given syntax tree.
+/// Applies all the safe fixes to the given syntax tree.
 pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut tree: CssRoot = params.parse.tree();
-    let Some(settings) = params.workspace.settings() else {
-        return Ok(FixFileResult {
-            actions: Vec::new(),
-            errors: 0,
-            skipped_suggested_fixes: 0,
-            code: tree.syntax().to_string(),
-        });
-    };
 
     // Compute final rules (taking `overrides` into account)
-    let rules = settings.as_linter_rules(params.biome_path.as_path());
-    let analyzer_options = params.workspace.analyzer_options::<CssLanguage>(
+    let rules = params.settings.as_linter_rules(params.biome_path.as_path());
+    let analyzer_options = params.settings.analyzer_options::<CssLanguage>(
         params.biome_path,
         &params.document_file_source,
         params.suppression_reason.as_deref(),
     );
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
@@ -724,7 +701,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             None => {
                 let code = if params.should_format {
                     format_node(
-                        params.workspace.format_options::<CssLanguage>(
+                        params.settings.format_options::<CssLanguage>(
                             params.biome_path,
                             &params.document_file_source,
                         ),
@@ -754,9 +731,9 @@ mod test {
     #[test]
     fn inherit_global_format_settings() {
         let format_options = CssLanguage::resolve_format_options(
-            Some(&FormatSettings::default()),
-            None,
-            None,
+            &FormatSettings::default(),
+            &OverrideSettings::default(),
+            &CssFormatterSettings::default(),
             &BiomePath::new(""),
             &DocumentFileSource::Css(CssFileSource::css()),
         );

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -166,7 +166,7 @@ impl ServiceLanguage for CssLanguage {
             .or(global.line_ending)
             .unwrap_or_default();
 
-        let options = CssFormatOptions::new(
+        let mut options = CssFormatOptions::new(
             document_file_source
                 .to_css_file_source()
                 .unwrap_or_default(),
@@ -176,7 +176,10 @@ impl ServiceLanguage for CssLanguage {
         .with_line_width(line_width)
         .with_line_ending(line_ending)
         .with_quote_style(language.quote_style.unwrap_or_default());
-        overrides.to_override_css_format_options(path, options)
+
+        overrides.apply_override_css_format_options(path, &mut options);
+
+        options
     }
 
     fn resolve_analyzer_options(
@@ -384,9 +387,11 @@ fn parse(
             .into(),
         grit_metavariables: false,
     };
-    options = settings
+
+    settings
         .override_settings
-        .to_override_css_parser_options(biome_path, options);
+        .apply_override_css_parser_options(biome_path, &mut options);
+
     let parse = biome_css_parser::parse_css_with_cache(text, cache, options);
     ParseResult {
         any_parse: parse.into(),

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -10,7 +10,7 @@ use crate::file_handlers::{
 };
 use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
-    Settings, WorkspaceSettingsHandle, check_feature_activity, check_override_feature_activity,
+    Settings, check_feature_activity, check_override_feature_activity,
 };
 use crate::workspace::{
     CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
@@ -104,33 +104,33 @@ impl ServiceLanguage for GraphqlLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&FormatSettings>,
-        overrides: Option<&OverrideSettings>,
-        language: Option<&Self::FormatterSettings>,
+        global: &FormatSettings,
+        overrides: &OverrideSettings,
+        language: &Self::FormatterSettings,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> Self::FormatOptions {
         let indent_style = language
-            .and_then(|l| l.indent_style)
-            .or(global.and_then(|g| g.indent_style))
+            .indent_style
+            .or(global.indent_style)
             .unwrap_or_default();
         let line_width = language
-            .and_then(|l| l.line_width)
-            .or(global.and_then(|g| g.line_width))
+            .line_width
+            .or(global.line_width)
             .unwrap_or_default();
         let indent_width = language
-            .and_then(|l| l.indent_width)
-            .or(global.and_then(|g| g.indent_width))
+            .indent_width
+            .or(global.indent_width)
             .unwrap_or_default();
 
         let line_ending = language
-            .and_then(|l| l.line_ending)
-            .or(global.and_then(|g| g.line_ending))
+            .line_ending
+            .or(global.line_ending)
             .unwrap_or_default();
 
         let bracket_spacing = language
-            .and_then(|l| l.bracket_spacing)
-            .or(global.and_then(|g| g.bracket_spacing))
+            .bracket_spacing
+            .or(global.bracket_spacing)
             .unwrap_or_default();
 
         let options = GraphqlFormatOptions::new(
@@ -143,17 +143,13 @@ impl ServiceLanguage for GraphqlLanguage {
         .with_line_width(line_width)
         .with_line_ending(line_ending)
         .with_bracket_spacing(bracket_spacing)
-        .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default());
-        if let Some(overrides) = overrides {
-            overrides.to_override_graphql_format_options(path, options)
-        } else {
-            options
-        }
+        .with_quote_style(language.quote_style.unwrap_or_default());
+        overrides.to_override_graphql_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        _global: Option<&Settings>,
-        _language: Option<&Self::LinterSettings>,
+        _global: &Settings,
+        _language: &Self::LinterSettings,
         _environment: Option<&Self::EnvironmentSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
@@ -164,94 +160,88 @@ impl ServiceLanguage for GraphqlLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.graphql.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.graphql.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn assist_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.graphql.assist.enabled,
+                        pattern.assist.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.graphql.assist.enabled,
+                settings.assist.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.graphql.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn linter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.graphql.linter.enabled,
+                        pattern.linter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.graphql.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.graphql.linter.enabled,
+                settings.linter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn resolve_environment(_settings: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
+    fn resolve_environment(_settings: &Settings) -> Option<&Self::EnvironmentSettings> {
         None
     }
 }
@@ -293,19 +283,19 @@ impl ExtensionHandler for GraphqlFileHandler {
     }
 }
 
-fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<GraphqlLanguage>(path)
+fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<GraphqlLanguage>(path)
 }
 
-fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<GraphqlLanguage>(path)
+fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<GraphqlLanguage>(path)
 }
 
-fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<GraphqlLanguage>(path)
+fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<GraphqlLanguage>(path)
 }
 
-fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -313,7 +303,7 @@ fn parse(
     _biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let parse = parse_graphql_with_cache(text, cache);
@@ -337,7 +327,7 @@ fn debug_formatter_ir(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<GraphqlLanguage>(biome_path, document_file_source);
 
@@ -353,7 +343,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GraphqlLanguage>(biome_path, document_file_source);
 
@@ -370,7 +360,7 @@ fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GraphqlLanguage>(biome_path, document_file_source);
@@ -384,7 +374,7 @@ fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GraphqlLanguage>(biome_path, document_file_source);
@@ -420,7 +410,7 @@ fn format_on_type(
 fn lint(params: LintParams) -> LintResults {
     let _ = debug_span!("Linting GraphQL file", path =? params.path, language =? params.language)
         .entered();
-    let workspace_settings = &params.workspace;
+    let workspace_settings = &params.settings;
     let analyzer_options = workspace_settings.analyzer_options::<GraphqlLanguage>(
         params.path,
         &params.language,
@@ -429,7 +419,7 @@ fn lint(params: LintParams) -> LintResults {
     let tree = params.parse.tree();
 
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
@@ -458,7 +448,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     let CodeActionsParams {
         parse,
         range,
-        workspace,
+        settings,
         path,
         module_graph: _,
         project_layout,
@@ -480,14 +470,14 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
         };
     };
 
-    let analyzer_options = workspace.analyzer_options::<GraphqlLanguage>(
+    let analyzer_options = settings.analyzer_options::<GraphqlLanguage>(
         path,
         &language,
         suppression_reason.as_deref(),
     );
     let mut actions = Vec::new();
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(settings, analyzer_options)
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
@@ -524,24 +514,16 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 /// If applies all the safe fixes to the given syntax tree.
 pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut tree: GraphqlRoot = params.parse.tree();
-    let Some(settings) = params.workspace.settings() else {
-        return Ok(FixFileResult {
-            actions: Vec::new(),
-            errors: 0,
-            skipped_suggested_fixes: 0,
-            code: tree.syntax().to_string(),
-        });
-    };
 
     // Compute final rules (taking `overrides` into account)
-    let rules = settings.as_linter_rules(params.biome_path.as_path());
-    let analyzer_options = params.workspace.analyzer_options::<GraphqlLanguage>(
+    let rules = params.settings.as_linter_rules(params.biome_path.as_path());
+    let analyzer_options = params.settings.analyzer_options::<GraphqlLanguage>(
         params.biome_path,
         &params.document_file_source,
         params.suppression_reason.as_deref(),
     );
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
@@ -632,7 +614,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             None => {
                 let code = if params.should_format {
                     format_node(
-                        params.workspace.format_options::<GraphqlLanguage>(
+                        params.settings.format_options::<GraphqlLanguage>(
                             params.biome_path,
                             &params.document_file_source,
                         ),

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -133,7 +133,7 @@ impl ServiceLanguage for GraphqlLanguage {
             .or(global.bracket_spacing)
             .unwrap_or_default();
 
-        let options = GraphqlFormatOptions::new(
+        let mut options = GraphqlFormatOptions::new(
             document_file_source
                 .to_graphql_file_source()
                 .unwrap_or_default(),
@@ -144,7 +144,10 @@ impl ServiceLanguage for GraphqlLanguage {
         .with_line_ending(line_ending)
         .with_bracket_spacing(bracket_spacing)
         .with_quote_style(language.quote_style.unwrap_or_default());
-        overrides.to_override_graphql_format_options(path, options)
+
+        overrides.apply_override_graphql_format_options(path, &mut options);
+
+        options
     }
 
     fn resolve_analyzer_options(

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -7,7 +7,7 @@ use crate::settings::{check_feature_activity, check_override_feature_activity};
 use crate::workspace::{FixFileResult, GetSyntaxTreeResult};
 use crate::{
     WorkspaceError,
-    settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle},
+    settings::{ServiceLanguage, Settings},
 };
 use biome_analyze::{AnalyzerOptions, QueryMatch};
 use biome_configuration::grit::{
@@ -89,28 +89,28 @@ impl ServiceLanguage for GritLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&crate::settings::FormatSettings>,
-        overrides: Option<&crate::settings::OverrideSettings>,
-        language: Option<&Self::FormatterSettings>,
+        global: &crate::settings::FormatSettings,
+        overrides: &crate::settings::OverrideSettings,
+        language: &Self::FormatterSettings,
         path: &biome_fs::BiomePath,
         file_source: &super::DocumentFileSource,
     ) -> Self::FormatOptions {
         let indent_style = language
-            .and_then(|l| l.indent_style)
-            .or(global.and_then(|g| g.indent_style))
+            .indent_style
+            .or(global.indent_style)
             .unwrap_or_default();
         let line_width = language
-            .and_then(|l| l.line_width)
-            .or(global.and_then(|g| g.line_width))
+            .line_width
+            .or(global.line_width)
             .unwrap_or_default();
         let indent_width = language
-            .and_then(|l| l.indent_width)
-            .or(global.and_then(|g| g.indent_width))
+            .indent_width
+            .or(global.indent_width)
             .unwrap_or_default();
 
         let line_ending = language
-            .and_then(|l| l.line_ending)
-            .or(global.and_then(|g| g.line_ending))
+            .line_ending
+            .or(global.line_ending)
             .unwrap_or_default();
 
         let options = GritFormatOptions::new(file_source.to_grit_file_source().unwrap_or_default())
@@ -118,16 +118,12 @@ impl ServiceLanguage for GritLanguage {
             .with_indent_width(indent_width)
             .with_line_width(line_width)
             .with_line_ending(line_ending);
-        if let Some(overrides) = overrides {
-            overrides.to_override_grit_format_options(path, options)
-        } else {
-            options
-        }
+        overrides.to_override_grit_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        _global: Option<&crate::settings::Settings>,
-        _language: Option<&Self::LinterSettings>,
+        _global: &Settings,
+        _language: &Self::LinterSettings,
         _environment: Option<&Self::EnvironmentSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
@@ -138,94 +134,88 @@ impl ServiceLanguage for GritLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.grit.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.grit.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn assist_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.grit.assist.enabled,
+                        pattern.assist.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.grit.assist.enabled,
+                settings.assist.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.grit.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn linter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.grit.linter.enabled,
+                        pattern.linter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.grit.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.grit.linter.enabled,
+                settings.linter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn resolve_environment(_settings: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
+    fn resolve_environment(_settings: &Settings) -> Option<&Self::EnvironmentSettings> {
         None
     }
 }
@@ -267,19 +257,19 @@ impl ExtensionHandler for GritFileHandler {
     }
 }
 
-fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<GritLanguage>(path)
+fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<GritLanguage>(path)
 }
 
-fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<GritLanguage>(path)
+fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<GritLanguage>(path)
 }
 
-fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<GritLanguage>(path)
+fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<GritLanguage>(path)
 }
 
-fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -287,7 +277,7 @@ fn parse(
     _biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _handle: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let parse = parse_grit_with_cache(text, cache);
@@ -311,7 +301,7 @@ fn debug_formatter_ir(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<GritLanguage>(biome_path, document_file_source);
 
@@ -327,7 +317,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GritLanguage>(biome_path, document_file_source);
 
@@ -345,7 +335,7 @@ fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GritLanguage>(biome_path, document_file_source);
@@ -360,7 +350,7 @@ fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<GritLanguage>(biome_path, document_file_source);
@@ -420,7 +410,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let code = if params.should_format {
         format_node(
             params
-                .workspace
+                .settings
                 .format_options::<GritLanguage>(params.biome_path, &params.document_file_source),
             tree.syntax(),
         )?

--- a/crates/biome_service/src/file_handlers/grit.rs
+++ b/crates/biome_service/src/file_handlers/grit.rs
@@ -113,12 +113,16 @@ impl ServiceLanguage for GritLanguage {
             .or(global.line_ending)
             .unwrap_or_default();
 
-        let options = GritFormatOptions::new(file_source.to_grit_file_source().unwrap_or_default())
-            .with_indent_style(indent_style)
-            .with_indent_width(indent_width)
-            .with_line_width(line_width)
-            .with_line_ending(line_ending);
-        overrides.to_override_grit_format_options(path, options)
+        let mut options =
+            GritFormatOptions::new(file_source.to_grit_file_source().unwrap_or_default())
+                .with_indent_style(indent_style)
+                .with_indent_width(indent_width)
+                .with_line_width(line_width)
+                .with_line_ending(line_ending);
+
+        overrides.apply_override_grit_format_options(path, &mut options);
+
+        options
     }
 
     fn resolve_analyzer_options(

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -111,17 +111,21 @@ impl ServiceLanguage for HtmlLanguage {
         let indent_script_and_style = language.indent_script_and_style.unwrap_or_default();
         let self_close_void_elements = language.self_close_void_elements.unwrap_or_default();
 
-        let options = HtmlFormatOptions::new(file_source.to_html_file_source().unwrap_or_default())
-            .with_indent_style(indent_style)
-            .with_indent_width(indent_width)
-            .with_line_width(line_width)
-            .with_line_ending(line_ending)
-            .with_attribute_position(attribute_position)
-            .with_bracket_same_line(bracket_same_line)
-            .with_whitespace_sensitivity(whitespace_sensitivity)
-            .with_indent_script_and_style(indent_script_and_style)
-            .with_self_close_void_elements(self_close_void_elements);
-        overrides.to_override_html_format_options(path, options)
+        let mut options =
+            HtmlFormatOptions::new(file_source.to_html_file_source().unwrap_or_default())
+                .with_indent_style(indent_style)
+                .with_indent_width(indent_width)
+                .with_line_width(line_width)
+                .with_line_ending(line_ending)
+                .with_attribute_position(attribute_position)
+                .with_bracket_same_line(bracket_same_line)
+                .with_whitespace_sensitivity(whitespace_sensitivity)
+                .with_indent_script_and_style(indent_script_and_style)
+                .with_self_close_void_elements(self_close_void_elements);
+
+        overrides.apply_override_html_format_options(path, &mut options);
+
+        options
     }
 
     fn resolve_analyzer_options(

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -7,7 +7,7 @@ use crate::settings::{check_feature_activity, check_override_feature_activity};
 use crate::workspace::FixFileResult;
 use crate::{
     WorkspaceError,
-    settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle},
+    settings::{ServiceLanguage, Settings},
     workspace::GetSyntaxTreeResult,
 };
 use biome_analyze::AnalyzerOptions;
@@ -77,45 +77,39 @@ impl ServiceLanguage for HtmlLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&crate::settings::FormatSettings>,
-        overrides: Option<&crate::settings::OverrideSettings>,
-        language: Option<&Self::FormatterSettings>,
+        global: &crate::settings::FormatSettings,
+        overrides: &crate::settings::OverrideSettings,
+        language: &Self::FormatterSettings,
         path: &biome_fs::BiomePath,
         file_source: &super::DocumentFileSource,
     ) -> Self::FormatOptions {
         let indent_style = language
-            .and_then(|l| l.indent_style)
-            .or(global.and_then(|g| g.indent_style))
+            .indent_style
+            .or(global.indent_style)
             .unwrap_or_default();
         let line_width = language
-            .and_then(|l| l.line_width)
-            .or(global.and_then(|g| g.line_width))
+            .line_width
+            .or(global.line_width)
             .unwrap_or_default();
         let indent_width = language
-            .and_then(|l| l.indent_width)
-            .or(global.and_then(|g| g.indent_width))
+            .indent_width
+            .or(global.indent_width)
             .unwrap_or_default();
         let line_ending = language
-            .and_then(|l| l.line_ending)
-            .or(global.and_then(|g| g.line_ending))
+            .line_ending
+            .or(global.line_ending)
             .unwrap_or_default();
         let attribute_position = language
-            .and_then(|l| l.attribute_position)
-            .or(global.and_then(|g| g.attribute_position))
+            .attribute_position
+            .or(global.attribute_position)
             .unwrap_or_default();
         let bracket_same_line = language
-            .and_then(|l| l.bracket_same_line)
-            .or(global.and_then(|g| g.bracket_same_line))
+            .bracket_same_line
+            .or(global.bracket_same_line)
             .unwrap_or_default();
-        let whitespace_sensitivity = language
-            .and_then(|l| l.whitespace_sensitivity)
-            .unwrap_or_default();
-        let indent_script_and_style = language
-            .and_then(|l| l.indent_script_and_style)
-            .unwrap_or_default();
-        let self_close_void_elements = language
-            .and_then(|l| l.self_close_void_elements)
-            .unwrap_or_default();
+        let whitespace_sensitivity = language.whitespace_sensitivity.unwrap_or_default();
+        let indent_script_and_style = language.indent_script_and_style.unwrap_or_default();
+        let self_close_void_elements = language.self_close_void_elements.unwrap_or_default();
 
         let options = HtmlFormatOptions::new(file_source.to_html_file_source().unwrap_or_default())
             .with_indent_style(indent_style)
@@ -127,16 +121,12 @@ impl ServiceLanguage for HtmlLanguage {
             .with_whitespace_sensitivity(whitespace_sensitivity)
             .with_indent_script_and_style(indent_script_and_style)
             .with_self_close_void_elements(self_close_void_elements);
-        if let Some(overrides) = overrides {
-            overrides.to_override_html_format_options(path, options)
-        } else {
-            options
-        }
+        overrides.to_override_html_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        _global: Option<&Settings>,
-        _language: Option<&Self::LinterSettings>,
+        _global: &Settings,
+        _language: &Self::LinterSettings,
         _environment: Option<&Self::EnvironmentSettings>,
         path: &biome_fs::BiomePath,
         _file_source: &super::DocumentFileSource,
@@ -147,44 +137,42 @@ impl ServiceLanguage for HtmlLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.html.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.html.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.html.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.html.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(_settings: Option<&Settings>, _path: &Utf8Path) -> bool {
+    fn assist_enabled_for_file_path(_settings: &Settings, _path: &Utf8Path) -> bool {
         false
     }
 
-    fn linter_enabled_for_file_path(_settings: Option<&Settings>, _path: &Utf8Path) -> bool {
+    fn linter_enabled_for_file_path(_settings: &Settings, _path: &Utf8Path) -> bool {
         false
     }
 
-    fn resolve_environment(_settings: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
+    fn resolve_environment(_settings: &Settings) -> Option<&Self::EnvironmentSettings> {
         None
     }
 }
@@ -226,19 +214,19 @@ impl ExtensionHandler for HtmlFileHandler {
     }
 }
 
-fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<HtmlLanguage>(path)
+fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<HtmlLanguage>(path)
 }
 
-fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<HtmlLanguage>(path)
+fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<HtmlLanguage>(path)
 }
 
-fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<HtmlLanguage>(path)
+fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<HtmlLanguage>(path)
 }
 
-fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -246,7 +234,7 @@ fn parse(
     _biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    _handle: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let parse = parse_html_with_cache(text, cache);
@@ -270,7 +258,7 @@ fn debug_formatter_ir(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<HtmlLanguage>(path, document_file_source);
 
@@ -286,7 +274,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<HtmlLanguage>(biome_path, document_file_source);
 
@@ -326,7 +314,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let code = if params.should_format {
         format_node(
             params
-                .workspace
+                .settings
                 .format_options::<HtmlLanguage>(params.biome_path, &params.document_file_source),
             tree.syntax(),
         )?

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -507,6 +507,12 @@ fn parse(
             .unwrap_or_default()
             .into(),
     };
+
+    settings
+        .override_settings
+        .apply_override_js_parser_options(biome_path, &mut options);
+
+    let mut file_source = file_source.to_js_file_source().unwrap_or_default();
     let jsx_everywhere = settings
         .languages
         .javascript
@@ -514,11 +520,6 @@ fn parse(
         .jsx_everywhere
         .unwrap_or_default()
         .into();
-    options = settings
-        .override_settings
-        .to_override_js_parser_options(biome_path, options);
-
-    let mut file_source = file_source.to_js_file_source().unwrap_or_default();
     if jsx_everywhere && !file_source.is_typescript() {
         file_source = file_source.with_variant(LanguageVariant::Jsx);
     }

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -12,10 +12,7 @@ use crate::settings::{
 use crate::workspace::DocumentFileSource;
 use crate::{
     WorkspaceError,
-    settings::{
-        FormatSettings, LanguageListSettings, LanguageSettings, ServiceLanguage,
-        WorkspaceSettingsHandle,
-    },
+    settings::{FormatSettings, LanguageListSettings, LanguageSettings, ServiceLanguage},
     workspace::{
         CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
         RenameResult,
@@ -181,9 +178,9 @@ impl ServiceLanguage for JsLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&FormatSettings>,
-        overrides: Option<&OverrideSettings>,
-        language: Option<&JsFormatterSettings>,
+        global: &FormatSettings,
+        overrides: &OverrideSettings,
+        language: &JsFormatterSettings,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> JsFormatOptions {
@@ -195,134 +192,114 @@ impl ServiceLanguage for JsLanguage {
         )
         .with_indent_style(
             language
-                .and_then(|l| l.indent_style)
-                .or(global.and_then(|g| g.indent_style))
+                .indent_style
+                .or(global.indent_style)
                 .unwrap_or_default(),
         )
         .with_indent_width(
             language
-                .and_then(|l| l.indent_width)
-                .or(global.and_then(|g| g.indent_width))
+                .indent_width
+                .or(global.indent_width)
                 .unwrap_or_default(),
         )
         .with_line_width(
             language
-                .and_then(|l| l.line_width)
-                .or(global.and_then(|g| g.line_width))
+                .line_width
+                .or(global.line_width)
                 .unwrap_or_default(),
         )
         .with_line_ending(
             language
-                .and_then(|l| l.line_ending)
-                .or(global.and_then(|g| g.line_ending))
+                .line_ending
+                .or(global.line_ending)
                 .unwrap_or_default(),
         )
-        .with_quote_style(language.and_then(|l| l.quote_style).unwrap_or_default())
-        .with_jsx_quote_style(language.and_then(|l| l.jsx_quote_style).unwrap_or_default())
-        .with_quote_properties(
-            language
-                .and_then(|l| l.quote_properties)
-                .unwrap_or_default(),
-        )
-        .with_trailing_commas(language.and_then(|l| l.trailing_commas).unwrap_or_default())
-        .with_semicolons(language.and_then(|l| l.semicolons).unwrap_or_default())
-        .with_arrow_parentheses(
-            language
-                .and_then(|l| l.arrow_parentheses)
-                .unwrap_or_default(),
-        )
+        .with_quote_style(language.quote_style.unwrap_or_default())
+        .with_jsx_quote_style(language.jsx_quote_style.unwrap_or_default())
+        .with_quote_properties(language.quote_properties.unwrap_or_default())
+        .with_trailing_commas(language.trailing_commas.unwrap_or_default())
+        .with_semicolons(language.semicolons.unwrap_or_default())
+        .with_arrow_parentheses(language.arrow_parentheses.unwrap_or_default())
         .with_bracket_spacing(
             language
-                .and_then(|l| l.bracket_spacing)
-                .or(global.and_then(|g| g.bracket_spacing))
+                .bracket_spacing
+                .or(global.bracket_spacing)
                 .unwrap_or_default(),
         )
         .with_bracket_same_line(
             language
-                .and_then(|l| l.bracket_same_line)
-                .or(global.and_then(|g| g.bracket_same_line))
+                .bracket_same_line
+                .or(global.bracket_same_line)
                 .unwrap_or_default(),
         )
         .with_attribute_position(
             language
-                .and_then(|l| l.attribute_position)
-                .or(global.and_then(|g| g.attribute_position))
+                .attribute_position
+                .or(global.attribute_position)
                 .unwrap_or_default(),
         )
-        .with_expand(
-            language
-                .and_then(|l| l.expand)
-                .or(global.and_then(|g| g.expand))
-                .unwrap_or_default(),
-        );
+        .with_expand(language.expand.or(global.expand).unwrap_or_default());
 
-        if let Some(overrides) = overrides {
-            overrides.override_js_format_options(path, options)
-        } else {
-            options
-        }
+        overrides.override_js_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        global: Option<&Settings>,
-        _language: Option<&Self::LinterSettings>,
+        global: &Settings,
+        _language: &Self::LinterSettings,
         environment: Option<&Self::EnvironmentSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
         suppression_reason: Option<&str>,
     ) -> AnalyzerOptions {
-        let preferred_quote =
-            global
-                .and_then(|global| {
-                    global.languages.javascript.formatter.quote_style.map(
-                        |quote_style: QuoteStyle| {
-                            if quote_style == QuoteStyle::Single {
-                                PreferredQuote::Single
-                            } else {
-                                PreferredQuote::Double
-                            }
-                        },
-                    )
-                })
-                .unwrap_or_default();
+        let preferred_quote = global
+            .languages
+            .javascript
+            .formatter
+            .quote_style
+            .map(|quote_style: QuoteStyle| {
+                if quote_style == QuoteStyle::Single {
+                    PreferredQuote::Single
+                } else {
+                    PreferredQuote::Double
+                }
+            })
+            .unwrap_or_default();
         let preferred_jsx_quote = global
-            .and_then(|global| {
-                global.languages.javascript.formatter.jsx_quote_style.map(
-                    |quote_style: QuoteStyle| {
-                        if quote_style == QuoteStyle::Single {
-                            PreferredQuote::Single
-                        } else {
-                            PreferredQuote::Double
-                        }
-                    },
-                )
+            .languages
+            .javascript
+            .formatter
+            .jsx_quote_style
+            .map(|quote_style: QuoteStyle| {
+                if quote_style == QuoteStyle::Single {
+                    PreferredQuote::Single
+                } else {
+                    PreferredQuote::Double
+                }
             })
             .unwrap_or_default();
 
         let mut configuration = AnalyzerConfiguration::default();
         let mut globals = Vec::new();
-        let overrides = global.map(|global| &global.override_settings);
-        if let (Some(overrides), Some(global)) = (overrides, global) {
-            let jsx_runtime = match overrides.override_jsx_runtime(
-                path,
-                environment
-                    .and_then(|env| env.jsx_runtime)
-                    .unwrap_or_default(),
-            ) {
-                // In the future, we may wish to map an `Auto` variant to a concrete
-                // analyzer value for easy access by the analyzer.
-                JsxRuntime::Transparent => biome_analyze::options::JsxRuntime::Transparent,
-                JsxRuntime::ReactClassic => biome_analyze::options::JsxRuntime::ReactClassic,
-            };
-            configuration = configuration.with_jsx_runtime(jsx_runtime);
+        let overrides = &global.override_settings;
+        let jsx_runtime = match overrides.override_jsx_runtime(
+            path,
+            environment
+                .and_then(|env| env.jsx_runtime)
+                .unwrap_or_default(),
+        ) {
+            // In the future, we may wish to map an `Auto` variant to a concrete
+            // analyzer value for easy access by the analyzer.
+            JsxRuntime::Transparent => biome_analyze::options::JsxRuntime::Transparent,
+            JsxRuntime::ReactClassic => biome_analyze::options::JsxRuntime::ReactClassic,
+        };
+        configuration = configuration.with_jsx_runtime(jsx_runtime);
 
-            globals.extend(
-                overrides
-                    .override_js_globals(path, &global.languages.javascript.globals)
-                    .into_iter()
-                    .collect::<Vec<_>>(),
-            );
-        }
+        globals.extend(
+            overrides
+                .override_js_globals(path, &global.languages.javascript.globals)
+                .into_iter()
+                .collect::<Vec<_>>(),
+        );
 
         if let Some(filename) = path.file_name() {
             if filename.ends_with(".vue") {
@@ -361,11 +338,7 @@ impl ServiceLanguage for JsLanguage {
         }
 
         let configuration = configuration
-            .with_rules(
-                global
-                    .map(|g| to_analyzer_rules(g, path.as_path()))
-                    .unwrap_or_default(),
-            )
+            .with_rules(to_analyzer_rules(global, path.as_path()))
             .with_globals(globals)
             .with_preferred_quote(preferred_quote)
             .with_preferred_jsx_quote(preferred_jsx_quote);
@@ -376,95 +349,89 @@ impl ServiceLanguage for JsLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.javascript.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.javascript.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn assist_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.javascript.assist.enabled,
+                        pattern.assist.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.javascript.assist.enabled,
+                settings.assist.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.javascript.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn linter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.javascript.linter.enabled,
+                        pattern.linter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.javascript.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.javascript.linter.enabled,
+                settings.linter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn resolve_environment(global: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
-        global.map(|g| &g.languages.javascript.environment)
+    fn resolve_environment(global: &Settings) -> Option<&Self::EnvironmentSettings> {
+        Some(&global.languages.javascript.environment)
     }
 }
 
@@ -507,19 +474,19 @@ impl ExtensionHandler for JsFileHandler {
     }
 }
 
-pub fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<JsLanguage>(path)
+pub fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<JsLanguage>(path)
 }
 
-pub fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<JsLanguage>(path)
+pub fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<JsLanguage>(path)
 }
 
-pub fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<JsLanguage>(path)
+pub fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<JsLanguage>(path)
 }
 
-pub fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+pub fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -527,36 +494,29 @@ fn parse(
     biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    handle: WorkspaceSettingsHandle,
+    settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let settings = handle.settings();
     let mut options = JsParserOptions {
         grit_metavariables: false,
-        parse_class_parameter_decorators: settings.is_some_and(|settings| {
-            settings
-                .languages
-                .javascript
-                .parser
-                .parse_class_parameter_decorators
-                .unwrap_or_default()
-                .into()
-        }),
-    };
-    let jsx_everywhere = settings.is_some_and(|settings| {
-        settings
+        parse_class_parameter_decorators: settings
             .languages
             .javascript
             .parser
-            .jsx_everywhere
+            .parse_class_parameter_decorators
             .unwrap_or_default()
-            .into()
-    });
-    if let Some(settings) = settings {
-        options = settings
-            .override_settings
-            .to_override_js_parser_options(biome_path, options);
-    }
+            .into(),
+    };
+    let jsx_everywhere = settings
+        .languages
+        .javascript
+        .parser
+        .jsx_everywhere
+        .unwrap_or_default()
+        .into();
+    options = settings
+        .override_settings
+        .to_override_js_parser_options(biome_path, options);
 
     let mut file_source = file_source.to_js_file_source().unwrap_or_default();
     if jsx_everywhere && !file_source.is_typescript() {
@@ -626,7 +586,7 @@ fn debug_formatter_ir(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<JsLanguage>(path, document_file_source);
 
@@ -754,13 +714,13 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
         };
     };
     let tree = params.parse.tree();
-    let analyzer_options = params.workspace.analyzer_options::<JsLanguage>(
+    let analyzer_options = params.settings.analyzer_options::<JsLanguage>(
         params.path,
         &params.language,
         params.suppression_reason.as_deref(),
     );
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
@@ -795,7 +755,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     let CodeActionsParams {
         parse,
         range,
-        workspace,
+        settings,
         path,
         module_graph,
         project_layout,
@@ -811,10 +771,10 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     let tree = parse.tree();
     let _ = trace_span!("Parsed file").entered();
     let analyzer_options =
-        workspace.analyzer_options::<JsLanguage>(path, &language, suppression_reason.as_deref());
+        settings.analyzer_options::<JsLanguage>(path, &language, suppression_reason.as_deref());
     let mut actions = Vec::new();
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(settings, analyzer_options)
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
@@ -866,24 +826,16 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 /// If applies all the safe fixes to the given syntax tree.
 pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut tree: AnyJsRoot = params.parse.tree();
-    let Some(settings) = params.workspace.settings() else {
-        return Ok(FixFileResult {
-            actions: Vec::new(),
-            errors: 0,
-            skipped_suggested_fixes: 0,
-            code: tree.syntax().to_string(),
-        });
-    };
 
     // Compute final rules (taking `overrides` into account)
-    let rules = settings.as_linter_rules(params.biome_path.as_path());
-    let analyzer_options = params.workspace.analyzer_options::<JsLanguage>(
+    let rules = params.settings.as_linter_rules(params.biome_path.as_path());
+    let analyzer_options = params.settings.analyzer_options::<JsLanguage>(
         params.biome_path,
         &params.document_file_source,
         params.suppression_reason.as_deref(),
     );
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
@@ -998,7 +950,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             None => {
                 let code = if params.should_format {
                     format_node(
-                        params.workspace.format_options::<JsLanguage>(
+                        params.settings.format_options::<JsLanguage>(
                             params.biome_path,
                             &params.document_file_source,
                         ),
@@ -1024,7 +976,7 @@ pub(crate) fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsLanguage>(biome_path, document_file_source);
     debug!("{:?}", &options);
@@ -1044,7 +996,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsLanguage>(biome_path, document_file_source);
@@ -1059,7 +1011,7 @@ pub(crate) fn format_on_type(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsLanguage>(path, document_file_source);

--- a/crates/biome_service/src/file_handlers/javascript.tests.rs
+++ b/crates/biome_service/src/file_handlers/javascript.tests.rs
@@ -34,7 +34,7 @@ const f = <T1>(arg1: T1) => <T2>(arg2: T2) => {
         &BiomePath::new("file.test"),
         DocumentFileSource::Js(JsFileSource::ts()),
         source,
-        settings.into(),
+        &settings,
         &mut NodeCache::default(),
     );
     assert!(!result.any_parse.has_errors());

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -177,7 +177,7 @@ impl ServiceLanguage for JsonLanguage {
             .to_json_file_source()
             .unwrap_or_default();
 
-        let options = JsonFormatOptions::new(file_source)
+        let mut options = JsonFormatOptions::new(file_source)
             .with_line_ending(line_ending)
             .with_indent_style(indent_style)
             .with_indent_width(indent_width)
@@ -186,7 +186,9 @@ impl ServiceLanguage for JsonLanguage {
             .with_expand(expand_lists)
             .with_bracket_spacing(bracket_spacing);
 
-        overrides.to_override_json_format_options(path, options)
+        overrides.apply_override_json_format_options(path, &mut options);
+
+        options
     }
 
     fn resolve_analyzer_options(
@@ -360,7 +362,7 @@ fn parse(
         let parser = &settings.languages.json.parser;
         let overrides = &settings.override_settings;
         let optional_json_file_source = file_source.to_json_file_source();
-        let options = JsonParserOptions {
+        let mut options = JsonParserOptions {
             allow_comments: parser.allow_comments.map_or_else(
                 || optional_json_file_source.is_some_and(|x| x.allow_comments()),
                 |value| value.value(),
@@ -370,7 +372,10 @@ fn parse(
                 |value| value.value(),
             ),
         };
-        overrides.to_override_json_parser_options(biome_path, options)
+
+        overrides.apply_override_json_parser_options(biome_path, &mut options);
+
+        options
     };
 
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -10,7 +10,7 @@ use crate::file_handlers::{
 };
 use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
-    Settings, WorkspaceSettingsHandle, check_feature_activity, check_override_feature_activity,
+    Settings, check_feature_activity, check_override_feature_activity,
 };
 use crate::workspace::{
     CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
@@ -129,51 +129,48 @@ impl ServiceLanguage for JsonLanguage {
     }
 
     fn resolve_format_options(
-        global: Option<&FormatSettings>,
-        overrides: Option<&OverrideSettings>,
-        language: Option<&JsonFormatterSettings>,
+        global: &FormatSettings,
+        overrides: &OverrideSettings,
+        language: &JsonFormatterSettings,
         path: &BiomePath,
         document_file_source: &DocumentFileSource,
     ) -> Self::FormatOptions {
         let indent_style = language
-            .and_then(|l| l.indent_style)
-            .or(global.and_then(|g| g.indent_style))
+            .indent_style
+            .or(global.indent_style)
             .unwrap_or_default();
         let line_width = language
-            .and_then(|l| l.line_width)
-            .or(global.and_then(|g| g.line_width))
+            .line_width
+            .or(global.line_width)
             .unwrap_or_default();
         let indent_width = language
-            .and_then(|l| l.indent_width)
-            .or(global.and_then(|g| g.indent_width))
+            .indent_width
+            .or(global.indent_width)
             .unwrap_or_default();
 
         let line_ending = language
-            .and_then(|l| l.line_ending)
-            .or(global.and_then(|g| g.line_ending))
+            .line_ending
+            .or(global.line_ending)
             .unwrap_or_default();
 
         // ensure it never formats biome.json into a form it can't parse
         let trailing_commas = if matches!(path.file_name(), Some("biome.json")) {
             TrailingCommas::None
         } else {
-            language.and_then(|l| l.trailing_commas).unwrap_or_default()
+            language.trailing_commas.unwrap_or_default()
         };
 
-        let expand_lists = language
-            .and_then(|l| l.expand)
-            .or(global.and_then(|g| g.expand))
-            .unwrap_or_else(|| {
-                if path.file_name() == Some("package.json") {
-                    Expand::Always
-                } else {
-                    Expand::default()
-                }
-            });
+        let expand_lists = language.expand.or(global.expand).unwrap_or_else(|| {
+            if path.file_name() == Some("package.json") {
+                Expand::Always
+            } else {
+                Expand::default()
+            }
+        });
 
         let bracket_spacing = language
-            .and_then(|l| l.bracket_spacing)
-            .or(global.and_then(|g| g.bracket_spacing))
+            .bracket_spacing
+            .or(global.bracket_spacing)
             .unwrap_or_default();
 
         let file_source = document_file_source
@@ -189,27 +186,19 @@ impl ServiceLanguage for JsonLanguage {
             .with_expand(expand_lists)
             .with_bracket_spacing(bracket_spacing);
 
-        if let Some(overrides) = overrides {
-            overrides.to_override_json_format_options(path, options)
-        } else {
-            options
-        }
+        overrides.to_override_json_format_options(path, options)
     }
 
     fn resolve_analyzer_options(
-        global: Option<&Settings>,
-        _language: Option<&Self::LinterSettings>,
+        global: &Settings,
+        _language: &Self::LinterSettings,
         _environment: Option<&Self::EnvironmentSettings>,
         path: &BiomePath,
         _file_source: &DocumentFileSource,
         suppression_reason: Option<&str>,
     ) -> AnalyzerOptions {
         let configuration = AnalyzerConfiguration::default()
-            .with_rules(
-                global
-                    .map(|g| to_analyzer_rules(g, path.as_path()))
-                    .unwrap_or_default(),
-            )
+            .with_rules(to_analyzer_rules(global, path.as_path()))
             .with_preferred_quote(PreferredQuote::Double);
         AnalyzerOptions::default()
             .with_file_path(path.as_path())
@@ -217,94 +206,88 @@ impl ServiceLanguage for JsonLanguage {
             .with_suppression_reason(suppression_reason)
     }
 
-    fn formatter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.formatter.enabled,
-                                pattern.formatter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn formatter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.json.formatter.enabled,
+                        pattern.formatter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.formatter.enabled,
-                    settings.formatter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.json.formatter.enabled,
+                settings.formatter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn assist_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.assist.enabled,
-                                pattern.assist.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn assist_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.json.assist.enabled,
+                        pattern.assist.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.assist.enabled,
-                    settings.assist.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.json.assist.enabled,
+                settings.assist.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn linter_enabled_for_file_path(settings: Option<&Settings>, path: &Utf8Path) -> bool {
-        settings
-            .and_then(|settings| {
-                let overrides_activity =
-                    settings
-                        .override_settings
-                        .patterns
-                        .iter()
-                        .rev()
-                        .find_map(|pattern| {
-                            check_override_feature_activity(
-                                pattern.languages.json.linter.enabled,
-                                pattern.linter.enabled,
-                            )
-                            .filter(|_| {
-                                // Then check whether the path satisfies
-                                pattern.is_file_included(path)
-                            })
-                        });
+    fn linter_enabled_for_file_path(settings: &Settings, path: &Utf8Path) -> bool {
+        let overrides_activity =
+            settings
+                .override_settings
+                .patterns
+                .iter()
+                .rev()
+                .find_map(|pattern| {
+                    check_override_feature_activity(
+                        pattern.languages.json.linter.enabled,
+                        pattern.linter.enabled,
+                    )
+                    .filter(|_| {
+                        // Then check whether the path satisfies
+                        pattern.is_file_included(path)
+                    })
+                });
 
-                overrides_activity.or(check_feature_activity(
-                    settings.languages.json.linter.enabled,
-                    settings.linter.enabled,
-                ))
-            })
+        overrides_activity
+            .or(check_feature_activity(
+                settings.languages.json.linter.enabled,
+                settings.linter.enabled,
+            ))
             .unwrap_or_default()
             .into()
     }
 
-    fn resolve_environment(_settings: Option<&Settings>) -> Option<&Self::EnvironmentSettings> {
+    fn resolve_environment(_settings: &Settings) -> Option<&Self::EnvironmentSettings> {
         None
     }
 }
@@ -346,19 +329,19 @@ impl ExtensionHandler for JsonFileHandler {
     }
 }
 
-fn formatter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.formatter_enabled_for_file_path::<JsonLanguage>(path)
+fn formatter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.formatter_enabled_for_file_path::<JsonLanguage>(path)
 }
 
-fn linter_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.linter_enabled_for_file_path::<JsonLanguage>(path)
+fn linter_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.linter_enabled_for_file_path::<JsonLanguage>(path)
 }
 
-fn assist_enabled(path: &Utf8Path, handle: &WorkspaceSettingsHandle) -> bool {
-    handle.assist_enabled_for_file_path::<JsonLanguage>(path)
+fn assist_enabled(path: &Utf8Path, settings: &Settings) -> bool {
+    settings.assist_enabled_for_file_path::<JsonLanguage>(path)
 }
 
-fn search_enabled(_path: &Utf8Path, _handle: &WorkspaceSettingsHandle) -> bool {
+fn search_enabled(_path: &Utf8Path, _settings: &Settings) -> bool {
     true
 }
 
@@ -366,33 +349,28 @@ fn parse(
     biome_path: &BiomePath,
     file_source: DocumentFileSource,
     text: &str,
-    handle: WorkspaceSettingsHandle,
+    settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
-    let settings = handle.settings();
     let options = if biome_path.ends_with(ConfigName::biome_jsonc()) {
         JsonParserOptions::default()
             .with_allow_comments()
             .with_allow_trailing_commas()
     } else {
-        let parser = settings.map(|s| &s.languages.json.parser);
-        let overrides = settings.map(|s| &s.override_settings);
+        let parser = &settings.languages.json.parser;
+        let overrides = &settings.override_settings;
         let optional_json_file_source = file_source.to_json_file_source();
         let options = JsonParserOptions {
-            allow_comments: parser.and_then(|p| p.allow_comments).map_or_else(
+            allow_comments: parser.allow_comments.map_or_else(
                 || optional_json_file_source.is_some_and(|x| x.allow_comments()),
                 |value| value.value(),
             ),
-            allow_trailing_commas: parser.and_then(|p| p.allow_trailing_commas).map_or_else(
+            allow_trailing_commas: parser.allow_trailing_commas.map_or_else(
                 || optional_json_file_source.is_some_and(|x| x.allow_trailing_commas()),
                 |value| value.value(),
             ),
         };
-        if let Some(overrides) = overrides {
-            overrides.to_override_json_parser_options(biome_path, options)
-        } else {
-            options
-        }
+        overrides.to_override_json_parser_options(biome_path, options)
     };
 
     let parse = biome_json_parser::parse_json_with_cache(text, cache, options);
@@ -416,7 +394,7 @@ fn debug_formatter_ir(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<String, WorkspaceError> {
     let options = settings.format_options::<JsonLanguage>(path, document_file_source);
 
@@ -432,7 +410,7 @@ fn format(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsonLanguage>(path, document_file_source);
 
@@ -449,7 +427,7 @@ fn format_range(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsonLanguage>(path, document_file_source);
@@ -463,7 +441,7 @@ fn format_on_type(
     path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     let options = settings.format_options::<JsonLanguage>(path, document_file_source);
@@ -512,14 +490,14 @@ fn lint(params: LintParams) -> LintResults {
     };
     let root: JsonRoot = params.parse.tree();
 
-    let analyzer_options = params.workspace.analyzer_options::<JsonLanguage>(
+    let analyzer_options = params.settings.analyzer_options::<JsonLanguage>(
         params.path,
         &params.language,
         params.suppression_reason.as_deref(),
     );
 
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
@@ -564,7 +542,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     let CodeActionsParams {
         parse,
         range,
-        workspace,
+        settings: workspace,
         path,
         module_graph: _,
         project_layout,
@@ -586,7 +564,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
     );
     let mut actions = Vec::new();
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
@@ -626,24 +604,16 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
 #[instrument(level = "debug", skip(params))]
 fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
     let mut tree: JsonRoot = params.parse.tree();
-    let Some(settings) = params.workspace.settings() else {
-        return Ok(FixFileResult {
-            actions: Vec::new(),
-            errors: 0,
-            skipped_suggested_fixes: 0,
-            code: tree.syntax().to_string(),
-        });
-    };
 
     // Compute final rules (taking `overrides` into account)
-    let rules = settings.as_linter_rules(params.biome_path.as_path());
-    let analyzer_options = params.workspace.analyzer_options::<JsonLanguage>(
+    let rules = params.settings.as_linter_rules(params.biome_path.as_path());
+    let analyzer_options = params.settings.analyzer_options::<JsonLanguage>(
         params.biome_path,
         &params.document_file_source,
         params.suppression_reason.as_deref(),
     );
     let (enabled_rules, disabled_rules, analyzer_options) =
-        AnalyzerVisitorBuilder::new(params.workspace.settings(), analyzer_options)
+        AnalyzerVisitorBuilder::new(params.settings, analyzer_options)
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
@@ -742,7 +712,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
             None => {
                 let code = if params.should_format {
                     format_node(
-                        params.workspace.format_options::<JsonLanguage>(
+                        params.settings.format_options::<JsonLanguage>(
                             params.biome_path,
                             &params.document_file_source,
                         ),

--- a/crates/biome_service/src/file_handlers/svelte.rs
+++ b/crates/biome_service/src/file_handlers/svelte.rs
@@ -4,7 +4,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities, javascript,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::Settings;
 use crate::workspace::{DocumentFileSource, FixFileResult, PullActionsResult};
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
@@ -118,7 +118,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = SvelteFileHandler::input(text);
@@ -139,7 +139,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -147,7 +147,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -157,7 +157,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -4,7 +4,7 @@ use crate::file_handlers::{
     ExtensionHandler, FixAllParams, FormatterCapabilities, LintParams, LintResults, ParseResult,
     ParserCapabilities, javascript,
 };
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::Settings;
 use crate::workspace::{DocumentFileSource, FixFileResult, PullActionsResult};
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
@@ -118,7 +118,7 @@ fn parse(
     _rome_path: &BiomePath,
     _file_source: DocumentFileSource,
     text: &str,
-    _settings: WorkspaceSettingsHandle,
+    _settings: &Settings,
     cache: &mut NodeCache,
 ) -> ParseResult {
     let script = VueFileHandler::input(text);
@@ -139,7 +139,7 @@ fn format(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format(biome_path, document_file_source, parse, settings)
 }
@@ -148,7 +148,7 @@ pub(crate) fn format_range(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     range: TextRange,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_range(biome_path, document_file_source, parse, settings, range)
@@ -158,7 +158,7 @@ pub(crate) fn format_on_type(
     biome_path: &BiomePath,
     document_file_source: &DocumentFileSource,
     parse: AnyParse,
-    settings: WorkspaceSettingsHandle,
+    settings: &Settings,
     offset: TextSize,
 ) -> Result<Printed, WorkspaceError> {
     javascript::format_on_type(biome_path, document_file_source, parse, settings, offset)

--- a/crates/biome_service/src/settings.tests.rs
+++ b/crates/biome_service/src/settings.tests.rs
@@ -46,7 +46,7 @@ fn correctly_lookups_environment_settings() {
     settings
         .merge_with_configuration(configuration, None)
         .expect("valid configuration");
-    let environment = JsLanguage::resolve_environment(Some(&settings));
+    let environment = JsLanguage::resolve_environment(&settings);
 
     assert_eq!(
         environment.unwrap().jsx_runtime,
@@ -68,11 +68,11 @@ fn correctly_computes_analyzer_options() {
     settings
         .merge_with_configuration(configuration, None)
         .expect("valid configuration");
-    let environment = JsLanguage::resolve_environment(Some(&settings));
+    let environment = JsLanguage::resolve_environment(&settings);
     let language = JsLanguage::lookup_settings(&settings.languages);
     let options = JsLanguage::resolve_analyzer_options(
-        Some(&settings),
-        Some(&language.linter),
+        &settings,
+        &language.linter,
         environment,
         &BiomePath::new(Utf8PathBuf::new()),
         &DocumentFileSource::from_language_id("javascript"),

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -60,7 +60,7 @@ mod watcher;
 use crate::file_handlers::Capabilities;
 pub use crate::file_handlers::DocumentFileSource;
 use crate::projects::ProjectKey;
-use crate::settings::WorkspaceSettingsHandle;
+use crate::settings::Settings;
 pub use crate::workspace::scanner::ScanKind;
 use crate::{Deserialize, Serialize, WorkspaceError};
 use biome_analyze::{ActionCategory, RuleCategories};
@@ -207,17 +207,17 @@ impl FileFeaturesResult {
     /// Checks if a feature is enabled for the current path.
     ///
     /// The method checks the configuration enables a certain feature for the given path.
-    #[instrument(level = "debug", skip(self, handle, capabilities))]
+    #[instrument(level = "debug", skip(self, settings, capabilities))]
     pub(crate) fn with_settings_and_language(
         mut self,
-        handle: &WorkspaceSettingsHandle,
+        settings: &Settings,
         path: &Utf8Path,
         capabilities: &Capabilities,
     ) -> Self {
         // formatter
         let formatter_enabled = capabilities.enabled_for_path.formatter;
         if let Some(formatter_enabled) = formatter_enabled {
-            let formatter_enabled = formatter_enabled(path, handle);
+            let formatter_enabled = formatter_enabled(path, settings);
 
             if !formatter_enabled {
                 self.features_supported
@@ -228,7 +228,7 @@ impl FileFeaturesResult {
         // linter
         let linter_enabled = capabilities.enabled_for_path.linter;
         if let Some(linter_enabled) = linter_enabled {
-            let linter_enabled = linter_enabled(path, handle);
+            let linter_enabled = linter_enabled(path, settings);
             if !linter_enabled {
                 self.features_supported
                     .insert(FeatureKind::Lint, SupportKind::FeatureNotEnabled);
@@ -237,7 +237,7 @@ impl FileFeaturesResult {
         // assist
         let assist_enabled = capabilities.enabled_for_path.assist;
         if let Some(assist_enabled) = assist_enabled {
-            let assist_enabled = assist_enabled(path, handle);
+            let assist_enabled = assist_enabled(path, settings);
             if !assist_enabled {
                 self.features_supported
                     .insert(FeatureKind::Assist, SupportKind::FeatureNotEnabled);
@@ -247,7 +247,7 @@ impl FileFeaturesResult {
         // search
         let search_enabled = capabilities.enabled_for_path.search;
         if let Some(search_enabled) = search_enabled {
-            let search_enabled = search_enabled(path, handle);
+            let search_enabled = search_enabled(path, settings);
             if !search_enabled {
                 self.features_supported
                     .insert(FeatureKind::Search, SupportKind::FeatureNotEnabled);

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -84,13 +84,12 @@ use enumflags2::{BitFlags, bitflags};
 use schemars::{r#gen::SchemaGenerator, schema::Schema};
 pub use server::WorkspaceServer;
 use smallvec::SmallVec;
-use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{borrow::Cow, panic::RefUnwindSafe};
 use tokio::sync::watch;
-use tracing::{debug, instrument};
+use tracing::debug;
 
 /// Notification regarding a workspace's service data.
 #[derive(Clone, Copy, Debug)]
@@ -119,17 +118,18 @@ pub struct SupportsFeatureResult {
     pub reason: Option<SupportKind>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Default, Clone, Eq, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct FileFeaturesResult {
-    pub features_supported: HashMap<FeatureKind, SupportKind>,
+    pub features_supported: [SupportKind; NUM_FEATURE_KINDS],
 }
 
 impl std::fmt::Display for FileFeaturesResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (feature, support_kind) in self.features_supported.iter() {
-            write!(f, "{}: {}, ", feature, support_kind)?;
+        for (index, support_kind) in self.features_supported.iter().enumerate() {
+            let feature = FeatureKind::from_index(index);
+            write!(f, "{feature}: {support_kind}")?;
         }
         Ok(())
     }
@@ -156,39 +156,39 @@ impl FileFeaturesResult {
     }
 
     /// By default, all features are not supported by a file.
-    const WORKSPACE_FEATURES: [(FeatureKind, SupportKind); 5] = [
-        (FeatureKind::Lint, SupportKind::FileNotSupported),
-        (FeatureKind::Format, SupportKind::FileNotSupported),
-        (FeatureKind::Search, SupportKind::FileNotSupported),
-        (FeatureKind::Assist, SupportKind::FileNotSupported),
-        (FeatureKind::Debug, SupportKind::FileNotSupported),
+    const WORKSPACE_FEATURES: [SupportKind; NUM_FEATURE_KINDS] = [
+        SupportKind::FileNotSupported,
+        SupportKind::FileNotSupported,
+        SupportKind::FileNotSupported,
+        SupportKind::FileNotSupported,
+        SupportKind::FileNotSupported,
     ];
 
     pub fn new() -> Self {
         Self {
-            features_supported: HashMap::from(Self::WORKSPACE_FEATURES),
+            features_supported: Self::WORKSPACE_FEATURES,
         }
     }
 
+    #[inline]
+    fn insert_feature_support(&mut self, feature: FeatureKind, support: SupportKind) {
+        self.features_supported[feature.index()] = support;
+    }
+
     /// Adds the features that are enabled in `capabilities` to this result.
+    #[inline]
     pub fn with_capabilities(mut self, capabilities: &Capabilities) -> Self {
         if capabilities.formatter.format.is_some() {
-            self.features_supported
-                .insert(FeatureKind::Format, SupportKind::Supported);
+            self.insert_feature_support(FeatureKind::Format, SupportKind::Supported);
         }
         if capabilities.analyzer.lint.is_some() {
-            self.features_supported
-                .insert(FeatureKind::Lint, SupportKind::Supported);
+            self.insert_feature_support(FeatureKind::Lint, SupportKind::Supported);
         }
-
         if capabilities.analyzer.code_actions.is_some() {
-            self.features_supported
-                .insert(FeatureKind::Assist, SupportKind::Supported);
+            self.insert_feature_support(FeatureKind::Assist, SupportKind::Supported);
         }
-
         if capabilities.search.search.is_some() {
-            self.features_supported
-                .insert(FeatureKind::Search, SupportKind::Supported);
+            self.insert_feature_support(FeatureKind::Search, SupportKind::Supported);
         }
 
         if capabilities.debug.debug_syntax_tree.is_some()
@@ -197,8 +197,7 @@ impl FileFeaturesResult {
             || capabilities.debug.debug_type_info.is_some()
             || capabilities.debug.debug_registered_types.is_some()
         {
-            self.features_supported
-                .insert(FeatureKind::Debug, SupportKind::Supported);
+            self.insert_feature_support(FeatureKind::Debug, SupportKind::Supported);
         }
 
         self
@@ -207,7 +206,7 @@ impl FileFeaturesResult {
     /// Checks if a feature is enabled for the current path.
     ///
     /// The method checks the configuration enables a certain feature for the given path.
-    #[instrument(level = "debug", skip(self, settings, capabilities))]
+    #[inline]
     pub(crate) fn with_settings_and_language(
         mut self,
         settings: &Settings,
@@ -220,8 +219,7 @@ impl FileFeaturesResult {
             let formatter_enabled = formatter_enabled(path, settings);
 
             if !formatter_enabled {
-                self.features_supported
-                    .insert(FeatureKind::Format, SupportKind::FeatureNotEnabled);
+                self.insert_feature_support(FeatureKind::Format, SupportKind::FeatureNotEnabled);
             }
         }
 
@@ -230,8 +228,7 @@ impl FileFeaturesResult {
         if let Some(linter_enabled) = linter_enabled {
             let linter_enabled = linter_enabled(path, settings);
             if !linter_enabled {
-                self.features_supported
-                    .insert(FeatureKind::Lint, SupportKind::FeatureNotEnabled);
+                self.insert_feature_support(FeatureKind::Lint, SupportKind::FeatureNotEnabled);
             }
         }
         // assist
@@ -239,8 +236,7 @@ impl FileFeaturesResult {
         if let Some(assist_enabled) = assist_enabled {
             let assist_enabled = assist_enabled(path, settings);
             if !assist_enabled {
-                self.features_supported
-                    .insert(FeatureKind::Assist, SupportKind::FeatureNotEnabled);
+                self.insert_feature_support(FeatureKind::Assist, SupportKind::FeatureNotEnabled);
             }
         }
 
@@ -249,8 +245,7 @@ impl FileFeaturesResult {
         if let Some(search_enabled) = search_enabled {
             let search_enabled = search_enabled(path, settings);
             if !search_enabled {
-                self.features_supported
-                    .insert(FeatureKind::Search, SupportKind::FeatureNotEnabled);
+                self.insert_feature_support(FeatureKind::Search, SupportKind::FeatureNotEnabled);
             }
         }
 
@@ -263,100 +258,116 @@ impl FileFeaturesResult {
     }
 
     /// The file will be ignored for all features
+    #[inline]
     pub fn set_ignored_for_all_features(&mut self) {
-        for support_kind in self.features_supported.values_mut() {
+        for support_kind in self.features_supported.iter_mut() {
             *support_kind = SupportKind::Ignored;
         }
     }
 
     /// The file will be protected for all features
     pub fn set_protected_for_all_features(&mut self) {
-        for support_kind in self.features_supported.values_mut() {
+        for support_kind in self.features_supported.iter_mut() {
             *support_kind = SupportKind::Protected;
         }
     }
 
-    pub fn ignored(&mut self, feature: FeatureKind) {
-        self.features_supported
-            .insert(feature, SupportKind::Ignored);
+    #[inline]
+    pub fn set_ignored(&mut self, feature: FeatureKind) {
+        self.insert_feature_support(feature, SupportKind::Ignored);
     }
 
     /// Checks whether the file support the given `feature`
-    fn supports_for(&self, feature: &FeatureKind) -> bool {
-        self.features_supported
-            .get(feature)
-            .is_some_and(|support_kind| matches!(support_kind, SupportKind::Supported))
+    #[inline]
+    fn supports(&self, feature: FeatureKind) -> bool {
+        let support_kind = self.features_supported[feature.index()];
+        matches!(support_kind, SupportKind::Supported)
     }
 
     pub fn supports_lint(&self) -> bool {
-        self.supports_for(&FeatureKind::Lint)
+        self.supports(FeatureKind::Lint)
     }
 
     pub fn supports_format(&self) -> bool {
-        self.supports_for(&FeatureKind::Format)
+        self.supports(FeatureKind::Format)
     }
 
     pub fn supports_assist(&self) -> bool {
-        self.supports_for(&FeatureKind::Assist)
+        self.supports(FeatureKind::Assist)
     }
 
     pub fn supports_search(&self) -> bool {
-        self.supports_for(&FeatureKind::Search)
+        self.supports(FeatureKind::Search)
+    }
+
+    /// Returns the [`SupportKind`] for the given `feature`, but only if it is
+    /// not enabled.
+    #[inline(always)]
+    pub fn support_kind_for(&self, feature: FeatureKind) -> SupportKind {
+        self.features_supported[feature.index()]
+    }
+
+    /// Returns the [`SupportKind`] for the given `feature`, but only if it is
+    /// not enabled.
+    pub fn support_kind_if_not_enabled(&self, feature: FeatureKind) -> Option<SupportKind> {
+        let support_kind = self.support_kind_for(feature);
+        if support_kind.is_not_enabled() {
+            Some(support_kind)
+        } else {
+            None
+        }
     }
 
     /// Loops through all the features of the current file, and if a feature is [SupportKind::FileNotSupported],
     /// it gets changed to [SupportKind::Ignored]
     pub fn ignore_not_supported(&mut self) {
-        for support_kind in self.features_supported.values_mut() {
+        for support_kind in self.features_supported.iter_mut() {
             if matches!(support_kind, SupportKind::FileNotSupported) {
                 *support_kind = SupportKind::Ignored;
             }
         }
     }
 
-    pub fn support_kind_for(&self, feature: &FeatureKind) -> Option<&SupportKind> {
-        self.features_supported.get(feature)
-    }
-
     /// If at least one feature is supported, the file is supported
     pub fn is_supported(&self) -> bool {
         self.features_supported
-            .values()
+            .iter()
             .any(|support_kind| support_kind.is_supported())
     }
 
     /// The file is ignored only if all the features marked it as ignored
     pub fn is_ignored(&self) -> bool {
         self.features_supported
-            .values()
+            .iter()
             .all(|support_kind| support_kind.is_ignored())
     }
 
     /// The file is protected only if all the features marked it as protected
     pub fn is_protected(&self) -> bool {
         self.features_supported
-            .values()
+            .iter()
             .all(|support_kind| support_kind.is_protected())
     }
 
     /// The file is not supported if all the features are unsupported
     pub fn is_not_supported(&self) -> bool {
         self.features_supported
-            .values()
+            .iter()
             .all(|support_kind| support_kind.is_not_supported())
     }
 
     /// The file is not enabled if all the features aren't enabled
     pub fn is_not_enabled(&self) -> bool {
         self.features_supported
-            .values()
+            .iter()
             .all(|support_kind| support_kind.is_not_enabled())
     }
 
     /// The file is not processed if for every enabled feature
     /// the file is either protected, not supported, ignored.
+    #[inline]
     pub fn is_not_processed(&self) -> bool {
-        self.features_supported.values().all(|support_kind| {
+        self.features_supported.iter().all(|support_kind| {
             matches!(
                 support_kind,
                 SupportKind::FeatureNotEnabled
@@ -385,7 +396,7 @@ impl SupportsFeatureResult {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq, Clone)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub enum SupportKind {
@@ -444,6 +455,8 @@ pub enum FeatureKind {
     Debug,
 }
 
+pub const NUM_FEATURE_KINDS: usize = 5;
+
 impl std::fmt::Display for FeatureKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -452,6 +465,36 @@ impl std::fmt::Display for FeatureKind {
             Self::Search => write!(f, "Search"),
             Self::Assist => write!(f, "Assist"),
             Self::Debug => write!(f, "Debug"),
+        }
+    }
+}
+
+impl FeatureKind {
+    /// Returns the feature kind from its index.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if the index is higher than or equal to [`NUM_FEATURE_KINDS`].
+    fn from_index(index: usize) -> Self {
+        match index {
+            0 => Self::Format,
+            1 => Self::Lint,
+            2 => Self::Search,
+            3 => Self::Assist,
+            4 => Self::Debug,
+            _ => unreachable!("invalid index for FeatureKind"),
+        }
+    }
+
+    /// Returns the index for the feature kind.
+    #[inline]
+    fn index(self) -> usize {
+        match self {
+            Self::Format => 0,
+            Self::Lint => 1,
+            Self::Search => 2,
+            Self::Assist => 3,
+            Self::Debug => 4,
         }
     }
 }

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -103,7 +103,7 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>
     let evaluated_paths = ctx.evaluated_paths();
     let mut configs = Vec::new();
     let mut manifests = Vec::new();
-    let mut handleable_paths = Vec::new();
+    let mut handleable_paths = Vec::with_capacity(evaluated_paths.len());
     let mut ignore_paths = Vec::new();
     // We want to process files that closest to the project root first. For example, we must process
     // first the `.gitignore` at the root of the project.
@@ -329,7 +329,12 @@ impl TraversalContext for ScanContext<'_> {
             }
             Ok(PathKind::File { .. }) => match &self.scan_kind {
                 ScanKind::KnownFiles | ScanKind::TargetedKnownFiles { .. } => {
-                    path.is_required_during_scan() && !path.is_dependency()
+                    path.is_required_during_scan()
+                        && !path.is_dependency()
+                        && !self
+                            .workspace
+                            .projects
+                            .is_ignored_by_top_level_config(self.project_key, path)
                 }
                 ScanKind::Project => {
                     if path.is_dependency() {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1036,7 +1036,7 @@ impl Workspace for WorkspaceServer {
             &params.path,
             params.features,
             language,
-            capabilities,
+            &capabilities,
         )
     }
 

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -18,7 +18,7 @@ use biome_rowan::{Direction, Language, SyntaxKind, SyntaxNode, SyntaxSlot};
 use biome_service::configuration::to_analyzer_rules;
 use biome_service::file_handlers::DocumentFileSource;
 use biome_service::projects::Projects;
-use biome_service::settings::{ServiceLanguage, Settings, WorkspaceSettingsHandle};
+use biome_service::settings::{ServiceLanguage, Settings};
 use biome_string_case::StrLikeExtension;
 use camino::{Utf8Path, Utf8PathBuf};
 use json_comments::StripComments;
@@ -163,9 +163,8 @@ where
             .merge_with_configuration(configuration, None)
             .unwrap();
 
-        let handle = WorkspaceSettingsHandle::from(settings);
         let document_file_source = DocumentFileSource::from_path(input_file);
-        handle.format_options::<L>(&input_file.into(), &document_file_source)
+        settings.format_options::<L>(&input_file.into(), &document_file_source)
     }
 }
 

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -324,16 +324,15 @@ where
     let file_source = &test.document_file_source();
     let supression_reason = None;
 
-    let settings = workspace_settings.get_root_settings(project_key);
-    let language_settings = settings
-        .as_ref()
-        .map(|s| L::lookup_settings(&s.languages))
-        .map(|result| &result.linter);
+    let Some(settings) = workspace_settings.get_root_settings(project_key) else {
+        return AnalyzerOptions::default();
+    };
+    let language_settings = &L::lookup_settings(&settings.languages).linter;
 
-    let environment = L::resolve_environment(settings.as_ref());
+    let environment = L::resolve_environment(&settings);
 
     L::resolve_analyzer_options(
-        settings.as_ref(),
+        &settings,
         language_settings,
         environment,
         &path,


### PR DESCRIPTION
## Summary

Fixes #6509.

If a nested configuration file is ignored by the root configuration, it will now actually be ignored.

Biome has an exception in place for configuration files so they cannot be ignored, because the configuration files are vital to Biome itself. But this exception was incorrectly applied to nested configurations as well. Now only the root configuration is exempt from being ignored.

Additionally, I ran into quite a bit of a refactoring. I moved most of the implementation of `WorkspaceServer::file_features()` into `projects.rs`, so that we can again save ourselves some cloning and unnecessary Papaya lookups. But it turned out `WorkspaceSettingsHandle` was getting in the way of me doing that, so I had a hard look at `WorkspaceSettingsHandle` itself. Turned out that `WorkspaceSettingsHandle` was entirely unnecessary, and the fact it wrapped settings in an `Option` was unnecessary too. So I removed `WorkspaceSettingsHandle` and a lot of places that used to pass `Option<&Settings>` now pass a plain `&Settings`.

## Test Plan

Test added and snapshots updated.

You may notice that for some snapshots, the amount of files checked has decreased by one. These are nested configuration files that were checked before, where this behaviour is unexpected with the new logic.
