### PR TITLE
fix(core): infer for-of and for-in loop variables

### DIFF
--- a/.changeset/iterable-items-infer.md
+++ b/.changeset/iterable-items-infer.md
@@ -1,0 +1,36 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6796](https://github.com/biomejs/biome/issues/6796): Fixed a false positive that happened in `noFloatingPromises` when calling functions that were declared as part of `for ... of` syntax inside `async` functions.
+
+Instead, the variables declared inside `for ... of` loops are now correctly
+inferred if the expression being iterated evaluates to an `Array` (support for other iterables will follow later).
+
+**Invalid example**
+
+```tsx
+const txStatements: Array<(tx) => Promise<any>> = [];
+
+db.transaction((tx: any) => {
+    for (const stmt of txStatements) {
+        // We correctly flag this resolves to a `Promise`:
+        stmt(tx)
+    }
+});
+```
+
+**Valid example**
+
+```tsx
+async function valid(db) {
+    const txStatements: Array<(tx: any) => void> = [(tx) => tx.insert().run()];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            // We don't flag a false positive here anymore:
+            stmt(tx)
+        }
+    });
+}
+```

--- a/.changeset/sync-sinuses-stutter.md
+++ b/.changeset/sync-sinuses-stutter.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6796](https://github.com/biomejs/biome/issues/6796): `noFloatingPromises` will no longer suggest to add `await` keyword inside synchronous callbacks nested inside `async` functions.
+`noFloatingPromises` will no longer suggest to add `await` keyword inside synchronous callbacks nested inside `async` functions.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -17,6 +17,7 @@
   "no-duplicate-heading": null,
   "blanks-around-lists": null,
   "no-multiple-blanks": null,
+  "no-emphasis-as-heading": null,
   "blanks-around-fences": null,
   "blanks-around-headings": null,
   "heading-increment": null,

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -26,9 +26,15 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"const condition = Math.random() > -1; // Always true, but dynamic to linter
-condition ? Promise.reject("ternary bypass") : null;
-"#;
+    const SOURCE: &str = r#"async function doStuff(db) {
+    const txStatements: Array<(tx: any) => Promise<number>> = [(tx) => tx.insert().run()];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            stmt(tx)
+        }
+    });
+}"#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalidSyncCallbackInsideAsyncFn.ts.snap
@@ -14,6 +14,16 @@ async function doStuff(db) {
     });
 }
 
