### PR TITLE
fix(core): scanner ignores files inside VCS

### DIFF
--- a/.changeset/green-banks-feel.md
+++ b/.changeset/green-banks-feel.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where the root ignore file wasn't correctly loaded during the scanning phase, causing false positives and incorrect expectations among users.
+
+Now, when using `vcs.useIgnoreFile`, the **the globs specified in the root ignore file** will have the same semantics of the root `files.includes`.
+
+Refer to the [relative web page](https://biomejs.dev/internals/architecture/#configuring-the-scanner) to understand how they work.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -882,6 +882,7 @@ pub(crate) trait CommandRunner: Sized {
         workspace: &dyn Workspace,
         cli_options: &CliOptions,
     ) -> Result<ConfiguredWorkspace, CliDiagnostic> {
+        // Load configuration
         let configuration_path_hint = cli_options.as_configuration_path_hint();
         let loaded_configuration = load_configuration(fs, configuration_path_hint)?;
         if self.should_validate_configuration_diagnostics() {
@@ -897,6 +898,8 @@ pub(crate) trait CommandRunner: Sized {
             loaded_configuration.diagnostics.len(),
         );
         let configuration_dir_path = loaded_configuration.directory_path.clone();
+
+        // Merge the FS configuration with the CLI arguments
         let configuration = self.merge_configuration(loaded_configuration, fs, console)?;
 
         let execution = self.get_execution(cli_options, console, workspace)?;
@@ -934,6 +937,7 @@ pub(crate) trait CommandRunner: Sized {
             }
         };
 
+        // Open the project
         let open_project_result = workspace.open_project(params)?;
 
         let scan_kind = get_forced_scan_kind(&execution, &root_configuration_dir, &working_dir)
@@ -951,6 +955,22 @@ pub(crate) trait CommandRunner: Sized {
                     open_project_result.scan_kind
                 }
             });
