### PR TITLE
ci: download js-api artifacts before publish

### DIFF
--- a/.changeset/early-pots-win.md
+++ b/.changeset/early-pots-win.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/js-api": patch
+---
+
+Fixed [#6722](https://github.com/biomejs/biome/issues/6772): where the necessary files were not included in the `@biomejs/js-api` package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,6 +393,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Download JS API artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: js-api
+          merge-multiple: true
+
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -431,5 +437,3 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           make_latest: false # Keep the CLI release as latest
-
-


### PR DESCRIPTION
## Summary

The built files were not downloaded in the publish workflow job and were not included in the published package.

## Test Plan

I will dispatch a new releaset for the JS API.