### PR TITLE
feat(biome_analyzer): support shebang together with `// biome-ignore-all` file-level suppressions

### DIFF
--- a/.changeset/afraid-coats-post.md
+++ b/.changeset/afraid-coats-post.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Biome now supports shebang, whitespace and arbitrary comments preceding `// biome-ignore-all` file-level suppressions. Fixed #6595.
+Biome now supports `// biome-ignore-all` file-level suppressions in files that start with a shebang (`#!`). Fixed #6595.

--- a/.changeset/afraid-coats-post.md
+++ b/.changeset/afraid-coats-post.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Biome now supports shebang, whitespace and arbitrary comments preceding `// biome-ignore-all` file-level suppressions. Fixed #6595.

--- a/crates/biome_analyze/src/lib.rs
+++ b/crates/biome_analyze/src/lib.rs
@@ -421,7 +421,7 @@ where
             }
 
             if let Some(comment) = piece.as_comments() {
-                self.handle_comment(&token, true, index, comment.text(), piece.text_range())?;
+                self.handle_comment(true, index, comment.text(), piece.text_range())?;
             }
         }
 
@@ -438,7 +438,7 @@ where
             }
 
             if let Some(comment) = piece.as_comments() {
-                self.handle_comment(&token, false, index, comment.text(), piece.text_range())?;
+                self.handle_comment(false, index, comment.text(), piece.text_range())?;
             }
         }
 
