### PR TITLE
perf: optimise `noImportCycles`

### DIFF
--- a/.changeset/cyclic-checks-charge.md
+++ b/.changeset/cyclic-checks-charge.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Improved the performance of `noImportCycles` by ~30%.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,7 @@ dependencies = [
  "camino",
  "cfg-if",
  "codspeed-criterion-compat",
+ "indexmap",
  "insta",
  "mimalloc",
  "once_cell",

--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use biome_analyze::{
     Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
 };
@@ -10,6 +8,7 @@ use biome_module_graph::{JsModuleInfo, ResolvedPath};
 use biome_rowan::AstNode;
 use biome_rule_options::no_import_cycles::NoImportCyclesOptions;
 use camino::{Utf8Path, Utf8PathBuf};
+use rustc_hash::FxHashSet;
 
 use crate::services::module_graph::ResolvedImports;
 
@@ -166,36 +165,32 @@ fn find_cycle(
     start_path: &Utf8Path,
     mut module_info: JsModuleInfo,
 ) -> Option<Box<[Box<str>]>> {
-    let mut seen = HashSet::new();
+    let mut seen = FxHashSet::default();
     let mut stack: Vec<(Box<str>, JsModuleInfo)> = Vec::new();
 
     'outer: loop {
         for resolved_path in module_info.all_import_paths() {
-            let Some(resolved_path) = resolved_path.as_path() else {
+            let Some(path) = resolved_path.as_path() else {
                 continue;
             };
 
-            if resolved_path == ctx.file_path() {
+            if !seen.insert(resolved_path.clone()) {
+                continue;
+            }
+
+            if path == ctx.file_path() {
                 // Return all the paths from `start_path` to `resolved_path`:
                 let paths = Some(start_path.as_str())
                     .into_iter()
                     .map(Box::from)
                     .chain(stack.into_iter().map(|(path, _)| path))
-                    .chain(Some(Box::from(resolved_path.as_str())))
+                    .chain(Some(Box::from(path.as_str())))
                     .collect();
                 return Some(paths);
             }
 
-            // FIXME: Use `get_or_insert_with()` once it's stabilized.
-            //        See: https://github.com/rust-lang/rust/issues/60896
-            if seen.contains(resolved_path.as_str()) {
-                continue;
-            }
-
-            seen.insert(resolved_path.to_string());
-
-            if let Some(next_module_info) = ctx.module_info_for_path(resolved_path) {
-                stack.push((resolved_path.as_str().into(), module_info));
+            if let Some(next_module_info) = ctx.module_info_for_path(path) {
+                stack.push((path.as_str().into(), module_info));
                 module_info = next_module_info;
                 continue 'outer;
             }

--- a/crates/biome_module_graph/Cargo.toml
+++ b/crates/biome_module_graph/Cargo.toml
@@ -26,6 +26,7 @@ biome_resolver       = { workspace = true }
 biome_rowan          = { workspace = true }
 camino               = { workspace = true }
 cfg-if               = { workspace = true }
+indexmap             = { workspace = true }
 once_cell            = "1.21.3"             # Use `std::sync::OnceLock::get_or_try_init` when it is stable.
 papaya               = { workspace = true }
 rust-lapper          = { workspace = true }

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -1,8 +1,4 @@
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-};
+use std::{borrow::Cow, collections::BTreeSet, sync::Arc};
 
 use biome_js_semantic::{SemanticEvent, SemanticEventExtractor};
 use biome_js_syntax::{
@@ -19,6 +15,7 @@ use biome_js_type_info::{
 };
 use biome_jsdoc_comment::JsdocComment;
 use biome_rowan::{AstNode, Text, TextRange, TextSize, TokenText};
+use indexmap::IndexMap;
 use rust_lapper::{Interval, Lapper};
 use rustc_hash::FxHashMap;
 
@@ -77,11 +74,11 @@ pub(super) struct JsModuleInfoCollector {
 
     /// Map with all static import paths, from the source specifier to the
     /// resolved path.
-    static_import_paths: BTreeMap<Text, ResolvedPath>,
+    static_import_paths: IndexMap<Text, ResolvedPath>,
 
     /// Map with all dynamic import paths, from the import source to the
     /// resolved path.
-    dynamic_import_paths: BTreeMap<Text, ResolvedPath>,
+    dynamic_import_paths: IndexMap<Text, ResolvedPath>,
 
     /// All collected exports.
     ///
@@ -96,7 +93,7 @@ pub(super) struct JsModuleInfoCollector {
     types: TypeStore,
 
     /// Static imports mapped from the local name of the binding being imported.
-    static_imports: BTreeMap<Text, JsImport>,
+    static_imports: IndexMap<Text, JsImport>,
 }
 
 /// Intermediary representation for an exported symbol.
@@ -519,7 +516,7 @@ impl JsModuleInfoCollector {
         }
     }
 
-    fn finalise(&mut self) -> (BTreeMap<Text, JsExport>, Lapper<u32, ScopeId>) {
+    fn finalise(&mut self) -> (IndexMap<Text, JsExport>, Lapper<u32, ScopeId>) {
         let scope_by_range = Lapper::new(
             self.scope_range_by_start
                 .iter()
@@ -767,8 +764,8 @@ impl JsModuleInfoCollector {
         }
     }
 
-    fn collect_exports(&mut self) -> BTreeMap<Text, JsExport> {
-        let mut finalised_exports = BTreeMap::new();
+    fn collect_exports(&mut self) -> IndexMap<Text, JsExport> {
+        let mut finalised_exports = IndexMap::new();
 
         let exports = std::mem::take(&mut self.exports);
         for export in exports {

--- a/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
@@ -22,11 +22,11 @@ export = shared;
 
 ```
 Exports {
-  "default" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(3))
-  }
   "foo" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(1))
+  }
+  "default" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(3))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_export_types.snap
@@ -42,11 +42,11 @@ export const superComputer = new DeepThought();
 
 ```
 Exports {
-  "superComputer" => {
-    ExportOwnExport => JsOwnExport::Binding(3)
-  }
   "theAnswer" => {
     ExportOwnExport => JsOwnExport::Binding(0)
+  }
+  "superComputer" => {
+    ExportOwnExport => JsOwnExport::Binding(3)
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -60,29 +60,35 @@ export * as renamed2 from "./renamed-reexports";
 
 ```
 Exports {
+  "foo" => {
+    ExportOwnExport => JsOwnExport::Binding(0)
+  }
+  "qux" => {
+    ExportOwnExport => JsOwnExport::Binding(4)
+  }
+  "bar" => {
+    ExportOwnExport => JsOwnExport::Binding(1)
+  }
+  "quz" => {
+    ExportOwnExport => JsOwnExport::Binding(2)
+  }
+  "baz" => {
+    ExportOwnExport => JsOwnExport::Binding(3)
+  }
   "a" => {
     ExportOwnExport => JsOwnExport::Binding(5)
   }
   "b" => {
     ExportOwnExport => JsOwnExport::Binding(6)
   }
-  "bar" => {
-    ExportOwnExport => JsOwnExport::Binding(1)
-  }
-  "baz" => {
-    ExportOwnExport => JsOwnExport::Binding(3)
-  }
   "d" => {
     ExportOwnExport => JsOwnExport::Binding(7)
-  }
-  "default" => {
-    ExportOwnExport => JsOwnExport::Binding(11)
   }
   "e" => {
     ExportOwnExport => JsOwnExport::Binding(8)
   }
-  "foo" => {
-    ExportOwnExport => JsOwnExport::Binding(0)
+  "default" => {
+    ExportOwnExport => JsOwnExport::Binding(11)
   }
   "oh\nno" => {
     ExportReexport => Reexport(
@@ -90,12 +96,6 @@ Exports {
       Resolved path: "/src/renamed-reexports.ts"
       Import Symbol: ohNo
     )
-  }
-  "qux" => {
-    ExportOwnExport => JsOwnExport::Binding(4)
-  }
-  "quz" => {
-    ExportOwnExport => JsOwnExport::Binding(2)
   }
   "renamed2" => {
     ExportReexport => Reexport(

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_types.snap
@@ -25,17 +25,17 @@ export { A, B };
 
 ```
 Exports {
-  "A" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(2))
-  }
-  "B" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(10))
-  }
   "Union" => {
     ExportOwnExport => JsOwnExport::Binding(3)
   }
   "Union2" => {
     ExportOwnExport => JsOwnExport::Binding(7)
+  }
+  "A" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(2))
+  }
+  "B" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(10))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_multiple_reexports.snap
@@ -2,7 +2,7 @@
 source: crates/biome_module_graph/tests/snap/mod.rs
 expression: content
 ---
-# `/src/bar.ts` (Module 2)
+# `/src/bar.ts` (Module 3)
 
 ## Source
 
@@ -95,7 +95,7 @@ Module TypeId(3) => Module(0) TypeId(2).bar
 Module TypeId(4) => Call Module(0) TypeId(3)(No parameters)
 ```
 
-# `/src/foo.ts` (Module 3)
+# `/src/foo.ts` (Module 2)
 
 ## Source
 
@@ -174,7 +174,7 @@ Full TypeId(1) => namespace for ModuleId(2)
 
 Full TypeId(2) => namespace for ModuleId(3)
 
-Full TypeId(3) => Module(3) TypeId(1)
+Full TypeId(3) => Module(2) TypeId(1)
 
 Full TypeId(4) => number
 

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -72,8 +72,8 @@ Exports {
   "SubdivisionInfo" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(14))
   }
-  "codes" => {
-    ExportOwnExport => JsOwnExport::Binding(18)
+  "subdivision" => {
+    ExportOwnExport => JsOwnExport::Binding(12)
   }
   "country" => {
     ExportOwnExport => JsOwnExport::Binding(15)
@@ -81,8 +81,8 @@ Exports {
   "data" => {
     ExportOwnExport => JsOwnExport::Binding(17)
   }
-  "subdivision" => {
-    ExportOwnExport => JsOwnExport::Binding(12)
+  "codes" => {
+    ExportOwnExport => JsOwnExport::Binding(18)
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
@@ -174,50 +174,50 @@ export = vfile;
 
 ```
 Exports {
-  "basename" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
-  }
-  "contents" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(44))
-  }
-  "cwd" => {
-    ExportOwnExport => JsOwnExport::Type(string)
+  "history" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(49))
   }
   "data" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(34))
   }
-  "default" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(6))
+  "messages" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(35))
+  }
+  "contents" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(44))
+  }
+  "path" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
   }
   "dirname" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
   }
