### PR TITLE
ci: use `name` instead of `pattern` for downloading artifact

### DIFF
--- a/.changeset/early-pots-win.md
+++ b/.changeset/early-pots-win.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/js-api": patch
+---
+
+Fixed [#6722](https://github.com/biomejs/biome/issues/6772): Missing `dist/` files are now included in the `@biomejs/js-api` package. The previous release haven't fixed the issue properly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,7 @@ jobs:
       - name: Download JS API artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: js-api
+          name: js-api
           path: packages/@biomejs/js-api/dist
 
       - name: Install Node.js


### PR DESCRIPTION
## Summary

Follow-up of #6776 (again and again 😓)

When `pattern` is used for the `download-artifact` step, the action extracts an artifact within a dedicated directory. Enabling `merge-mulitple` will change this behaviour, but changing `pattern` to `name` is also fine.

## Test Plan

Release again 😢 

## Docs

N/A
