### PR TITLE
fix(service): biome/file_features still should return a map instead of an array

### DIFF
--- a/crates/biome_cli/src/execute/process_file.rs
+++ b/crates/biome_cli/src/execute/process_file.rs
@@ -11,7 +11,7 @@ use biome_analyze::RuleCategoriesBuilder;
 use biome_diagnostics::{DiagnosticExt, DiagnosticTags, Error, category};
 use biome_fs::BiomePath;
 use biome_service::workspace::{
-    DocumentFileSource, FeatureKind, SupportKind, SupportsFeatureParams,
+    DocumentFileSource, FeatureKind, FileFeaturesResult, SupportKind, SupportsFeatureParams,
 };
 use check::check_file;
 use format::format;
@@ -128,7 +128,9 @@ impl<'ctx, 'app> Deref for SharedTraversalOptions<'ctx, 'app> {
 /// write mode is enabled
 pub(crate) fn process_file(ctx: &TraversalOptions, biome_path: &BiomePath) -> FileResult {
     let _ = tracing::trace_span!("process_file", path = ?biome_path).entered();
-    let file_features = ctx
+    let FileFeaturesResult {
+        features_supported: file_features,
+    } = ctx
         .workspace
         .file_features(SupportsFeatureParams {
             project_key: ctx.project_key,

--- a/crates/biome_cli/src/execute/process_file/check.rs
+++ b/crates/biome_cli/src/execute/process_file/check.rs
@@ -6,12 +6,12 @@ use biome_analyze::RuleCategoriesBuilder;
 use biome_diagnostics::DiagnosticExt;
 use biome_fs::{BiomePath, TraversalContext};
 use biome_service::diagnostics::FileTooLarge;
-use biome_service::workspace::FileFeaturesResult;
+use biome_service::workspace::FeaturesSupported;
 
 pub(crate) fn check_file<'ctx>(
     ctx: &'ctx SharedTraversalOptions<'ctx, '_>,
     path: BiomePath,
-    file_features: FileFeaturesResult,
+    file_features: FeaturesSupported,
 ) -> FileResult {
     let mut has_failures = false;
     let mut workspace_file = WorkspaceFile::new(ctx, path)?;

--- a/crates/biome_cli/src/execute/std_in.rs
+++ b/crates/biome_cli/src/execute/std_in.rs
@@ -14,7 +14,7 @@ use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileH
 use biome_service::projects::ProjectKey;
 use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DropPatternParams, FeaturesBuilder, FileContent,
-    FixFileParams, FormatFileParams, OpenFileParams, SupportsFeatureParams,
+    FileFeaturesResult, FixFileParams, FormatFileParams, OpenFileParams, SupportsFeatureParams,
 };
 use std::borrow::Cow;
 
@@ -39,7 +39,9 @@ pub(crate) fn run<'a>(
     }
 
     if mode.is_format() {
-        let file_features = workspace.file_features(SupportsFeatureParams {
+        let FileFeaturesResult {
+            features_supported: file_features,
+        } = workspace.file_features(SupportsFeatureParams {
             project_key,
             path: biome_path.clone(),
             features: FeaturesBuilder::new().with_formatter().build(),
@@ -108,8 +110,11 @@ pub(crate) fn run<'a>(
             document_file_source: None,
             persist_node_cache: false,
         })?;
+
         // apply fix file of the linter
-        let file_features = workspace.file_features(SupportsFeatureParams {
+        let FileFeaturesResult {
+            features_supported: file_features,
+        } = workspace.file_features(SupportsFeatureParams {
             project_key,
             path: biome_path.clone(),
             features: FeaturesBuilder::new()

--- a/crates/biome_cli/src/execute/traverse.rs
+++ b/crates/biome_cli/src/execute/traverse.rs
@@ -11,7 +11,9 @@ use biome_diagnostics::{DiagnosticExt, Error, Resource, Severity, category};
 use biome_fs::{BiomePath, FileSystem, PathInterner};
 use biome_fs::{TraversalContext, TraversalScope};
 use biome_service::projects::ProjectKey;
-use biome_service::workspace::{DocumentFileSource, DropPatternParams, IsPathIgnoredParams};
+use biome_service::workspace::{
+    DocumentFileSource, DropPatternParams, FileFeaturesResult, IsPathIgnoredParams,
+};
 use biome_service::{Workspace, WorkspaceError, extension_error, workspace::SupportsFeatureParams};
 use camino::{Utf8Path, Utf8PathBuf};
 use crossbeam::channel::{Receiver, Sender, unbounded};
@@ -562,7 +564,9 @@ impl TraversalContext for TraversalOptions<'_, '_> {
         let can_read = DocumentFileSource::can_read(biome_path);
 
         let file_features = match file_features {
-            Ok(file_features) => {
+            Ok(FileFeaturesResult {
+                features_supported: file_features,
+            }) => {
                 if file_features.is_protected() {
                     self.protected_file(biome_path);
                     return false;

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -14,7 +14,7 @@ use biome_service::App;
 use biome_service::projects::ProjectKey;
 use biome_service::settings::Settings;
 use biome_service::workspace::{
-    DocumentFileSource, FeaturesBuilder, OpenProjectParams, OpenProjectResult,
+    DocumentFileSource, FeaturesBuilder, FileFeaturesResult, OpenProjectParams, OpenProjectResult,
     SupportsFeatureParams, UpdateSettingsParams,
 };
 use camino::{Utf8Path, Utf8PathBuf};
@@ -64,7 +64,9 @@ impl<'a> SpecTestFile<'a> {
             app.workspace.update_settings(settings).unwrap();
         }
         let mut input_file = BiomePath::new(file_path);
-        let can_format = app
+        let FileFeaturesResult {
+            features_supported: file_features,
+        } = app
             .workspace
             .file_features(SupportsFeatureParams {
                 project_key,
@@ -73,7 +75,7 @@ impl<'a> SpecTestFile<'a> {
             })
             .unwrap();
 
-        if can_format.supports_format() {
+        if file_features.supports_format() {
             let mut input_code = input_file.get_buffer_from_file();
 
             let (_, range_start_index, range_end_index) = strip_rome_placeholders(&mut input_code);

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -16,8 +16,8 @@ use biome_rowan::{TextRange, TextSize};
 use biome_service::WorkspaceError;
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::workspace::{
-    CheckFileSizeParams, FeaturesBuilder, FixFileMode, FixFileParams, GetFileContentParams,
-    IsPathIgnoredParams, PullActionsParams, SupportsFeatureParams,
+    CheckFileSizeParams, FeaturesBuilder, FileFeaturesResult, FixFileMode, FixFileParams,
+    GetFileContentParams, IsPathIgnoredParams, PullActionsParams, SupportsFeatureParams,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -69,7 +69,9 @@ pub(crate) fn code_actions(
         return Ok(Some(Vec::new()));
     }
 
-    let file_features = &session.workspace.file_features(SupportsFeatureParams {
+    let FileFeaturesResult {
+        features_supported: file_features,
+    } = &session.workspace.file_features(SupportsFeatureParams {
         project_key: doc.project_key,
         path: path.clone(),
         features,
@@ -295,7 +297,9 @@ fn fix_all(
         return Ok(None);
     }
 
-    let file_features = session.workspace.file_features(SupportsFeatureParams {
+    let FileFeaturesResult {
+        features_supported: file_features,
+    } = session.workspace.file_features(SupportsFeatureParams {
         project_key: doc.project_key,
         path: path.clone(),
         features: FeaturesBuilder::new()

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -16,11 +16,11 @@ use biome_service::WorkspaceError;
 use biome_service::configuration::{LoadedConfiguration, load_configuration, load_editorconfig};
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::projects::ProjectKey;
-use biome_service::workspace::ServiceDataNotification;
 use biome_service::workspace::{
     FeaturesBuilder, GetFileContentParams, OpenProjectParams, OpenProjectResult,
     PullDiagnosticsParams, SupportsFeatureParams,
 };
+use biome_service::workspace::{FileFeaturesResult, ServiceDataNotification};
 use biome_service::workspace::{RageEntry, RageParams, RageResult, UpdateSettingsParams};
 use biome_service::workspace::{ScanKind, ScanProjectFolderParams};
 use camino::Utf8Path;
@@ -401,7 +401,9 @@ impl Session {
             }
         }
 
-        let file_features = self.workspace.file_features(SupportsFeatureParams {
+        let FileFeaturesResult {
+            features_supported: file_features,
+        } = self.workspace.file_features(SupportsFeatureParams {
             project_key: doc.project_key,
             features: FeaturesBuilder::new().with_linter().with_assist().build(),
             path: biome_path.clone(),

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -1,7 +1,7 @@
 use crate::WorkspaceError;
 use crate::file_handlers::Capabilities;
 use crate::settings::Settings;
-use crate::workspace::{DocumentFileSource, FeatureName, FileFeaturesResult};
+use crate::workspace::{DocumentFileSource, FeatureName, FeaturesSupported, FileFeaturesResult};
 use biome_fs::ConfigName;
 use camino::{Utf8Path, Utf8PathBuf};
 use papaya::HashMap;
@@ -187,7 +187,7 @@ impl Projects {
             .find(|(project_path, _)| path.starts_with(project_path))
             .map_or(&project_data.root_settings, |(_, settings)| settings);
 
-        let mut file_features = FileFeaturesResult::new();
+        let mut file_features = FeaturesSupported::default();
         file_features = file_features.with_capabilities(capabilities);
         file_features = file_features.with_settings_and_language(settings, path, capabilities);
 
@@ -225,7 +225,9 @@ impl Projects {
             file_features.set_protected_for_all_features();
         }
 
-        Ok(file_features)
+        Ok(FileFeaturesResult {
+            features_supported: file_features,
+        })
     }
 
     /// Sets the root settings for the given project.

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -445,46 +445,7 @@ pub fn generate_type<'a>(
                     property = property.with_leading_trivia(trivia);
                 }
 
-                let type_annotation = if let Some((container_type, key_type, value_type)) =
-                    match property_str.as_str() {
-                        "featuresSupported" => Some(("Map", "FeatureKind", "SupportKind")),
-                        _ => None,
-                    } {
-                    // HACK: force the `featuresSupported` property to be a Map<FeatureKind, SupportKind>
-                    // This is a temporary workaround to fix the type annotation for this property. The
-                    // better fix would be to use the `transform` feature that is available in `schemars` 1.0 to
-                    // add a metadata field that we can pick up here to generate the correct type annotation.
-                    // Alternatively, we could generate these types based on the actual rust types instead of the
-                    // json schema.
-                    //
-                    // We also manually fix the types for some other properties as well.
-                    let full_type = make::ts_reference_type(
-                        make::js_reference_identifier(make::ident(container_type)).into(),
-                    )
-                    .with_type_arguments(make::ts_type_arguments(
-                        make::token(T![<]),
-                        make::ts_type_argument_list(
-                            [
-                                make::ts_reference_type(
-                                    make::js_reference_identifier(make::ident(key_type)).into(),
-                                )
-                                .build()
-                                .into(),
-                                make::ts_reference_type(
-                                    make::js_reference_identifier(make::ident(value_type)).into(),
-                                )
-                                .build()
-                                .into(),
-                            ],
-                            [make::token(T![,])],
-                        ),
-                        make::token(T![>]),
-                    ))
-                    .build();
-                    make::ts_type_annotation(make::token(T![:]), full_type.into())
-                } else {
-                    make::ts_type_annotation(make::token(T![:]), ts_type)
-                };
+                let type_annotation = make::ts_type_annotation(make::token(T![:]), ts_type);
 
                 let mut builder = make::ts_property_signature_type_member(
                     AnyJsObjectMemberName::from(make::js_literal_member_name(property)),

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -10,7 +10,7 @@ export type BiomePath = string;
 export type ProjectKey = number;
 export type FeatureKind = "format" | "lint" | "search" | "assist" | "debug";
 export interface FileFeaturesResult {
-	featuresSupported: Map<FeatureKind, SupportKind>;
+	featuresSupported: FeaturesSupported;
 }
 export type FeaturesSupported = { [K in FeatureKind]?: SupportKind };
 export type SupportKind =

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -12,6 +12,7 @@ export type FeatureKind = "format" | "lint" | "search" | "assist" | "debug";
 export interface FileFeaturesResult {
 	featuresSupported: Map<FeatureKind, SupportKind>;
 }
+export type FeaturesSupported = { [K in FeatureKind]?: SupportKind };
 export type SupportKind =
 	| "supported"
 	| "ignored"


### PR DESCRIPTION
## Summary

Fixed a regression from #6662 that broke the playground. cc @arendjr 

The `FileFeaturesResult` struct has changed in the PR, but it is also exposed to the WASM API and caused a type mismatch. I added a custom implementation of `serde::Serialize`, `serde::Deserialize`, and `schemars::JsonSchema` to keep it the same as before.

## Test Plan

Manually tested with the playground
