### PR TITLE
fix(biome-service): override all formatter options with user configured overrides

### DIFF
--- a/.changeset/many-weeks-lose.md
+++ b/.changeset/many-weeks-lose.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6638](https://github.com/biomejs/biome/issues/6638): JavaScript formatter `overrides` options now correctly override `expand` option. JSON formatter `overrides` options now correctly override `bracketSpacing` and `expand` options.

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/overrides_javascript_formatting_options.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/overrides_javascript_formatting_options.snap
@@ -1,0 +1,124 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "includes": ["**/*.js"]
+  },
+  "javascript": {
+    "formatter": {
+      "enabled": true,
+      "arrowParentheses": "asNeeded",
+      "attributePosition": "auto",
+      "bracketSameLine": true,
+      "bracketSpacing": false,
+      "expand": "never",
+      "indentStyle": "tab",
+      "indentWidth": 4,
+      "jsxQuoteStyle": "single",
+      "lineEnding": "lf",
+      "lineWidth": 100,
+      "quoteProperties": "preserve",
+      "quoteStyle": "single",
+      "semicolons": "asNeeded",
+      "trailingCommas": "es5"
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["overrides.js"],
+      "javascript": {
+        "formatter": {
+          "enabled": true,
+          "arrowParentheses": "always",
+          "attributePosition": "multiline",
+          "bracketSameLine": false,
+          "bracketSpacing": true,
+          "expand": "always",
+          "indentStyle": "space",
+          "indentWidth": 2,
+          "jsxQuoteStyle": "double",
+          "lineEnding": "lf",
+          "lineWidth": 20,
+          "quoteProperties": "asNeeded",
+          "quoteStyle": "double",
+          "semicolons": "always",
+          "trailingCommas": "all"
+        }
+      }
+    }
+  ]
+}
+```
+
+## `base.js`
+
+```js
+import React from 'react'
+
+const arrowParentheses = a => {
+	return `${a} => ${b}`
+}
+
+const testObject = {'must-stay-wrapped': 'This is a test', 𐊧: 'no key quote wrap needed'}
+
+function MyComponent() {
+	return (
+		<>
+			<div autoFocus data-attribute='test'>
+				no self closing element
+			</div>
+			<input type='text' autoComplete='off' defaultValue='field value' />
+		</>
+	)
+}
+
+```
+
+## `overrides.js`
+
+```js
+import React from "react";
+
+const arrowParentheses =
+  (a) => {
+    return `${a} => ${b}`;
+  };
+
+const testObject = {
+  "must-stay-wrapped":
+    "This is a test",
+  𐊧: "no key quote wrap needed",
+};
+
+function MyComponent() {
+  return (
+    <>
+      <div
+        autoFocus
+        data-attribute="test"
+      >
+        no self
+        closing
+        element
+      </div>
+      <input
+        type="text"
+        autoComplete="off"
+        defaultValue="field value"
+      />
+    </>
+  );
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 files in <TIME>. Fixed 2 files.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/overrides_json_formatting_options.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_overrides_formatter/overrides_json_formatting_options.snap
@@ -1,0 +1,71 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "formatter": {
+    "includes": ["*.json"]
+  },
+  "json": {
+    "formatter": {
+      "enabled": true,
+      "bracketSpacing": true,
+      "expand": "never",
+      "indentStyle": "tab",
+      "indentWidth": 4,
+      "lineEnding": "lf",
+      "lineWidth": 240,
+      "trailingCommas": "none"
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["overrides.json"],
+      "json": {
+        "formatter": {
+          "enabled": true,
+          "bracketSpacing": false,
+          "expand": "always",
+          "indentStyle": "space",
+          "indentWidth": 2,
+          "lineEnding": "lf",
+          "lineWidth": 20,
+          "trailingCommas": "all"
+        }
+      }
+    }
+  ]
+}
+```
+
+## `base.json`
+
+```json
+{ "asta": ["lorem", "ipsum", { "key1": "value1 that has a way longer line width but it shouldn't break anything here", "key2": "value2" }] }
+
+```
+
+## `overrides.json`
+
+```json
+{
+  "asta": [
+    "lorem",
+    "ipsum",
+    {
+      "key1": "value1 that has a way longer line width but it shouldn't break anything here",
+      "key2": "value2",
+    },
+  ],
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 2 files in <TIME>. Fixed 2 files.
+```

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1356,6 +1356,9 @@ impl OverrideSettingPattern {
         if let Some(bracket_same_line) = js_formatter.bracket_same_line {
             options.set_bracket_same_line(bracket_same_line);
         }
+        if let Some(expand) = js_formatter.expand.or(formatter.expand) {
+            options.set_expand(expand);
+        }
         if let Some(attribute_position) = js_formatter
             .attribute_position
             .or(formatter.attribute_position)
@@ -1383,8 +1386,12 @@ impl OverrideSettingPattern {
         if let Some(trailing_commas) = json_formatter.trailing_commas {
             options.set_trailing_commas(trailing_commas);
         }
-        if let Some(expand_lists) = json_formatter.expand {
+        if let Some(expand_lists) = json_formatter.expand.or(formatter.expand) {
             options.set_expand(expand_lists);
+        }
+        if let Some(bracket_spacing) = json_formatter.bracket_spacing.or(formatter.bracket_spacing)
+        {
+            options.set_bracket_spacing(bracket_spacing);
         }
     }
 


### PR DESCRIPTION
## Summary

Hello, first time contributor here! I opened an issue (#6638) because I noticed formatter overrides weren't being applied for all specified options. Looking through the code I found that `expand` option in JS formatter and `bracketSpacing` in JSON formatter weren't being overwritten when specified in `overrides`.

I followed existing code while fixing this. Although a better solution would be to somehow map over all possible options and apply them, but my Rust experience/knowledge is non-existent so I really don't know how would I do this.

I also wanted to write a test that verifies that override options are being applied, but that test wouldn't automatically cover any options that would be added in the future so it wouldn't catch missing options later on. And since my Rust knowledge is zero, I had a bit of trouble actually writing that test.

Fixes #6638 

## Test Plan

I've used the repo mentioned in my issue #6638. Built a new Biome binary with these changes and ran current version and new binary one after another and observer the printed code.

Here is a before and after terminal output for JS formatting:

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/14c37123-0927-4a93-99d9-112c930cae3b) | ![image](https://github.com/user-attachments/assets/cf066c85-f904-4279-b7c6-9d20722ebc25) |

It's clearly visible `expand` option is now being properly overridden in the "after" case for files that are included for the override.

Here is a before and after terminal output for JSON formatting:

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/0c060e88-3330-4c9b-9a82-3d5745a40ba8) | ![image](https://github.com/user-attachments/assets/b0b7444e-462e-474e-94a1-77d5c8736410) |

It's clearly visible `bracketSpacing` option is now being properly overridden in the "after" case for files that are included for the override.
