### PR TITLE
chore: split benchmark workflows

### DIFF
--- a/.github/workflows/benchmark_analyzers.yml
+++ b/.github/workflows/benchmark_analyzers.yml
@@ -1,0 +1,70 @@
+name: Analyzer benchmarks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/**_analyze/**/*.rs'
+      - 'crates/**_semantic/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/**_analyze/**/*.rs'
+      - 'crates/**_semantic/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
+
+env:
+  RUST_LOG: info
+
+jobs:
+  bench:
+    permissions:
+      pull-requests: write
+    name: Bench
+    runs-on: depot-ubuntu-24.04-arm-16
+    strategy:
+      matrix:
+        package:
+          - biome_js_analyze
+          - biome_css_analyze
+          - biome_json_analyze
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.sha.outputs.result }}
+
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        with:
+          channel: stable
+          cache-target: release
+          bins: cargo-codspeed
+          cache-base: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile
+        timeout-minutes: 20
+        run: cargo codspeed build -p ${{ matrix.package }}
+        env:
+          CARGO_BUILD_JOBS: 3  # Default is 4 (equals to the vCPU count of the runner), which leads OOM on cargo build
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@c28fe9fbe7d57a3da1b7834ae3761c1d8217612d # v3.7.0
+        timeout-minutes: 50
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark_formatters.yml
+++ b/.github/workflows/benchmark_formatters.yml
@@ -1,0 +1,70 @@
+name: Formatter benchmarks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/**_formatter/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/**_formatter/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
+
+env:
+  RUST_LOG: info
+
+jobs:
+  bench:
+    permissions:
+      pull-requests: write
+    name: Bench
+    runs-on: depot-ubuntu-24.04-arm-16
+    strategy:
+      matrix:
+        package:
+          - biome_js_formatter
+          - biome_css_formatter
+          - biome_json_formatter
+          - biome_graphql_formatter
+          - biome_html_formatter
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.sha.outputs.result }}
+
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        with:
+          channel: stable
+          cache-target: release
+          bins: cargo-codspeed
+          cache-base: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile
+        timeout-minutes: 20
+        run: cargo codspeed build -p ${{ matrix.package }}
+        env:
+          CARGO_BUILD_JOBS: 3  # Default is 4 (equals to the vCPU count of the runner), which leads OOM on cargo build
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@c28fe9fbe7d57a3da1b7834ae3761c1d8217612d # v3.7.0
+        timeout-minutes: 50
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/benchmark_parsers.yml
+++ b/.github/workflows/benchmark_parsers.yml
@@ -1,4 +1,4 @@
-name: Benchmarks
+name: Parser benchmarks
 
 on:
   workflow_dispatch:
@@ -9,23 +9,18 @@ on:
       - next
     paths:
       - 'Cargo.lock'
-      - 'crates/**_analyze/**/*.rs'
-      - 'crates/**_formatter/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
       - 'crates/**_parser/**/*.rs'
-      - 'crates/biome_configuration/**/*.rs'
-      - 'crates/biome_grit_patterns/**/*.rs'
-      - 'crates/biome_package/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
   push:
     branches:
       - main
+      - next
     paths:
       - 'Cargo.lock'
-      - 'crates/**_analyze/**/*.rs'
-      - 'crates/**_formatter/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
       - 'crates/**_parser/**/*.rs'
-      - 'crates/biome_configuration/**/*.rs'
-      - 'crates/biome_grit_patterns/**/*.rs'
-      - 'crates/biome_package/**/*.rs'
+      - 'crates/**_syntax/**/*.rs'
 
 env:
   RUST_LOG: info
@@ -40,24 +35,12 @@ jobs:
       matrix:
         package:
           - biome_js_parser
-          - biome_js_formatter
-          - biome_js_analyze
           - biome_css_parser
-          - biome_css_formatter
-          - biome_css_analyze
           - biome_json_parser
-          - biome_json_formatter
-          - biome_json_analyze
           - biome_graphql_parser
-          - biome_graphql_formatter
           - biome_html_parser
-          - biome_html_formatter
-          - biome_module_graph
-          - biome_package
-          - biome_configuration
 
     steps:
