### PR TITLE
fix(format/html): fix mangling of embedded language tags if `whitespaceSensitivity` is `strict`

### DIFF
--- a/.changeset/clean-pumas-care.md
+++ b/.changeset/clean-pumas-care.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a case where the HTML formatter would mangle embedded language tags if `whitespaceSensitivity` was set to `strict`

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -80,10 +80,14 @@ impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
         // to borrow, while the child formatters are responsible for actually printing
         // the tokens. `HtmlElementList` prints them if they are borrowed, otherwise
         // they are printed by their original formatter.
-        let should_borrow_opening_r_angle =
-            is_whitespace_sensitive && !children.is_empty() && !content_has_leading_whitespace;
-        let should_borrow_closing_tag =
-            is_whitespace_sensitive && !children.is_empty() && !content_has_trailing_whitespace;
+        let should_borrow_opening_r_angle = is_whitespace_sensitive
+            && !children.is_empty()
+            && !content_has_leading_whitespace
+            && !should_be_verbatim;
+        let should_borrow_closing_tag = is_whitespace_sensitive
+            && !children.is_empty()
+            && !content_has_trailing_whitespace
+            && !should_be_verbatim;
 
         let borrowed_r_angle = if should_borrow_opening_r_angle {
             opening_element.r_angle_token().ok()

--- a/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/options.json
+++ b/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/options.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "html": {
+    "formatter": {
+      "whitespaceSensitivity": "strict"
+    }
+  }
+}

--- a/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/sensitive-style.html
+++ b/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/sensitive-style.html
@@ -1,0 +1,5 @@
+<style>
+body {
+  background-color: seagreen;
+}
+</style>

--- a/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/sensitive-style.html.snap
+++ b/crates/biome_html_formatter/tests/specs/html/embedded/strict-whitespace-sensitivity/sensitive-style.html.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: embedded/strict-whitespace-sensitivity/sensitive-style.html
+---
+# Input
+
+```html
+<style>
+body {
+  background-color: seagreen;
+}
+</style>
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: css
+Indent script and style: false
+Self close void elements: never
+-----
+
+```html
+<style>
+body {
+  background-color: seagreen;
+}
+</style>
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Attribute Position: Auto
+Bracket same line: false
+Whitespace sensitivity: strict
+Indent script and style: false
+Self close void elements: never
+-----
+
+```html
+<style>
+body {
+  background-color: seagreen;
+}
+</style>
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
When this option is set to strict, it means _all_ tags are whitespace sensitive. This means that every element's children tries to "borrow" the parent element's opening tag `>` and closing tag. Normally, this would be "given" to the element list formatter to print, however for verbatim elements like embedded language tags, we avoid invoking the element list formatter entirely in favor of just printing it verbatim.

Now we never borrow these tokens if the element is a verbatim element.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #6453

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