+
+        // Update the settings of the project
+        let result = workspace.update_settings(UpdateSettingsParams {
+            project_key: open_project_result.project_key,
+            workspace_directory: Some(BiomePath::new(project_dir)),
+            configuration,
+        })?;
+        if self.should_validate_configuration_diagnostics() {
+            print_diagnostics_from_workspace_result(
+                result.diagnostics.as_slice(),
+                console,
+                cli_options.verbose,
+            )?;
+        }
+
+        // Scan the project
         let scan_kind = match (scan_kind, execution.traversal_mode()) {
             (scan_kind, TraversalMode::Migrate { .. }) => scan_kind,
             (ScanKind::KnownFiles, _) => {
@@ -965,20 +985,6 @@ pub(crate) trait CommandRunner: Sized {
             }
             (scan_kind, _) => scan_kind,
         };
-
-        let result = workspace.update_settings(UpdateSettingsParams {
-            project_key: open_project_result.project_key,
-            workspace_directory: Some(BiomePath::new(project_dir)),
-            configuration,
-        })?;
-        if self.should_validate_configuration_diagnostics() {
-            print_diagnostics_from_workspace_result(
-                result.diagnostics.as_slice(),
-                console,
-                cli_options.verbose,
-            )?;
-        }
-
         let result = workspace.scan_project_folder(ScanProjectFolderParams {
             project_key: open_project_result.project_key,
             path: None,

--- a/crates/biome_service/src/diagnostics.rs
+++ b/crates/biome_service/src/diagnostics.rs
@@ -578,7 +578,7 @@ impl Diagnostic for TransportError {
 #[derive(Debug, Deserialize, Diagnostic, Serialize)]
 pub enum VcsDiagnostic {
     /// When the VCS folder couldn't be found
-    NoVcsFolderFound(NoVcsFolderFound),
+    NoIgnoreFileFound(NoIgnoreFileFound),
     /// VCS is disabled
     DisabledVcs(DisabledVcs),
 }
@@ -608,11 +608,11 @@ impl From<CompileError> for WorkspaceError {
     category = "internalError/fs",
     severity = Error,
     message(
-        description = "Biome couldn't find the VCS folder at the following path: {path}",
-        message("Biome couldn't find the VCS folder at the following path: "<Emphasis>{self.path}</Emphasis>),
+        description = "Biome couldn't find an ignore file at the following directory: {path}",
+        message("Biome couldn't find an ignore file at the following directory: "<Emphasis>{self.path}</Emphasis>),
     )
 )]
-pub struct NoVcsFolderFound {
+pub struct NoIgnoreFileFound {
     #[location(resource)]
     pub path: String,
 }

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -754,8 +754,29 @@ impl VcsSettings {
         })
     }
 
-    /// Stores the contents found in the ignore file.
-    pub fn store_ignore_patterns(
+    /// It stores the patterns of the root ignore file
+    pub fn store_root_ignore_patterns(
+        &mut self,
+        path: &Utf8Path,
+        patterns: &[&str],
+    ) -> Result<(), WorkspaceError> {
+        match self.client_kind {
+            Some(VcsClientKind::Git) => {
+                let git_ignore = VcsIgnoredPatterns::git_ignore(path, patterns)?;
+                self.ignore_matches = Some(VcsIgnoredPatterns::Git {
+                    root: git_ignore,
+                    root_path: path.to_path_buf(),
+                    nested: vec![],
+                });
+            }
+            None => {}
+        };
+
+        Ok(())
+    }
+
+    /// It stores a list of patterns inside as a nested ignore file
+    pub fn store_nested_ignore_patterns(
         &mut self,
         path: &Utf8Path,
         patterns: &[&str],
@@ -765,11 +786,6 @@ impl VcsSettings {
                 let git_ignore = VcsIgnoredPatterns::git_ignore(path, patterns)?;
                 if let Some(ignore_matches) = self.ignore_matches.as_mut() {
                     ignore_matches.insert_git_match(git_ignore);
-                } else {
-                    self.ignore_matches = Some(VcsIgnoredPatterns::Git {
-                        root: git_ignore,
-                        nested: vec![],
-                    });
                 }
             }
             None => {}
@@ -782,17 +798,27 @@ impl VcsSettings {
 #[derive(Clone, Debug)]
 pub enum VcsIgnoredPatterns {
     Git {
-        // Represents the `.gitignore` file at the root of the project
+        /// Represents the `.gitignore` file at the root of the project
         root: Gitignore,
-        // The list of nested `.gitignore` files found inside the project
+        /// The path of the root ignore file
+        root_path: Utf8PathBuf,
+        /// The list of nested `.gitignore` files found inside the project
         nested: Vec<Gitignore>,
     },
 }
 
 impl VcsIgnoredPatterns {
+    /// Checks whether the path ignored only by the root ignore file
+    pub fn is_root_ignored(&self, path: &Utf8Path, is_dir: bool) -> bool {
+        match self {
+            Self::Git { root, .. } => root.matched(path, is_dir).is_ignore(),
+        }
+    }
+
+    /// Checks whether the path ignored by any ignore file found inside the project
     pub fn is_ignored(&self, path: &Utf8Path, is_dir: bool) -> bool {
         match self {
-            Self::Git { root, nested } => {
+            Self::Git { root, nested, .. } => {
                 root.matched(path, is_dir).is_ignore()
                     || nested.iter().any(|gitignore| {
                         let ignore_directory = if gitignore.path().is_file() {

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -360,10 +360,7 @@ impl TraversalContext for ScanContext<'_> {
     }
 
     fn store_path(&self, path: BiomePath) {
-        self.evaluated_paths
-            .write()
-            .unwrap()
-            .insert(BiomePath::new(path.as_path()));
+        self.evaluated_paths.write().unwrap().insert(path);
     }
 }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -11,7 +11,7 @@ use super::{
     UpdateSettingsResult,
 };
 use crate::configuration::{LoadedConfiguration, ProjectScanComputer, read_config};
-use crate::diagnostics::FileTooLarge;
+use crate::diagnostics::{FileTooLarge, NoIgnoreFileFound, VcsDiagnostic};
 use crate::file_handlers::html::{extract_embedded_scripts, parse_embedded_styles};
 use crate::file_handlers::{
     Capabilities, CodeActionsParams, DocumentFileSource, Features, FixAllParams, LintParams,
@@ -30,6 +30,7 @@ use biome_analyze::{AnalyzerPluginVec, RuleCategory};
 use biome_configuration::analyzer::RuleSelector;
 use biome_configuration::bool::Bool;
 use biome_configuration::plugins::{PluginConfiguration, Plugins};
+use biome_configuration::vcs::VcsClientKind;
 use biome_configuration::{BiomeDiagnostic, Configuration, ConfigurationPathHint};
 use biome_deserialize::json::deserialize_from_json_str;
 use biome_deserialize::{Deserialized, Merge};
@@ -293,6 +294,7 @@ impl WorkspaceServer {
     }
 
     /// Opens the file and marks it as opened by the scanner.
+    #[instrument(level = "debug", skip(self, path))]
     pub(super) fn open_file_by_watcher(
         &self,
         project_key: ProjectKey,
@@ -626,6 +628,7 @@ impl WorkspaceServer {
 
         let filtered_paths = paths
             .iter()
+            // We remove the root configuration file from the list of paths
             // SAFETY: the paths received are files, so it's safe to assume they have a parent folder
             .filter(|config_path| project_path != config_path.parent().unwrap().as_std_path());
 
@@ -708,7 +711,10 @@ impl WorkspaceServer {
         project_key: ProjectKey,
         paths: &[BiomePath],
     ) -> Result<(), WorkspaceError> {
-        let project_path = self.projects.get_project_path(project_key);
+        let project_path = self
+            .projects
+            .get_project_path(project_key)
+            .ok_or_else(WorkspaceError::no_project)?;
         let mut settings = self
             .projects
             .get_root_settings(project_key)
@@ -724,10 +730,13 @@ impl WorkspaceServer {
             return Ok(());
         }
 
-        for path in paths.iter().filter(|path| path.is_ignore()) {
-            let is_in_project_path = project_path
-                .as_ref()
-                .is_some_and(|project_path| path.starts_with(project_path));
+        let filtered_paths = paths.iter().filter(|path| path.is_ignore()).filter(|path| {
+            // We filter out the root ignore file, because it's store when calling `update_settings`
+            // SAFETY: the paths received are files, so it's safe to assume they have a parent folder
+            project_path.as_path() != path.parent().unwrap()
+        });
+        for path in filtered_paths {
+            let is_in_project_path = path.starts_with(&project_path);
 
             // We need to pass the **directory** that contains the ignore file.
             let dir_ignore_file = path.parent().unwrap_or(path);
@@ -735,7 +744,7 @@ impl WorkspaceServer {
             if vcs_settings.is_ignore_file(path) && is_in_project_path {
                 let content = self.fs.read_file_from_path(path)?;
                 let patterns = content.lines().collect::<Vec<_>>();
-                vcs_settings.store_ignore_patterns(dir_ignore_file, patterns.as_slice())?;
+                vcs_settings.store_nested_ignore_patterns(dir_ignore_file, patterns.as_slice())?;
             }
         }
 
@@ -940,31 +949,36 @@ impl Workspace for WorkspaceServer {
         &self,
         params: UpdateSettingsParams,
     ) -> Result<UpdateSettingsResult, WorkspaceError> {
-        let workspace_directory = params.workspace_directory.map(|p| p.to_path_buf());
-        let is_root = params.configuration.is_root();
-        let extends_root = params.configuration.extends_root();
+        let UpdateSettingsParams {
+            workspace_directory,
+            configuration,
+            project_key,
+        } = params;
+        let workspace_directory = workspace_directory.map(|p| p.to_path_buf());
+        let is_root = configuration.is_root();
+        let extends_root = configuration.extends_root();
         let mut settings = if !is_root {
-            if !self.projects.is_project_registered(params.project_key) {
+            if !self.projects.is_project_registered(project_key) {
                 return Err(WorkspaceError::no_project());
             }
 
             if let Some(workspace_directory) = &workspace_directory {
                 self.projects
-                    .get_nested_settings(params.project_key, workspace_directory.as_path())
+                    .get_nested_settings(project_key, workspace_directory.as_path())
                     .unwrap_or_default()
             } else {
                 return Err(WorkspaceError::no_workspace_directory());
             }
         } else {
             self.projects
-                .get_root_settings(params.project_key)
+                .get_root_settings(project_key)
                 .ok_or_else(WorkspaceError::no_project)?
         };
 
-        settings.merge_with_configuration(params.configuration, workspace_directory.clone())?;
+        settings.merge_with_configuration(configuration, workspace_directory.clone())?;
 
         let loading_directory = if extends_root {
-            self.projects.get_project_path(params.project_key)
+            self.projects.get_project_path(project_key)
         } else {
             workspace_directory.clone()
         };
@@ -985,13 +999,44 @@ impl Workspace for WorkspaceServer {
 
         if !is_root {
             self.projects.set_nested_settings(
-                params.project_key,
+                project_key,
                 workspace_directory.unwrap_or_default(),
                 settings,
             );
         } else {
-            self.projects
-                .set_root_settings(params.project_key, settings);
+            if settings.is_vcs_enabled() && settings.vcs_settings.should_use_ignore_file() {
+                let directory = workspace_directory.unwrap_or_default();
+                match settings.vcs_settings.client_kind {
+                    None => {}
+                    Some(VcsClientKind::Git) => {
+                        let gitignore = directory.join(".gitignore");
+                        let ignore = directory.join(".ignore");
+                        let content = {
+                            let result = self.fs().read_file_from_path(gitignore.as_ref());
+                            match result {
+                                Ok(content) => content,
+                                Err(_) => match self.fs().read_file_from_path(ignore.as_ref()) {
+                                    Ok(content) => content,
+                                    Err(_) => {
+                                        return Err(VcsDiagnostic::NoIgnoreFileFound(
+                                            NoIgnoreFileFound {
+                                                path: directory.to_string(),
+                                            },
+                                        )
+                                        .into());
+                                    }
+                                },
+                            }
+                        };
+                        let lines: Vec<_> = content.lines().collect();
+                        settings
+                            .vcs_settings
+                            .store_root_ignore_patterns(directory.as_ref(), lines.as_slice())?;
+                    }
+                }
+            }
+
+            self.projects.set_root_settings(project_key, settings);
         }
 
         Ok(UpdateSettingsResult {

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -11,11 +11,11 @@
 
 use std::path::PathBuf;
 
+use crate::{WorkspaceError, workspace_watcher::WatcherSignalKind};
 use biome_fs::PathKind;
 use camino::{Utf8Path, Utf8PathBuf};
 use papaya::{Compute, Operation};
-
-use crate::{WorkspaceError, workspace_watcher::WatcherSignalKind};
+use tracing::instrument;
 
 use super::{
     ScanKind, ScanProjectFolderParams, ServiceDataNotification, Workspace, WorkspaceServer,
@@ -74,6 +74,7 @@ impl WorkspaceServer {
     ///
     /// If you already know the path is a folder, use
     /// `Self::open_folder_through_watcher()` instead.
+    #[instrument(level = "debug", skip_all)]
     pub fn open_path_through_watcher(&self, path: &Utf8Path) -> Result<(), WorkspaceError> {
         if let PathKind::Directory { .. } = self.fs.path_kind(path)? {
             return self.open_folder_through_watcher(path);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes a bug where the scanner didn't ignore files that are declared inside the **root** ignore files. 

While it doesn't cover all cases, with this fix we give to the root ignore file the same capabilities and semantics as `files. includes`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

I did some manual testing. How would like to add some tests, but I don't know how I can test the scanner result programmatically. Any tips @arendjr ?

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
