### PR TITLE
fix(core): infer array indices

### DIFF
--- a/.changeset/indexed-items-infer.md
+++ b/.changeset/indexed-items-infer.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6891](https://github.com/biomejs/biome/issues/6891): Improved type inference for array indices.
+
+**Example:**
+
+```ts
+const numbers: number[];
+numbers[42] // This now infers to `number | undefined`.
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue6891.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue6891.ts
@@ -1,0 +1,16 @@
+type State = "running" | "jumping" | "ducking"
+
+class Player {
+  state: State
+  constructor(state: State) {
+    this.state = state
+  }
+}
+
+export function updatePlayers(players: Player[]) {
+  switch(players[0].state) {
+    case "running":
+      break;
+    // Here Biome should error out saying that the "jumping" and "ducking" cases are not handled
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue6891.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue6891.ts.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidIssue6891.ts
+---
+# Input
+```ts
+type State = "running" | "jumping" | "ducking"
+
+class Player {
+  state: State
+  constructor(state: State) {
+    this.state = state
+  }
+}
+
+export function updatePlayers(players: Player[]) {
+  switch(players[0].state) {
+    case "running":
+      break;
+    // Here Biome should error out saying that the "jumping" and "ducking" cases are not handled
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalidIssue6891.ts:11:3 lint/nursery/useExhaustiveSwitchCases  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The switch statement is not exhaustive.
+  
+    10 │ export function updatePlayers(players: Player[]) {
+  > 11 │   switch(players[0].state) {
+       │   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 12 │     case "running":
+  > 13 │       break;
+  > 14 │     // Here Biome should error out saying that the "jumping" and "ducking" cases are not handled
+  > 15 │   }
+       │   ^
+    16 │ }
+    17 │ 
+  
+  i Some variants of the union type are not handled here.
+  
+  i These cases are missing:
+  
+  - "jumping"
+  - "ducking"
+  
+  i Unsafe fix: Add the missing cases to the switch statement.
+  
+    11 11 │     switch(players[0].state) {
+    12 12 │       case "running":
+    13    │ - ······break;
+       13 │ + ······break;
+       14 │ + ····case·"jumping":·throw·new·Error("TODO:·Not·implemented·yet");
+       15 │ + ····case·"ducking":·throw·new·Error("TODO:·Not·implemented·yet");
+    14 16 │       // Here Biome should error out saying that the "jumping" and "ducking" cases are not handled
+    15 17 │     }
+  
+
+```

--- a/crates/biome_js_type_info/src/flattening/expressions.rs
+++ b/crates/biome_js_type_info/src/flattening/expressions.rs
@@ -18,7 +18,7 @@ use crate::{
         GLOBAL_FUNCTION_STRING_LITERAL_ID, GLOBAL_NUMBER_STRING_LITERAL_ID,
         GLOBAL_OBJECT_STRING_LITERAL_ID, GLOBAL_STRING_STRING_LITERAL_ID,
         GLOBAL_SYMBOL_STRING_LITERAL_ID, GLOBAL_TYPEOF_OPERATOR_RETURN_UNION_ID,
-        GLOBAL_UNDEFINED_STRING_LITERAL_ID,
+        GLOBAL_UNDEFINED_ID, GLOBAL_UNDEFINED_STRING_LITERAL_ID,
     },
 };
 
@@ -119,62 +119,6 @@ pub(super) fn flattened_expression(
                 })
             }
         }
-        TypeofExpression::IterableValueOf(expr) => {
-            let ty = resolver.resolve_and_get(&expr.ty)?;
-            match ty.as_raw_data() {
-                TypeData::InstanceOf(instance)
-                    if instance.ty == GLOBAL_ARRAY_ID.into()
-                        && instance.has_known_type_parameters() =>
-                {
-                    instance
-                        .type_parameters
-                        .first()
-                        .map(|param| ty.apply_module_id_to_reference(param))
-                        .and_then(|param| resolver.resolve_and_get(&param))
-                        .map(ResolvedTypeData::to_data)
-                }
-                _ => {
-                    // TODO: Handle other iterable types
-                    None
-                }
-            }
-        }
-        TypeofExpression::LogicalAnd(expr) => {
-            let left = resolver.resolve_and_get(&expr.left)?;
-            let conditional = ConditionalType::from_resolved_data(left, resolver);
-            if conditional.is_falsy() {
-                Some(left.to_data())
-            } else if conditional.is_truthy() {
-                Some(TypeData::reference(expr.right.clone()))
-            } else if conditional.is_inferred() {
-                let left = reference_to_falsy_subset_of(&left.to_data(), resolver)
-                    .unwrap_or_else(|| expr.left.clone());
-                Some(TypeData::union_of(
-                    resolver,
-                    [left, expr.right.clone()].into(),
-                ))
-            } else {
-                None
-            }
-        }
-        TypeofExpression::LogicalOr(expr) => {
-            let left = resolver.resolve_and_get(&expr.left)?;
-            let conditional = ConditionalType::from_resolved_data(left, resolver);
-            if conditional.is_truthy() {
-                Some(left.to_data())
-            } else if conditional.is_falsy() {
-                Some(TypeData::reference(expr.right.clone()))
-            } else if conditional.is_inferred() {
-                let left = reference_to_truthy_subset_of(&left.to_data(), resolver)
-                    .unwrap_or_else(|| expr.left.clone());
-                Some(TypeData::union_of(
-                    resolver,
-                    [left, expr.right.clone()].into(),
-                ))
-            } else {
-                None
-            }
-        }
         TypeofExpression::Destructure(expr) => {
             let resolved = resolver.resolve_and_get(&expr.ty)?;
             match (resolved.as_raw_data(), &expr.destructure_field) {
@@ -241,6 +185,70 @@ pub(super) fn flattened_expression(
                 (_, DestructureField::RestExcept(excluded_names)) => {
                     Some(flattened_rest_object(resolver, resolved, excluded_names))
                 }
+            }
+        }
+        TypeofExpression::Index(expr) => {
+            let object = resolver.resolve_and_get(&expr.object)?;
+            let element_ty = object
+                .to_data()
+                .find_element_type_at_index(object.resolver_id(), resolver, expr.index)
+                .map_or_else(TypeData::unknown, ResolvedTypeData::to_data);
+            Some(element_ty)
+        }
+        TypeofExpression::IterableValueOf(expr) => {
+            let ty = resolver.resolve_and_get(&expr.ty)?;
+            match ty.as_raw_data() {
+                TypeData::InstanceOf(instance)
+                    if instance.ty == GLOBAL_ARRAY_ID.into()
+                        && instance.has_known_type_parameters() =>
+                {
+                    instance
+                        .type_parameters
+                        .first()
+                        .map(|param| ty.apply_module_id_to_reference(param))
+                        .and_then(|param| resolver.resolve_and_get(&param))
+                        .map(ResolvedTypeData::to_data)
+                }
+                _ => {
+                    // TODO: Handle other iterable types
+                    None
+                }
+            }
+        }
+        TypeofExpression::LogicalAnd(expr) => {
+            let left = resolver.resolve_and_get(&expr.left)?;
+            let conditional = ConditionalType::from_resolved_data(left, resolver);
+            if conditional.is_falsy() {
+                Some(left.to_data())
+            } else if conditional.is_truthy() {
+                Some(TypeData::reference(expr.right.clone()))
+            } else if conditional.is_inferred() {
+                let left = reference_to_falsy_subset_of(&left.to_data(), resolver)
+                    .unwrap_or_else(|| expr.left.clone());
+                Some(TypeData::union_of(
+                    resolver,
+                    [left, expr.right.clone()].into(),
+                ))
+            } else {
+                None
+            }
+        }
+        TypeofExpression::LogicalOr(expr) => {
+            let left = resolver.resolve_and_get(&expr.left)?;
+            let conditional = ConditionalType::from_resolved_data(left, resolver);
+            if conditional.is_truthy() {
+                Some(left.to_data())
+            } else if conditional.is_falsy() {
+                Some(TypeData::reference(expr.right.clone()))
+            } else if conditional.is_inferred() {
+                let left = reference_to_truthy_subset_of(&left.to_data(), resolver)
+                    .unwrap_or_else(|| expr.left.clone());
+                Some(TypeData::union_of(
+                    resolver,
+                    [left, expr.right.clone()].into(),
+                ))
+            } else {
+                None
             }
         }
         TypeofExpression::New(expr) => {
@@ -332,7 +340,11 @@ pub(super) fn flattened_expression(
                         .collect();
                     let types = types
                         .into_iter()
-                        .map(|variant| {
+                        .filter_map(|variant| {
+                            if variant == GLOBAL_UNDEFINED_ID.into() {
+                                return None;
+                            }
+
                             // Resolve and flatten the type member for each variant.
                             let variant = TypeData::TypeofExpression(Box::new(
                                 TypeofExpression::StaticMember(TypeofStaticMemberExpression {
@@ -341,7 +353,7 @@ pub(super) fn flattened_expression(
                                 }),
                             ));
 
-                            resolver.reference_to_owned_data(variant)
+                            Some(resolver.reference_to_owned_data(variant))
                         })
                         .collect();
 

--- a/crates/biome_js_type_info/src/format_type_info.rs
+++ b/crates/biome_js_type_info/src/format_type_info.rs
@@ -474,6 +474,15 @@ impl Format<FormatTypeContext> for TypeofExpression {
                     )
                 }
             },
+            Self::Index(expr) => {
+                write!(
+                    f,
+                    [&format_args![
+                        &expr.object,
+                        dynamic_text(&std::format!("[{}]", expr.index), TextSize::default()),
+                    ]]
+                )
+            }
             Self::IterableValueOf(expr) => {
                 write!(
                     f,

--- a/crates/biome_js_type_info/src/helpers.rs
+++ b/crates/biome_js_type_info/src/helpers.rs
@@ -163,7 +163,7 @@ impl TypeData {
         index: usize,
     ) -> Option<ResolvedTypeData<'a>> {
         match self {
-            Self::Tuple(tuple) => Some(tuple.get_ty(resolver, index)),
+            Self::Tuple(tuple) => tuple.get_ty(resolver, index),
             _ => {
                 let resolved = ResolvedTypeData::from((resolver_id, self));
                 if resolved.is_instance_of(resolver, GLOBAL_ARRAY_ID) {

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -36,10 +36,10 @@ use crate::{
     TypeOperatorType, TypeReference, TypeReferenceQualifier, TypeResolver,
     TypeofAdditionExpression, TypeofAwaitExpression, TypeofBitwiseNotExpression,
     TypeofCallExpression, TypeofConditionalExpression, TypeofDestructureExpression,
-    TypeofExpression, TypeofIterableValueOfExpression, TypeofLogicalAndExpression,
-    TypeofLogicalOrExpression, TypeofNewExpression, TypeofNullishCoalescingExpression,
-    TypeofStaticMemberExpression, TypeofThisOrSuperExpression, TypeofTypeofExpression,
-    TypeofUnaryMinusExpression, TypeofValue,
+    TypeofExpression, TypeofIndexExpression, TypeofIterableValueOfExpression,
+    TypeofLogicalAndExpression, TypeofLogicalOrExpression, TypeofNewExpression,
+    TypeofNullishCoalescingExpression, TypeofStaticMemberExpression, TypeofThisOrSuperExpression,
+    TypeofTypeofExpression, TypeofUnaryMinusExpression, TypeofValue,
 };
 
 impl TypeData {
@@ -495,6 +495,23 @@ impl TypeData {
                                     member,
                                 },
                             ))
+                        })
+                        .unwrap_or_default(),
+                    (
+                        Ok(object),
+                        Ok(AnyJsExpression::AnyJsLiteralExpression(
+                            AnyJsLiteralExpression::JsNumberLiteralExpression(member),
+                        )),
+                    ) => unescaped_text_from_token(member.value_token())
+                        .map(|member| match member.parse() {
+                            Ok(index) => {
+                                Self::from(TypeofExpression::Index(TypeofIndexExpression {
+                                    object: resolver
+                                        .reference_to_resolved_expression(scope_id, &object),
+                                    index,
+                                }))
+                            }
+                            Err(_) => Self::unknown(),
                         })
                         .unwrap_or_default(),
                     _ => Self::unknown(),

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -291,10 +291,6 @@ Module TypeId(17) => sync Function "Component" {
   }
   returns: Module(0) TypeId(16)
 }
-
-Module TypeId(18) => Module(0) TypeId(7)
-
-Module TypeId(19) => Module(0) TypeId(8)
 ```
 
 # `/src/renamed-reexports.ts`


### PR DESCRIPTION
## Summary

Fixed [#6891](https://github.com/biomejs/biome/issues/6891): Improved type inference for array indices.

**Example:**

```ts
const numbers: number[];
numbers[42] // This now infers to `number | undefined`.
```

## Test Plan

Test added.