### PR TITLE
fix(biome_js_analyze): ignore `as const` and similar wrappers in `noMagicNumbers` rule

### DIFF
--- a/.changeset/crazy-moments-sniff.md
+++ b/.changeset/crazy-moments-sniff.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#6910](https://github.com/biomejs/biome/issues/6910) - biome now ignores type casts and assertions when evaluating numbers for `noMagicNumbers` rule.
+Fixed [#6910](https://github.com/biomejs/biome/issues/6910): Biome now ignores type casts and assertions when evaluating numbers for `noMagicNumbers` rule.

--- a/.changeset/crazy-moments-sniff.md
+++ b/.changeset/crazy-moments-sniff.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6910](https://github.com/biomejs/biome/issues/6910) - biome now ignores type casts and assertions when evaluating numbers for `noMagicNumbers` rule.

--- a/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
@@ -44,9 +44,12 @@ declare_lint_rule! {
     ///
     /// ```js
     /// const TAX_RATE = 1.23;
-    /// const TAX_RATE_REDUCED = 1 as const;
     /// let total = price * TAX_RATE;
-    /// let reducedTotal = price * TAX_RATE_REDUCED;
+    /// ```
+    ///
+    /// ```ts
+    /// const TAX_RATE = 1.23 as const;
+    /// let total = price * TAX_RATE;
     /// ```
     pub NoMagicNumbers {
         version: "2.1.0",

--- a/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_magic_numbers.rs
@@ -10,8 +10,8 @@ use biome_js_syntax::{
     JsPropertyClassMember, JsPropertyObjectMember, JsSyntaxNode, JsUnaryExpression,
     JsUnaryOperator, JsxExpressionAttributeValue, JsxExpressionChild, TsAsExpression,
     TsEnumMemberList, TsIndexedAccessType, TsNonNullAssertionExpression, TsNumberLiteralType,
-    TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation, TsTypeAssertionExpression,
-    TsUnionTypeVariantList,
+    TsPredicateReturnType, TsReturnTypeAnnotation, TsSatisfiesExpression, TsTypeAnnotation,
+    TsTypeAssertionExpression, TsUnionTypeVariantList,
 };
 use biome_rowan::{AstNode, declare_node_union};
 use biome_rule_options::no_magic_numbers::NoMagicNumbersOptions;
@@ -384,6 +384,7 @@ fn get_sanitized_parent_node(node: &JsSyntaxNode) -> Option<JsSyntaxNode> {
             || TsNonNullAssertionExpression::can_cast(parent.kind())
             || TsSatisfiesExpression::can_cast(parent.kind())
             || TsTypeAssertionExpression::can_cast(parent.kind())
+            || TsPredicateReturnType::can_cast(parent.kind())
             || JsParenthesizedExpression::can_cast(parent.kind())
         {
             false

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
@@ -101,9 +101,9 @@ function f(x: string): 100 {
 }
 
 // bitwise operations
-let bitwiseOr = 1 | 2;
-let bitwiseAnd = 1 & 2;
-let bitwiseXor = 1 ^ 2;
+let bitwiseOr = 1 | 42;
+let bitwiseAnd = 1 & 42;
+let bitwiseXor = 1 ^ 42;
 
 let a = ~5;
 let a = -5;

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
@@ -147,3 +147,8 @@ f(1n)
 f(-1n)
 f(1)
 f((-1))
+
+// type predicate
+function isFourtyTwo(num): num is 42 {
+	return true;
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx
@@ -8,6 +8,12 @@ const MY_NUMBER = +42;
 const foo = 42;
 let foo = 42;
 let foo = -42;
+const foo = 42 as const;
+const foo = 42 as number;
+const foo = 42 satisfies number;
+const foo = (42 satisfies number) as const;
+const foo = ((42 satisfies number) as const);
+const foo = (42 satisfies number)!;
 
 // jsx
 let jsx = (<div>{5}</div>);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
@@ -107,9 +107,9 @@ function f(x: string): 100 {
 }
 
 // bitwise operations
-let bitwiseOr = 1 | 2;
-let bitwiseAnd = 1 & 2;
-let bitwiseXor = 1 ^ 2;
+let bitwiseOr = 1 | 42;
+let bitwiseAnd = 1 & 42;
+let bitwiseXor = 1 ^ 42;
 
 let a = ~5;
 let a = -5;

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 134
 expression: valid.tsx
 ---
 # Input
@@ -15,6 +14,12 @@ const MY_NUMBER = +42;
 const foo = 42;
 let foo = 42;
 let foo = -42;
+const foo = 42 as const;
+const foo = 42 as number;
+const foo = 42 satisfies number;
+const foo = (42 satisfies number) as const;
+const foo = ((42 satisfies number) as const);
+const foo = (42 satisfies number)!;
 
 // jsx
 let jsx = (<div>{5}</div>);

--- a/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noMagicNumbers/valid.tsx.snap
@@ -154,4 +154,9 @@ f(-1n)
 f(1)
 f((-1))
 
+// type predicate
+function isFourtyTwo(num): num is 42 {
+	return true;
+}
+
 ```


### PR DESCRIPTION
## Summary

Fixes #6910.

biome now ignores type casts and assertions when evaluating numbers for `noMagicNumbers` rule.

## Test Plan

Updated `valid` snapshot test with constant definitions that are supposed to be correct.

## Docs

Bugfix to a nursery rule - n/a.