+async function doStuff2(db) {
+    const txStatements: Array<Promise<(tx: any) => void>> = [];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            stmt
+        }
+    });
+}
+
 ```
 
 # Diagnostics
@@ -28,6 +38,23 @@ invalidSyncCallbackInsideAsyncFn.ts:6:13 lint/nursery/noFloatingPromises ━━�
       │             ^^^^^^^^
     7 │         }
     8 │     });
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalidSyncCallbackInsideAsyncFn.ts:16:13 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    14 │     db.transaction((tx: any) => {
+    15 │         for (const stmt of txStatements) {
+  > 16 │             stmt
+       │             ^^^^
+    17 │         }
+    18 │     });
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validSyncCallbackInsideAsyncFn.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validSyncCallbackInsideAsyncFn.ts
@@ -1,5 +1,7 @@
+/* should not generate diagnostics */
+
 async function doStuff(db) {
-    const txStatements: Array<(tx) => Promise<any>> = [];
+    const txStatements: Array<(tx: any) => void> = [(tx) => tx.insert().run()];
 
     db.transaction((tx: any) => {
         for (const stmt of txStatements) {
@@ -11,9 +13,9 @@ async function doStuff(db) {
 async function doStuff2(db) {
     const txStatements: Array<Promise<(tx: any) => void>> = [];
 
-    db.transaction((tx: any) => {
-        for (const stmt of txStatements) {
-            stmt
+    db.transaction(async (tx: any) => {
+        for await (const stmt of txStatements) {
+            stmt(tx)
         }
     });
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validSyncCallbackInsideAsyncFn.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/validSyncCallbackInsideAsyncFn.ts.snap
@@ -1,0 +1,29 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validSyncCallbackInsideAsyncFn.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+async function doStuff(db) {
+    const txStatements: Array<(tx: any) => void> = [(tx) => tx.insert().run()];
+
+    db.transaction((tx: any) => {
+        for (const stmt of txStatements) {
+            stmt(tx)
+        }
+    });
+}
+
+async function doStuff2(db) {
+    const txStatements: Array<Promise<(tx: any) => void>> = [];
+
+    db.transaction(async (tx: any) => {
+        for await (const stmt of txStatements) {
+            stmt(tx)
+        }
+    });
+}
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -119,6 +119,26 @@ pub(super) fn flattened_expression(
                 })
             }
         }
+        TypeofExpression::IterableValueOf(expr) => {
+            let ty = resolver.resolve_and_get(&expr.ty)?;
+            match ty.as_raw_data() {
+                TypeData::InstanceOf(instance)
+                    if instance.ty == GLOBAL_ARRAY_ID.into()
+                        && instance.has_known_type_parameters() =>
+                {
+                    instance
+                        .type_parameters
+                        .first()
+                        .map(|param| ty.apply_module_id_to_reference(param))
+                        .and_then(|param| resolver.resolve_and_get(&param))
+                        .map(ResolvedTypeData::to_data)
+                }
+                _ => {
+                    // TODO: Handle other iterable types
+                    None
+                }
+            }
+        }
         TypeofExpression::LogicalAnd(expr) => {
             let left = resolver.resolve_and_get(&expr.left)?;
             let conditional = ConditionalType::from_resolved_data(left, resolver);

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -474,6 +474,16 @@ impl Format<FormatTypeContext> for TypeofExpression {
                     )
                 }
             },
+            Self::IterableValueOf(expr) => {
+                write!(
+                    f,
+                    [&format_args![&group(&format_args![
+                        text("iterable_value_of"),
+                        soft_line_break_or_space(),
+                        &expr.ty
+                    ])]]
+                )
+            }
             Self::LogicalAnd(expr) => {
                 write!(
                     f,

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -1129,6 +1129,7 @@ pub enum TypeofExpression {
     Call(TypeofCallExpression),
     Conditional(TypeofConditionalExpression),
     Destructure(TypeofDestructureExpression),
+    IterableValueOf(TypeofIterableValueOfExpression),
     LogicalAnd(TypeofLogicalAndExpression),
     LogicalOr(TypeofLogicalOrExpression),
     New(TypeofNewExpression),
@@ -1185,6 +1186,12 @@ pub enum DestructureField {
     Name(Text),
     RestExcept(Box<[Text]>),
     RestFrom(usize),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
+pub struct TypeofIterableValueOfExpression {
+    /// The type being iterated over.
+    pub ty: TypeReference,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]


### PR DESCRIPTION
## Summary

Fixed [#6796](https://github.com/biomejs/biome/issues/6796): Fixed a false positive that happened in `noFloatingPromises` when calling functions that were declared as part of `for ... of` syntax inside `async` functions.

Instead, the variables declared inside `for ... of` loops are now correctly inferred if the expression being iterated evaluates to an `Array` (support for other iterables will [follow later](https://github.com/biomejs/biome/issues/6810)).

**Invalid example**

```tsx
const txStatements: Array<(tx) => Promise<any>> = [];

db.transaction((tx: any) => {
    for (const stmt of txStatements) {
        // We correctly flag this resolves to a `Promise`:
        stmt(tx)
    }
});
```

**Valid example**

```tsx
async function valid(db) {
    const txStatements: Array<(tx: any) => void> = [(tx) => tx.insert().run()];

    db.transaction((tx: any) => {
        for (const stmt of txStatements) {
            // We don't flag a false positive here anymore:
            stmt(tx)
        }
    });
}
```

## Test Plan

Tests added.