### PR TITLE
fix(core): ignore `ModifyKind::Any` in `Watcher`

### DIFF
--- a/crates/biome_service/src/workspace_watcher.rs
+++ b/crates/biome_service/src/workspace_watcher.rs
@@ -216,9 +216,9 @@ impl WorkspaceWatcher {
                     }
                     _ => Ok(()),
                 },
-                // `RenameMode::Any` and `ModifyKind::Any` need to be included as a catch-all.
+                // `RenameMode::Any` needs to be included as a catch-all.
                 // Without it, we'll miss events on Windows or macOS.
-                ModifyKind::Data(_) | ModifyKind::Name(RenameMode::Any) | ModifyKind::Any => {
+                ModifyKind::Data(_) | ModifyKind::Name(RenameMode::Any) => {
                     workspace.open_paths_through_watcher(paths, &scan_kind)
                 }
                 _ => Ok(()),


### PR DESCRIPTION
## Summary

I don't know yet if this will help, and it has a serious risk of regressions, but it _may_ help with #6784 _if_ my hypothesis is correct that it could be an OS/FS-specific issue with access time modification.

## Test Plan

Let's first see see if there are no CI regressions. If it passes, we can make a build and ask people to test it.