### PR TITLE
fix(core): use non-recursive watchers

### DIFF
--- a/.changeset/wobbly-watcher-winks.md
+++ b/.changeset/wobbly-watcher-winks.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6838](https://github.com/biomejs/biome/issues/6838): Reduce resource consumption in the Biome Language Server by using non-recursive filesystem watchers instead of recursive ones.
+
+Watchers are responsible for notifying Biome of changes to files in the filesystem. We used to set up a single recursive watcher, but that meant that Biome would receive filesystem notifications for _all_ files in your project, even for ignored folders such as `build/` or `dist/` folders.
+
+With this patch, we set up non-recursive watchers only for the folders that are relevant to a project.

--- a/crates/biome_fs/src/fs.rs
+++ b/crates/biome_fs/src/fs.rs
@@ -378,6 +378,12 @@ pub trait TraversalContext: Sync {
 
     /// Returns the paths that should be handled
     fn evaluated_paths(&self) -> BTreeSet<BiomePath>;
+
+    /// Returns whether directories are stored and returned by
+    /// `Self::evaluated_paths()`.
+    fn store_dirs(&self) -> bool {
+        false
+    }
 }
 
 impl<T> FileSystem for Arc<T>

--- a/crates/biome_fs/src/fs/os.rs
+++ b/crates/biome_fs/src/fs/os.rs
@@ -343,16 +343,18 @@ fn handle_any_file<'scope>(
     }
 
     if file_type.is_dir() {
+        let path_buf = path.to_path_buf();
         scope.spawn(move |scope| {
-            handle_dir(scope, ctx, &path, origin_path);
+            handle_dir(scope, ctx, &path_buf, origin_path);
         });
+        if ctx.store_dirs() {
+            ctx.store_path(BiomePath::new(path));
+        }
         return;
     }
 
     if file_type.is_file() {
-        scope.spawn(move |_| {
-            ctx.store_path(BiomePath::new(path));
-        });
+        ctx.store_path(BiomePath::new(path));
         return;
     }
 

--- a/crates/biome_service/src/workspace/scanner.rs
+++ b/crates/biome_service/src/workspace/scanner.rs
@@ -13,11 +13,11 @@ use super::{FeaturesBuilder, IgnoreKind, IsPathIgnoredParams};
 use crate::diagnostics::Panic;
 use crate::projects::ProjectKey;
 use crate::workspace::DocumentFileSource;
-use crate::{Workspace, WorkspaceError};
+use crate::{WatcherInstruction, Workspace, WorkspaceError};
 use biome_diagnostics::serde::Diagnostic;
 use biome_diagnostics::{Diagnostic as _, DiagnosticExt, Error, Severity};
 use biome_fs::{BiomePath, PathInterner, PathKind, TraversalContext, TraversalScope};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use crossbeam::channel::{Receiver, Sender, unbounded};
 use std::collections::BTreeSet;
 use std::panic::catch_unwind;
@@ -25,6 +25,12 @@ use std::sync::RwLock;
 use std::thread;
 use std::time::{Duration, Instant};
 use tracing::instrument;
