### PR TITLE
fix(formatter): trailing commas in json files

### DIFF
--- a/.changeset/loud-seals-fry.md
+++ b/.changeset/loud-seals-fry.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6537](https://github.com/biomejs/biome/issues/6537), where Biome removed the trailing comma from JSON files even when `formatter.json.trailingCommas` is explicitly set to `"all"`.

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -2189,12 +2189,6 @@ fn format_json_trailing_commas_all() {
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
-    assert_file_contents(
-        &fs,
-        Utf8Path::new(file_path),
-        "{\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\"\n}\n",
-    );
-
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_json_trailing_commas_all",
@@ -2235,12 +2229,6 @@ fn format_json_trailing_commas_overrides_all() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(
-        &fs,
-        Utf8Path::new(file_path),
-        "{\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\",\n\t\"loreum_ipsum_lorem_ipsum\": \"bar\"\n}\n",
-    );
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_all.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
-snapshot_kind: text
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -22,7 +21,7 @@ snapshot_kind: text
 	"loreum_ipsum_lorem_ipsum": "bar",
 	"loreum_ipsum_lorem_ipsum": "bar",
 	"loreum_ipsum_lorem_ipsum": "bar",
-	"loreum_ipsum_lorem_ipsum": "bar"
+	"loreum_ipsum_lorem_ipsum": "bar",
 }
 
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_all.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_json_trailing_commas_overrides_all.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
 expression: redactor(content)
-snapshot_kind: text
 ---
 ## `biome.json`
 
@@ -30,7 +29,7 @@ snapshot_kind: text
 	"loreum_ipsum_lorem_ipsum": "bar",
 	"loreum_ipsum_lorem_ipsum": "bar",
 	"loreum_ipsum_lorem_ipsum": "bar",
-	"loreum_ipsum_lorem_ipsum": "bar"
+	"loreum_ipsum_lorem_ipsum": "bar",
 }
 
 ```

--- a/crates/biome_json_formatter/src/context.rs
+++ b/crates/biome_json_formatter/src/context.rs
@@ -69,7 +69,7 @@ pub struct JsonFormatOptions {
     expand: Expand,
     bracket_spacing: BracketSpacing,
     /// The kind of file
-    file_source: JsonFileSource,
+    _file_source: JsonFileSource,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Deserializable, Merge, PartialEq)]
@@ -83,7 +83,7 @@ pub enum TrailingCommas {
     #[default]
     /// The formatter will remove the trailing commas.
     None,
-    /// The trailing commas are allowed and advised only in JSONC files. Trailing commas are removed from JSON files.
+    /// The trailing commas are allowed and advised in JSON and JSONC files.
     All,
 }
 
@@ -111,7 +111,7 @@ impl fmt::Display for TrailingCommas {
 impl JsonFormatOptions {
     pub fn new(file_source: JsonFileSource) -> Self {
         Self {
-            file_source,
+            _file_source: file_source,
             ..Default::default()
         }
     }
@@ -193,10 +193,6 @@ impl JsonFormatOptions {
             TrailingCommas::None => TrailingSeparator::Omit,
             TrailingCommas::All => TrailingSeparator::Allowed,
         }
-    }
-
-    pub(crate) fn file_source(&self) -> &JsonFileSource {
-        &self.file_source
     }
 }
 

--- a/crates/biome_json_formatter/src/json/lists/array_element_list.rs
+++ b/crates/biome_json_formatter/src/json/lists/array_element_list.rs
@@ -1,8 +1,7 @@
 use crate::prelude::*;
 use crate::separated::FormatAstSeparatedListExtension;
-use biome_formatter::separated::TrailingSeparator;
 use biome_formatter::{Expand, FormatContext, write};
-use biome_json_syntax::{AnyJsonValue, JsonArrayElementList, JsonFileVariant};
+use biome_json_syntax::{AnyJsonValue, JsonArrayElementList};
 use biome_rowan::{AstNode, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
@@ -22,12 +21,8 @@ impl FormatRule<JsonArrayElementList> for FormatJsonArrayElementList {
 
         match layout {
             ArrayLayout::Fill => {
-                let file_source = f.options().file_source();
-                let trailing_separator = if file_source.variant() == JsonFileVariant::Standard {
-                    TrailingSeparator::Omit
-                } else {
-                    f.options().to_trailing_separator()
-                };
+                let trailing_separator = f.options().to_trailing_separator();
+
                 let mut filler = f.fill();
 
                 for (element, formatted) in node
@@ -50,12 +45,7 @@ impl FormatRule<JsonArrayElementList> for FormatJsonArrayElementList {
             }
 
             ArrayLayout::OnePerLine => {
-                let file_source = f.options().file_source();
-                let trailing_separator = if file_source.variant() == JsonFileVariant::Standard {
-                    TrailingSeparator::Omit
-                } else {
-                    f.options().to_trailing_separator()
-                };
+                let trailing_separator = f.options().to_trailing_separator();
                 let mut join = f.join_nodes_with_soft_line();
 
                 for (element, formatted) in node

--- a/crates/biome_json_formatter/src/json/lists/member_list.rs
+++ b/crates/biome_json_formatter/src/json/lists/member_list.rs
@@ -1,7 +1,6 @@
 use crate::prelude::*;
 use crate::separated::FormatAstSeparatedListExtension;
-use biome_formatter::separated::TrailingSeparator;
-use biome_json_syntax::{JsonFileVariant, JsonMemberList};
+use biome_json_syntax::JsonMemberList;
 use biome_rowan::{AstNode, AstSeparatedList};
 
 #[derive(Debug, Clone, Default)]
@@ -10,12 +9,7 @@ pub(crate) struct FormatJsonMemberList;
 impl FormatRule<JsonMemberList> for FormatJsonMemberList {
     type Context = JsonFormatContext;
     fn fmt(&self, node: &JsonMemberList, f: &mut JsonFormatter) -> FormatResult<()> {
-        let file_source = f.options().file_source();
-        let trailing_separator = if file_source.variant() == JsonFileVariant::Standard {
-            TrailingSeparator::Omit
-        } else {
-            f.options().to_trailing_separator()
-        };
+        let trailing_separator = f.options().to_trailing_separator();
         let mut join = f.join_nodes_with_soft_line();
 
         for (element, formatted) in node

--- a/crates/biome_json_formatter/tests/language.rs
+++ b/crates/biome_json_formatter/tests/language.rs
@@ -21,7 +21,13 @@ impl TestFormatLanguage for JsonTestFormatLanguage {
     type FormatLanguage = JsonFormatLanguage;
 
     fn parse(&self, text: &str) -> AnyParse {
-        parse_json(text, JsonParserOptions::default().with_allow_comments()).into()
+        parse_json(
+            text,
+            JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
+        )
+        .into()
     }
 
     fn to_format_language(

--- a/crates/biome_json_formatter/tests/specs/json/trailing_comma_never/classic.json.snap
+++ b/crates/biome_json_formatter/tests/specs/json/trailing_comma_never/classic.json.snap
@@ -60,6 +60,6 @@ Bracket spacing: true
 	"list1": [],
 	"list2": [],
 	"list3": [],
-	"list4": []
+	"list4": [],
 }
 ```

