### PR TITLE
ci: add French, Spanish and Ukrainian to labeler

### DIFF
--- a/.github/documentation-issue-labeler.yaml
+++ b/.github/documentation-issue-labeler.yaml
@@ -7,8 +7,14 @@
 'Lang-Chinese':
   - 'https://biomejs.dev/zh-cn/'
 'Lang-English':
-  - 'https://biomejs.dev/(?!(zh-cn|ja|pt-br))'
+  - 'https://biomejs.dev/(?!(zh-cn|fr|ja|pt-br|es|uk))'
+'Lang-French':
+  - 'https://biomejs.dev/fr/'
 'Lang-Japanese':
   - 'https://biomejs.dev/ja/'
 'Lang-Portuguese':
   - 'https://biomejs.dev/pt-br/'
+'Lang-Spanish':
+  - 'https://biomejs.dev/es/'
+'Lang-Ukrainian':
+  - 'https://biomejs.dev/uk/'


### PR DESCRIPTION
## Summary

Add French, Spanish, and Ukrainian to the documentation issue labeler and adjust the English matching regex accordingly

CI:
- Add French, Spanish, and Ukrainian labels to the documentation-issue-labeler config
- Update English label regex to exclude fr, es, and uk locales

## How to verify your codes?

<img width="612" height="489" alt="image" src="https://github.com/user-attachments/assets/9b3bfe27-bb70-4b8a-b5a9-7f9c48e4d3f6" />