### PR TITLE
fix(lint/noUselessFragments): apply the same logic for shorthand fragments and Fragment elements

### DIFF
--- a/.changeset/mighty-tables-grab.md
+++ b/.changeset/mighty-tables-grab.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6688](https://github.com/biomejs/biome/issues/6688): the `noUselessFragments` no longer reports `<Fragment />` elements that includes HTML character entities.

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_fragments.rs
@@ -138,164 +138,63 @@ impl Rule for NoUselessFragments {
         let node = ctx.query();
         let model = ctx.model();
 
-        match node {
-            NoUselessFragmentsQuery::JsxFragment(fragment) => {
-                let mut in_jsx_attr_expr = false;
-                let mut in_js_logical_expr = false;
-                let mut in_jsx_expr = false;
-                let mut in_jsx_list = false;
-                let mut in_return_statement = false;
-                let parents_where_fragments_must_be_preserved =
-                    node.syntax().parent().is_some_and(|parent| {
-                        match JsxTagExpression::try_cast(parent.clone()) {
-                            Ok(parent) => parent
-                                .syntax()
-                                .parent()
-                                .and_then(|parent| {
-                                    if JsxExpressionAttributeValue::can_cast(parent.kind()) {
-                                        in_jsx_attr_expr = true;
-                                    }
-                                    if JsLogicalExpression::can_cast(parent.kind()) {
-                                        in_js_logical_expr = true;
-                                    }
-                                    if JsxExpressionChild::can_cast(parent.kind()) {
-                                        in_jsx_expr = true;
-                                    }
-                                    match JsParenthesizedExpression::try_cast(parent) {
-                                        Ok(parenthesized_expression) => {
-                                            parenthesized_expression.syntax().parent()
-                                        }
-                                        Err(parent) => Some(parent),
-                                    }
-                                })
-                                .is_some_and(|parent| {
-                                    if parent.kind() == JsSyntaxKind::JS_RETURN_STATEMENT {
-                                        in_return_statement = true;
-                                        false
-                                    } else {
-                                        // Preserve fragments in other kinds of parent
-                                        matches!(
-                                            parent.kind(),
-                                            JsSyntaxKind::JS_INITIALIZER_CLAUSE
-                                                | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
-                                                | JsSyntaxKind::JS_FUNCTION_EXPRESSION
-                                                | JsSyntaxKind::JS_FUNCTION_DECLARATION
-                                                | JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER
-                                        )
-                                    }
-                                }),
-                            Err(_) => {
-                                if JsxChildList::try_cast(parent.clone()).is_ok() {
-                                    in_jsx_list = true;
-                                    false
-                                } else {
-                                    JsxAttributeInitializerClause::try_cast(parent.clone()).is_ok()
-                                }
+        let mut in_jsx_attr_expr = false;
+        let mut in_js_logical_expr = false;
+        let mut in_jsx_expr = false;
+        let mut in_jsx_list = false;
+        let mut in_return_statement = false;
+        let parents_where_fragments_must_be_preserved =
+            node.syntax().parent().is_some_and(|parent| {
+                match JsxTagExpression::try_cast(parent.clone()) {
+                    Ok(parent) => parent
+                        .syntax()
+                        .parent()
+                        .and_then(|parent| {
+                            if JsxExpressionAttributeValue::can_cast(parent.kind()) {
+                                in_jsx_attr_expr = true;
                             }
-                        }
-                    });
-
-                let child_list = fragment.children();
-
-                if !parents_where_fragments_must_be_preserved {
-                    let mut significant_children = 0;
-                    let mut first_significant_child = None;
-                    let mut children_where_fragments_must_preserved = false;
-
-                    for child in child_list.iter() {
-                        match child.syntax().kind() {
-                            JsSyntaxKind::JSX_EXPRESSION_CHILD => {
-                                if !in_js_logical_expr {
-                                    significant_children += 1;
-                                    if first_significant_child.is_none() {
-                                        first_significant_child = Some(child);
-                                    }
-                                } else {
-                                    children_where_fragments_must_preserved = true;
-                                }
+                            if JsLogicalExpression::can_cast(parent.kind()) {
+                                in_js_logical_expr = true;
                             }
-                            JsSyntaxKind::JSX_SELF_CLOSING_ELEMENT
-                            | JsSyntaxKind::JSX_ELEMENT
-                            | JsSyntaxKind::JSX_FRAGMENT => {
-                                significant_children += 1;
-                                if first_significant_child.is_none() {
-                                    first_significant_child = Some(child);
-                                }
+                            if JsxExpressionChild::can_cast(parent.kind()) {
+                                in_jsx_expr = true;
                             }
-                            JsSyntaxKind::JSX_TEXT => {
-                                // We need to remove whitespaces and newlines from the original string.
-                                // Since in the JSX newlines aren't trivia, we require to allocate a string to trim from those characters.
-                                let original_text = child.to_trimmed_text();
-                                let trimmed_text = original_text.text().trim();
-
-                                if (in_jsx_expr || in_js_logical_expr)
-                                    && contains_html_character_references(trimmed_text)
-                                {
-                                    children_where_fragments_must_preserved = true;
-                                    break;
+                            match JsParenthesizedExpression::try_cast(parent) {
+                                Ok(parenthesized_expression) => {
+                                    parenthesized_expression.syntax().parent()
                                 }
-
-                                // Test whether a node is a padding spaces trimmed by the React runtime.
-                                let is_only_whitespace = trimmed_text.is_empty();
-                                let is_padding_spaces =
-                                    is_only_whitespace && original_text.contains('\n');
-
-                                if !is_padding_spaces {
-                                    significant_children += 1;
-                                    if first_significant_child.is_none() {
-                                        first_significant_child = Some(child);
-                                    }
-                                }
+                                Err(parent) => Some(parent),
                             }
-                            _ => {}
-                        }
-                        if significant_children > 1 || children_where_fragments_must_preserved {
-                            break;
-                        }
-                    }
-
-                    if children_where_fragments_must_preserved {
-                        return None;
-                    }
-
-                    match significant_children {
-                        0 => Some(NoUselessFragmentsState::Empty),
-                        1 => {
-                            if let Some(first) = first_significant_child {
-                                if JsxText::can_cast(first.syntax().kind()) && in_jsx_attr_expr {
-                                    None
-                                } else if JsxElement::can_cast(first.syntax().kind()) {
-                                    Some(NoUselessFragmentsState::Child(first))
-                                } else if in_return_statement {
-                                    // Preserve flagment with only one JsxExpressionChild in return statement
-                                    if JsxExpressionChild::can_cast(first.syntax().kind()) {
-                                        None
-                                    } else {
-                                        Some(NoUselessFragmentsState::Child(first))
-                                    }
-                                } else {
-                                    // Do not report the fragment as unnecessary if the only child is JsxText with an HTML reference
-                                    // or if the fragment is the only child in a JSX expression (e.g. {<>Foo</>})
-                                    if let AnyJsxChild::JsxText(text) = &first {
-                                        let value_token = text.value_token().ok()?;
-                                        let value = value_token.token_text();
-                                        if contains_html_character_references(value.as_ref()) {
-                                            return None;
-                                        }
-                                    }
-
-                                    Some(NoUselessFragmentsState::Child(first))
-                                }
+                        })
+                        .is_some_and(|parent| {
+                            if parent.kind() == JsSyntaxKind::JS_RETURN_STATEMENT {
+                                in_return_statement = true;
+                                false
                             } else {
-                                None
+                                // Preserve fragments in other kinds of parent
+                                matches!(
+                                    parent.kind(),
+                                    JsSyntaxKind::JS_INITIALIZER_CLAUSE
+                                        | JsSyntaxKind::JS_ARROW_FUNCTION_EXPRESSION
+                                        | JsSyntaxKind::JS_FUNCTION_EXPRESSION
+                                        | JsSyntaxKind::JS_FUNCTION_DECLARATION
+                                        | JsSyntaxKind::JS_PROPERTY_OBJECT_MEMBER
+                                )
                             }
+                        }),
+                    Err(_) => {
+                        if JsxChildList::try_cast(parent.clone()).is_ok() {
+                            in_jsx_list = true;
+                            false
+                        } else {
+                            JsxAttributeInitializerClause::try_cast(parent.clone()).is_ok()
                         }
-                        _ => in_jsx_list.then_some(NoUselessFragmentsState::Children(child_list)),
                     }
-                } else {
-                    None
                 }
-            }
+            });
+
+        let child_list = match node {
+            NoUselessFragmentsQuery::JsxFragment(fragment) => fragment.children(),
             NoUselessFragmentsQuery::JsxElement(element) => {
                 let opening_element = element.opening_element().ok()?;
                 let name = opening_element.name().ok()?;
@@ -312,38 +211,132 @@ impl Rule for NoUselessFragments {
                     | AnyJsxElementName::JsMetavariable(_) => false,
                 };
 
-                if is_valid_react_fragment {
-                    let child_list = element.children();
-                    // The `Fragment` component supports only the "key" prop and react emits a warning for not supported props.
-                    // We assume that the user knows - and fixed - that and only care about the prop that is actually supported.
-                    let attribute_key =
-                        opening_element
-                            .attributes()
-                            .into_iter()
-                            .find_map(|attribute| {
-                                let attribute = attribute.as_jsx_attribute()?;
-                                let attribute_name = attribute.name().ok()?;
-                                let attribute_name = attribute_name.as_jsx_name()?;
-
-                                if attribute_name.value_token().ok()?.text_trimmed() == "key" {
-                                    Some(())
-                                } else {
-                                    None
-                                }
-                            });
-                    if attribute_key.is_none() {
-                        return match child_list.first() {
-                            Some(first) if child_list.len() == 1 => {
-                                Some(NoUselessFragmentsState::Child(first))
-                            }
-                            None => Some(NoUselessFragmentsState::Empty),
-                            _ => None,
-                        };
-                    }
+                if !is_valid_react_fragment {
+                    return None;
                 }
 
-                None
+                // The `Fragment` component supports only the "key" prop and react emits a warning for not supported props.
+                // We assume that the user knows - and fixed - that and only care about the prop that is actually supported.
+                let attribute_key =
+                    opening_element
+                        .attributes()
+                        .into_iter()
+                        .find_map(|attribute| {
+                            let attribute = attribute.as_jsx_attribute()?;
+                            let attribute_name = attribute.name().ok()?;
+                            let attribute_name = attribute_name.as_jsx_name()?;
+
+                            if attribute_name.value_token().ok()?.text_trimmed() == "key" {
+                                Some(())
+                            } else {
+                                None
+                            }
+                        });
+
+                if attribute_key.is_some() {
+                    return None;
+                }
+
+                element.children()
             }
+        };
+
+        if parents_where_fragments_must_be_preserved {
+            return None;
+        }
+
+        let mut significant_children = 0;
+        let mut first_significant_child = None;
+        let mut children_where_fragments_must_preserved = false;
+
+        for child in child_list.iter() {
+            match child.syntax().kind() {
+                JsSyntaxKind::JSX_EXPRESSION_CHILD => {
+                    if !in_js_logical_expr {
+                        significant_children += 1;
+                        if first_significant_child.is_none() {
+                            first_significant_child = Some(child);
+                        }
+                    } else {
+                        children_where_fragments_must_preserved = true;
+                    }
+                }
+                JsSyntaxKind::JSX_SELF_CLOSING_ELEMENT
+                | JsSyntaxKind::JSX_ELEMENT
+                | JsSyntaxKind::JSX_FRAGMENT => {
+                    significant_children += 1;
+                    if first_significant_child.is_none() {
+                        first_significant_child = Some(child);
+                    }
+                }
+                JsSyntaxKind::JSX_TEXT => {
+                    // We need to remove whitespaces and newlines from the original string.
+                    // Since in the JSX newlines aren't trivia, we require to allocate a string to trim from those characters.
+                    let original_text = child.to_trimmed_text();
+                    let trimmed_text = original_text.text().trim();
+
+                    if (in_jsx_expr || in_js_logical_expr)
+                        && contains_html_character_references(trimmed_text)
+                    {
+                        children_where_fragments_must_preserved = true;
+                        break;
+                    }
+
+                    // Test whether a node is a padding spaces trimmed by the React runtime.
+                    let is_only_whitespace = trimmed_text.is_empty();
+                    let is_padding_spaces = is_only_whitespace && original_text.contains('\n');
+
+                    if !is_padding_spaces {
+                        significant_children += 1;
+                        if first_significant_child.is_none() {
+                            first_significant_child = Some(child);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if significant_children > 1 || children_where_fragments_must_preserved {
+                break;
+            }
+        }
+
+        if children_where_fragments_must_preserved {
+            return None;
+        }
+
+        match significant_children {
+            0 => Some(NoUselessFragmentsState::Empty),
+            1 => {
+                if let Some(first) = first_significant_child {
+                    if JsxText::can_cast(first.syntax().kind()) && in_jsx_attr_expr {
+                        None
+                    } else if JsxElement::can_cast(first.syntax().kind()) {
+                        Some(NoUselessFragmentsState::Child(first))
+                    } else if in_return_statement {
+                        // Preserve flagment with only one JsxExpressionChild in return statement
+                        if JsxExpressionChild::can_cast(first.syntax().kind()) {
+                            None
+                        } else {
+                            Some(NoUselessFragmentsState::Child(first))
+                        }
+                    } else {
+                        // Do not report the fragment as unnecessary if the only child is JsxText with an HTML reference
+                        // or if the fragment is the only child in a JSX expression (e.g. {<>Foo</>})
+                        if let AnyJsxChild::JsxText(text) = &first {
+                            let value_token = text.value_token().ok()?;
+                            let value = value_token.token_text();
+                            if contains_html_character_references(value.as_ref()) {
+                                return None;
+                            }
+                        }
+
+                        Some(NoUselessFragmentsState::Child(first))
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => in_jsx_list.then_some(NoUselessFragmentsState::Children(child_list)),
         }
     }
 

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/assigments.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/assigments.jsx
@@ -1,1 +1,3 @@
-arr = <>Error</>
+arr = <>Error</>;
+err = <Fragment>Error</Fragment>;
+err = <React.Fragment>Error</React.Fragment>;

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/assigments.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/assigments.jsx.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: assigments.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
-arr = <>Error</>
+arr = <>Error</>;
+err = <Fragment>Error</Fragment>;
+err = <React.Fragment>Error</React.Fragment>;
 
 ```
 
@@ -15,17 +16,67 @@ assigments.jsx:1:7 lint/complexity/noUselessFragments  FIXABLE  ━━━━━�
 
   i This fragment is unnecessary.
   
-  > 1 │ arr = <>Error</>
+  > 1 │ arr = <>Error</>;
       │       ^^^^^^^^^^
-    2 │ 
+    2 │ err = <Fragment>Error</Fragment>;
+    3 │ err = <React.Fragment>Error</React.Fragment>;
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
   i Unsafe fix: Remove the Fragment
   
-    1   │ - arr·=·<>Error</>
-      1 │ + arr·=·"Error"
-    2 2 │   
+    1   │ - arr·=·<>Error</>;
+      1 │ + arr·=·"Error";
+    2 2 │   err = <Fragment>Error</Fragment>;
+    3 3 │   err = <React.Fragment>Error</React.Fragment>;
+  
+
+```
+
+```
+assigments.jsx:2:7 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    1 │ arr = <>Error</>;
+  > 2 │ err = <Fragment>Error</Fragment>;
+      │       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ err = <React.Fragment>Error</React.Fragment>;
+    4 │ 
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    1 1 │   arr = <>Error</>;
+    2   │ - err·=·<Fragment>Error</Fragment>;
+      2 │ + err·=·"Error";
+    3 3 │   err = <React.Fragment>Error</React.Fragment>;
+    4 4 │   
+  
+
+```
+
+```
+assigments.jsx:3:7 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    1 │ arr = <>Error</>;
+    2 │ err = <Fragment>Error</Fragment>;
+  > 3 │ err = <React.Fragment>Error</React.Fragment>;
+      │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    1 1 │   arr = <>Error</>;
+    2 2 │   err = <Fragment>Error</Fragment>;
+    3   │ - err·=·<React.Fragment>Error</React.Fragment>;
+      3 │ + err·=·"Error";
+    4 4 │   
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/componentFragment.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/componentFragment.jsx
@@ -9,6 +9,8 @@ export function Component() {
       </Suspense>
 
       <Comp prop={<></>} />
+      <Comp prop={<Fragment></Fragment>} />
+      <Comp prop={<React.Fragment></React.Fragment>} />
     </div>
   );
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/componentFragment.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/componentFragment.jsx.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: componentFragment.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
@@ -16,9 +15,12 @@ export function Component() {
       </Suspense>
 
       <Comp prop={<></>} />
+      <Comp prop={<Fragment></Fragment>} />
+      <Comp prop={<React.Fragment></React.Fragment>} />
     </div>
   );
 }
+
 ```
 
 # Diagnostics
@@ -48,8 +50,41 @@ componentFragment.jsx:11:19 lint/complexity/noUselessFragments ━━━━━�
     10 │ 
   > 11 │       <Comp prop={<></>} />
        │                   ^^^^^
-    12 │     </div>
-    13 │   );
+    12 │       <Comp prop={<Fragment></Fragment>} />
+    13 │       <Comp prop={<React.Fragment></React.Fragment>} />
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+
+```
+
+```
+componentFragment.jsx:12:19 lint/complexity/noUselessFragments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    11 │       <Comp prop={<></>} />
+  > 12 │       <Comp prop={<Fragment></Fragment>} />
+       │                   ^^^^^^^^^^^^^^^^^^^^^
+    13 │       <Comp prop={<React.Fragment></React.Fragment>} />
+    14 │     </div>
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+
+```
+
+```
+componentFragment.jsx:13:19 lint/complexity/noUselessFragments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    11 │       <Comp prop={<></>} />
+    12 │       <Comp prop={<Fragment></Fragment>} />
+  > 13 │       <Comp prop={<React.Fragment></React.Fragment>} />
+       │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    14 │     </div>
+    15 │   );
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3668.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3668.jsx
@@ -1,9 +1,11 @@
-// should not trigger
+/* should not generate diagnostics */
 function Component2() {
     const str = 'str';
     return (<>{str}</>);
 }
 
 const obj = {
-    element: <>test</>
+    element: <>test</>,
+    element2: <Fragment>test</Fragment>,
+    element3: <React.Fragment>test</React.Fragment>,
 };

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3668.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3668.jsx.snap
@@ -4,16 +4,16 @@ expression: issue_3668.jsx
 ---
 # Input
 ```jsx
-// should not trigger
+/* should not generate diagnostics */
 function Component2() {
     const str = 'str';
     return (<>{str}</>);
 }
 
 const obj = {
-    element: <>test</>
+    element: <>test</>,
+    element2: <Fragment>test</Fragment>,
+    element3: <React.Fragment>test</React.Fragment>,
 };
 
 ```
-
-

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3926.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3926.jsx
@@ -1,3 +1,4 @@
+/* should not generate diagnostics */
 export function Panic() {
   return <div>{foo && <>{`(${bar})`}</>}</div>;
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3926.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_3926.jsx.snap
@@ -4,7 +4,9 @@ expression: issue_3926.jsx
 ---
 # Input
 ```jsx
+/* should not generate diagnostics */
 export function Panic() {
   return <div>{foo && <>{`(${bar})`}</>}</div>;
 }
+
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4059.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4059.jsx
@@ -1,3 +1,4 @@
+/* should not generate diagnostics */
 function MyComponent() {
     return (
         <div key={index}>{line || <>&nbsp;</>}</div>
@@ -13,5 +14,23 @@ function MyComponent2() {
 function MyComponent3() {
     return (
         <div key={index}>{value ?? <>&nbsp;</>}</div>
+    )
+}
+
+function MyComponent4() {
+    return (
+        <div key={index}>{line || <Fragment>&nbsp;</Fragment>}</div>
+    )
+}
+
+function MyComponent5() {
+    return (
+        <div key={index}>{<Fragment>&nbsp;</Fragment>}</div>
+    )
+}
+
+function MyComponent6() {
+    return (
+        <div key={index}>{value ?? <Fragment>&nbsp;</Fragment>}</div>
     )
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4059.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4059.jsx.snap
@@ -4,6 +4,7 @@ expression: issue_4059.jsx
 ---
 # Input
 ```jsx
+/* should not generate diagnostics */
 function MyComponent() {
     return (
         <div key={index}>{line || <>&nbsp;</>}</div>
@@ -21,4 +22,23 @@ function MyComponent3() {
         <div key={index}>{value ?? <>&nbsp;</>}</div>
     )
 }
+
+function MyComponent4() {
+    return (
+        <div key={index}>{line || <Fragment>&nbsp;</Fragment>}</div>
+    )
+}
+
+function MyComponent5() {
+    return (
+        <div key={index}>{<Fragment>&nbsp;</Fragment>}</div>
+    )
+}
+
+function MyComponent6() {
+    return (
+        <div key={index}>{value ?? <Fragment>&nbsp;</Fragment>}</div>
+    )
+}
+
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx
@@ -1,3 +1,4 @@
+/* should not generate diagnostics */
 export function SomeComponent() {
-  return <div x-some-prop={<>Foo</>} />;
+	return <div x-some-prop={<>Foo</>} x-another-prop={<Fragment>foo</Fragment>} />;
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_4639.jsx.snap
@@ -4,8 +4,9 @@ expression: issue_4639.jsx
 ---
 # Input
 ```jsx
+/* should not generate diagnostics */
 export function SomeComponent() {
-  return <div x-some-prop={<>Foo</>} />;
+	return <div x-some-prop={<>Foo</>} x-another-prop={<Fragment>foo</Fragment>} />;
 }
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx
@@ -1,1 +1,3 @@
 appendToLastRow(rows, <> {character.leftBracket}</>);
+appendToLastRow(rows, <Fragment> {character.leftBracket}</Fragment>);
+appendToLastRow(rows, <React.Fragment> {character.leftBracket}</React.Fragment>);

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6391.jsx.snap
@@ -5,5 +5,7 @@ expression: issue_6391.jsx
 # Input
 ```jsx
 appendToLastRow(rows, <> {character.leftBracket}</>);
+appendToLastRow(rows, <Fragment> {character.leftBracket}</Fragment>);
+appendToLastRow(rows, <React.Fragment> {character.leftBracket}</React.Fragment>);
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6508.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6508.jsx
@@ -1,1 +1,3 @@
 <>&#9650;</>
+<Fragment>&#9650;</Fragment>
+<React.Fragment>&#9650;</React.Fragment>

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6508.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/issue_6508.jsx.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 134
 expression: issue_6508.jsx
 ---
 # Input
 ```jsx
 <>&#9650;</>
+<Fragment>&#9650;</Fragment>
+<React.Fragment>&#9650;</React.Fragment>
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/valid.jsx
@@ -5,3 +5,11 @@ import React, {Fragment} from "react";
     <React.Fragment key="1"></React.Fragment>
     <Fragment key="1"></Fragment>
 </>
+
+<Fragment>
+	<Fragment key="1"></Fragment>
+</Fragment>
+
+<React.Fragment>
+	<React.Fragment key="1"></React.Fragment>
+</React.Fragment>

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/valid.jsx.snap
@@ -11,4 +11,13 @@ import React, {Fragment} from "react";
     <React.Fragment key="1"></React.Fragment>
     <Fragment key="1"></Fragment>
 </>
+
+<Fragment>
+	<Fragment key="1"></Fragment>
+</Fragment>
+
+<React.Fragment>
+	<React.Fragment key="1"></React.Fragment>
+</React.Fragment>
+
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxElementInvalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxElementInvalid.jsx
@@ -1,4 +1,6 @@
-<><Component /></>
+<><Component /></>;
+<Fragment><Component /></Fragment>;
+<React.Fragment><Component /></React.Fragment>;
 
 function jsxElement() {
 	return <><JsxElement /></>;

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxElementInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxElementInvalid.jsx.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: withJsxElementInvalid.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
-<><Component /></>
+<><Component /></>;
+<Fragment><Component /></Fragment>;
+<React.Fragment><Component /></React.Fragment>;
 
 function jsxElement() {
 	return <><JsxElement /></>;
@@ -23,56 +24,97 @@ withJsxElementInvalid.jsx:1:1 lint/complexity/noUselessFragments  FIXABLE  ━�
 
   i This fragment is unnecessary.
   
-  > 1 │ <><Component /></>
+  > 1 │ <><Component /></>;
       │ ^^^^^^^^^^^^^^^^^^
-    2 │ 
-    3 │ function jsxElement() {
+    2 │ <Fragment><Component /></Fragment>;
+    3 │ <React.Fragment><Component /></React.Fragment>;
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
   i Unsafe fix: Remove the Fragment
   
-    1 │ <><Component·/></>
-      │  --          ---  
+    1 │ <><Component·/></>;
+      │  --          ---   
 
 ```
 
 ```
-withJsxElementInvalid.jsx:4:9 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+withJsxElementInvalid.jsx:2:1 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i This fragment is unnecessary.
   
-    3 │ function jsxElement() {
-  > 4 │ 	return <><JsxElement /></>;
-      │ 	       ^^^^^^^^^^^^^^^^^^^
-    5 │ }
-    6 │ 
+    1 │ <><Component /></>;
+  > 2 │ <Fragment><Component /></Fragment>;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ <React.Fragment><Component /></React.Fragment>;
+    4 │ 
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
   i Unsafe fix: Remove the Fragment
   
-    4 │ → return·<><JsxElement·/></>;
+    2 │ <Fragment><Component·/></Fragment>;
+      │  ----------           -----------  
+
+```
+
+```
+withJsxElementInvalid.jsx:3:1 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    1 │ <><Component /></>;
+    2 │ <Fragment><Component /></Fragment>;
+  > 3 │ <React.Fragment><Component /></React.Fragment>;
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+    5 │ function jsxElement() {
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    3 │ <React.Fragment><Component·/></React.Fragment>;
+      │  ----------------           -----------------  
+
+```
+
+```
+withJsxElementInvalid.jsx:6:9 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    5 │ function jsxElement() {
+  > 6 │ 	return <><JsxElement /></>;
+      │ 	       ^^^^^^^^^^^^^^^^^^^
+    7 │ }
+    8 │ 
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    6 │ → return·<><JsxElement·/></>;
       │           --           ---   
 
 ```
 
 ```
-withJsxElementInvalid.jsx:8:10 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━
+withJsxElementInvalid.jsx:10:10 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━
 
   i This fragment is unnecessary.
   
-     7 │ function jsxElement() {
-   > 8 │ 	return (<><JsxElement /></>);
+     9 │ function jsxElement() {
+  > 10 │ 	return (<><JsxElement /></>);
        │ 	        ^^^^^^^^^^^^^^^^^^^
-     9 │ }
-    10 │ 
+    11 │ }
+    12 │ 
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
   i Unsafe fix: Remove the Fragment
   
-    8 │ → return·(<><JsxElement·/></>);
-      │            --           ---    
+    10 │ → return·(<><JsxElement·/></>);
+       │            --           ---    
 
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxExpressionChildValid.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxExpressionChildValid.jsx
@@ -2,3 +2,12 @@
 function jsxExpressionChild() {
     return <>{foo}</>
 }
+
+function jsxExpressionChildFragment() {
+	return <Fragment>{foo}</Fragment>
+}
+
+function jsxExpressionChildReactFragment() {
+	return <React.Fragment>{foo}</React.Fragment>
+}
+

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxExpressionChildValid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxExpressionChildValid.jsx.snap
@@ -9,4 +9,13 @@ function jsxExpressionChild() {
     return <>{foo}</>
 }
 
+function jsxExpressionChildFragment() {
+	return <Fragment>{foo}</Fragment>
+}
+
+function jsxExpressionChildReactFragment() {
+	return <React.Fragment>{foo}</React.Fragment>
+}
+
+
 ```

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxTextInvalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxTextInvalid.jsx
@@ -1,1 +1,3 @@
 <>foo</>
+<Fragment>foo</Fragment>
+<React.Fragment>foo</React.Fragment>

--- a/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxTextInvalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noUselessFragments/withJsxTextInvalid.jsx.snap
@@ -1,11 +1,13 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: withJsxTextInvalid.jsx
-snapshot_kind: text
 ---
 # Input
 ```jsx
 <>foo</>
+<Fragment>foo</Fragment>
+<React.Fragment>foo</React.Fragment>
+
 ```
 
 # Diagnostics
@@ -16,13 +18,41 @@ withJsxTextInvalid.jsx:1:1 lint/complexity/noUselessFragments  FIXABLE  ━━�
   
   > 1 │ <>foo</>
       │ ^^^^^^^^
+    2 │ <Fragment>foo</Fragment>
+    3 │ <React.Fragment>foo</React.Fragment>
   
   i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
   
   i Unsafe fix: Remove the Fragment
   
-  - <>foo</>
-  + "foo"
+    1   │ - <>foo</>
+      1 │ + "foo"
+    2 2 │   <Fragment>foo</Fragment>
+    3 3 │   <React.Fragment>foo</React.Fragment>
+  
+
+```
+
+```
+withJsxTextInvalid.jsx:3:1 lint/complexity/noUselessFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i This fragment is unnecessary.
+  
+    1 │ <>foo</>
+    2 │ <Fragment>foo</Fragment>
+  > 3 │ <React.Fragment>foo</React.Fragment>
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 
+  
+  i A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a keyed fragment.
+  
+  i Unsafe fix: Remove the Fragment
+  
+    1 1 │   <>foo</>
+    2 2 │   <Fragment>foo</Fragment>
+    3   │ - <React.Fragment>foo</React.Fragment>
+      3 │ + "foo"
+    4 4 │   
   
 
 ```


### PR DESCRIPTION
## Summary

Fixes #6688 

Fixed the `noUselessFragments` rule used different logic for shorthand fragments (`<></>`) and Fragment elements (`<Fragment></Fragment>`), causing some false positives only on the latter.

## Test Plan

Updated snapshot tests.
