### PR TITLE
fix: typo `@vitest/eslint-plugin` source url

### DIFF
--- a/.changeset/eleven-clouds-slide.md
+++ b/.changeset/eleven-clouds-slide.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `@vitest/eslint-plugin` source url.

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -336,7 +336,7 @@ impl RuleSource {
             Self::EslintNoSecrets(_) => "https://github.com/nickdeis/eslint-plugin-no-secrets/blob/master/README.md".to_string(),
             Self::EslintRegexp(rule_name) => format!("https://ota-meshi.github.io/eslint-plugin-regexp/rules/{rule_name}.html"),
             Self::DenoLint(rule_name) => format!("https://lint.deno.land/rules/{rule_name}"),
-            Self::EslintVitest(rule_name) => format!("https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rule/{rule_name}.md"),
+            Self::EslintVitest(rule_name) => format!("https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintVueJs(rule_name) => format!("https://eslint.vuejs.org/rules/{rule_name}"),
         }
     }


### PR DESCRIPTION
## Summary

Correct the source URL path for the ESLint Vitest rule links

Bug Fixes:
- Fix typo in [ESLint Vitest plugin](https://github.com/vitest-dev/eslint-plugin-vitest) URL segment from "rule" to "rules"

Chores:
- Add a changeset entry for the URL fix

## Test Plan

| Before | After |
|--------|--------|
| https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rule/max-nested-describe.md | https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md | 

## Docs

[@vitest/eslint-plugin](https://biomejs.dev/linter/javascript/sources/#vitesteslint-plugin)