### PR TITLE
fix(cli): improve error messages when given incompatible arguments

### DIFF
--- a/.changeset/itchy-bananas-retire.md
+++ b/.changeset/itchy-bananas-retire.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the error messages when Biome is provided incompatible arguments on the CLI.

--- a/crates/biome_cli/src/commands/ci.rs
+++ b/crates/biome_cli/src/commands/ci.rs
@@ -132,7 +132,11 @@ impl CommandRunner for CiCommandPayload {
             ));
         }
         if self.since.is_some() && !self.changed {
-            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+            return Err(CliDiagnostic::incompatible_arguments(
+                "--since",
+                "--changed",
+                "In order to use --since, you must also use --changed.",
+            ));
         }
         Ok(())
     }

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -719,16 +719,28 @@ fn get_files_to_process_with_cli_options(
 ) -> Result<Option<Vec<OsString>>, CliDiagnostic> {
     if since.is_some() {
         if !changed {
-            return Err(CliDiagnostic::incompatible_arguments("since", "changed"));
+            return Err(CliDiagnostic::incompatible_arguments(
+                "--since",
+                "--changed",
+                "In order to use --since, you must also use --changed.",
+            ));
         }
         if staged {
-            return Err(CliDiagnostic::incompatible_arguments("since", "staged"));
+            return Err(CliDiagnostic::incompatible_arguments(
+                "--since",
+                "--staged",
+                "--staged selects files that you have staged in version control. --since can't be used in this context.",
+            ));
         }
     }
 
     if changed {
         if staged {
-            return Err(CliDiagnostic::incompatible_arguments("changed", "staged"));
+            return Err(CliDiagnostic::incompatible_arguments(
+                "--changed",
+                "--staged",
+                "--staged selects files that you have staged in version control. --changed selects files that have been committed since your default branch. You must either use --changed or --staged, but not both.",
+            ));
         }
         Ok(Some(get_changed_files(fs, configuration, since)?))
     } else if staged {
@@ -787,14 +799,23 @@ fn check_fix_incompatible_arguments(options: FixFileModeOptions) -> Result<(), C
         ..
     } = options;
     if write && fix {
-        return Err(CliDiagnostic::incompatible_arguments("--write", "--fix"));
+        return Err(CliDiagnostic::incompatible_arguments(
+            "--write",
+            "--fix",
+            "These arguments do the same thing, but --fix is deprecated. Prefer to use --write.",
+        ));
     } else if suppress && write {
         return Err(CliDiagnostic::incompatible_arguments(
             "--suppress",
             "--write",
+            "--write is used to write fixes, and --suppress is used to suppress diagnostics. Remove one of these arguments depending on what you want to do.",
         ));
     } else if suppress && fix {
-        return Err(CliDiagnostic::incompatible_arguments("--suppress", "--fix"));
+        return Err(CliDiagnostic::incompatible_arguments(
+            "--suppress",
+            "--fix",
+            "--fix is used to write fixes, and --suppress is used to suppress diagnostics. Remove one of these arguments depending on what you want to do. Also, --fix is deprecated. Prefer to use --write.",
+        ));
     } else if !suppress && suppression_reason.is_some() {
         return Err(CliDiagnostic::unexpected_argument(
             "--reason",

--- a/crates/biome_cli/src/diagnostics.rs
+++ b/crates/biome_cli/src/diagnostics.rs
@@ -145,12 +145,13 @@ pub struct EmptyArguments;
     severity = Error,
     message(
         description = "Incompatible arguments {first_argument} and {second_argument}",
-        message("Incompatible arguments "<Emphasis>{self.first_argument}</Emphasis>" and "<Emphasis>{self.second_argument}</Emphasis>)
+        message("Incompatible arguments "<Emphasis>{self.first_argument}</Emphasis>" and "<Emphasis>{self.second_argument}</Emphasis>". "{self.reason})
     )
 )]
 pub struct IncompatibleArguments {
     first_argument: String,
     second_argument: String,
+    reason: String,
 }
 
 #[derive(Debug, Diagnostic)]
@@ -307,10 +308,12 @@ impl CliDiagnostic {
     pub fn incompatible_arguments(
         first_argument: impl Into<String>,
         second_argument: impl Into<String>,
+        reason: impl Into<String>,
     ) -> Self {
         Self::IncompatibleArguments(IncompatibleArguments {
             first_argument: first_argument.into(),
             second_argument: second_argument.into(),
+            reason: reason.into(),
         })
     }
 

--- a/crates/biome_cli/tests/snapshots/main_cases_suppressions/err_when_both_write_and_suppress_are_passed.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_suppressions/err_when_both_write_and_suppress_are_passed.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-assertion_line: 423
-expression: content
+expression: redactor(content)
 ---
 ## `check.js`
 
@@ -15,7 +14,7 @@ statement();
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments --suppress and --write
+  × Incompatible arguments --suppress and --write. --write is used to write fixes, and --suppress is used to suppress diagnostics. Remove one of these arguments depending on what you want to do.
   
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_check/fix_suggested_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/fix_suggested_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `fix.js`
 
@@ -16,7 +16,7 @@ console.log(a);
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments --write and --fix
+  × Incompatible arguments --write and --fix. These arguments do the same thing, but --fix is deprecated. Prefer to use --write.
   
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/fix_suggested_error.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/fix_suggested_error.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `fix.js`
 
@@ -16,7 +16,7 @@ console.log(a);
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments --write and --fix
+  × Incompatible arguments --write and --fix. These arguments do the same thing, but --fix is deprecated. Prefer to use --write.
   
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_changed_flag_and_staged_flag_are_active_at_the_same_time.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_changed_flag_and_staged_flag_are_active_at_the_same_time.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Termination Message
 
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments changed and staged
+  × Incompatible arguments --changed and --staged. --staged selects files that you have staged in version control. --changed selects files that have been committed since your default branch. You must either use --changed or --staged, but not both.
   
 
 

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_since_arg_is_used_without_changed.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_error_if_since_arg_is_used_without_changed.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.js`
 
@@ -19,10 +19,8 @@ console.log('file2');
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments since and changed
+  × Incompatible arguments --since and --changed. In order to use --since, you must also use --changed.
   
 
 
 ```
-
-

--- a/crates/biome_cli/tests/snapshots/main_commands_migrate/should_suggest_error_incompatible_arguments.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_migrate/should_suggest_error_incompatible_arguments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `biome.json`
 
@@ -13,7 +13,7 @@ expression: content
 ```block
 flags/invalid ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Incompatible arguments --write and --fix
+  × Incompatible arguments --write and --fix. These arguments do the same thing, but --fix is deprecated. Prefer to use --write.
   
 
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The error messages we provided previously in these cases resulted in some confusing error messages, particularly when `--since` was provided without `--changed`. This fixes that.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
partially addresses #4225. I didn't link the issue in the changeset because the issue is primarily something different.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Updated snapshots.
