### PR TITLE
refactor: make Watcher aware of `ScanKind`

### DIFF
--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3364,10 +3364,7 @@ export function bar() {
 
     server.initialize().await?;
 
-    let OpenProjectResult {
-        project_key,
-        scan_kind,
-    } = server
+    let OpenProjectResult { project_key, .. } = server
         .request(
             "biome/open_project",
             "open_project",
@@ -3391,7 +3388,7 @@ export function bar() {
                 path: None,
                 watch: true,
                 force: false,
-                scan_kind,
+                scan_kind: ScanKind::Project,
                 verbose: false,
             },
         )

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -12,32 +12,39 @@
 use std::path::PathBuf;
 
 use super::{
-    FeaturesBuilder, IgnoreKind, IsPathIgnoredParams, ScanKind, ScanProjectFolderParams,
-    ServiceDataNotification, Workspace, WorkspaceServer, document::Document,
+    ScanKind, ScanProjectFolderParams, ServiceDataNotification, Workspace, WorkspaceServer,
+    document::Document,
 };
 use crate::{WorkspaceError, workspace_watcher::WatcherSignalKind};
-use biome_fs::PathKind;
+use biome_fs::{BiomePath, PathKind};
 use camino::{Utf8Path, Utf8PathBuf};
 use papaya::{Compute, Operation};
-use tracing::instrument;
 
 impl WorkspaceServer {
     /// Filters the given `paths` and returns only those the watcher is
     /// interested in.
-    pub fn filter_paths_for_watcher(&self, paths: Vec<PathBuf>) -> Vec<Utf8PathBuf> {
+    pub fn filter_paths_for_watcher(
+        &self,
+        paths: Vec<PathBuf>,
+        scan_kind: &ScanKind,
+    ) -> Vec<Utf8PathBuf> {
         paths
             .into_iter()
             .filter_map(|path| {
                 let path = Utf8PathBuf::from_path_buf(path).ok()?;
                 self.projects
                     .find_project_for_path(&path)
-                    .and_then(|project_key| {
-                        if self.is_ignored_by_scanner(project_key, &path) {
-                            None
-                        } else {
-                            Some(path)
+                    .filter(|project_key| {
+                        match self.is_ignored_by_scanner(
+                            *project_key,
+                            scan_kind,
+                            &BiomePath::new(&path),
+                        ) {
+                            Ok(is_ignored) => !is_ignored,
+                            Err(_) => true,
                         }
                     })
+                    .map(|_| path)
             })
             .collect()
     }
@@ -49,9 +56,10 @@ impl WorkspaceServer {
     pub fn open_paths_through_watcher(
         &self,
         paths: Vec<Utf8PathBuf>,
+        scan_kind: &ScanKind,
     ) -> Result<(), WorkspaceError> {
         for path in paths {
-            self.open_path_through_watcher(&path)?;
+            self.open_path_through_watcher(&path, scan_kind)?;
         }
 
         Ok(())
@@ -61,9 +69,10 @@ impl WorkspaceServer {
     pub fn open_folders_through_watcher(
         &self,
         paths: Vec<Utf8PathBuf>,
+        scan_kind: &ScanKind,
     ) -> Result<(), WorkspaceError> {
         for path in paths {
-            self.open_folder_through_watcher(&path)?;
+            self.open_folder_through_watcher(&path, scan_kind)?;
         }
 
         Ok(())
@@ -72,34 +81,30 @@ impl WorkspaceServer {
     /// Used indirectly by the watcher to open an individual file or folder.
     ///
     /// If you already know the path is a folder, use
-    /// `Self::open_folder_through_watcher()` instead.
-    #[instrument(level = "debug", skip_all)]
-    pub fn open_path_through_watcher(&self, path: &Utf8Path) -> Result<(), WorkspaceError> {
+    /// [`Self::open_folder_through_watcher()`] instead. If you know it is a
+    /// file, you can directly call [`Self::open_file_by_watcher()`] instead.
+    pub fn open_path_through_watcher(
+        &self,
+        path: &Utf8Path,
+        scan_kind: &ScanKind,
+    ) -> Result<(), WorkspaceError> {
         if let PathKind::Directory { .. } = self.fs.path_kind(path)? {
-            return self.open_folder_through_watcher(path);
+            self.open_folder_through_watcher(path, scan_kind)
+        } else {
+            let Some(project_key) = self.projects.find_project_for_path(path) else {
+                return Ok(()); // file events outside our projects can be safely ignored.
+            };
+
+            self.open_file_by_watcher(project_key, scan_kind, path)
         }
-
-        let Some(project_key) = self.projects.find_project_for_path(path) else {
-            return Ok(()); // file events outside our projects can be safely ignored.
-        };
-
-        let ignored = self.is_ignored_by_scanner(project_key, path)
-            || self.is_path_ignored(IsPathIgnoredParams {
-                path: path.into(),
-                project_key,
-                features: FeaturesBuilder::new().build(),
-                ignore_kind: IgnoreKind::Ancestors,
-            })?;
-
-        if ignored {
-            return Ok(());
-        }
-
-        self.open_file_by_watcher(project_key, path)
     }
 
     /// Used indirectly by the watcher to open an individual folder.
-    fn open_folder_through_watcher(&self, path: &Utf8Path) -> Result<(), WorkspaceError> {
+    fn open_folder_through_watcher(
+        &self,
+        path: &Utf8Path,
+        scan_kind: &ScanKind,
+    ) -> Result<(), WorkspaceError> {
         let Some(project_key) = self.projects.find_project_for_path(path) else {
             return Ok(()); // file events outside our projects can be safely ignored.
         };
@@ -109,7 +114,7 @@ impl WorkspaceServer {
             path: Some(path.into()),
             watch: false, // It's already being watched.
             force: true,
-            scan_kind: ScanKind::Project,
+            scan_kind: scan_kind.clone(),
             verbose: false,
         })
         .map(|_| ())
@@ -196,11 +201,32 @@ impl WorkspaceServer {
         &self,
         from: &Utf8Path,
         to: &Utf8Path,
+        scan_kind: &ScanKind,
     ) -> Result<(), WorkspaceError> {
         self.close_path_through_watcher(from)?;
-        self.open_path_through_watcher(to)?;
+        self.open_path_through_watcher(to, scan_kind)?;
 
         Ok(())
+    }
+
+    /// Reopens an individual file if the watcher (still) has interest in it.
+    pub fn resync_file_through_watcher(
+        &self,
+        path: &Utf8Path,
+        scan_kind: &ScanKind,
+    ) -> Result<(), WorkspaceError> {
+        let Some(project_key) = self.projects.find_project_for_path(path) else {
+            return Ok(()); // file events outside our projects can be safely ignored.
+        };
+
+        if self
+            .is_ignored_by_scanner(project_key, scan_kind, &BiomePath::new(path))
+            .unwrap_or(true)
+        {
+            return Ok(());
+        }
+
+        self.open_path_through_watcher(path, scan_kind)
     }
 
     /// Used by the watcher to indicate it has stopped.

--- a/crates/biome_service/src/workspace/watcher.tests.rs
+++ b/crates/biome_service/src/workspace/watcher.tests.rs
@@ -54,7 +54,7 @@ fn should_not_open_an_ignored_file_inside_vcs_ignore_file() {
         .expect("can update settings");
 
     workspace
-        .open_path_through_watcher(Utf8Path::new("/project/a.js"))
+        .open_path_through_watcher(Utf8Path::new("/project/a.js"), &ScanKind::Project)
         .expect("can open file");
 
     let result = workspace.format_file(FormatFileParams {
@@ -100,7 +100,10 @@ fn should_not_open_an_ignored_file_inside_file_includes() {
         .expect("can update settings");
 
     workspace
-        .open_path_through_watcher(Utf8Path::new("/project/dist/minified.js"))
+        .open_path_through_watcher(
+            Utf8Path::new("/project/dist/minified.js"),
+            &ScanKind::Project,
+        )
         .expect("can open file");
 
     let result = workspace.format_file(FormatFileParams {
@@ -131,7 +134,7 @@ fn close_file_through_watcher_before_client() {
         .expect("can open project");
 
     workspace
-        .open_path_through_watcher(Utf8Path::new("/project/a.js"))
+        .open_path_through_watcher(Utf8Path::new("/project/a.js"), &ScanKind::Project)
         .expect("can open file");
 
     workspace
@@ -312,7 +315,7 @@ fn close_modified_file_from_client_before_watcher() {
     );
     // call the instruction handler manually for the sake of the test:
     workspace
-        .open_path_through_watcher(Utf8Path::new("/project/a.js"))
+        .open_path_through_watcher(Utf8Path::new("/project/a.js"), &ScanKind::Project)
         .expect("path to be updated by us");
 
     let content = workspace


### PR DESCRIPTION
## Summary

This moves the logic for the scanner's `can_handle()` implementation into the workspace method `is_ignored_by_scanner()`, from where it can be reused by the Watcher. But because this logic depends on the `ScanKind`, we now keep track of the `ScanKind` inside the Watcher too, which should align the behaviours much better.

I'm also somewhat hopeful this can be a step towards solving #6838, although that will require an even tighter integration between the watcher and the rest of the scanner.

This may have a tiny overlap with #6839, so we should wait for that one to be merged first.

## Test Plan

Everything should stay green, especially the tests introduced in #6839. Once #6839 is merged, I will also create a few variations to ensure differences in `ScanKind` are respected.

## Docs

N/A