-  "extname" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
-  }
-  "fail" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(40))
-  }
-  "history" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(49))
-  }
-  "info" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(38))
-  }
-  "message" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(38))
-  }
-  "messages" => {
-    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(35))
-  }
-  "path" => {
+  "basename" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
   }
   "stem" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
   }
+  "extname" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(26))
+  }
+  "cwd" => {
+    ExportOwnExport => JsOwnExport::Type(string)
+  }
   "toString" => {
     ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(36))
+  }
+  "message" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(38))
+  }
+  "fail" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(40))
+  }
+  "info" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(38))
+  }
+  "default" => {
+    ExportOwnExport => JsOwnExport::Type(Module(0) TypeId(6))
   }
 }
 Imports {

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -454,7 +454,7 @@ fn test_resolve_exports() {
 
     // Remove this entry, or the Windows tests fail on the path in the snapshot below:
     assert_eq!(
-        exports.remove(&Text::Static("oh\nno")),
+        exports.swap_remove(&Text::Static("oh\nno")),
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
@@ -465,7 +465,7 @@ fn test_resolve_exports() {
         }))
     );
     assert_eq!(
-        exports.remove(&Text::Static("renamed2")),
+        exports.swap_remove(&Text::Static("renamed2")),
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),


### PR DESCRIPTION
## Summary

Improved the performance of `noImportCycles` by ~30%.

The majority of the savings are achieved by using an `IndexMap` instead of `BTreeMap` for storing the imports in the module info. These savings are likely to have some positive impact on type inference as well, although I expect the savings to be less pronounced there.

The rest of the savings were achieved by using an `FxHashSet` instead of a regular `HashSet` to track the paths that have been already been seen during cycle detection. Also, I'm storing the `resolved_path` in the set now, since it has an internal `Arc`, meaning we don't need another allocation for storing it, and we can call `.insert()` directly without needing to call `.contains()` first, since that was also just an attempt at avoiding the allocation.

Note that the performance of `noImportCycles` appears to fluctuate _highly_. On `main`, with a largish repository, I got timings between 12s and 28s. With these fixes it appears to be between 8s and 18s. Still widely inconsistent, but it appears to be a clear improvement :)

## Test Plan

Everything should stay green.