-
       - name: Checkout PR Branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/benchmark_project.yml
+++ b/.github/workflows/benchmark_project.yml
@@ -1,0 +1,80 @@
+name: Project benchmarks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_configuration/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/biome_js_syntax/**/*.rs'
+      - 'crates/biome_js_type_info/**/*.rs'
+      - 'crates/biome_json_syntax/**/*.rs'
+      - 'crates/biome_module_graph/**/*.rs'
+      - 'crates/biome_package/**/*.rs'
+      - 'crates/biome_project_layout/**/*.rs'
+      - 'crates/biome_resolver/**/*.rs'
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - 'Cargo.lock'
+      - 'crates/biome_configuration/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
+      - 'crates/biome_js_syntax/**/*.rs'
+      - 'crates/biome_js_type_info/**/*.rs'
+      - 'crates/biome_json_syntax/**/*.rs'
+      - 'crates/biome_module_graph/**/*.rs'
+      - 'crates/biome_package/**/*.rs'
+      - 'crates/biome_project_layout/**/*.rs'
+      - 'crates/biome_resolver/**/*.rs'
+
+env:
+  RUST_LOG: info
+
+jobs:
+  bench:
+    permissions:
+      pull-requests: write
+    name: Bench
+    runs-on: depot-ubuntu-24.04-arm-16
+    strategy:
+      matrix:
+        package:
+          - biome_configuration
+          - biome_module_graph
+          - biome_package
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.sha.outputs.result }}
+
+      - name: Install toolchain
+        uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
+        with:
+          channel: stable
+          cache-target: release
+          bins: cargo-codspeed
+          cache-base: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compile
+        timeout-minutes: 20
+        run: cargo codspeed build -p ${{ matrix.package }}
+        env:
+          CARGO_BUILD_JOBS: 3  # Default is 4 (equals to the vCPU count of the runner), which leads OOM on cargo build
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@c28fe9fbe7d57a3da1b7834ae3761c1d8217612d # v3.7.0
+        timeout-minutes: 50
+        with:
+          run: cargo codspeed run
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/crates/biome_module_graph/benches/module_graph.rs
+++ b/crates/biome_module_graph/benches/module_graph.rs
@@ -34,10 +34,10 @@ fn bench_module_graph(criterion: &mut Criterion) {
             include_bytes!("./next_font_google.d.ts") as &[u8],
         ),
         // FIXME: enable it once the perf reaches a decent number
-        (
-            "RedisCommander.d.ts",
-            include_bytes!("./RedisCommander.d.ts") as &[u8],
-        ),
+        // (
+        //     "RedisCommander.d.ts",
+        //     include_bytes!("./RedisCommander.d.ts") as &[u8],
+        // ),
     ];
 
     let mut group = criterion.benchmark_group("module_graph");

--- a/crates/biome_module_graph/benches/module_graph.rs
+++ b/crates/biome_module_graph/benches/module_graph.rs
@@ -34,10 +34,10 @@ fn bench_module_graph(criterion: &mut Criterion) {
             include_bytes!("./next_font_google.d.ts") as &[u8],
         ),
         // FIXME: enable it once the perf reaches a decent number
-        // (
-        //     "RedisCommander.d.ts",
-        //     include_bytes!("./RedisCommander.d.ts") as &[u8],
-        // ),
+        (
+            "RedisCommander.d.ts",
+            include_bytes!("./RedisCommander.d.ts") as &[u8],
+        ),
     ];
 
     let mut group = criterion.benchmark_group("module_graph");


### PR DESCRIPTION
## Summary

This PR splits the workflows for our benchmarks into four:
- analyzer benchmarks
- formatter benchmarks
- parser benchmarks
- project benchmarks (module graph, configuration, package manifests)

Also specified the dependencies per type of benchmark a little bit accurately, I hope. The result is that fewer benchmarks need to run for most PRs, while the benchmarks that _should_ run are more likely to run (my previous PR incorrectly didn't run project benchmarks, for instance).

I could have split them even further, but if we go too far it becomes too much copy and paste, and manual maintenance, so I felt this was good enough :)

## Test Plan

Benchmarks should still run correctly.