### PR TITLE
chore: don't break up paragraphs in changesets

### DIFF
--- a/.changeset/angry-asses-attack.md
+++ b/.changeset/angry-asses-attack.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": minor
 ---
 
-The rule [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-misused-promises/)
-can now detect floating arrays of `Promise`s.
+The rule [`noFloatingPromises`](https://biomejs.dev/linter/rules/no-misused-promises/) can now detect floating arrays of `Promise`s.
 
 **Invalid examples**
 

--- a/.changeset/bare-beasts-bark.md
+++ b/.changeset/bare-beasts-bark.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6573](https://github.com/biomejs/biome/issues/6573): Grit plugins can
-now match bare imports.
+Fixed [#6573](https://github.com/biomejs/biome/issues/6573): Grit plugins can now match bare imports.
 
 **Example**
 

--- a/.changeset/cold-houses-melt.md
+++ b/.changeset/cold-houses-melt.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#4494](https://github.com/biomejs/biome/issues/4494): The `noSecrets`
-rule now correctly uses the `entropyThreshold` option to detect secret like
-strings.
+Fixed [#4494](https://github.com/biomejs/biome/issues/4494): The `noSecrets` rule now correctly uses the `entropyThreshold` option to detect secret like strings.

--- a/.changeset/conditional-clauses-check.md
+++ b/.changeset/conditional-clauses-check.md
@@ -4,8 +4,7 @@
 
 Type inference is now able to handle ternary conditions in type aliases.
 
-Note that we don't attempt to evaluate the condition itself. The resulting type
-is simply a union of both conditional outcomes.
+Note that we don't attempt to evaluate the condition itself. The resulting type is simply a union of both conditional outcomes.
 
 **Example**
 

--- a/.changeset/consequtive_commas_collaborate.md
+++ b/.changeset/consequtive_commas_collaborate.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": minor
 ---
 
-Type inference is now able to handle the sequence operator (`,`), as well as
-post- and pre-update operators: `++`.
+Type inference is now able to handle the sequence operator (`,`), as well as post- and pre-update operators: `++`.
 
 **Example**
 

--- a/.changeset/dry-frogs-push.md
+++ b/.changeset/dry-frogs-push.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6654](https://github.com/biomejs/biome/issues/6654): Fixed range
-highlighting of `<explanation>` placeholder in inline suppression block
-comments.
+Fixed [#6654](https://github.com/biomejs/biome/issues/6654): Fixed range highlighting of `<explanation>` placeholder in inline suppression block comments.

--- a/.changeset/five-dodos-promise.md
+++ b/.changeset/five-dodos-promise.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6669](https://github.com/biomejs/biome/issues/6669): Added an exception
-to `noUnusedImports` to allow type augmentation imports.
+Fixed [#6669](https://github.com/biomejs/biome/issues/6669): Added an exception to `noUnusedImports` to allow type augmentation imports.
 
 ```ts
 import type {} from "@mui/lab/themeAugmentation";

--- a/.changeset/fix_capabilities_dynamic_registration.md
+++ b/.changeset/fix_capabilities_dynamic_registration.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#4994]([https://github.com/biomejs/biome/discussions/4994): LSP server
-registered some capabilities even when the client did not support dynamic
-registration.
+Fixed [#4994]([https://github.com/biomejs/biome/discussions/4994): LSP server registered some capabilities even when the client did not support dynamic registration.

--- a/.changeset/fix_no_focused_tests_diagnostic_message_to_have_correct_fn_name.md
+++ b/.changeset/fix_no_focused_tests_diagnostic_message_to_have_correct_fn_name.md
@@ -2,13 +2,9 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6380](https://github.com/biomejs/biome/issues/6380): The
-`noFocusedTests` rule now correctly displays the function name in the diagnostic
-message when a test is focused.
+Fixed [#6380](https://github.com/biomejs/biome/issues/6380): The `noFocusedTests` rule now correctly displays the function name in the diagnostic message when a test is focused.
 
-Every instance of a focused test function (like `fdescribe`, `fit`, `ftest` and
-`only`) had the word 'only' hardcoded. This has been updated to use the actual
-function name, so the message is now more accurate and specific.
+Every instance of a focused test function (like `fdescribe`, `fit`, `ftest` and `only`) had the word 'only' hardcoded. This has been updated to use the actual function name, so the message is now more accurate and specific.
 
 Example for `fdescribe`:
 

--- a/.changeset/fix_use_readonly_class_properties_to__flag_mutation_in_class_getter.md
+++ b/.changeset/fix_use_readonly_class_properties_to__flag_mutation_in_class_getter.md
@@ -2,9 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6634](https://github.com/biomejs/biome/issues/6634): The
-`useReadonlyClassProperties` rule now correctly flags mutations in class getters
-and in arrow functions within class properties.
+Fixed [#6634](https://github.com/biomejs/biome/issues/6634): The `useReadonlyClassProperties` rule now correctly flags mutations in class getters and in arrow functions within class properties.
 
 Examples:
 

--- a/.changeset/free-owls-check.md
+++ b/.changeset/free-owls-check.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6668](https://github.com/biomejs/biome/issues/6668): Biome Assist is now
-enabled by default for CSS files.
+Fixed [#6668](https://github.com/biomejs/biome/issues/6668): Biome Assist is now enabled by default for CSS files.

--- a/.changeset/funky-functions-follow.md
+++ b/.changeset/funky-functions-follow.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Type inference can now infer the return types of functions and methods without
-annotations.
+Type inference can now infer the return types of functions and methods without annotations.
 
 **Examples**
 

--- a/.changeset/happy-berries-fail.md
+++ b/.changeset/happy-berries-fail.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-`organizeImports` is now able to sort named specifiers and import attributes
-with bogus nodes.
+`organizeImports` is now able to sort named specifiers and import attributes with bogus nodes.

--- a/.changeset/heavy-signs-judge.md
+++ b/.changeset/heavy-signs-judge.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6610](https://github.com/biomejs/biome/issues/6610): JSON import
-attributes are now correctly detected when they contain extra whitespace.
+Fixed [#6610](https://github.com/biomejs/biome/issues/6610): JSON import attributes are now correctly detected when they contain extra whitespace.

--- a/.changeset/ignored-iguanodons-ignite.md
+++ b/.changeset/ignored-iguanodons-ignite.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": minor
 ---
 
-Fixed [#6646](https://github.com/biomejs/biome/issues/6646): `.gitignore` files
-are now picked up even when running Biome from a nested directory, or when the
-ignore file itself is ignored through `files.includes`.
+Fixed [#6646](https://github.com/biomejs/biome/issues/6646): `.gitignore` files are now picked up even when running Biome from a nested directory, or when the ignore file itself is ignored through `files.includes`.

--- a/.changeset/itchy-bananas-retire.md
+++ b/.changeset/itchy-bananas-retire.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Improved the error messages when Biome is provided incompatible arguments on the
-CLI.
+Improved the error messages when Biome is provided incompatible arguments on the CLI.

--- a/.changeset/itchy-cloths-brush.md
+++ b/.changeset/itchy-cloths-brush.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6491](https://github.com/biomejs/biome/issues/6491): The action of
-`useSortedKeys` removed comments or wrongly transferred them to distinct nodes.
+Fixed [#6491](https://github.com/biomejs/biome/issues/6491): The action of `useSortedKeys` removed comments or wrongly transferred them to distinct nodes.

--- a/.changeset/long-glasses-know.md
+++ b/.changeset/long-glasses-know.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6633](https://github.com/biomejs/biome/6633): The `noImplicitCoercion`
-rule no longer reports diagnostics for `1 / value` expressions.
+Fixed [#6633](https://github.com/biomejs/biome/6633): The `noImplicitCoercion` rule no longer reports diagnostics for `1 / value` expressions.
 
 ```js
 1 / value // no error

--- a/.changeset/loud-seals-fry.md
+++ b/.changeset/loud-seals-fry.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6537](https://github.com/biomejs/biome/issues/6537): Biome no longer
-removes the trailing comma from JSON files when
-`formatter.json.trailingCommas` is explicitly set to `"all"`.
+Fixed [#6537](https://github.com/biomejs/biome/issues/6537): Biome no longer removes the trailing comma from JSON files when `formatter.json.trailingCommas` is explicitly set to `"all"`.

--- a/.changeset/lucky-adults-rhyme.md
+++ b/.changeset/lucky-adults-rhyme.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6691](https://github.com/biomejs/biome/issues/6691): The HTML parser
-will now consider `.` to be a valid character for tag names.
+Fixed [#6691](https://github.com/biomejs/biome/issues/6691): The HTML parser will now consider `.` to be a valid character for tag names.

--- a/.changeset/lucky-parrots-marry.md
+++ b/.changeset/lucky-parrots-marry.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-The Biome LSP server no longer responds with an error for a
-`textDocument/codeActions` request when Biome doesn't support a feature for the
-file (e.g. Code actions aren't supported in GritQL files).
+The Biome LSP server no longer responds with an error for a `textDocument/codeActions` request when Biome doesn't support a feature for the file (e.g. Code actions aren't supported in GritQL files).

--- a/.changeset/modern-turtles-exist.md
+++ b/.changeset/modern-turtles-exist.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#4677](https://github.com/biomejs/biome/issues/4677): The
-`noUnusedImports` rule won't produce diagnostics for types used in comments of
-static members anymore.
+Fixed [#4677](https://github.com/biomejs/biome/issues/4677): The `noUnusedImports` rule won't produce diagnostics for types used in comments of static members anymore.

--- a/.changeset/muddy-migrations-melt.md
+++ b/.changeset/muddy-migrations-melt.md
@@ -2,8 +2,6 @@
 "@biomejs/biome": minor
 ---
 
-`biome migrate` no longer enables style rules that were recommended in v1,
-because that would be undesirable for users upgrading from 2.0.
+`biome migrate` no longer enables style rules that were recommended in v1, because that would be undesirable for users upgrading from 2.0.
 
-Users who are upgrading from Biome 1.x are therefore advised to first upgrade to
-Biome 2.0, and run the migration, before continuing to Biome 2.1 or later.
+Users who are upgrading from Biome 1.x are therefore advised to first upgrade to Biome 2.0, and run the migration, before continuing to Biome 2.1 or later.

--- a/.changeset/muddy-mules-meander.md
+++ b/.changeset/muddy-mules-meander.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": minor
 ---
 
-Added the nursery rule
-[`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/).
+Added the nursery rule [`noMisusedPromises`](https://biomejs.dev/linter/rules/no-misused-promises/).
 
 It signals `Promise`s in places where conditionals or iterables are expected.
 

--- a/.changeset/nested-nettles-neglect.md
+++ b/.changeset/nested-nettles-neglect.md
@@ -2,10 +2,6 @@
 "@biomejs/biome": patch
 ---
 
-If a nested configuration file is ignored by the root configuration, it will now
-actually be ignored.
+If a nested configuration file is ignored by the root configuration, it will now actually be ignored.
 
-Biome has an exception in place for configuration files so they cannot be
-ignored, because the configuration files are vital to Biome itself. But this
-exception was incorrectly applied to nested configurations as well. Now only the
-root configuration is exempt from being ignored.
+Biome has an exception in place for configuration files so they cannot be ignored, because the configuration files are vital to Biome itself. But this exception was incorrectly applied to nested configurations as well. Now only the root configuration is exempt from being ignored.

--- a/.changeset/ninety-parks-grab.md
+++ b/.changeset/ninety-parks-grab.md
@@ -2,9 +2,6 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6566](https://github.com/biomejs/biome/issues/6566): Biome no longer
-errors when using the option `--files-ignore-unknown=true` in `stdin` mode.
+Fixed [#6566](https://github.com/biomejs/biome/issues/6566): Biome no longer errors when using the option `--files-ignore-unknown=true` in `stdin` mode.
 
-Biome has also become less strict when using `--stdin-file-path` in `stdin`
-mode. It will no longer error if the file path doesn't contain an extension, but
-instead it will return the original content.
+Biome has also become less strict when using `--stdin-file-path` in `stdin` mode. It will no longer error if the file path doesn't contain an extension, but instead it will return the original content.

--- a/.changeset/no_magic_numbers.md
+++ b/.changeset/no_magic_numbers.md
@@ -2,10 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Added the nursery rule
-[noMagicNumbers](https://github.com/biomejs/biome/issues/4333). The rule detects
-and reports the use of "magic numbers" — numeric literals that are used directly
-in code without being assigned to a named constant.
+Added the nursery rule [noMagicNumbers](https://github.com/biomejs/biome/issues/4333). The rule detects and reports the use of "magic numbers" — numeric literals that are used directly in code without being assigned to a named constant.
 
 **Example**
 

--- a/.changeset/no_unused_function_parameters_add_option_ignore_rest_siblings.md
+++ b/.changeset/no_unused_function_parameters_add_option_ignore_rest_siblings.md
@@ -2,10 +2,11 @@
 "@biomejs/biome": minor
 ---
 
-Added [ignoreRestSiblings](https://github.com/biomejs/biome/issues/5941) option
-to `noUnusedFunctionParameters` rule to ignore unused function parameters that
-are siblings of the rest parameter. Default is `false`, which means that unused
-function parameters that are siblings of the rest parameter will be reported.
+Added the `ignoreRestSiblings` option to the `noUnusedFunctionParameters` rule.
+
+This option is used to ignore unused function parameters that are siblings of the rest parameter.
+
+The default is `false`, which means that unused function parameters that are siblings of the rest parameter will be reported.
 
 **Example**
 

--- a/.changeset/old-rice-feel.md
+++ b/.changeset/old-rice-feel.md
@@ -2,9 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6656](https://github.com/biomejs/biome/issues/6656): Biome now correctly
-formats HTML void elements such as `<meta>` when they contain a self-closing
-slash.
+Fixed [#6656](https://github.com/biomejs/biome/issues/6656): Biome now correctly formats HTML void elements such as `<meta>` when they contain a self-closing slash.
 
 ```diff
 - <meta foo="bar" />

--- a/.changeset/package_json_parse_improve.md
+++ b/.changeset/package_json_parse_improve.md
@@ -2,5 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Resolved [#6281](https://github.com/biomejs/biome/issues/6281): Improved
-performance of handling `package.json` files in the scanner.
+Resolved [#6281](https://github.com/biomejs/biome/issues/6281): Improved performance of handling `package.json` files in the scanner.

--- a/.changeset/rebellious-roots-respect.md
+++ b/.changeset/rebellious-roots-respect.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6616](https://github.com/biomejs/biome/issues/6616): Fixed an issue with
-extending configurations that contained an explicit `root` field while the
-configuration in the project did not.
+Fixed [#6616](https://github.com/biomejs/biome/issues/6616): Fixed an issue with extending configurations that contained an explicit `root` field while the configuration in the project did not.

--- a/.changeset/salty-tigers-slide.md
+++ b/.changeset/salty-tigers-slide.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6621](https://github.com/biomejs/biome/issues/6621): Improved handling
-of multiple adjacent line suppressions. Biome now handles such suppressions
-separately, tracking whether each one is used.
+Fixed [#6621](https://github.com/biomejs/biome/issues/6621): Improved handling of multiple adjacent line suppressions. Biome now handles such suppressions separately, tracking whether each one is used.

--- a/.changeset/sixty-things-pump.md
+++ b/.changeset/sixty-things-pump.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6680](https://github.com/biomejs/biome/issues/6680): Biome incorrectly
-formatted container-style queries by inserting misplaced spaces.
+Fixed [#6680](https://github.com/biomejs/biome/issues/6680): Biome incorrectly formatted container-style queries by inserting misplaced spaces.
 
 ```diff
 - @container style (--responsive: true) {}

--- a/.changeset/spicy-lizards-enjoy.md
+++ b/.changeset/spicy-lizards-enjoy.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6038](https://github.com/biomejs/biome/issues/6038): Fixed a false
-positive in `noShadow` where a function parameter in a type definition was
-erroneously flagged as a violation.
+Fixed [#6038](https://github.com/biomejs/biome/issues/6038): Fixed a false positive in `noShadow` where a function parameter in a type definition was erroneously flagged as a violation.

--- a/.changeset/targeted-tigers-tango.md
+++ b/.changeset/targeted-tigers-tango.md
@@ -2,20 +2,10 @@
 "@biomejs/biome": minor
 ---
 
-We have implemented a more targeted version of the scanner, which ensures that
-if you provide file paths to handle on the CLI, the scanner will exclude
-directories that are not relevant to those paths.
+We have implemented a more targeted version of the scanner, which ensures that if you provide file paths to handle on the CLI, the scanner will exclude directories that are not relevant to those paths.
 
-Note that for many commands, such as `biome check` and `biome format`, the file
-paths to handle are implicitly set to the current working directory if you do
-not provide any path explicitly. The targeted scanner also works with such
-implicit paths, which means that if you run Biome from a subfolder, other
-folders that are part of the project are automatically exempted.
+Note that for many commands, such as `biome check` and `biome format`, the file paths to handle are implicitly set to the current working directory if you do not provide any path explicitly. The targeted scanner also works with such implicit paths, which means that if you run Biome from a subfolder, other folders that are part of the project are automatically exempted.
 
-Use cases where you invoke Biome from the root of the project without providing
-a path, as well as those where project rules are enabled, are not expected to
-see performance benefits from this.
+Use cases where you invoke Biome from the root of the project without providing a path, as well as those where project rules are enabled, are not expected to see performance benefits from this.
 
-Implemented [#6234](https://github.com/biomejs/biome/issues/6234), and fixed
-[#6483](https://github.com/biomejs/biome/issues/6483) and
-[#6563](https://github.com/biomejs/biome/issues/6563).
+Implemented [#6234](https://github.com/biomejs/biome/issues/6234), and fixed [#6483](https://github.com/biomejs/biome/issues/6483) and [#6563](https://github.com/biomejs/biome/issues/6563).

--- a/.changeset/tsc.md
+++ b/.changeset/tsc.md
@@ -2,18 +2,13 @@
 "@biomejs/js-api": minor
 ---
 
-Biome's JavaScript Bindings now have specific
-[subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for the
-three packages:
+Biome's JavaScript Bindings now have specific [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for the three packages:
 
 - `import { Biome } from "@biomejs/js-api/bundler";`
 - `import { Biome } from "@biomejs/js-api/nodejs";`
 - `import { Biome } from "@biomejs/js-api/web";`
 
-These new subpath exports load only TypeScript declarations, whereas the default
-export loads declarations for all three packages. This was a problem if you
-checked your code with
-[`tsc`](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
+These new subpath exports load only TypeScript declarations, whereas the default export loads declarations for all three packages. This was a problem if you checked your code with [`tsc`](https://www.typescriptlang.org/docs/handbook/compiler-options.html).
 
 - Old usage with default export (no subpath):
 

--- a/.changeset/weak-nights-go.md
+++ b/.changeset/weak-nights-go.md
@@ -3,6 +3,7 @@
 ---
 
 Added `MemoryFileSystem` to the WASM API.
+
 You can now insert a file from your JS code:
 
 ```js

--- a/.changeset/whole-pandas-joke.md
+++ b/.changeset/whole-pandas-joke.md
@@ -2,6 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6528](https://github.com/biomejs/biome/issues/6528): Biome didn't return
-the correct output when applying `source.fixAll.biome` inside Astro/Vue/Svelte
-files that contained safe fixed.
+Fixed [#6528](https://github.com/biomejs/biome/issues/6528): Biome didn't return the correct output when applying `source.fixAll.biome` inside Astro/Vue/Svelte files that contained safe fixed.

--- a/.changeset/whole-parks-grab.md
+++ b/.changeset/whole-parks-grab.md
@@ -2,9 +2,7 @@
 "@biomejs/biome": minor
 ---
 
-Added `$` symbol to
-[organizeImports](https://biomejs.dev/assist/actions/organize-imports) `:ALIAS:`
-group.
+Added `$` symbol to [organizeImports](https://biomejs.dev/assist/actions/organize-imports) `:ALIAS:` group.
 
 `import { action } from '$lib'` will be treated as alias import.
 


### PR DESCRIPTION
## Summary

One more pass on the changelogs: Turns out my setting to break up paragraphs into multiple lines actually messes with the Markdown rendering of the changelogs :(

## Test Plan

N/A