@@ -525,8 +525,7 @@ where
     /// comments, and create line suppression entries accordingly
     fn handle_comment(
         &mut self,
-        token: &SyntaxToken<L>,
-        _is_leading: bool,
+        is_leading: bool,
         _index: usize,
         text: &str,
         range: TextRange,
@@ -573,7 +572,7 @@ where
 
             if let Err(diagnostic) =
                 self.suppressions
-                    .push_suppression(&suppression, range, token.text_range())
+                    .push_suppression(&suppression, range, is_leading)
             {
                 let signal = DiagnosticSignal::new(|| diagnostic.clone());
                 (self.emit_signal)(&signal)?;

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use biome_console::markup;
 use biome_diagnostics::category;
-use biome_rowan::{TextRange, TextSize};
+use biome_rowan::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 const PLUGIN_LINT_RULE_FILTER: RuleFilter<'static> = RuleFilter::Group("lint/plugin");
@@ -48,10 +48,10 @@ impl TopLevelSuppression {
         &mut self,
         suppression: &AnalyzerSuppression,
         filter: Option<RuleFilter<'static>>,
-        token_range: TextRange,
         comment_range: TextRange,
+        is_leading: bool,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
-        if suppression.is_top_level() && token_range.start() > TextSize::from(0) {
+        if suppression.is_top_level() && !is_leading {
             let mut diagnostic = AnalyzerSuppressionDiagnostic::new(
                 category!("suppressions/incorrect"),
                 comment_range,
@@ -512,7 +512,7 @@ impl<'analyzer> Suppressions<'analyzer> {
         &mut self,
         suppression: &AnalyzerSuppression,
         comment_range: TextRange,
-        token_range_not_trimmed: TextRange,
+        is_leading: bool,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
         let filter = self.map_to_rule_filter(suppression, comment_range)?;
         let instances = self.map_to_rule_instances(&suppression.kind);
@@ -531,8 +531,8 @@ impl<'analyzer> Suppressions<'analyzer> {
             AnalyzerSuppressionVariant::TopLevel => self.top_level_suppression.push_suppression(
                 suppression,
                 filter,
-                token_range_not_trimmed,
                 comment_range,
+                is_leading,
             ),
             AnalyzerSuppressionVariant::RangeStart | AnalyzerSuppressionVariant::RangeEnd => self
                 .range_suppressions

--- a/crates/biome_analyze/src/suppressions.rs
+++ b/crates/biome_analyze/src/suppressions.rs
@@ -49,9 +49,9 @@ impl TopLevelSuppression {
         suppression: &AnalyzerSuppression,
         filter: Option<RuleFilter<'static>>,
         comment_range: TextRange,
-        is_leading: bool,
+        is_leading_in_file: bool,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
-        if suppression.is_top_level() && !is_leading {
+        if suppression.is_top_level() && !is_leading_in_file {
             let mut diagnostic = AnalyzerSuppressionDiagnostic::new(
                 category!("suppressions/incorrect"),
                 comment_range,
@@ -512,7 +512,7 @@ impl<'analyzer> Suppressions<'analyzer> {
         &mut self,
         suppression: &AnalyzerSuppression,
         comment_range: TextRange,
-        is_leading: bool,
+        is_leading_in_file: bool,
     ) -> Result<(), AnalyzerSuppressionDiagnostic> {
         let filter = self.map_to_rule_filter(suppression, comment_range)?;
         let instances = self.map_to_rule_instances(&suppression.kind);
@@ -532,7 +532,7 @@ impl<'analyzer> Suppressions<'analyzer> {
                 suppression,
                 filter,
                 comment_range,
-                is_leading,
+                is_leading_in_file,
             ),
             AnalyzerSuppressionVariant::RangeStart | AnalyzerSuppressionVariant::RangeEnd => self
                 .range_suppressions

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresComments.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresComments.js
@@ -1,0 +1,6 @@
+// This is a leading comment
+/* And this is too */
+
+  /** biome-ignore-all lint/correctness/noUnusedVariables: explanation */
+
+const test = "hello";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresComments.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresComments.js.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: suppressionIgnoresComments.js
+---
+# Input
+```js
+// This is a leading comment
+/* And this is too */
+
+  /** biome-ignore-all lint/correctness/noUnusedVariables: explanation */
+
+const test = "hello";
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresShebang.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresShebang.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env bun
+
+/** biome-ignore-all lint/correctness/noUnusedVariables: explanation */
+
+const test = "hello";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresShebang.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedVariables/suppressionIgnoresShebang.js.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: ignoreShebang.js
+---
+# Input
+```js
+#!/usr/bin/env bun
+
+/** biome-ignore-all lint/correctness/noUnusedVariables: explanation */
+
+const test = "hello";
+
+```

--- a/crates/biome_js_syntax/src/lib.rs
+++ b/crates/biome_js_syntax/src/lib.rs
@@ -159,6 +159,10 @@ impl biome_rowan::SyntaxKind for JsSyntaxKind {
     fn to_string(&self) -> Option<&'static str> {
         Self::to_string(self)
     }
+
+    fn is_allowed_before_suppressions(&self) -> bool {
+        matches!(self, Self::JS_SHEBANG)
+    }
 }
 
 impl TryFrom<JsSyntaxKind> for TriviaPieceKind {

--- a/crates/biome_rowan/src/syntax.rs
+++ b/crates/biome_rowan/src/syntax.rs
@@ -50,6 +50,11 @@ pub trait SyntaxKind: fmt::Debug + PartialEq + Copy {
     /// Returns a string for keywords, punctuation tokens, and the `EOL` token,
     /// or `None` otherwise.
     fn to_string(&self) -> Option<&'static str>;
+
+    /// Returns `true` if this kind is allowed to precede file suppression comments,
+    fn is_allowed_before_suppressions(&self) -> bool {
+        false
+    }
 }
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {


### PR DESCRIPTION
## Summary

Fixes #6595.

Instead of comparing comment token range with 0, we can check whether it is only preceded by trivial tokens such as comments and whitespace. Fortunately, this information is readily available at that moment, so it just needs to be passed instead of the token range.

While this might cause some counter-intuitive behavior if some lint rules applying to shebang or comments (are there any such rules?) are silenced by a following `// biome-ignore-all` comment, IMO this is the case where practicality beats purity. There is obviously no way to place a comment before shebang. File-level suppressions are defined as comments that affect the whole file, so this should be fine.


## Test Plan

Added testcases adapted from #6595 example, verified that the shebang example fails on current master and passes here. Added a test with preceding comment, it already passes on master - just added it for consistency.
