### PR TITLE
fix(grit): match bare imports

### DIFF
--- a/.changeset/bare-beasts-bark.md
+++ b/.changeset/bare-beasts-bark.md
@@ -1,0 +1,20 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6573](https://github.com/biomejs/biome/issues/6573): Grit plugins can
+now match bare imports.
+
+## Example
+
+The following snippet:
+
+```grit
+`import $source`
+```
+
+will now match:
+
+```ts
+import "main.css";
+```

--- a/crates/biome_grit_patterns/tests/specs/ts/bareImport.grit
+++ b/crates/biome_grit_patterns/tests/specs/ts/bareImport.grit
@@ -1,0 +1,1 @@
+`import $source`

--- a/crates/biome_grit_patterns/tests/specs/ts/bareImport.snap
+++ b/crates/biome_grit_patterns/tests/specs/ts/bareImport.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_grit_patterns/tests/spec_tests.rs
+expression: bareImport
+---
+SnapshotResult {
+    messages: [],
+    matched_ranges: [
+        "1:1-1:19",
+    ],
+    rewritten_files: [],
+    created_files: [],
+}

--- a/crates/biome_grit_patterns/tests/specs/ts/bareImport.ts
+++ b/crates/biome_grit_patterns/tests/specs/ts/bareImport.ts
@@ -1,0 +1,1 @@
+import "main.css";


### PR DESCRIPTION
## Summary

Fixed [#6573](https://github.com/biomejs/biome/issues/6573): Grit plugins can now match bare imports.

## Example

The following snippet:

```grit
`import $source`
```

will now match:

```ts
import "main.css";
```

## Test Plan

Test added
