### PR TITLE
fix(core): do not update the opened document when change observed by the watcher

### DIFF
--- a/.changeset/stupid-socks-visit.md
+++ b/.changeset/stupid-socks-visit.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed that `textDocument/codeAction` in LSP could response outdated text edits after the workspace watcher observed outdated changes to the file.

--- a/.changeset/stupid-socks-visit.md
+++ b/.changeset/stupid-socks-visit.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed that `textDocument/codeAction` in LSP could response outdated text edits after the workspace watcher observed outdated changes to the file.
+Fixed an issue where `textDocument/codeAction` in the LSP could respond with outdated text edits after the workspace watcher observed outdated changes to the file.

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -355,10 +355,10 @@ impl WorkspaceServer {
             match path.extension() {
                 Some("js") => {
                     let manifest = self.project_layout.find_node_manifest_for_path(&path);
-                    if let Some((_, manifest)) = manifest {
-                        if manifest.r#type == Some(PackageType::CommonJs) {
-                            js.set_module_kind(ModuleKind::Script);
-                        }
+                    if let Some((_, manifest)) = manifest
+                        && manifest.r#type == Some(PackageType::CommonJs)
+                    {
+                        js.set_module_kind(ModuleKind::Script);
                     }
                 }
                 Some("cjs") => {
@@ -407,32 +407,15 @@ impl WorkspaceServer {
         let opened_by_scanner = reason.is_opened_by_scanner();
 
         // Second-pass parsing for HTML files with embedded JavaScript and CSS content
-        let (embedded_scripts, embedded_styles) = if let Some(file_source) = self.get_source(index)
+        let (embedded_scripts, embedded_styles) = if let Some(DocumentFileSource::Html(_)) =
+            self.get_source(index)
+            && let Some(Ok(any_parse)) = &syntax
+            && let Some(html_root) = biome_html_syntax::HtmlRoot::cast(any_parse.syntax())
         {
-            if matches!(file_source, DocumentFileSource::Html(_)) {
-                if let Some(Ok(any_parse)) = &syntax {
-                    if let Some(html_root) =
-                        biome_html_syntax::HtmlRoot::cast(any_parse.syntax().clone())
-                    {
-                        let mut node_cache = NodeCache::default();
-                        let scripts = crate::file_handlers::html::extract_embedded_scripts(
-                            &html_root,
-                            &mut node_cache,
-                        );
-                        let styles = crate::file_handlers::html::parse_embedded_styles(
-                            &html_root,
-                            &mut node_cache,
-                        );
-                        (scripts, styles)
-                    } else {
-                        (Vec::new(), Vec::new())
-                    }
-                } else {
-                    (Vec::new(), Vec::new())
-                }
-            } else {
-                (Vec::new(), Vec::new())
-            }
+            let mut node_cache = NodeCache::default();
+            let scripts = extract_embedded_scripts(&html_root, &mut node_cache);
+            let styles = parse_embedded_styles(&html_root, &mut node_cache);
+            (scripts, styles)
         } else {
             (Vec::new(), Vec::new())
         };
@@ -480,14 +463,14 @@ impl WorkspaceServer {
                     // content is coming from the scanner, we keep the same
                     // content that was already in the document. This means,
                     // active clients are leading over the filesystem.
-                    let content = if document.version.is_some() && opened_by_scanner {
-                        document.content.clone()
-                    } else {
-                        content.clone()
+                    if document.version.is_some() && opened_by_scanner {
+                        let mut doc = document.clone();
+                        doc.opened_by_scanner = true;
+                        return Operation::Insert(doc);
                     };
 
                     Operation::Insert::<Document, bool>(Document {
-                        content,
+                        content: content.clone(),
                         version,
                         file_source_index: index,
                         syntax: syntax.clone(),


### PR DESCRIPTION
## Summary

When both "Apply safe fixes on save" and "Sort imports on save" are enabled in the IntelliJ Biome plugin, the file occasionally becomes broken on save. After investigation, I realised that the Biome LSP returns incorrect text edits for the second code action request:

1. Editor sends a `textDocument/codeAction` request for `source.fixAll.biome`.
2. Biome LSP responses text edits to apply all safe fixes.
3. Editor applies the edits to the file and saves the file.
4. Editor sends a `textDocument/didChange` notification.
5. Biome LSP receives the notification and updates the opened document.
6. **The workspace watcher observes the file changes occurred in 3. and updates the opened document with the outdated content.**
7. Editor sends a `textDocument/codeAction` request for `source.organizeImports.biome`.
8. **Biome LSP responses wrong text edits as the opened document is outdated.**

The watcher watches _filesystem changes_ that is powered by the operating system and can vary among environments. It can observe some outdated (delayed) changes. In `WorkspaceServer::open_file_internal`, updating the content of the opened document is skipped when it's called by the watcher. However, the parsed syntax tree is still updated and caused mismatch between the saved text content and the syntax tree.

## Test Plan

Manually tested; I typed ⌘S and ⌘Z many times on WebStorm with the Biome plugin.

## Docs

N/A
