### PR TITLE
fix(core): silence diagnostics in scanner

### DIFF
--- a/.changeset/silent-scanner-speaks.md
+++ b/.changeset/silent-scanner-speaks.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6510](https://github.com/biomejs/biome/issues/6510): The scanner no longer shows diagnostics on inaccessible files unless `--verbose` is used.

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -985,6 +985,7 @@ pub(crate) trait CommandRunner: Sized {
             watch: cli_options.use_server,
             force: false, // TODO: Maybe we'll want a CLI flag for this.
             scan_kind,
+            verbose: cli_options.verbose,
         })?;
 
         if self.should_validate_configuration_diagnostics() {

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3286,6 +3286,7 @@ export function bar() {
                 watch: true,
                 force: false,
                 scan_kind,
+                verbose: false,
             },
         )
         .await?
@@ -3505,6 +3506,7 @@ export function bar() {
                 watch: true,
                 force: false,
                 scan_kind: ScanKind::Project,
+                verbose: false,
             },
         )
         .await?

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -681,6 +681,7 @@ impl Session {
                     watch: true,
                     force: false,
                     scan_kind,
+                    verbose: false,
                 });
 
             match result {

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1234,6 +1234,9 @@ pub struct ScanProjectFolderParams {
     pub force: bool,
 
     pub scan_kind: ScanKind,
+
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub verbose: bool,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -338,6 +338,7 @@ fn files_loaded_by_the_scanner_are_only_unloaded_when_the_project_is_unregistere
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -430,6 +431,7 @@ fn too_large_files_are_tracked_but_not_parsed() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -490,6 +492,7 @@ fn plugins_are_loaded_and_used_during_analysis() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -559,6 +562,7 @@ language css;
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -624,6 +628,7 @@ fn plugins_may_use_invalid_span() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -743,6 +748,7 @@ const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -15,7 +15,7 @@ use crate::projects::ProjectKey;
 use crate::workspace::DocumentFileSource;
 use crate::{Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
-use biome_diagnostics::{Diagnostic as _, Error, Severity};
+use biome_diagnostics::{Diagnostic as _, DiagnosticExt, Error, Severity};
 use biome_fs::{BiomePath, PathInterner, PathKind, TraversalContext, TraversalScope};
 use camino::Utf8Path;
 use crossbeam::channel::{Receiver, Sender, unbounded};
@@ -48,11 +48,12 @@ impl WorkspaceServer {
         project_key: ProjectKey,
         folder: &Utf8Path,
         scan_kind: ScanKind,
+        verbose: bool,
     ) -> Result<ScanResult, WorkspaceError> {
         let (interner, _path_receiver) = PathInterner::new();
         let (diagnostics_sender, diagnostics_receiver) = unbounded();
 
-        let collector = DiagnosticsCollector::new();
+        let collector = DiagnosticsCollector::new(verbose);
 
         let (duration, diagnostics, configuration_files) = thread::scope(|scope| {
             let handler = thread::Builder::new()
@@ -166,23 +167,22 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>
 struct DiagnosticsCollector {
     /// The minimum level of diagnostic we should collect.
     diagnostic_level: Severity,
-
-    /// Whether we should collect verbose diagnostics.
-    verbose: bool,
 }
 
 impl DiagnosticsCollector {
-    fn new() -> Self {
+    fn new(verbose: bool) -> Self {
         Self {
-            diagnostic_level: Severity::Hint,
-            verbose: false,
+            diagnostic_level: if verbose {
+                Severity::Hint
+            } else {
+                Severity::Error
+            },
         }
     }
 
     /// Checks whether the given `diagnostic` should be collected or not.
     fn should_collect(&self, diagnostic: &Diagnostic) -> bool {
         diagnostic.severity() >= self.diagnostic_level
-            && (self.verbose || !diagnostic.tags().is_verbose())
     }
 
     fn run(&self, receiver: Receiver<Diagnostic>) -> Vec<Diagnostic> {
@@ -408,7 +408,11 @@ fn open_file(ctx: &ScanContext, path: &BiomePath) {
     }) {
         Ok(Ok(())) => {}
         Ok(Err(err)) => {
-            ctx.send_diagnostic(err);
+            let mut error: Error = err.into();
+            if !path.is_config() && error.severity() == Severity::Error {
+                error = error.with_severity(Severity::Warning);
+            }
+            ctx.send_diagnostic(Diagnostic::new(error));
         }
         Err(err) => {
             let error = match err.downcast::<String>() {
@@ -423,3 +427,7 @@ fn open_file(ctx: &ScanContext, path: &BiomePath) {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "scanner.tests.rs"]
+mod tests;

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use biome_fs::{BiomePath, TemporaryFs};
+use crossbeam::channel::bounded;
+use tokio::sync::watch;
+
+use crate::{
+    Workspace, WorkspaceServer,
+    workspace::{OpenProjectParams, ScanKind, ScanProjectFolderParams, ServiceDataNotification},
+};
+
+#[test]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn scanner_doesnt_show_errors_for_inaccessible_files() {
+    use std::os::unix::fs::PermissionsExt;
+
+    const FILE_CONTENT: &str = "import 'foo';";
+
+    let mut fs = TemporaryFs::new("scanner_doesnt_show_errors_for_inaccessible_files");
+    fs.create_file("a.js", FILE_CONTENT);
+
+    let (watcher_tx, _) = bounded(0);
+    let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
+    let workspace =
+        WorkspaceServer::new(Arc::new(fs.create_os()), watcher_tx, service_data_tx, None);
+
+    let permissions = PermissionsExt::from_mode(0o000);
+    std::fs::set_permissions(format!("{}/a.js", fs.cli_path()), permissions)
+        .expect("Cannot set permissions");
+
+    let result = workspace
+        .open_project(OpenProjectParams {
+            path: BiomePath::new(fs.cli_path()),
+            open_uninitialized: true,
+            skip_rules: None,
+            only_rules: None,
+        })
+        .unwrap();
+    let project_key = result.project_key;
+
+    let result = workspace
+        .scan_project_folder(ScanProjectFolderParams {
+            project_key,
+            path: None,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::Project,
+            verbose: false,
+        })
+        .unwrap();
+
+    assert!(result.diagnostics.is_empty());
+
+    let result = workspace
+        .scan_project_folder(ScanProjectFolderParams {
+            project_key,
+            path: None,
+            watch: false,
+            force: false,
+            scan_kind: ScanKind::Project,
+            verbose: true,
+        })
+        .unwrap();
+
+    assert_eq!(result.diagnostics.len(), 1);
+}

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -919,7 +919,7 @@ impl Workspace for WorkspaceServer {
                 .try_send(WatcherInstruction::WatchFolder(path.clone()));
         }
 
-        let result = self.scan(params.project_key, &path, params.scan_kind)?;
+        let result = self.scan(params.project_key, &path, params.scan_kind, params.verbose)?;
 
         let _ = self.notification_tx.send(ServiceDataNotification::Updated);
 

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -33,6 +33,7 @@ fn commonjs_file_rejects_import_statement() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -95,6 +96,7 @@ fn store_embedded_nodes_with_corrent_ranges() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/watcher.rs
+++ b/crates/biome_service/src/workspace/watcher.rs
@@ -102,6 +102,7 @@ impl WorkspaceServer {
             watch: false, // It's already being watched.
             force: true,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .map(|_| ())
     }

--- a/crates/biome_service/tests/spec_tests.rs
+++ b/crates/biome_service/tests/spec_tests.rs
@@ -55,6 +55,7 @@ fn test_scanner_only_loads_type_definitions_from_node_modules() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -144,6 +145,7 @@ fn test_scanner_ignored_files_are_not_loaded() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 
@@ -212,6 +214,7 @@ fn test_scanner_required_files_are_only_ignored_in_ignored_directories() {
             watch: false,
             force: false,
             scan_kind: ScanKind::Project,
+            verbose: false,
         })
         .unwrap();
 


### PR DESCRIPTION
## Summary

Fixed [#6510](https://github.com/biomejs/biome/issues/6510): The scanner no longer shows diagnostics on inaccessible files unless `--verbose` is used.

## Test Plan

Test added.