--- a/crates/biome_json_formatter/tests/specs/prettier/json/json/array.json.snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/json/array.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/json/array.json
 ---
-
 # Input
 
 ```json
@@ -37,86 +36,6 @@ info: json/json/array.json
 
 # Errors
 ```
-array.json:4:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-    2 │   [
-    3 │ 1,null],
-  > 4 │   [1,null,],
-      │           ^
-    5 │   [null,],
-    6 │   [0,],
-  
-  i Expected an array, an object, or a literal here.
-  
-    2 │   [
-    3 │ 1,null],
-  > 4 │   [1,null,],
-      │           ^
-    5 │   [null,],
-    6 │   [0,],
-  
-array.json:5:9 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-    3 │ 1,null],
-    4 │   [1,null,],
-  > 5 │   [null,],
-      │         ^
-    6 │   [0,],
-    7 │   [false,],
-  
-  i Expected an array, an object, or a literal here.
-  
-    3 │ 1,null],
-    4 │   [1,null,],
-  > 5 │   [null,],
-      │         ^
-    6 │   [0,],
-    7 │   [false,],
-  
-array.json:6:6 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-    4 │   [1,null,],
-    5 │   [null,],
-  > 6 │   [0,],
-      │      ^
-    7 │   [false,],
-    8 │   ['',]
-  
-  i Expected an array, an object, or a literal here.
-  
-    4 │   [1,null,],
-    5 │   [null,],
-  > 6 │   [0,],
-      │      ^
-    7 │   [false,],
-    8 │   ['',]
-  
-array.json:7:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-    5 │   [null,],
-    6 │   [0,],
-  > 7 │   [false,],
-      │          ^
-    8 │   ['',]
-    9 │ ]
-  
-  i Expected an array, an object, or a literal here.
-  
-    5 │   [null,],
-    6 │   [0,],
-  > 7 │   [false,],
-      │          ^
-    8 │   ['',]
-    9 │ ]
-  
 array.json:8:4 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × JSON standard does not allow single quoted strings
@@ -130,27 +49,5 @@ array.json:8:4 parse ━━━━━━━━━━━━━━━━━━━�
   
   i Use double quotes to escape the string.
   
