### PR TITLE
fix: classes with single quotes in functions should use double quotes

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -217,12 +217,15 @@ impl Rule for UseSortedClasses {
         let mut mutation = ctx.root().begin();
         match ctx.query() {
             AnyClassStringLike::JsStringLiteralExpression(string_literal) => {
-                let replacement =
-                    js_string_literal_expression(if ctx.as_preferred_quote().is_double() {
-                        js_string_literal(state)
-                    } else {
-                        js_string_literal_single_quotes(state)
-                    });
+                let is_double_quote = string_literal
+                    .value_token()
+                    .map(|token| token.text_trimmed().starts_with('"'))
+                    .unwrap_or(ctx.as_preferred_quote().is_double());
+                let replacement = js_string_literal_expression(if is_double_quote {
+                    js_string_literal(state)
+                } else {
+                    js_string_literal_single_quotes(state)
+                });
                 mutation.replace_node(string_literal.clone(), replacement);
             }
             AnyClassStringLike::JsLiteralMemberName(string_literal) => {

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.jsx
@@ -1,0 +1,9 @@
+// functions
+tw("content-[''] absolute");
+tw({ base: "content-[''] absolute" });
+tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+
+// function in jsx attribute
+<div class={tw("content-[''] absolute")}>Hello</div>;
+<div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+<div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.jsx.snap
@@ -1,0 +1,203 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: quoteStyleInFunction.jsx
+---
+# Input
+```jsx
+// functions
+tw("content-[''] absolute");
+tw({ base: "content-[''] absolute" });
+tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+
+// function in jsx attribute
+<div class={tw("content-[''] absolute")}>Hello</div>;
+<div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+<div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+
+```
+
+# Diagnostics
+```
+quoteStyleInFunction.jsx:2:4 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ // functions
+  > 2 │ tw("content-[''] absolute");
+      │    ^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ tw({ base: "content-[''] absolute" });
+    4 │ tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+  
+  i Unsafe fix: Sort the classes.
+  
+     1  1 │   // functions
+     2    │ - tw("content-['']·absolute");
+        2 │ + tw("absolute·content-['']");
+     3  3 │   tw({ base: "content-[''] absolute" });
+     4  4 │   tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:3:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ // functions
+    2 │ tw("content-[''] absolute");
+  > 3 │ tw({ base: "content-[''] absolute" });
+      │            ^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+    5 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+     1  1 │   // functions
+     2  2 │   tw("content-[''] absolute");
+     3    │ - tw({·base:·"content-['']·absolute"·});
+        3 │ + tw({·base:·"absolute·content-['']"·});
+     4  4 │   tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+     5  5 │   
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:4:23 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    2 │ tw("content-[''] absolute");
+    3 │ tw({ base: "content-[''] absolute" });
+  > 4 │ tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+      │                       ^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ // function in jsx attribute
+  
+  i Unsafe fix: Sort the classes.
+  
+     2  2 │   tw("content-[''] absolute");
+     3  3 │   tw({ base: "content-[''] absolute" });
+     4    │ - tw({·variant:·{·dark:·"content-['']·absolute",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·});
+        4 │ + tw({·variant:·{·dark:·"absolute·content-['']",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·});
+     5  5 │   
+     6  6 │   // function in jsx attribute
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:4:55 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    2 │ tw("content-[''] absolute");
+    3 │ tw({ base: "content-[''] absolute" });
+  > 4 │ tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } });
+      │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │ 
+    6 │ // function in jsx attribute
+  
+  i Unsafe fix: Sort the classes.
+  
+     2  2 │   tw("content-[''] absolute");
+     3  3 │   tw({ base: "content-[''] absolute" });
+     4    │ - tw({·variant:·{·dark:·"content-['']·absolute",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·});
+        4 │ + tw({·variant:·{·dark:·"content-['']·absolute",·light:·"m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*='size-'])]:w-4"·}·});
+     5  5 │   
+     6  6 │   // function in jsx attribute
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:7:16 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    6 │ // function in jsx attribute
+  > 7 │ <div class={tw("content-[''] absolute")}>Hello</div>;
+      │                ^^^^^^^^^^^^^^^^^^^^^^^
+    8 │ <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+    9 │ <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+  
+  i Unsafe fix: Sort the classes.
+  
+     5  5 │   
+     6  6 │   // function in jsx attribute
+     7    │ - <div·class={tw("content-['']·absolute")}>Hello</div>;
+        7 │ + <div·class={tw("absolute·content-['']")}>Hello</div>;
+     8  8 │   <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+     9  9 │   <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:8:24 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     6 │ // function in jsx attribute
+     7 │ <div class={tw("content-[''] absolute")}>Hello</div>;
+   > 8 │ <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+       │                        ^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+    10 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+     6  6 │   // function in jsx attribute
+     7  7 │   <div class={tw("content-[''] absolute")}>Hello</div>;
+     8    │ - <div·class={tw({·base:·"content-['']·absolute"·})}>Hello</div>;
+        8 │ + <div·class={tw({·base:·"absolute·content-['']"·})}>Hello</div>;
+     9  9 │   <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+    10 10 │   
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:9:35 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     7 │ <div class={tw("content-[''] absolute")}>Hello</div>;
+     8 │ <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+   > 9 │ <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+       │                                   ^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+     7  7 │   <div class={tw("content-[''] absolute")}>Hello</div>;
+     8  8 │   <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+     9    │ - <div·class={tw({·variant:·{·dark:·"content-['']·absolute",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·})}>Hello</div>;
+        9 │ + <div·class={tw({·variant:·{·dark:·"absolute·content-['']",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·})}>Hello</div>;
+    10 10 │   
+  
+
+```
+
+```
+quoteStyleInFunction.jsx:9:67 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     7 │ <div class={tw("content-[''] absolute")}>Hello</div>;
+     8 │ <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+   > 9 │ <div class={tw({ variant: { dark: "content-[''] absolute", light: "flex gap-2 p-4 m-2 [&_svg:not([class*='size-'])]:w-4 items-center" } })}>Hello</div>;
+       │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    10 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+     7  7 │   <div class={tw("content-[''] absolute")}>Hello</div>;
+     8  8 │   <div class={tw({ base: "content-[''] absolute" })}>Hello</div>;
+     9    │ - <div·class={tw({·variant:·{·dark:·"content-['']·absolute",·light:·"flex·gap-2·p-4·m-2·[&_svg:not([class*='size-'])]:w-4·items-center"·}·})}>Hello</div>;
+        9 │ + <div·class={tw({·variant:·{·dark:·"content-['']·absolute",·light:·"m-2·flex·items-center·gap-2·p-4·[&_svg:not([class*='size-'])]:w-4"·}·})}>Hello</div>;
+    10 10 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/quoteStyleInFunction.options.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "linter": {
+    "rules": {
+      "nursery": {
+        "useSortedClasses": {
+          "level": "error",
+          "options": {
+            "functions": ["tw"]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

### Problem

Similar to the issue that #5781 fixes, sorting classes with quotes in functions results in the wrong quote being used.

For example, `"content-['']·absolute"` would be transformed into `'absolute·content-['']'`.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

### Fix

This PR applies the same fix as #5781 but to functions that are configured to contain strings of classes.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Added snapshot test for functions with a minimal configuration determining the specific function that contains strings of classes.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
