### PR TITLE
fix(core): correctly identify sync callbacks inside async functions

### DIFF
--- a/.changeset/sync-sinuses-stutter.md
+++ b/.changeset/sync-sinuses-stutter.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6796](https://github.com/biomejs/biome/issues/6796): `noFloatingPromises` will no longer suggest to add `await` keyword inside synchronous callbacks nested inside `async` functions.

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts
@@ -1,0 +1,9 @@
+async function doStuff(db) {
+    const txStatements: Array<(tx) => Promise<any>> = [];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            stmt(tx)
+        }
+    });
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts.snap
@@ -1,0 +1,35 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidSyncCallbackInsideAsyncFn.ts
+---
+# Input
+```ts
+async function doStuff(db) {
+    const txStatements: Array<(tx) => Promise<any>> = [];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            stmt(tx)
+        }
+    });
+}
+
+```
+
+# Diagnostics
+```
+invalidSyncCallbackInsideAsyncFn.ts:6:13 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    4 │     db.transaction((tx: any) => {
+    5 │         for (const stmt of txStatements) {
+  > 6 │             stmt(tx)
+      │             ^^^^^^^^
+    7 │         }
+    8 │     });
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```


### PR DESCRIPTION
## Summary

Fixed [#6796](https://github.com/biomejs/biome/issues/6796): `noFloatingPromises` will no longer suggest to add `await` keyword inside synchronous callbacks nested inside `async` functions.

## Test Plan

Test case added.