### PR TITLE
fix(core): fix type inference of `this`

### DIFF
--- a/.changeset/tiny-this-trembles.md
+++ b/.changeset/tiny-this-trembles.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6777](https://github.com/biomejs/biome/issues/6777): Fixed type inference handling of `this` to avoid infinite recursion.
+
+Thanks to @sterliakov for the thorough investigation!

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/18_invalid.js
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/18_invalid.js
@@ -1,0 +1,14 @@
+class Foo {
+    get foo() {
+        if (!this.initialised) {
+            this.initialise();
+            return "foo";
+        }
+
+        return "foo";
+    }
+
+    async initialise() {
+        // Do stuff
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/18_invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/18_invalid.js.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: 18_invalid.js
+---
+# Input
+```js
+class Foo {
+    get foo() {
+        if (!this.initialised) {
+            this.initialise();
+            return "foo";
+        }
+
+        return "foo";
+    }
+
+    async initialise() {
+        // Do stuff
+    }
+}
+
+```
+
+# Diagnostics
+```
+18_invalid.js:4:13 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    2 │     get foo() {
+    3 │         if (!this.initialised) {
+  > 4 │             this.initialise();
+      │             ^^^^^^^^^^^^^^^^^^
+    5 │             return "foo";
+    6 │         }
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/issue6777Valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/issue6777Valid.ts
@@ -1,0 +1,12 @@
+/* should not generate diagnostics */
+
+class Foo {
+    private readonly version = "42";
+
+    public bar(): void {
+        // @ts-ignore
+        const x = {
+            version: this.version,
+        };
+    }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/issue6777Valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMisusedPromises/issue6777Valid.ts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6777Valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+class Foo {
+    private readonly version = "42";
+
+    public bar(): void {
+        // @ts-ignore
+        const x = {
+            version: this.version,
+        };
+    }
+}
+
+```

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_property_with_getter.snap.new
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_property_with_getter.snap.new
@@ -1,0 +1,71 @@
+---
+source: crates/biome_module_graph/tests/snap/mod.rs
+assertion_line: 129
+expression: content
+---
+# `/src/index.ts`
+
+## Source
+
+```ts
+class Foo {
+	get foo() {
+		if (!this.initialised) {
+			this.initialise();
+			return "foo";
+		}
+
+		return "foo";
+	}
+}
+
+const fooness = new Foo();
+const foo = fooness.foo;
+```
+
+## Module Info
+
+```
+Exports {
+  No exports
+}
+Imports {
+  No imports
+}
+```
+
+## Registered types
+
+```
+Module TypeId(0) => unknown
+
+Module TypeId(1) => Module(0) TypeId(0).initialised
+
+Module TypeId(2) => boolean
+
+Module TypeId(3) => Module(0) TypeId(0).initialise
+
+Module TypeId(4) => Call Module(0) TypeId(3)(No parameters)
+
+Module TypeId(5) => value: foo
+
+Module TypeId(6) => Module(0) TypeId(10)
+
+Module TypeId(7) => instanceof Module(0) TypeId(6)
+
+Module TypeId(8) => Module(0) TypeId(5)
+
+Module TypeId(9) => sync Function "foo" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(5)
+}
+
+Module TypeId(10) => class "Foo" {
+  extends: none
+  implements: []
+  type_args: []
+}
+```


### PR DESCRIPTION
## Summary

Fixed #6777: Fixed type inference handling of `this` to avoid infinite recursion.

Thanks to @sterliakov for the thorough investigation!

## Test Plan

Test added.