### PR TITLE
perf(biome_package): updated incorrect generic passed to deserialize_…

### DIFF
--- a/.changeset/tsconfig_json_parse_update_incorrect_generic.md
+++ b/.changeset/tsconfig_json_parse_update_incorrect_generic.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Resolved [#6745](hhttps://github.com/biomejs/biome/issues/6745): Updated perf test for `tsconfig.json` parsing to use the correct generic type.

--- a/crates/biome_package/benches/tsconfig_json.rs
+++ b/crates/biome_package/benches/tsconfig_json.rs
@@ -1,6 +1,6 @@
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_json_parser::JsonParserOptions;
-use biome_package::PackageJson;
+use biome_package::TsConfigJson;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 #[cfg(target_os = "windows")]
@@ -28,7 +28,7 @@ fn bench_tsconfig(criterion: &mut Criterion) {
         &code,
         |b, _| {
             b.iter(|| {
-                black_box(deserialize_from_json_str::<PackageJson>(
+                black_box(deserialize_from_json_str::<TsConfigJson>(
                     code,
                     JsonParserOptions::default(),
                     "tsconfig.json",


### PR DESCRIPTION
## Summary

 Updated perf test for `tsconfig.json` parsing to use the correct generic type.

Closes [#6745]
