### PR TITLE
feat(biome-js-analyze): expanded support for useReadonlyClassProperties to cover async class methods too

### DIFF
--- a/.changeset/use_readonly_class_properties_add_async_await_method_check.md
+++ b/.changeset/use_readonly_class_properties_add_async_await_method_check.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6919](https://github.com/biomejs/biome/issues/6919) and [#6920](https://github.com/biomejs/biome/issues/6920):
+`useReadonlyClassProperties` now does checks for mutations in async class methods.
+
+Example:
+
+```typescript
+class Counter3 {
+  private counter: number;
+  async count() {
+    this.counter = 1;
+    const counterString = `${this.counter++}`;
+  }
+}
+```

--- a/crates/biome_js_analyze/src/lint/nursery/use_readonly_class_properties.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_readonly_class_properties.rs
@@ -7,8 +7,8 @@ use biome_js_factory::make;
 use biome_js_syntax::{
     AnyJsAssignment, AnyJsClassMember, AnyJsClassMemberName, AnyJsConstructorParameter,
     AnyJsPropertyModifier, AnyTsPropertyParameterModifier, JsArrayAssignmentPattern,
-    JsArrowFunctionExpression, JsAssignmentExpression, JsBlockStatement, JsCallArgumentList,
-    JsCallArguments, JsCallExpression, JsClassDeclaration, JsClassMemberList,
+    JsArrowFunctionExpression, JsAssignmentExpression, JsAwaitExpression, JsBlockStatement,
+    JsCallArgumentList, JsCallArguments, JsCallExpression, JsClassDeclaration, JsClassMemberList,
     JsConditionalExpression, JsConstructorClassMember, JsElseClause, JsExpressionStatement,
     JsFunctionBody, JsFunctionExpression, JsGetterClassMember, JsGetterObjectMember, JsIfStatement,
     JsInitializerClause, JsLanguage, JsMethodClassMember, JsMethodObjectMember,
@@ -310,7 +310,8 @@ declare_node_union! {
     JsTemplateExpression |
     JsVariableDeclaration |
     JsVariableDeclarator |
-    JsVariableStatement
+    JsVariableStatement |
+    JsAwaitExpression
 }
 
 enum MethodBodyElementOrStatementList {

--- a/crates/biome_js_analyze/tests/specs/nursery/useReadonlyClassProperties/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useReadonlyClassProperties/valid.ts
@@ -610,3 +610,19 @@ class Counter2 {
 		const counterString = `${this.counter++}`
 	}
 }
+
+class Counter3 {
+	private counter: number
+	async count() {
+		this.counter = 1
+		const counterString = `${this.counter++}`
+	}
+}
+
+class Counter4 {
+	private counter: number
+	async count() {
+		await console.log(this.counter++)
+		const counterString = await `${this.counter++}`
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useReadonlyClassProperties/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useReadonlyClassProperties/valid.ts.snap
@@ -617,4 +617,20 @@ class Counter2 {
 		const counterString = `${this.counter++}`
 	}
 }
+
+class Counter3 {
+	private counter: number
+	async count() {
+		this.counter = 1
+		const counterString = `${this.counter++}`
+	}
+}
+
+class Counter4 {
+	private counter: number
+	async count() {
+		await console.log(this.counter++)
+		const counterString = await `${this.counter++}`
+	}
+}
 ```


### PR DESCRIPTION
## Summary
Fixed [#6919](https://github.com/biomejs/biome/issues/6919)
 Fixed [#6920](https://github.com/biomejs/biome/issues/6920):
`useReadonlyClassProperties` now does checks for mutations in async class methods.

Example:

```typescript
class Counter3 {
  private counter: number;
  async count() {
    this.counter = 1;
    const counterString = `${this.counter++}`;
  }
}
```