### PR TITLE
fix(core): .gitignore is discovered in more scenarios

### DIFF
--- a/.changeset/ignored-iguanodons-ignite.md
+++ b/.changeset/ignored-iguanodons-ignite.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": minor
+---
+
+Fixed [#6646](https://github.com/biomejs/biome/issues/6646): `.gitignore` files
+are now picked up even when running Biome from a nested directory, or when the
+ignore file itself is ignored through `files.includes`.

--- a/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/use_root_gitignore_when_running_from_subdirectory.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_vcs_ignored_files/use_root_gitignore_when_running_from_subdirectory.snap
@@ -1,0 +1,67 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "files": {
+    "includes": ["packages/**"]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  }
+}
+```
+
+## `.gitignore`
+
+```gitignore
+dist/
+```
+
+## `packages/lib/dist/out.js`
+
+```js
+foo.call(); bar.call();
+```
+
+## `packages/lib/src/in.js`
+
+```js
+foo.call(); bar.call();
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+src/in.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - foo.call();·bar.call();
+      1 │ + foo.call();
+      2 │ + bar.call();
+      3 │ + 
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+Found 1 error.
+```

--- a/crates/biome_fs/src/path.rs
+++ b/crates/biome_fs/src/path.rs
@@ -170,7 +170,7 @@ impl BiomePath {
     pub fn is_dependency(&self) -> bool {
         self.path
             .components()
-            .any(|component| component.as_str() == "node_modules")
+            .any(|component| component.as_str().as_bytes() == b"node_modules")
     }
 
     /// Whether this is a file named `package.json`

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -329,12 +329,14 @@ impl TraversalContext for ScanContext<'_> {
             }
             Ok(PathKind::File { .. }) => match &self.scan_kind {
                 ScanKind::KnownFiles | ScanKind::TargetedKnownFiles { .. } => {
-                    path.is_required_during_scan()
-                        && !path.is_dependency()
-                        && !self
+                    if path.is_config() {
+                        !self
                             .workspace
                             .projects
                             .is_ignored_by_top_level_config(self.project_key, path)
+                    } else {
+                        path.is_ignore() || path.is_manifest()
+                    }
                 }
                 ScanKind::Project => {
                     if path.is_dependency() {


### PR DESCRIPTION
## Summary

Fixed [#6646](https://github.com/biomejs/biome/issues/6646): `.gitignore` files are now picked up even when running Biome from a nested directory, or when the ignore file itself is ignored through `files.includes`.

## Test Plan

Added a test case.
