### PR TITLE
feat(linter): add $ to organize imports :ALIAS: group

### DIFF
--- a/.changeset/whole-parks-grab.md
+++ b/.changeset/whole-parks-grab.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": minor
+---
+
+Added `$` symbol to [organizeImports](https://biomejs.dev/assist/actions/organize-imports) `:ALIAS:` group.
+`import { action } from '$lib'` will be treated as alias import.
+

--- a/crates/biome_js_analyze/src/assist/source/organize_imports.rs
+++ b/crates/biome_js_analyze/src/assist/source/organize_imports.rs
@@ -160,7 +160,7 @@ declare_source_rule! {
     /// 1. URLs such as `https://example.org`.
     /// 2. Packages with a protocol such as `node:path`, `bun:test`, `jsr:@my?lib`, or `npm:lib`.
     /// 3. Packages such as `mylib` or `@my/lib`.
-    /// 4. Aliases: sources starting with `@/`, `#`, `~`, or `%`.
+    /// 4. Aliases: sources starting with `@/`, `#`, `~`, `$`, or `%`.
     ///    They usually are [Node.js subpath imports](https://nodejs.org/api/packages.html#subpath-imports) or [TypeScript path aliases](https://www.typescriptlang.org/tsconfig/#paths).
     /// 5. Absolute and relative paths.
     ///
@@ -257,7 +257,7 @@ declare_source_rule! {
     /// Predefined group matchers are strings in `CONSTANT_CASE` prefixed and suffixed by `:`.
     /// The sorter provides several predefined group matchers:
     ///
-    /// - `:ALIAS:`: sources starting with `#`, `@/`, `~`, or `%`.
+    /// - `:ALIAS:`: sources starting with `#`, `@/`, `~`, `$`, or `%`.
     /// - `:BUN:`: sources starting with the protocol `bun:` or that correspond to a built-in Bun module such as `bun`.
     /// - `:NODE:`: sources starting with the protocol `node:` or that correspond to a built-in Node.js module such as `fs` or `path`.
     /// - `:PACKAGE:`: scoped and bare packages.

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js
@@ -1,0 +1,9 @@
+/* should generate diagnostics */
+import { aa } from './aa'
+import { a } from '%f'
+import { b } from '#b'
+import { bb } from './bb'
+import { c } from '~c'
+import { d } from '@/d'
+import { cc } from '../cc'
+import { e } from '$e'

--- a/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
+++ b/crates/biome_js_analyze/tests/specs/source/organizeImports/unsorted-alias.js.snap
@@ -1,0 +1,53 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: unsorted-alias.js
+---
+# Input
+```js
+/* should generate diagnostics */
+import { aa } from './aa'
+import { a } from '%f'
+import { b } from '#b'
+import { bb } from './bb'
+import { c } from '~c'
+import { d } from '@/d'
+import { cc } from '../cc'
+import { e } from '$e'
+
+```
+
+# Diagnostics
+```
+unsorted-alias.js:2:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The imports and exports are not sorted.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import { aa } from './aa'
+      │ ^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ import { a } from '%f'
+    4 │ import { b } from '#b'
+  
+  i Safe fix: Organize Imports (Biome)
+  
+     1  1 │   /* should generate diagnostics */
+     2    │ - import·{·aa·}·from·'./aa'
+     3    │ - import·{·a·}·from·'%f'
+     4    │ - import·{·b·}·from·'#b'
+     5    │ - import·{·bb·}·from·'./bb'
+        2 │ + 
+        3 │ + import·{·b·}·from·'#b'
+        4 │ + import·{·d·}·from·'@/d'
+        5 │ + import·{·a·}·from·'%f'
+        6 │ + import·{·e·}·from·'$e'
+     6  7 │   import { c } from '~c'
+     7    │ - import·{·d·}·from·'@/d'
+     8    │ - import·{·cc·}·from·'../cc'
+     9    │ - import·{·e·}·from·'$e'
+        8 │ + import·{·cc·}·from·'../cc'
+        9 │ + import·{·aa·}·from·'./aa'
+       10 │ + import·{·bb·}·from·'./bb'
+    10 11 │   
+  
+
+```

--- a/crates/biome_rule_options/src/organize_imports/import_source.rs
+++ b/crates/biome_rule_options/src/organize_imports/import_source.rs
@@ -81,7 +81,7 @@ pub enum ImportSourceKind {
     ProtocolPackage,
     /// `package`
     Package,
-    /// Import sources that start with `@/`, `#`, `~`, or `%`
+    /// Import sources that start with `@/`, `#`, `~`, `$`, or `%`
     /// Node.js subpath imports and TypeScript aliases.
     Alias,
     /// Import sources that start with `/`, `./`, or `../`
@@ -102,7 +102,7 @@ impl ImportSourceKind {
                 }
             }
             // Node.js subpath imports
-            Some(b'#' | b'~' | b'%') => Self::Alias,
+            Some(b'#' | b'~' | b'$' | b'%') => Self::Alias,
             Some(b'/') => Self::Path,
             Some(b'.') => match iter.next() {
                 Some(b'.') => {


### PR DESCRIPTION
## Summary

Adds `$` to organize imports `:ALIAS:` group.
Frameworks like:
- [Sveltekit](https://svelte.dev/docs/kit/$lib) `import '$lib'`
- [Fresh](https://fresh.deno.dev/docs/concepts/routes) `import '$fresh/server.ts'`

use them as path alias.

## Test Plan

Added new snapshot with all possible aliases