+
+pub(crate) struct ScanOptions {
+    pub scan_kind: ScanKind,
+    pub verbose: bool,
+    pub watch: bool,
+}
 
 pub(crate) struct ScanResult {
     /// Diagnostics reported while scanning the project.
@@ -47,8 +53,11 @@ impl WorkspaceServer {
         &self,
         project_key: ProjectKey,
         folder: &Utf8Path,
-        scan_kind: ScanKind,
-        verbose: bool,
+        ScanOptions {
+            scan_kind,
+            verbose,
+            watch,
+        }: ScanOptions,
     ) -> Result<ScanResult, WorkspaceError> {
         let (interner, _path_receiver) = PathInterner::new();
         let (diagnostics_sender, diagnostics_receiver) = unbounded();
@@ -63,7 +72,11 @@ impl WorkspaceServer {
 
             // The traversal context is scoped to ensure all the channels it
             // contains are properly closed once scanning finishes.
-            let (duration, configuration_files) = scan_folder(
+            let ScanFolderResult {
+                duration,
+                configuration_files,
+                folders_to_watch,
+            } = scan_folder(
                 folder,
                 ScanContext {
                     workspace: self,
@@ -71,9 +84,16 @@ impl WorkspaceServer {
                     interner,
                     diagnostics_sender,
                     evaluated_paths: Default::default(),
-                    scan_kind,
+                    scan_kind: scan_kind.clone(),
+                    watch,
                 },
             );
+
+            for folder in folders_to_watch {
+                let _ = self
+                    .watcher_tx
+                    .try_send(WatcherInstruction::WatchFolder(folder, scan_kind.clone()));
+            }
 
             // Wait for the collector thread to finish.
             let diagnostics = handler.join().unwrap();
@@ -93,6 +113,7 @@ impl WorkspaceServer {
         project_key: ProjectKey,
         scan_kind: &ScanKind,
         path: &BiomePath,
+        ignore_kind: IgnoreKind,
     ) -> Result<bool, WorkspaceError> {
         if self.projects.is_ignored_by_scanner(project_key, path) {
             return Ok(true);
@@ -107,7 +128,7 @@ impl WorkspaceServer {
 
                 if self
                     .projects
-                    .is_ignored_by_top_level_config(project_key, path, IgnoreKind::Path)
+                    .is_ignored_by_top_level_config(project_key, path, ignore_kind)
                 {
                     return Ok(true); // Nobody cares about ignored paths.
                 }
@@ -129,11 +150,8 @@ impl WorkspaceServer {
             PathKind::File { .. } => match scan_kind {
                 ScanKind::KnownFiles | ScanKind::TargetedKnownFiles { .. } => {
                     if path.is_config() {
-                        self.projects.is_ignored_by_top_level_config(
-                            project_key,
-                            path,
-                            IgnoreKind::Path,
-                        )
+                        self.projects
+                            .is_ignored_by_top_level_config(project_key, path, ignore_kind)
                     } else {
                         !path.is_ignore() && !path.is_manifest()
                     }
@@ -156,11 +174,24 @@ impl WorkspaceServer {
     }
 }
 
+struct ScanFolderResult {
+    /// Duration of the scan.
+    pub duration: Duration,
+
+    /// List of nested configuration files found inside the folder.
+    ///
+    /// The root configuration is not included in this.
+    pub configuration_files: Vec<BiomePath>,
+
+    /// List of directories that need to be watched.
+    pub folders_to_watch: Vec<Utf8PathBuf>,
+}
+
 /// Initiates the filesystem traversal tasks from the provided path and runs it to completion.
 ///
 /// Returns the duration of the process and the evaluated paths.
 #[instrument(level = "debug", skip(ctx))]
-fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>) {
+fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> ScanFolderResult {
     let start = Instant::now();
     let fs = ctx.workspace.fs();
     let ctx_ref = &ctx;
@@ -173,17 +204,20 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>
     let mut manifests = Vec::new();
     let mut handleable_paths = Vec::with_capacity(evaluated_paths.len());
     let mut ignore_paths = Vec::new();
-    // We want to process files that closest to the project root first. For example, we must process
-    // first the `.gitignore` at the root of the project.
-    let iter = evaluated_paths.into_iter();
+    let mut folders_to_watch = Vec::new();
 
-    for path in iter {
+    // We want to process files that closest to the project root first. For
+    // example, we must process first the `.gitignore` at the root of the
+    // project.
+    for path in evaluated_paths {
         if path.is_config() {
             configs.push(path);
         } else if path.is_manifest() {
             manifests.push(path);
         } else if path.is_ignore() {
             ignore_paths.push(path);
+        } else if path.is_dir() {
+            folders_to_watch.push(path.into());
         } else {
             handleable_paths.push(path);
         }
@@ -228,7 +262,11 @@ fn scan_folder(folder: &Utf8Path, ctx: ScanContext) -> (Duration, Vec<BiomePath>
         }
     }));
 
-    (start.elapsed(), configs)
+    ScanFolderResult {
+        duration: start.elapsed(),
+        configuration_files: configs,
+        folders_to_watch,
+    }
 }
 
 struct DiagnosticsCollector {
@@ -284,6 +322,9 @@ pub(crate) struct ScanContext<'app> {
 
     /// What the scanner should target.
     scan_kind: ScanKind,
+
+    /// Whether the scanned folders need to be watched.
+    watch: bool,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -355,10 +396,12 @@ impl TraversalContext for ScanContext<'_> {
     // - The kind of file system entry the path points to.
     // - The kind of scan we are performing.
     fn can_handle(&self, path: &BiomePath) -> bool {
-        match self
-            .workspace
-            .is_ignored_by_scanner(self.project_key, &self.scan_kind, path)
-        {
+        match self.workspace.is_ignored_by_scanner(
+            self.project_key,
+            &self.scan_kind,
+            path,
+            IgnoreKind::Path,
+        ) {
             Ok(is_ignored) => !is_ignored,
             Err(_) => {
                 // Pretend we can handle it so we can give a meaningful error
@@ -374,6 +417,10 @@ impl TraversalContext for ScanContext<'_> {
 
     fn store_path(&self, path: BiomePath) {
         self.evaluated_paths.write().unwrap().insert(path);
+    }
+
+    fn store_dirs(&self) -> bool {
+        self.watch
     }
 }
 

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1,14 +1,14 @@
 use super::document::Document;
 use super::{
     ChangeFileParams, CheckFileSizeParams, CheckFileSizeResult, CloseFileParams,
-    CloseProjectParams, FeaturesBuilder, FileContent, FileExitsParams, FixFileParams,
-    FixFileResult, FormatFileParams, FormatOnTypeParams, FormatRangeParams,
-    GetControlFlowGraphParams, GetFormatterIRParams, GetSemanticModelParams, GetSyntaxTreeParams,
-    GetSyntaxTreeResult, IgnoreKind, OpenFileParams, OpenProjectParams, ParsePatternParams,
-    ParsePatternResult, PatternId, ProjectKey, PullActionsParams, PullActionsResult,
-    PullDiagnosticsParams, PullDiagnosticsResult, RenameResult, ScanProjectFolderParams,
-    ScanProjectFolderResult, SearchPatternParams, SearchResults, ServiceDataNotification,
-    SupportsFeatureParams, UpdateSettingsParams, UpdateSettingsResult,
+    CloseProjectParams, FileContent, FileExitsParams, FixFileParams, FixFileResult,
+    FormatFileParams, FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams,
+    GetFormatterIRParams, GetSemanticModelParams, GetSyntaxTreeParams, GetSyntaxTreeResult,
+    IgnoreKind, OpenFileParams, OpenProjectParams, ParsePatternParams, ParsePatternResult,
+    PatternId, ProjectKey, PullActionsParams, PullActionsResult, PullDiagnosticsParams,
+    PullDiagnosticsResult, RenameResult, ScanProjectFolderParams, ScanProjectFolderResult,
+    SearchPatternParams, SearchResults, ServiceDataNotification, SupportsFeatureParams,
+    UpdateSettingsParams, UpdateSettingsResult,
 };
 use crate::configuration::{LoadedConfiguration, ProjectScanComputer, read_config};
 use crate::diagnostics::{FileTooLarge, NoIgnoreFileFound, VcsDiagnostic};
@@ -18,6 +18,7 @@ use crate::file_handlers::{
     ParseResult,
 };
 use crate::projects::Projects;
+use crate::workspace::scanner::ScanOptions;
 use crate::workspace::{
     FileFeaturesResult, GetFileContentParams, GetRegisteredTypesParams, GetTypeInfoParams,
     IsPathIgnoredParams, OpenProjectResult, RageEntry, RageParams, RageResult, ScanKind,
@@ -112,10 +113,10 @@ pub struct WorkspaceServer {
     pub(super) fs: Arc<dyn FsWithResolverProxy>,
 
     /// Channel sender for instructions to the [crate::WorkspaceWatcher].
-    watcher_tx: Sender<WatcherInstruction>,
+    pub(super) watcher_tx: Sender<WatcherInstruction>,
 
     /// Set containing all the watched folders.
-    watched_folders: HashSet<Utf8PathBuf>,
+    pub(super) watched_folders: HashSet<Utf8PathBuf>,
 
     /// Channel sender for sending notifications of service data updates.
     pub(super) notification_tx: watch::Sender<ServiceDataNotification>,
@@ -306,14 +307,7 @@ impl WorkspaceServer {
             return Ok(()); // file events outside our projects can be safely ignored.
         };
 
-        let is_ignored = self.is_ignored_by_scanner(project_key, scan_kind, &path)?
-            || self.is_path_ignored(IsPathIgnoredParams {
-                project_key,
-                path: path.clone(),
-                features: FeaturesBuilder::default().build(),
-                ignore_kind: IgnoreKind::Ancestors,
-            })?;
-        if is_ignored {
+        if self.is_ignored_by_scanner(project_key, scan_kind, &path, IgnoreKind::Ancestors)? {
             return Ok(());
         }
 
@@ -895,19 +889,24 @@ impl Workspace for WorkspaceServer {
 
     fn scan_project_folder(
         &self,
-        params: ScanProjectFolderParams,
+        ScanProjectFolderParams {
+            project_key,
+            path,
+            watch,
+            force,
+            scan_kind,
+            verbose,
+        }: ScanProjectFolderParams,
     ) -> Result<ScanProjectFolderResult, WorkspaceError> {
-        let path = params
-            .path
+        let path = path
             .map(Utf8PathBuf::from)
-            .or_else(|| self.projects.get_project_path(params.project_key))
+            .or_else(|| self.projects.get_project_path(project_key))
             .ok_or_else(WorkspaceError::no_project)?;
 
-        let scan_kind = params.scan_kind;
         if scan_kind.is_none() {
             let manifest = path.join("package.json");
             if self.fs.path_exists(&manifest) {
-                self.open_file_during_initial_scan(params.project_key, manifest.clone())?;
+                self.open_file_during_initial_scan(project_key, manifest.clone())?;
                 self.update_project_layout(
                     WatcherSignalKind::AddedOrChanged(OpenFileReason::InitialScan),
                     &manifest,
@@ -920,7 +919,7 @@ impl Workspace for WorkspaceServer {
             });
         }
 
-        let should_scan = params.force
+        let should_scan = force
             || !self
                 .watched_folders
                 .pin()
@@ -935,16 +934,13 @@ impl Workspace for WorkspaceServer {
             });
         }
 
-        if params.watch {
-            self.watched_folders.pin().insert(path.clone());
+        let scan_options = ScanOptions {
+            scan_kind,
+            verbose,
+            watch,
+        };
 
-            let _ = self.watcher_tx.try_send(WatcherInstruction::WatchFolder(
-                path.clone(),
-                scan_kind.clone(),
-            ));
-        }
-
-        let result = self.scan(params.project_key, &path, scan_kind, params.verbose)?;
+        let result = self.scan(project_key, &path, scan_options)?;
 
         let _ = self.notification_tx.send(ServiceDataNotification::Updated);
 

--- a/crates/biome_service/src/workspace/watcher.tests.rs
+++ b/crates/biome_service/src/workspace/watcher.tests.rs
@@ -1,21 +1,23 @@
-use super::*;
-use crate::workspace::{FormatFileParams, OpenProjectResult, UpdateSettingsParams};
-use crate::{
-    WatcherInstruction,
-    workspace::{
-        ChangeFileParams, CloseFileParams, FileContent, GetFileContentParams, OpenFileParams,
-        OpenProjectParams, ServiceDataNotification,
-    },
-};
+use std::{str::FromStr, sync::Arc};
+
 use biome_configuration::vcs::{VcsClientKind, VcsConfiguration};
 use biome_configuration::{Configuration, FilesConfiguration};
 use biome_fs::{BiomePath, MemoryFileSystem};
 use biome_glob::NormalizedGlob;
 use camino::Utf8PathBuf;
 use crossbeam::channel::unbounded;
-use std::str::FromStr;
-use std::sync::Arc;
 use tokio::sync::watch;
+
+use crate::{
+    WatcherInstruction,
+    workspace::{
+        ChangeFileParams, CloseFileParams, FileContent, FormatFileParams, GetFileContentParams,
+        OpenFileParams, OpenProjectParams, OpenProjectResult, ServiceDataNotification,
+        UpdateSettingsParams,
+    },
+};
+
+use super::*;
 
 #[test]
 fn should_not_open_an_ignored_file_inside_vcs_ignore_file() {
@@ -54,7 +56,7 @@ fn should_not_open_an_ignored_file_inside_vcs_ignore_file() {
         .expect("can update settings");
 
     workspace
-        .open_path_through_watcher(Utf8Path::new("/project/a.js"), &ScanKind::Project)
+        .open_path_through_watcher(Utf8Path::new("/project/a.js"), &ScanKind::KnownFiles)
         .expect("can open file");
 
     let result = workspace.format_file(FormatFileParams {
@@ -102,7 +104,7 @@ fn should_not_open_an_ignored_file_inside_file_includes() {
     workspace
         .open_path_through_watcher(
             Utf8Path::new("/project/dist/minified.js"),
-            &ScanKind::Project,
+            &ScanKind::KnownFiles,
         )
         .expect("can open file");
 


### PR DESCRIPTION
## Summary

Fixed [#6838](https://github.com/biomejs/biome/issues/6838): Reduce resource consumption in the Biome Language Server by using non-recursive filesystem watchers instead of recursive ones.

Watchers are responsible for notifying Biome of changes to files in the filesystem. We used to set up a single recursive watcher, but that meant that Biome would receive filesystem notifications for _all_ files in your project, even for ignored folders such as `build/` or `dist/` folders.

With this patch, we set up non-recursive watchers only for the folders that are relevant to a project.

## Test Plan

Test added. Updated some existing tests.