-array.json:8:7 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-     6 │   [0,],
-     7 │   [false,],
-   > 8 │   ['',]
-       │       ^
-     9 │ ]
-    10 │ 
-  
-  i Expected an array, an object, or a literal here.
-  
-     6 │   [0,],
-     7 │   [false,],
-   > 8 │   ['',]
-       │       ^
-     9 │ ]
-    10 │ 
-  
 
 ```
-
-

--- a/crates/biome_json_formatter/tests/specs/prettier/json/json/json5.json.snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/json/json5.json.snap
@@ -241,26 +241,6 @@ json5.json:7:5 parse ━━━━━━━━━━━━━━━━━━━�
     8 │   ],
     9 │   Infinity: NaN,
   
-json5.json:8:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-     6 │     -Infinity,
-     7 │     NaN,
-   > 8 │   ],
-       │   ^
-     9 │   Infinity: NaN,
-    10 │   NaN: Infinity,
-  
-  i Expected an array, an object, or a literal here.
-  
-     6 │     -Infinity,
-     7 │     NaN,
-   > 8 │   ],
-       │   ^
-     9 │   Infinity: NaN,
-    10 │   NaN: Infinity,
-  
 json5.json:9:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × String values must be double quoted.
@@ -346,7 +326,7 @@ json5.json:11:8 parse ━━━━━━━━━━━━━━━━━━━�
   
 json5.json:12:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected an array, an object, or a literal but instead found '}'.
+  × expected `]` but instead found `}`
   
     10 │   NaN: Infinity,
     11 │   NaN: -Infinity,
@@ -355,14 +335,7 @@ json5.json:12:1 parse ━━━━━━━━━━━━━━━━━━━�
     13 │ {
     14 │   '//': 'JSON5 numbers',
   
-  i Expected an array, an object, or a literal here.
-  
-    10 │   NaN: Infinity,
-    11 │   NaN: -Infinity,
-  > 12 │ },
-       │ ^
-    13 │ {
-    14 │   '//': 'JSON5 numbers',
+  i Remove }
   
 json5.json:13:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/crates/biome_json_formatter/tests/specs/prettier/json/json5-as-json-with-trailing-commas/nested-quotes.json.snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/json5-as-json-with-trailing-commas/nested-quotes.json.snap
@@ -191,26 +191,6 @@ nested-quotes.json:7:17 parse ━━━━━━━━━━━━━━━━�
   
   i Use an array for a sequence of values: `[1, 2]`
   
-nested-quotes.json:12:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected an array, an object, or a literal but instead found ']'.
-  
-    10 │     {"type": "office",
-    11 │       "trailing": "commas by accident"},
-  > 12 │   ],
-       │   ^
-    13 │ }
-    14 │ 
-  
-  i Expected an array, an object, or a literal here.
-  
-    10 │     {"type": "office",
-    11 │       "trailing": "commas by accident"},
-  > 12 │   ],
-       │   ^
-    13 │ }
-    14 │ 
-  
 nested-quotes.json:7:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × End of file expected

--- a/crates/biome_json_formatter/tests/specs/prettier/json/range/cross-object-2.json.snap
+++ b/crates/biome_json_formatter/tests/specs/prettier/json/range/cross-object-2.json.snap
@@ -2,7 +2,6 @@
 source: crates/biome_formatter_test/src/snapshot_builder.rs
 info: json/range/cross-object-2.json
 ---
-
 # Input
 
 ```json
@@ -72,26 +71,6 @@ cross-object-2.json:3:5 parse ━━━━━━━━━━━━━━━━�
     4 │ c: {d:     6}
     5 │ }
   
-cross-object-2.json:3:11 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × Expected a property but instead found '}'.
-  
-    1 │ {a:
-    2 │ { "b": 2, "c": 3,
-  > 3 │ d: {d:4}, },
-      │           ^
-    4 │ c: {d:     6}
-    5 │ }
-  
-  i Expected a property here.
-  
-    1 │ {a:
-    2 │ { "b": 2, "c": 3,
-  > 3 │ d: {d:4}, },
-      │           ^
-    4 │ c: {d:     6}
-    5 │ }
-  
 cross-object-2.json:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   × Property key must be double quoted
@@ -116,5 +95,3 @@ cross-object-2.json:4:5 parse ━━━━━━━━━━━━━━━━�
   
 
 ```
-
-

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -12540,7 +12540,7 @@
 					"enum": ["none"]
 				},
 				{
-					"description": "The trailing commas are allowed and advised only in JSONC files. Trailing commas are removed from JSON files.",
+					"description": "The trailing commas are allowed and advised in JSON and JSONC files.",
 					"type": "string",
 					"enum": ["all"]
 				}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/6537

Now the formatter follows the `formatter.json.trailingCommas` option, even though it might emit an invalid JSON file.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

## Test Plan

Tests updated

<!-- What demonstrates that your implementation is correct? -->
