### PR TITLE
perf: introduce `Path` type

### DIFF
--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -1,7 +1,7 @@
 use biome_rowan::Text;
 
 use crate::{
-    Class, Function, Interface, Intersection, Literal, Namespace, Object, ResolvedTypeData,
+    Class, Function, Interface, Intersection, Literal, Namespace, Object, Path, ResolvedTypeData,
     ReturnType, TypeData, TypeMember, TypeMemberKind, TypeResolver,
 };
 
@@ -274,7 +274,7 @@ impl MergedType {
             }),
             Self::Namespace(members) => TypeData::from(Namespace {
                 members: members.into_iter().collect(),
-                path: [].into(),
+                path: Path::from(Text::Static("")),
             }),
             Self::Never => TypeData::NeverKeyword,
             Self::Object(members) => TypeData::from(Object {

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -454,8 +454,10 @@ impl TypeResolver for GlobalsResolver {
             Some(GLOBAL_ARRAY_ID)
         } else if qualifier.is_promise() && !qualifier.has_known_type_parameters() {
             Some(GLOBAL_PROMISE_ID)
-        } else if !qualifier.type_only && qualifier.path.len() == 1 {
-            self.resolve_type_of(&qualifier.path[0], qualifier.scope_id)
+        } else if !qualifier.type_only
+            && let Some(ident) = qualifier.path.identifier()
+        {
+            self.resolve_type_of(ident, qualifier.scope_id)
         } else {
             None
         }

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -433,7 +433,7 @@ impl From<TypeofValue> for TypeData {
 impl TypeData {
     pub fn array_of(scope_id: ScopeId, ty: TypeReference) -> Self {
         Self::instance_of(TypeReference::from(
-            TypeReferenceQualifier::from_name(scope_id, Text::Static("Array"))
+            TypeReferenceQualifier::from_path(scope_id, Text::Static("Array"))
                 .with_type_parameters([ty]),
         ))
     }
@@ -855,7 +855,7 @@ pub struct Module {
 /// A namespace definition.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
 pub struct Namespace {
-    pub path: Box<[Text]>,
+    pub path: Path,
     pub members: Box<[TypeMember]>,
 }
 
@@ -883,6 +883,98 @@ impl ObjectLiteral {
 
     pub fn members(&self) -> &[TypeMember] {
         &self.0
+    }
+}
+
+/// Path used to identify a type.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Resolvable)]
+pub enum Path {
+    /// Path consisting of a single identifier.
+    Identifier(Text),
+
+    /// Qualified path of identifiers, such as `foo.bar`.
+    Qualified(Box<[Text]>),
+}
+
+impl From<Text> for Path {
+    fn from(identifier: Text) -> Self {
+        Self::Identifier(identifier)
+    }
+}
+
+impl Path {
+    /// Creates a new path from its path in reverse order.
+    ///
+    /// For example, if you wish to create the path for `foo.bar`, the parts
+    /// should be `["bar", "foo"]`. This is an optimisation used during local
+    /// inference from the CST.TokenText
+    pub fn from_reversed_parts(mut parts: Vec<Text>) -> Self {
+        match parts.len() {
+            0 => Self::Identifier(Text::Static("")),
+            1 => Self::Identifier(parts.remove(0)),
+            _ => {
+                parts.reverse();
+                Self::Qualified(parts.into())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn identifier(&self) -> Option<&Text> {
+        match self {
+            Self::Identifier(identifier) => Some(identifier),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn is_identifier(&self, ident: &str) -> bool {
+        match self {
+            Self::Identifier(identifier) => identifier.text() == ident,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &Text> {
+        PathIterator {
+            path: self,
+            index: 0,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Identifier(_) => 1,
+            Self::Qualified(identifiers) => identifiers.len(),
+        }
+    }
+}
+
+struct PathIterator<'a> {
+    path: &'a Path,
+    index: usize,
+}
+
+impl<'a> Iterator for PathIterator<'a> {
+    type Item = &'a Text;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.path {
+            Path::Identifier(identifier) => (self.index == 0).then(|| {
+                self.index = 1;
+                identifier
+            }),
+            Path::Qualified(identifiers) => identifiers.get(self.index).inspect(|_| {
+                self.index += 1;
+            }),
+        }
     }
 }
 
@@ -1424,7 +1516,7 @@ impl From<&'static str> for ImportSymbol {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct TypeReferenceQualifier {
     /// The identifier path.
-    pub path: Box<[Text]>,
+    pub path: Path,
 
     /// Generic type parameters specified in the reference.
     pub type_parameters: Box<[TypeReference]>,
@@ -1454,7 +1546,7 @@ impl TypeReferenceQualifier {
     /// `Array` symbol in scope, but should not be used _instead of_ such type
     /// resolution.
     pub fn is_array(&self) -> bool {
-        self.path.len() == 1 && self.path[0] == "Array"
+        self.path.is_identifier("Array")
     }
 
     /// Checks whether this type qualifier references a `Promise` type.
@@ -1465,7 +1557,7 @@ impl TypeReferenceQualifier {
     /// `Promise` symbol in scope, but should not be used _instead of_ such type
     /// resolution.
     pub fn is_promise(&self) -> bool {
-        self.path.len() == 1 && self.path[0] == "Promise"
+        self.path.is_identifier("Promise")
     }
 
     pub fn with_excluded_binding_id(mut self, binding_id: BindingId) -> Self {

--- a/crates/biome_js_type_info/tests/utils.rs
+++ b/crates/biome_js_type_info/tests/utils.rs
@@ -194,7 +194,7 @@ impl TypeResolver for HardcodedSymbolResolver {
     }
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
-        if qualifier.path.len() == 1 && qualifier.path[0] == self.name {
+        if qualifier.path.is_identifier(self.name) {
             Some(ResolvedTypeId::new(self.level(), TypeId::new(0)))
         } else {
             self.globals.resolve_qualifier(qualifier)

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -920,7 +920,8 @@ impl TypeResolver for JsModuleInfoCollector {
     }
 
     fn resolve_qualifier(&self, qualifier: &TypeReferenceQualifier) -> Option<ResolvedTypeId> {
-        let identifier = qualifier.path.first()?;
+        let mut path_parts = qualifier.path.iter();
+        let identifier = path_parts.next()?;
         let Some(binding_ref) = self.find_binding_in_scope(identifier, qualifier.scope_id) else {
             return GLOBAL_RESOLVER.resolve_qualifier(qualifier);
         };
@@ -936,7 +937,7 @@ impl TypeResolver for JsModuleInfoCollector {
         }
 
         let mut ty = Cow::Borrowed(&binding.ty);
-        for identifier in &qualifier.path[1..] {
+        for identifier in path_parts {
             let resolved = self.resolve_and_get(&ty)?;
             let member = resolved
                 .all_members(self)


### PR DESCRIPTION
## Summary

Modest optimisation by storing identifier paths in a dedicated type that avoids an extra allocation if the path consists of a single identifier.

Appears to result in a ~2-4% performance improvement in updating the module graph.

## Test Plan

Everything should stay green.