### PR TITLE
fix(wasm): serialize map as a plain object

### DIFF
--- a/.changeset/flat-wolves-fall.md
+++ b/.changeset/flat-wolves-fall.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the `FileFeaturesResult` interface in the WASM API was defined as a mapped object but the actual value was a `Map` object.

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -266,8 +266,12 @@ impl Default for Workspace {
     }
 }
 
+const SERIALIZER: serde_wasm_bindgen::Serializer = serde_wasm_bindgen::Serializer::new()
+    .serialize_missing_as_null(true)
+    .serialize_maps_as_objects(true);
+
 fn to_value<T: serde::ser::Serialize + ?Sized>(
     value: &T,
 ) -> Result<JsValue, serde_wasm_bindgen::Error> {
-    value.serialize(&serde_wasm_bindgen::Serializer::new().serialize_missing_as_null(true))
+    value.serialize(&SERIALIZER)
 }


### PR DESCRIPTION
## Summary

Fixed that the generated TypeScript type declares as `{ [K in FeatureKind]?: SupportKind }` but the actual value was `Map<FeatureKind, SupportKind>`. I enabled the `serialize_maps_as_objects` option in the serde_wasm_bindgen serializer.

## Test Plan

Manually tested with the playground
