### PR TITLE
ci: correct restore path of the artifact

### DIFF
--- a/.changeset/early-pots-win.md
+++ b/.changeset/early-pots-win.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/js-api": patch
+---
+
+Fixed [#6722](https://github.com/biomejs/biome/issues/6772): Missing `dist/` files are now included in the `@biomejs/js-api` package. The previous release haven't fixed the issue properly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,7 +397,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: js-api
-          merge-multiple: true
+          path: packages/@biomejs/js-api/dist
 
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
## Summary

Follow-up of #6776 

The `dist/` files were still missing in the package. I forgot to specify the target path in the `download-artifact` step.

## Test Plan

Release again?
