### PR TITLE
perf: shrink `Text`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,10 +14,13 @@ on:
       - 'crates/**_parser/**/*.rs'
       - 'crates/biome_configuration/**/*.rs'
       - 'crates/biome_grit_patterns/**/*.rs'
+      - 'crates/biome_module_graph/**/*.rs'
       - 'crates/biome_package/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
   push:
     branches:
       - main
+      - next
     paths:
       - 'Cargo.lock'
       - 'crates/**_analyze/**/*.rs'
@@ -25,7 +28,9 @@ on:
       - 'crates/**_parser/**/*.rs'
       - 'crates/biome_configuration/**/*.rs'
       - 'crates/biome_grit_patterns/**/*.rs'
+      - 'crates/biome_module_graph/**/*.rs'
       - 'crates/biome_package/**/*.rs'
+      - 'crates/biome_rowan/**/*.rs'
 
 env:
   RUST_LOG: info

--- a/crates/biome_deserialize/src/json.rs
+++ b/crates/biome_deserialize/src/json.rs
@@ -323,9 +323,9 @@ pub fn unescape_json_string(text: TokenText) -> Text {
                     State::Normal => string.push(c),
                 }
             }
-            Text::Owned(string)
+            string.into()
         }
-        None => Text::Borrowed(text),
+        None => text.into(),
     }
 }
 

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -281,7 +281,7 @@ fn get_restricted_imports_from_module_source(
     let results = match node.syntax().parent().and_then(AnyJsImportClause::cast) {
         Some(AnyJsImportClause::JsImportCombinedClause(node)) => {
             let range = node.default_specifier()?.range();
-            get_restricted_import_visibility(&Text::Static("default"), options)
+            get_restricted_import_visibility(&Text::new_static("default"), options)
                 .map(|visibility| NoPrivateImportsState {
                     range,
                     path: path.clone(),
@@ -298,7 +298,7 @@ fn get_restricted_imports_from_module_source(
                         .filter_map(get_named_specifier_import_name)
                         .filter_map(|name| {
                             get_restricted_import_visibility(
-                                &Text::Borrowed(name.token_text_trimmed()),
+                                &Text::from(name.token_text_trimmed()),
                                 options,
                             )
                             .map(|visibility| NoPrivateImportsState {
@@ -312,7 +312,7 @@ fn get_restricted_imports_from_module_source(
         }
         Some(AnyJsImportClause::JsImportDefaultClause(node)) => {
             let range = node.default_specifier()?.range();
-            get_restricted_import_visibility(&Text::Static("default"), options)
+            get_restricted_import_visibility(&Text::new_static("default"), options)
                 .map(|visibility| NoPrivateImportsState {
                     range,
                     path,
@@ -328,15 +328,12 @@ fn get_restricted_imports_from_module_source(
             .flatten()
             .filter_map(get_named_specifier_import_name)
             .filter_map(|name| {
-                get_restricted_import_visibility(
-                    &Text::Borrowed(name.token_text_trimmed()),
-                    options,
-                )
-                .map(|visibility| NoPrivateImportsState {
-                    range: name.text_trimmed_range(),
-                    path: path.clone(),
-                    visibility,
-                })
+                get_restricted_import_visibility(&Text::from(name.token_text_trimmed()), options)
+                    .map(|visibility| NoPrivateImportsState {
+                        range: name.text_trimmed_range(),
+                        path: path.clone(),
+                        visibility,
+                    })
             })
             .collect(),
         Some(

--- a/crates/biome_js_analyze/src/lint/nursery/use_readonly_class_properties.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_readonly_class_properties.rs
@@ -576,7 +576,7 @@ fn contains_this_or_static_member_kind(
 
                     return this_aliases.iter().any(
                         |ThisAliasesAndTheirScope { aliases, scope }| {
-                            aliases.contains(&Text::Borrowed(value_token.token_text_trimmed()))
+                            aliases.contains(&Text::from(value_token.token_text_trimmed()))
                                 && name_syntax
                                     .ancestors()
                                     .any(|ancestor| ancestor.key() == scope.syntax().key())

--- a/crates/biome_js_syntax/src/unescape.rs
+++ b/crates/biome_js_syntax/src/unescape.rs
@@ -160,9 +160,9 @@ pub fn unescape_js_string(text: TokenText) -> Text {
                     }
                 }
             }
-            Text::Owned(string)
+            string.into()
         }
-        None => Text::Borrowed(text),
+        None => text.into(),
     }
 }
 

--- a/crates/biome_js_type_info/src/flattening/conditionals.rs
+++ b/crates/biome_js_type_info/src/flattening/conditionals.rs
@@ -267,12 +267,14 @@ pub fn reference_to_falsy_subset_of(
     resolver: &mut dyn TypeResolver,
 ) -> Option<TypeReference> {
     let filter = |ty: &TypeData| match ty {
-        TypeData::BigInt => FilteredData::Mapped(Literal::BigInt(Text::Static("0n")).into()),
+        TypeData::BigInt => FilteredData::Mapped(Literal::BigInt(Text::new_static("0n")).into()),
         TypeData::Boolean => FilteredData::Mapped(Literal::Boolean(false.into()).into()),
         TypeData::Number => {
-            FilteredData::Mapped(Literal::Number(NumberLiteral::new(Text::Static("0"))).into())
+            FilteredData::Mapped(Literal::Number(NumberLiteral::new(Text::new_static("0"))).into())
         }
-        TypeData::String => FilteredData::Mapped(Literal::String(Text::Static("").into()).into()),
+        TypeData::String => {
+            FilteredData::Mapped(Literal::String(Text::new_static("").into()).into())
+        }
         other => {
             if ConditionalType::from_data_shallow(other)
                 .is_none_or(|conditional| !conditional.is_truthy())

--- a/crates/biome_js_type_info/src/flattening/intersections.rs
+++ b/crates/biome_js_type_info/src/flattening/intersections.rs
@@ -269,12 +269,12 @@ impl MergedType {
             Self::Interface(members) => TypeData::from(Interface {
                 extends: [].into(),
                 members: members.into_iter().collect(),
-                name: Text::Static("(merged)"),
+                name: Text::new_static("(merged)"),
                 type_parameters: [].into(),
             }),
             Self::Namespace(members) => TypeData::from(Namespace {
                 members: members.into_iter().collect(),
-                path: Path::from(Text::Static("")),
+                path: Path::from(Text::new_static("")),
             }),
             Self::Never => TypeData::NeverKeyword,
             Self::Object(members) => TypeData::from(Object {

--- a/crates/biome_js_type_info/src/globals.rs
+++ b/crates/biome_js_type_info/src/globals.rs
@@ -26,7 +26,7 @@ pub static GLOBAL_TYPE_MEMBERS: LazyLock<Vec<TypeMember>> = LazyLock::new(|| {
     (0..NUM_PREDEFINED_TYPES)
         .map(TypeId::new)
         .map(|id| TypeMember {
-            kind: TypeMemberKind::Named(Text::Static(global_type_name(id))),
+            kind: TypeMemberKind::Named(Text::new_static(global_type_name(id))),
             ty: ResolvedTypeId::new(GLOBAL_LEVEL, id).into(),
         })
         .collect()
@@ -173,12 +173,12 @@ pub struct GlobalsResolver {
 impl Default for GlobalsResolver {
     fn default() -> Self {
         let method = |name: &'static str, id: TypeId| TypeMember {
-            kind: TypeMemberKind::Named(Text::Static(name)),
+            kind: TypeMemberKind::Named(Text::new_static(name)),
             ty: ResolvedTypeId::new(TypeResolverLevel::Global, id).into(),
         };
 
         let static_method = |name: &'static str, id: TypeId| TypeMember {
-            kind: TypeMemberKind::NamedStatic(Text::Static(name)),
+            kind: TypeMemberKind::NamedStatic(Text::new_static(name)),
             ty: ResolvedTypeId::new(TypeResolverLevel::Global, id).into(),
         };
 
@@ -190,7 +190,7 @@ impl Default for GlobalsResolver {
                 TypeData::from(Function {
                     is_async: false,
                     type_parameters,
-                    name: Some(Text::Static(global_type_name(id))),
+                    name: Some(Text::new_static(global_type_name(id))),
                     parameters: [FunctionParameter::Pattern(PatternFunctionParameter {
                         bindings: Default::default(),
                         is_optional: false,
@@ -208,14 +208,14 @@ impl Default for GlobalsResolver {
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(id))),
+                name: Some(Text::new_static(global_type_name(id))),
                 parameters: Default::default(),
                 return_type: ReturnType::Type(GLOBAL_INSTANCEOF_PROMISE_ID.into()),
             })
         };
 
         let string_literal = |value: &'static str| -> TypeData {
-            TypeData::from(Literal::String(Text::Static(value).into()))
+            TypeData::from(Literal::String(Text::new_static(value).into()))
         };
 
         let types = vec![
@@ -231,7 +231,7 @@ impl Default for GlobalsResolver {
                 type_parameters: [GLOBAL_U_ID.into()].into(),
             }),
             TypeData::Class(Box::new(Class {
-                name: Some(Text::Static("Array")),
+                name: Some(Text::new_static("Array")),
                 type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
                 extends: None,
                 implements: [].into(),
@@ -240,7 +240,7 @@ impl Default for GlobalsResolver {
                     method("forEach", ARRAY_FOREACH_ID),
                     method("map", ARRAY_MAP_ID),
                     TypeMember {
-                        kind: TypeMemberKind::Named(Text::Static("length")),
+                        kind: TypeMemberKind::Named(Text::new_static("length")),
                         ty: GLOBAL_NUMBER_ID.into(),
                     },
                 ]),
@@ -266,7 +266,7 @@ impl Default for GlobalsResolver {
             TypeData::Global,
             TypeData::instance_of(TypeReference::from(GLOBAL_PROMISE_ID)),
             TypeData::Class(Box::new(Class {
-                name: Some(Text::Static("Promise")),
+                name: Some(Text::new_static("Promise")),
                 type_parameters: Box::new([TypeReference::from(GLOBAL_T_ID)]),
                 extends: None,
                 implements: [].into(),
@@ -290,7 +290,7 @@ impl Default for GlobalsResolver {
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(PROMISE_CONSTRUCTOR_ID))),
+                name: Some(Text::new_static(global_type_name(PROMISE_CONSTRUCTOR_ID))),
                 parameters: [FunctionParameter::Pattern(PatternFunctionParameter {
                     bindings: Default::default(),
                     is_optional: false,
@@ -329,26 +329,26 @@ impl Default for GlobalsResolver {
                 GLOBAL_UNDEFINED_STRING_LITERAL_ID.into(),
             ])))),
             TypeData::from(GenericTypeParameter {
-                name: Text::Static("T"),
+                name: Text::new_static("T"),
                 constraint: TypeReference::Unknown,
                 default: TypeReference::Unknown,
             }),
             TypeData::from(GenericTypeParameter {
-                name: Text::Static("U"),
+                name: Text::new_static("U"),
                 constraint: TypeReference::Unknown,
                 default: TypeReference::Unknown,
             }),
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(CONDITIONAL_CALLBACK_ID))),
+                name: Some(Text::new_static(global_type_name(CONDITIONAL_CALLBACK_ID))),
                 parameters: Default::default(),
                 return_type: ReturnType::Type(GLOBAL_CONDITIONAL_ID.into()),
             }),
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(MAP_CALLBACK_ID))),
+                name: Some(Text::new_static(global_type_name(MAP_CALLBACK_ID))),
                 parameters: [FunctionParameter::Pattern(PatternFunctionParameter {
                     ty: GLOBAL_U_ID.into(),
                     bindings: Default::default(),
@@ -361,14 +361,14 @@ impl Default for GlobalsResolver {
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(VOID_CALLBACK_ID))),
+                name: Some(Text::new_static(global_type_name(VOID_CALLBACK_ID))),
                 parameters: Default::default(),
                 return_type: ReturnType::Type(GLOBAL_VOID_ID.into()),
             }),
             TypeData::from(Function {
                 is_async: false,
                 type_parameters: Default::default(),
-                name: Some(Text::Static(global_type_name(FETCH_ID))),
+                name: Some(Text::new_static(global_type_name(FETCH_ID))),
                 parameters: Default::default(),
                 return_type: ReturnType::Type(GLOBAL_INSTANCEOF_PROMISE_ID.into()),
             }),

--- a/crates/biome_js_type_info/src/type_info.rs
+++ b/crates/biome_js_type_info/src/type_info.rs
@@ -433,7 +433,7 @@ impl From<TypeofValue> for TypeData {
 impl TypeData {
     pub fn array_of(scope_id: ScopeId, ty: TypeReference) -> Self {
         Self::instance_of(TypeReference::from(
-            TypeReferenceQualifier::from_path(scope_id, Text::Static("Array"))
+            TypeReferenceQualifier::from_path(scope_id, Text::new_static("Array"))
                 .with_type_parameters([ty]),
         ))
     }
@@ -910,7 +910,7 @@ impl Path {
     /// inference from the CST.TokenText
     pub fn from_reversed_parts(mut parts: Vec<Text>) -> Self {
         match parts.len() {
-            0 => Self::Identifier(Text::Static("")),
+            0 => Self::Identifier(Text::new_static("")),
             1 => Self::Identifier(parts.remove(0)),
             _ => {
                 parts.reverse();
@@ -1178,7 +1178,7 @@ impl TypeMemberKind {
     pub fn name(&self) -> Option<Text> {
         match self {
             Self::CallSignature => None,
-            Self::Constructor => Some(Text::Static("constructor")),
+            Self::Constructor => Some(Text::new_static("constructor")),
             Self::Getter(name) | Self::Named(name) | Self::NamedStatic(name) => Some(name.clone()),
         }
     }

--- a/crates/biome_js_type_info/src/type_info/literal.rs
+++ b/crates/biome_js_type_info/src/type_info/literal.rs
@@ -106,13 +106,13 @@ impl From<Text> for StringLiteral {
 
 impl From<String> for StringLiteral {
     fn from(value: String) -> Self {
-        Self(Text::Owned(value))
+        Self(value.into())
     }
 }
 
 impl From<&str> for StringLiteral {
     fn from(value: &str) -> Self {
-        Self(Text::Owned(value.to_string()))
+        Self(value.to_string().into())
     }
 }
 
@@ -135,51 +135,78 @@ mod tests {
     #[test]
     fn parse_number_basic() {
         assert_eq!(
-            NumberLiteral(Text::Static("1234567890")).to_f64(),
+            NumberLiteral(Text::new_static("1234567890")).to_f64(),
             Some(1_234_567_890.0)
         );
-        assert_eq!(NumberLiteral(Text::Static("42")).to_f64(), Some(42.0));
-        assert_eq!(NumberLiteral(Text::Static("0")).to_f64(), Some(0.0));
+        assert_eq!(NumberLiteral(Text::new_static("42")).to_f64(), Some(42.0));
+        assert_eq!(NumberLiteral(Text::new_static("0")).to_f64(), Some(0.0));
     }
 
     #[test]
     fn parse_number_legacy_octal() {
-        assert_eq!(NumberLiteral(Text::Static("0888")).to_f64(), Some(888.0));
-        assert_eq!(NumberLiteral(Text::Static("0788")).to_f64(), Some(788.0));
-        assert_eq!(NumberLiteral(Text::Static("0777")).to_f64(), Some(511.0));
+        assert_eq!(
+            NumberLiteral(Text::new_static("0888")).to_f64(),
+            Some(888.0)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("0788")).to_f64(),
+            Some(788.0)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("0777")).to_f64(),
+            Some(511.0)
+        );
     }
 
     #[test]
     fn parse_number_exponential() {
-        assert_eq!(NumberLiteral(Text::Static("0e-5")).to_f64(), Some(0.0));
-        assert_eq!(NumberLiteral(Text::Static("0e+5")).to_f64(), Some(0.0));
-        assert_eq!(NumberLiteral(Text::Static("5e1")).to_f64(), Some(50.0));
-        assert_eq!(NumberLiteral(Text::Static("175e-2")).to_f64(), Some(1.75));
-        assert_eq!(NumberLiteral(Text::Static("1e3")).to_f64(), Some(1000.0));
-        assert_eq!(NumberLiteral(Text::Static("1e-3")).to_f64(), Some(0.001));
-        assert_eq!(NumberLiteral(Text::Static("1E3")).to_f64(), Some(1000.0));
+        assert_eq!(NumberLiteral(Text::new_static("0e-5")).to_f64(), Some(0.0));
+        assert_eq!(NumberLiteral(Text::new_static("0e+5")).to_f64(), Some(0.0));
+        assert_eq!(NumberLiteral(Text::new_static("5e1")).to_f64(), Some(50.0));
+        assert_eq!(
+            NumberLiteral(Text::new_static("175e-2")).to_f64(),
+            Some(1.75)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("1e3")).to_f64(),
+            Some(1000.0)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("1e-3")).to_f64(),
+            Some(0.001)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("1E3")).to_f64(),
+            Some(1000.0)
+        );
     }
 
     #[test]
     fn parse_number_binary() {
         assert_eq!(
-            NumberLiteral(Text::Static("0b10000000000000000000000000000000")).to_f64(),
+            NumberLiteral(Text::new_static("0b10000000000000000000000000000000")).to_f64(),
             Some(2_147_483_648.0)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("0b01111111100000000000000000000000")).to_f64(),
+            NumberLiteral(Text::new_static("0b01111111100000000000000000000000")).to_f64(),
             Some(2_139_095_040.0)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("0B00000000011111111111111111111111")).to_f64(),
+            NumberLiteral(Text::new_static("0B00000000011111111111111111111111")).to_f64(),
             Some(8_388_607.0)
         );
     }
 
     #[test]
     fn parse_number_octal() {
-        assert_eq!(NumberLiteral(Text::Static("0O755")).to_f64(), Some(493.0));
-        assert_eq!(NumberLiteral(Text::Static("0o644")).to_f64(), Some(420.0));
+        assert_eq!(
+            NumberLiteral(Text::new_static("0O755")).to_f64(),
+            Some(493.0)
+        );
+        assert_eq!(
+            NumberLiteral(Text::new_static("0o644")).to_f64(),
+            Some(420.0)
+        );
     }
 
     #[test]
@@ -188,36 +215,36 @@ mod tests {
         //       However it's a valid number literal in ECMAScript, though it will be truncated
         //       to the precision of f64.
         // assert_eq!(
-        //     NumberLiteral(Text::Static("0xFFFFFFFFFFFFFFFFF"),
+        //     NumberLiteral(Text::new_static("0xFFFFFFFFFFFFFFFFF"),
         //     Some(295147905179352830000.0)
         // );
         assert_eq!(
-            NumberLiteral(Text::Static("0x123456789ABCDEF")).to_f64(),
+            NumberLiteral(Text::new_static("0x123456789ABCDEF")).to_f64(),
             Some(81_985_529_216_486_900.0)
         );
-        assert_eq!(NumberLiteral(Text::Static("0XA")).to_f64(), Some(10.0));
+        assert_eq!(NumberLiteral(Text::new_static("0XA")).to_f64(), Some(10.0));
     }
 
     #[test]
     fn parse_number_separators() {
         assert_eq!(
-            NumberLiteral(Text::Static("1_000_000_000_000")).to_f64(),
+            NumberLiteral(Text::new_static("1_000_000_000_000")).to_f64(),
             Some(1_000_000_000_000.0)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("1_050.95")).to_f64(),
+            NumberLiteral(Text::new_static("1_050.95")).to_f64(),
             Some(1050.95)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("0b1010_0001_1000_0101")).to_f64(),
+            NumberLiteral(Text::new_static("0b1010_0001_1000_0101")).to_f64(),
             Some(41349.0)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("0o2_2_5_6")).to_f64(),
+            NumberLiteral(Text::new_static("0o2_2_5_6")).to_f64(),
             Some(1198.0)
         );
         assert_eq!(
-            NumberLiteral(Text::Static("0xA0_B0_C0")).to_f64(),
+            NumberLiteral(Text::new_static("0xA0_B0_C0")).to_f64(),
             Some(10_531_008.0)
         );
     }

--- a/crates/biome_js_type_info/tests/type_info.rs
+++ b/crates/biome_js_type_info/tests/type_info.rs
@@ -59,7 +59,7 @@ fn verify_type_sizes() {
 
     assert_eq!(
         std::mem::size_of::<TypeMember>(),
-        48,
+        40,
         "The size shouldn't go higher"
     );
 
@@ -107,7 +107,7 @@ fn verify_type_sizes() {
 
     assert_eq!(
         std::mem::size_of::<TypeofStaticMemberExpression>(),
-        40,
+        32,
         "The size shouldn't go higher"
     );
 
@@ -155,7 +155,7 @@ fn verify_type_sizes() {
 
     assert_eq!(
         std::mem::size_of::<GenericTypeParameter>(),
-        56,
+        48,
         "The size shouldn't go higher"
     );
 

--- a/crates/biome_json_value/src/json_value.rs
+++ b/crates/biome_json_value/src/json_value.rs
@@ -253,7 +253,7 @@ impl Borrow<str> for JsonString {
 
 impl From<&str> for JsonString {
     fn from(value: &str) -> Self {
-        Self(Text::Owned(value.to_string()))
+        Self(value.to_string().into())
     }
 }
 
@@ -261,24 +261,20 @@ impl From<JsonStringValue> for JsonString {
     fn from(value: JsonStringValue) -> Self {
         match value.inner_string_text() {
             Ok(text) => text.into(),
-            Err(_) => Self(Text::Owned(String::new())),
+            Err(_) => Self(Text::default()),
         }
     }
 }
 
 impl From<String> for JsonString {
     fn from(value: String) -> Self {
-        Self(Text::Owned(value))
+        Self(value.into())
     }
 }
 
 impl From<Text> for JsonString {
     fn from(text: Text) -> Self {
-        match text {
-            Text::Borrowed(token_text) => token_text.into(),
-            Text::Owned(string) => Self(Text::Owned(string)),
-            Text::Static(string) => Self(Text::Static(string)),
-        }
+        Self(text)
     }
 }
 

--- a/crates/biome_module_graph/src/format_module_graph.rs
+++ b/crates/biome_module_graph/src/format_module_graph.rs
@@ -3,7 +3,7 @@ use crate::{JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport};
 use biome_formatter::prelude::*;
 use biome_formatter::{format_args, write};
 use biome_js_type_info::FormatTypeContext;
-use biome_rowan::{Text, TextSize};
+use biome_rowan::TextSize;
 use std::fmt::Formatter;
 use std::ops::Deref;
 
@@ -67,31 +67,14 @@ impl Format<FormatTypeContext> for Exports {
     ) -> FormatResult<()> {
         let mut joiner = f.join();
         for (export_name, export) in self.deref() {
-            let name = format_with(|f| match export_name {
-                Text::Borrowed(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(
-                            &std::format!("{:?}", t.text()),
-                            TextSize::default()
-                        ),]
-                    )
-                }
-                Text::Owned(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(
-                            &std::format!("{:?}", t.as_str()),
-                            TextSize::default()
-                        ),]
-                    )
-                }
-                Text::Static(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(&std::format!("{t:?}"), TextSize::default()),]
-                    )
-                }
+            let name = format_with(|f| {
+                write!(
+                    f,
+                    [dynamic_text(
+                        &std::format!("{:?}", export_name.text()),
+                        TextSize::default()
+                    ),]
+                )
             });
             let arrow = format_with(|f| write!(f, [&format_args![space(), text("=>"), space()]]));
 
@@ -126,31 +109,14 @@ impl Format<FormatTypeContext> for Imports {
         let mut joiner = f.join();
 
         for (import_name, import) in &self.0 {
-            let name = format_with(|f| match import_name {
-                Text::Borrowed(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(
-                            &std::format!("{:?}", t.text()),
-                            TextSize::default()
-                        )]
-                    )
-                }
-                Text::Owned(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(
-                            &std::format!("{:?}", t.as_str()),
-                            TextSize::default()
-                        )]
-                    )
-                }
-                Text::Static(t) => {
-                    write!(
-                        f,
-                        [dynamic_text(&std::format!("{t:?}"), TextSize::default()),]
-                    )
-                }
+            let name = format_with(|f| {
+                write!(
+                    f,
+                    [dynamic_text(
+                        &std::format!("{:?}", import_name.text()),
+                        TextSize::default()
+                    ),]
+                )
             });
             let arrow = format_with(|f| {
                 write!(

--- a/crates/biome_module_graph/src/js_module_info/collector.rs
+++ b/crates/biome_module_graph/src/js_module_info/collector.rs
@@ -826,7 +826,7 @@ impl JsModuleInfoCollector {
                     let resolved = self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID);
 
                     let export = JsExport::Own(JsOwnExport::Type(resolved));
-                    finalised_exports.insert(Text::Static("default"), export);
+                    finalised_exports.insert(Text::new_static("default"), export);
                 }
                 JsCollectedExport::ExportDefaultAssignment { ty } => {
                     let resolved = self.resolve_reference(&ty).unwrap_or(GLOBAL_UNKNOWN_ID);
@@ -853,7 +853,7 @@ impl JsModuleInfoCollector {
                     }
 
                     let export = JsExport::Own(JsOwnExport::Type(resolved));
-                    finalised_exports.insert(Text::Static("default"), export);
+                    finalised_exports.insert(Text::new_static("default"), export);
                 }
                 JsCollectedExport::Reexport {
                     export_name,

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -368,10 +368,9 @@ impl TypeResolver for ModuleResolver {
     ) -> Option<ResolvedTypeId> {
         self.resolve_import_internal(
             module_id,
-            Cow::Owned(ImportSymbol::Named(Text::Borrowed(TokenText::new_raw(
-                RawSyntaxKind(0),
-                name,
-            )))),
+            Cow::Owned(ImportSymbol::Named(
+                TokenText::new_raw(RawSyntaxKind(0), name).into(),
+            )),
             false,
             FxHashSet::default(),
         )

--- a/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_export_const_type_declaration_with_namespace.snap
@@ -56,16 +56,12 @@ Module TypeId(3) => Module(0) TypeId(2)
 
 Module TypeId(4) => Namespace {
     path: Identifier(
-        Borrowed(
-            "shared",
-        ),
+        "shared",
     ),
     members: [
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Result",
-                ),
+                "Result",
             ),
             ty: Resolved(
                 string,

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_exports.snap
@@ -218,9 +218,7 @@ Module TypeId(6) => Tuple(
                 Module(0) TypeId(7),
             ),
             name: Some(
-                Borrowed(
-                    "first",
-                ),
+                "first",
             ),
             is_optional: false,
             is_rest: false,
@@ -230,9 +228,7 @@ Module TypeId(6) => Tuple(
                 Module(0) TypeId(8),
             ),
             name: Some(
-                Borrowed(
-                    "last",
-                ),
+                "last",
             ),
             is_optional: false,
             is_rest: false,

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_merged_namespace_with_type.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_merged_namespace_with_type.snap
@@ -32,16 +32,12 @@ Imports {
 ```
 Module TypeId(0) => Namespace {
     path: Identifier(
-        Borrowed(
-            "Foo",
-        ),
+        "Foo",
     ),
     members: [
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Bar",
-                ),
+                "Bar",
             ),
             ty: Resolved(
                 Module(0) TypeId(1),

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_country_info.snap
@@ -163,16 +163,12 @@ Module TypeId(5) => interface "Full" {
 
 Module TypeId(6) => Namespace {
     path: Identifier(
-        Borrowed(
-            "SubdivisionInfo",
-        ),
+        "SubdivisionInfo",
     ),
     members: [
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Partial",
-                ),
+                "Partial",
             ),
             ty: Resolved(
                 Module(0) TypeId(4),
@@ -180,9 +176,7 @@ Module TypeId(6) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Full",
-                ),
+                "Full",
             ),
             ty: Resolved(
                 Module(0) TypeId(5),
@@ -190,9 +184,7 @@ Module TypeId(6) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Map",
-                ),
+                "Map",
             ),
             ty: Resolved(
                 Module(0) TypeId(1),
@@ -218,16 +210,12 @@ Module TypeId(9) => sync Function "subdivision" {
 
 Module TypeId(10) => Namespace {
     path: Identifier(
-        Borrowed(
-            "CountryInfo",
-        ),
+        "CountryInfo",
     ),
     members: [
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Partial",
-                ),
+                "Partial",
             ),
             ty: Resolved(
                 Module(0) TypeId(2),
@@ -235,9 +223,7 @@ Module TypeId(10) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Full",
-                ),
+                "Full",
             ),
             ty: Resolved(
                 Module(0) TypeId(3),
@@ -245,9 +231,7 @@ Module TypeId(10) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Map",
-                ),
+                "Map",
             ),
             ty: Resolved(
                 Module(0) TypeId(1),

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_recursive_looking_vfile.snap
@@ -253,16 +253,12 @@ Module TypeId(6) => Module(0) TypeId(42)
 
 Module TypeId(7) => Namespace {
     path: Identifier(
-        Borrowed(
-            "vfile",
-        ),
+        "vfile",
     ),
     members: [
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "BufferEncoding",
-                ),
+                "BufferEncoding",
             ),
             ty: Resolved(
                 Module(0) TypeId(51),
@@ -270,9 +266,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "VFileContents",
-                ),
+                "VFileContents",
             ),
             ty: Resolved(
                 Module(0) TypeId(44),
@@ -280,9 +274,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "VFileCompatible",
-                ),
+                "VFileCompatible",
             ),
             ty: Resolved(
                 Module(0) TypeId(18),
@@ -290,9 +282,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "Settings",
-                ),
+                "Settings",
             ),
             ty: Resolved(
                 Module(0) TypeId(22),
@@ -300,9 +290,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "VFileReporter",
-                ),
+                "VFileReporter",
             ),
             ty: Resolved(
                 Module(0) TypeId(24),
@@ -310,9 +298,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "T",
-                ),
+                "T",
             ),
             ty: Resolved(
                 Module(0) TypeId(23),
@@ -320,9 +306,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "VFileOptions",
-                ),
+                "VFileOptions",
             ),
             ty: Resolved(
                 Module(0) TypeId(46),
@@ -330,9 +314,7 @@ Module TypeId(7) => Namespace {
         },
         TypeMember {
             kind: NamedStatic(
-                Borrowed(
-                    "VFile",
-                ),
+                "VFile",
             ),
             ty: Resolved(
                 Module(0) TypeId(42),

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -454,7 +454,7 @@ fn test_resolve_exports() {
 
     // Remove this entry, or the Windows tests fail on the path in the snapshot below:
     assert_eq!(
-        exports.swap_remove(&Text::Static("oh\nno")),
+        exports.swap_remove(&Text::new_static("oh\nno")),
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
@@ -465,7 +465,7 @@ fn test_resolve_exports() {
         }))
     );
     assert_eq!(
-        exports.swap_remove(&Text::Static("renamed2")),
+        exports.swap_remove(&Text::new_static("renamed2")),
         Some(JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
@@ -495,7 +495,7 @@ fn test_resolve_exports() {
         .unwrap();
     assert_eq!(data.exports.len(), 1);
     assert_eq!(
-        data.exports.get(&Text::Static("renamed")),
+        data.exports.get(&Text::new_static("renamed")),
         Some(&JsExport::Reexport(JsReexport {
             import: JsImport {
                 specifier: "./renamed-reexports".into(),
@@ -593,7 +593,7 @@ export const promise = makePromiseCb();
     ));
 
     let promise_id = resolver
-        .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("promise"), ScopeId::GLOBAL)
         .expect("promise variable not found");
     let promise_ty = resolver.resolved_type_for_id(promise_id);
     assert!(promise_ty.is_promise_instance());
@@ -626,7 +626,7 @@ fn test_resolve_generic_mapped_value() {
     ));
 
     let mapped_id = resolver
-        .resolve_type_of(&Text::Static("mapped"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("mapped"), ScopeId::GLOBAL)
         .expect("mapped variable not found");
     let mapped_ty = resolver.resolved_type_for_id(mapped_id);
     let _mapped_ty_string = format!("{:?}", mapped_ty.deref()); // for debugging
@@ -688,7 +688,7 @@ fn test_resolve_generic_return_value_with_multiple_modules() {
     ));
 
     let result_id = resolver
-        .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("result"), ScopeId::GLOBAL)
         .expect("result variable not found");
     let result_ty = resolver.resolved_type_for_id(result_id);
     assert!(result_ty.is_string());
@@ -735,7 +735,7 @@ fn test_resolve_import_as_namespace() {
     ));
 
     let result_id = resolver
-        .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("result"), ScopeId::GLOBAL)
         .expect("result variable not found");
     let result_ty = resolver.resolved_type_for_id(result_id);
     assert!(result_ty.is_number());
@@ -812,7 +812,7 @@ fn test_resolve_return_value_of_function() {
     ));
 
     let foo_id = resolver
-        .resolve_type_of(&Text::Static("foo"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("foo"), ScopeId::GLOBAL)
         .expect("foo variable not found");
     let foo_ty = resolver.resolved_type_for_id(foo_id);
     let _foo_string_ty = format!("{foo_ty:?}");
@@ -870,7 +870,7 @@ fn test_resolve_type_of_property_with_getter() {
     ));
 
     let foo_id = resolver
-        .resolve_type_of(&Text::Static("foo"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("foo"), ScopeId::GLOBAL)
         .expect("foo variable not found");
     let foo_ty = resolver.resolved_type_for_id(foo_id);
     let _foo_string_ty = format!("{foo_ty:?}");
@@ -965,7 +965,7 @@ fn class_this_test_helper(case_name: &str, prefix: &str) {
     for i in 1..=7 {
         let name = format!("foo{i}");
         let foo_id = resolver
-            .resolve_type_of(&Text::Owned(name.clone()), ScopeId::GLOBAL)
+            .resolve_type_of(&Text::from(name.clone()), ScopeId::GLOBAL)
             .unwrap_or_else(|| panic!("{name} variable not found"));
         let foo_ty = resolver.resolved_type_for_id(foo_id);
         assert!(foo_ty.is_string_literal("foo"), "{name}: {foo_ty:?}");
@@ -1040,7 +1040,7 @@ fn test_resolve_type_of_this_in_object() {
     for i in 1..=5 {
         let name = format!("foo{i}");
         let foo_id = resolver
-            .resolve_type_of(&Text::Owned(name.clone()), ScopeId::GLOBAL)
+            .resolve_type_of(&Text::from(name.clone()), ScopeId::GLOBAL)
             .unwrap_or_else(|| panic!("{name} variable not found"));
         let foo_ty = resolver.resolved_type_for_id(foo_id);
         assert!(foo_ty.is_string_literal("foo"), "{name}: {foo_ty:?}");
@@ -1048,7 +1048,7 @@ fn test_resolve_type_of_this_in_object() {
     for i in 1..=2 {
         let name = format!("notFoo{i}");
         let foo_id = resolver
-            .resolve_type_of(&Text::Owned(name.clone()), ScopeId::GLOBAL)
+            .resolve_type_of(&Text::from(name.clone()), ScopeId::GLOBAL)
             .unwrap_or_else(|| panic!("{name} variable not found"));
         let foo_ty = resolver.resolved_type_for_id(foo_id);
         assert!(!foo_ty.is_string_literal("foo"), "{name}: {foo_ty:?}");
@@ -1132,7 +1132,7 @@ fn test_resolve_type_of_this_in_class_wrong_scope() {
     for i in 1..=5 {
         let name = format!("notFoo{i}");
         let foo_id = resolver
-            .resolve_type_of(&Text::Owned(name.clone()), ScopeId::GLOBAL)
+            .resolve_type_of(&Text::from(name.clone()), ScopeId::GLOBAL)
             .unwrap_or_else(|| panic!("{name} variable not found"));
         let foo_ty = resolver.resolved_type_for_id(foo_id);
         assert!(!foo_ty.is_string_literal("foo"), "{name}: {foo_ty:?}");
@@ -1512,13 +1512,13 @@ fn test_resolve_react_types() {
     ));
 
     let use_callback_id = resolver
-        .resolve_type_of(&Text::Static("useCallback"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("useCallback"), ScopeId::GLOBAL)
         .expect("useCallback variable not found");
     let use_callback_ty = resolver.resolved_type_for_id(use_callback_id);
     assert!(use_callback_ty.is_function());
 
     let promise_id = resolver
-        .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("promise"), ScopeId::GLOBAL)
         .expect("promise variable not found");
     let promise_ty = resolver.resolved_type_for_id(promise_id);
     assert!(promise_ty.is_promise_instance());
@@ -1568,7 +1568,7 @@ fn test_resolve_single_reexport() {
     ));
 
     let result_id = resolver
-        .resolve_type_of(&Text::Static("result"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("result"), ScopeId::GLOBAL)
         .expect("result variable not found");
     let ty = resolver.resolved_type_for_id(result_id);
     assert!(ty.is_number());
@@ -1633,13 +1633,13 @@ fn test_resolve_multiple_reexports() {
     ));
 
     let result1_id = resolver
-        .resolve_type_of(&Text::Static("result1"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("result1"), ScopeId::GLOBAL)
         .expect("result1 variable not found");
     let ty = resolver.resolved_type_for_id(result1_id);
     assert!(ty.is_number());
 
     let result2_id = resolver
-        .resolve_type_of(&Text::Static("result2"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("result2"), ScopeId::GLOBAL)
         .expect("result2 variable not found");
     let ty = resolver.resolved_type_for_id(result2_id);
     assert!(ty.is_string());
@@ -1725,7 +1725,7 @@ fn test_resolve_promise_from_imported_function_returning_imported_promise_type()
     ));
 
     let resolved_id = resolver
-        .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("promise"), ScopeId::GLOBAL)
         .expect("promise variable not found");
 
     let ty = resolver.resolved_type_for_id(resolved_id);
@@ -1789,7 +1789,7 @@ fn test_resolve_promise_from_imported_function_returning_reexported_promise_type
     ));
 
     let resolved_id = resolver
-        .resolve_type_of(&Text::Static("promise"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("promise"), ScopeId::GLOBAL)
         .expect("promise variable not found");
 
     let ty = resolver.resolved_type_for_id(resolved_id);
@@ -1844,7 +1844,7 @@ const { mutate } = useSWRConfig();
     ));
 
     let use_swr_config_id = resolver
-        .resolve_type_of(&Text::Static("useSWRConfig"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("useSWRConfig"), ScopeId::GLOBAL)
         .expect("mutate variable not found");
     let use_swr_config_ty = resolver.resolved_type_for_id(use_swr_config_id);
     let _use_swr_config_ty_string = format!("{:?}", use_swr_config_ty.deref()); // for debugging
@@ -1854,7 +1854,7 @@ const { mutate } = useSWRConfig();
     }));
 
     let mutate_id = resolver
-        .resolve_type_of(&Text::Static("mutate"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("mutate"), ScopeId::GLOBAL)
         .expect("mutate variable not found");
     let mutate_ty = resolver.resolved_type_for_id(mutate_id);
     let _mutate_ty_string = format!("{:?}", mutate_ty.deref()); // for debugging
@@ -1905,7 +1905,7 @@ type Intersection = Foo & Bar;"#,
     ));
 
     let intersection_id = resolver
-        .resolve_type_of(&Text::Static("Intersection"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("Intersection"), ScopeId::GLOBAL)
         .expect("Intersection type not found");
     let intersection_ty = resolver.resolved_type_for_id(intersection_id);
     let _intersection_ty = format!("{:?}", intersection_ty.deref()); // for debugging
@@ -1997,7 +1997,7 @@ fn test_resolve_swr_types() {
     ));
 
     let mutate_id = resolver
-        .resolve_type_of(&Text::Static("mutate"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("mutate"), ScopeId::GLOBAL)
         .expect("mutate variable not found");
 
     let mutate_ty = resolver.resolved_type_for_id(mutate_id);
@@ -2005,7 +2005,7 @@ fn test_resolve_swr_types() {
     assert!(mutate_ty.is_interface_with_member(|member| member.kind().is_call_signature()));
 
     let mutate_result_id = resolver
-        .resolve_type_of(&Text::Static("mutateResult"), ScopeId::GLOBAL)
+        .resolve_type_of(&Text::new_static("mutateResult"), ScopeId::GLOBAL)
         .expect("mutateResult variable not found");
 
     let mutate_result_ty = resolver.resolved_type_for_id(mutate_result_id);

--- a/crates/biome_rowan/src/syntax_node_text.rs
+++ b/crates/biome_rowan/src/syntax_node_text.rs
@@ -152,8 +152,8 @@ impl SyntaxNodeText {
     /// the node consists of a single token.
     pub fn into_text(self) -> Text {
         match self.node.first_token() {
-            Some(token) if token.text_range() == self.range => Text::Borrowed(token.token_text()),
-            _ => Text::Owned(self.to_string()),
+            Some(token) if token.text_range() == self.range => token.token_text().into(),
+            _ => self.to_string().into(),
         }
     }
 }

--- a/crates/biome_rowan/src/text.rs
+++ b/crates/biome_rowan/src/text.rs
@@ -1,17 +1,30 @@
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
+use std::mem::{self, ManuallyDrop};
 use std::ops::Deref;
+use std::ptr::{self, NonNull};
+use std::{slice, str};
 
 use crate::TokenText;
 
-/// Type that allows deserializing a string without heap-allocation when possible.
+/// Type used for storing text from a syntax tree that avoids heap-allocations
+/// when possible.
 ///
-/// This is analogous to [std::borrow::Cow], except for strings.
-#[derive(Clone, Debug)]
-pub enum Text {
-    Borrowed(TokenText),
-    Owned(String),
-    Static(&'static str),
+/// This is somewhat similar to [std::borrow::Cow], except it's optimised for
+/// token strings.
+pub struct Text(TextRepr);
+
+// SAFETY: `Text` is immutable, and is safe to `Send`.
+#[expect(unsafe_code)]
+unsafe impl Send for Text {}
+
+// SAFETY: `Text` is immutable, and is `Sync` safe.
+#[expect(unsafe_code)]
+unsafe impl Sync for Text {}
+
+union TextRepr {
+    token: ManuallyDrop<TokenText>,
+    string: ManuallyDrop<SmallStr>,
 }
 
 impl Borrow<str> for Text {
@@ -20,14 +33,42 @@ impl Borrow<str> for Text {
     }
 }
 
+impl Clone for Text {
+    #[expect(unsafe_code)]
+    fn clone(&self) -> Self {
+        if self.is_string() {
+            // SAFETY: We checked it's a string.
+            unsafe {
+                Self(TextRepr {
+                    string: self.0.string.clone(),
+                })
+            }
+        } else {
+            // SAFETY: If it's not a string, it must be a token.
+            unsafe {
+                Self(TextRepr {
+                    token: self.0.token.clone(),
+                })
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.text())
+    }
+}
+
 impl Default for Text {
     fn default() -> Self {
-        Self::Owned(String::new())
+        Self::new_static("")
     }
 }
 
 impl Deref for Text {
     type Target = str;
+
     fn deref(&self) -> &Self::Target {
         self.text()
     }
@@ -39,17 +80,40 @@ impl std::fmt::Display for Text {
     }
 }
 
+impl Drop for Text {
+    #[expect(unsafe_code)]
+    fn drop(&mut self) {
+        if self.is_string() {
+            // SAFETY: We checked it's a string.
+            unsafe {
+                ManuallyDrop::drop(&mut self.0.string);
+            }
+        } else {
+            // SAFETY: If it's not a string, it must be a token.
+            unsafe {
+                ManuallyDrop::drop(&mut self.0.token);
+            }
+        }
+    }
+}
+
 impl Eq for Text {}
 
 impl From<TokenText> for Text {
     fn from(text: TokenText) -> Self {
-        Self::Borrowed(text)
+        Self::new_token(text)
+    }
+}
+
+impl From<String> for Text {
+    fn from(string: String) -> Self {
+        Self::new_owned(string.into())
     }
 }
 
 impl From<&'static str> for Text {
     fn from(string: &'static str) -> Self {
-        Self::Static(string)
+        Self::new_static(string)
     }
 }
 
@@ -84,27 +148,208 @@ impl PartialOrd for Text {
 }
 
 impl From<Text> for String {
-    fn from(value: Text) -> Self {
-        match value {
-            Text::Borrowed(token_text) => token_text.to_string(),
-            Text::Owned(string) => string,
-            Text::Static(string) => string.to_string(),
+    #[inline]
+    #[expect(unsafe_code)]
+    fn from(mut value: Text) -> Self {
+        if value.is_string() {
+            // SAFETY: We checked it's a string.
+            let string = unsafe { ManuallyDrop::take(&mut value.0.string) };
+            mem::forget(value);
+            string.into_boxed_str().into()
+        } else {
+            // SAFETY: If it's not a string, it must be a token.
+            unsafe { value.0.token.to_string() }
         }
     }
 }
 
 impl From<Text> for Box<str> {
+    #[inline]
     fn from(value: Text) -> Self {
         Self::from(value.text())
     }
 }
 
 impl Text {
+    #[inline]
+    pub fn new_owned(string: Box<str>) -> Self {
+        Self(TextRepr {
+            string: ManuallyDrop::new(SmallStr::new_owned(string)),
+        })
+    }
+
+    #[inline]
+    pub fn new_static(string: &'static str) -> Self {
+        Self(TextRepr {
+            string: ManuallyDrop::new(SmallStr::new_static(string)),
+        })
+    }
+
+    #[inline]
+    pub fn new_token(token: TokenText) -> Self {
+        Self(TextRepr {
+            token: ManuallyDrop::new(token),
+        })
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    pub fn is_string(&self) -> bool {
+        // SAFETY: See [`SmallStr::tag`] for details.
+        unsafe { self.0.string.tag == SmallStr::TAG }
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
     pub fn text(&self) -> &str {
-        match self {
-            Self::Borrowed(token_text) => token_text.text(),
-            Self::Owned(string) => string,
-            Self::Static(string) => string,
+        if self.is_string() {
+            // SAFETY: We checked it's a string.
+            unsafe { self.0.string.as_str() }
+        } else {
+            // SAFETY: If it's not a string, it must be a token.
+            unsafe { self.0.token.text() }
         }
+    }
+}
+
+/// Small string whose maximum length cannot exceed 2GB.
+///
+/// Functions the same as `Cow<str>` but is designed to still have an niche
+/// optimisation bit so it can fit inside `Text` while keeping `Text` at 16
+/// bytes only.
+#[derive(Debug)]
+#[repr(C)]
+struct SmallStr {
+    /// Pointer to the string data.
+    ///
+    /// We use `NonNull` to expose a niche optimisation bit available.
+    ptr: ptr::NonNull<u8>,
+
+    /// The length of the string, with the first bit used for marking ownership.
+    ///
+    /// If `flag_and_len & OWNED_FLAG != 0`, the string data pointed to by `ptr`
+    /// is owned and must be freed on drop. Otherwise it's a `&'static str`.
+    flag_and_len: u32,
+
+    /// Tag that must have the value [Self::TAG] for the `SmallStr` to be valid.
+    ///
+    /// If the tag contains any other value, we know `TextRepr` union does not
+    /// contain a `SmallStr`, but a `TokenText` instead. This works because in
+    /// the same position as the tag, `TokenText` stores the `end` field of its
+    /// `TextRange`. And because the upper bit of `TextSize` can never be set,
+    /// we can use it to represent this tag.
+    tag: u32,
+}
+
+impl SmallStr {
+    const LEN_MASK: u32 = 0x7fff_ffff; // 31 bits for length.
+    const OWNED_FLAG: u32 = 0x8000_0000; // 1 bit for ownership.
+    const TAG: u32 = 0x8000_0000; // 1 bit for ownership.
+
+    #[inline]
+    fn new_owned(string: Box<str>) -> Self {
+        let len = string.len() as u32;
+        debug_assert!(len <= Self::LEN_MASK, "string too long (>2GB)");
+        let ptr = NonNull::from(Box::leak(string)).cast();
+        Self {
+            ptr,
+            flag_and_len: len | Self::OWNED_FLAG,
+            tag: Self::TAG,
+        }
+    }
+
+    #[inline]
+    fn new_static(string: &'static str) -> Self {
+        let len = string.len() as u32;
+        debug_assert!(len <= Self::LEN_MASK, "string too long (>2GB)");
+        let ptr = NonNull::from(string).cast();
+        Self {
+            ptr,
+            flag_and_len: len, // OWNED_FLAG = 0
+            tag: Self::TAG,
+        }
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    fn as_str(&self) -> &str {
+        // SAFETY: `SmallStr` only gets initialised from valid strings, so we
+        //         know this is UTF-8. For the same reason, we know the `ptr` is
+        //         valid too.
+        unsafe { str::from_utf8_unchecked(slice::from_raw_parts(self.ptr.as_ptr(), self.len())) }
+    }
+
+    /// Converts the small string into a `Box<str>`.
+    ///
+    /// Allocates if the string was static.
+    #[inline]
+    #[expect(unsafe_code)]
+    fn into_boxed_str(self) -> Box<str> {
+        if self.is_owned() {
+            let slice = ptr::slice_from_raw_parts_mut(self.ptr.as_ptr(), self.len());
+            mem::forget(self);
+            // SAFETY: We checked this is an owned instance, so we can safely
+            //         transfer the ownership into a `Box`. We also know the
+            //         data is valid UTF-8, because `SmallStr` only gets
+            //         initialised from valid strings. We also made sure to
+            //         "forget" `self` to avoid a double-free.
+            unsafe { str::from_boxed_utf8_unchecked(Box::from_raw(slice)) }
+        } else {
+            let slice = self.as_str();
+            slice.into()
+        }
+    }
+
+    #[inline]
+    fn is_owned(&self) -> bool {
+        self.flag_and_len & Self::OWNED_FLAG == Self::OWNED_FLAG
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        (self.flag_and_len & Self::LEN_MASK) as usize
+    }
+}
+
+impl Clone for SmallStr {
+    fn clone(&self) -> Self {
+        if self.is_owned() {
+            let slice = self.as_str();
+            Self::new_owned(slice.into())
+        } else {
+            Self {
+                ptr: self.ptr,
+                flag_and_len: self.flag_and_len,
+                tag: Self::TAG,
+            }
+        }
+    }
+}
+
+impl Drop for SmallStr {
+    #[inline]
+    #[expect(unsafe_code)]
+    fn drop(&mut self) {
+        if self.is_owned() {
+            // SAFETY: `SmallStr` only gets initialised from valid strings, so
+            //         we know the `ptr` and its length are valid.
+            drop(unsafe {
+                Box::from_raw(ptr::slice_from_raw_parts_mut(self.ptr.as_ptr(), self.len()))
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_type_size() {
+        assert_eq!(
+            std::mem::size_of::<Text>(),
+            16,
+            "`Text` should not be bigger than 16 bytes"
+        );
     }
 }

--- a/crates/biome_rowan/src/token_text.rs
+++ b/crates/biome_rowan/src/token_text.rs
@@ -5,6 +5,7 @@ use std::{borrow::Borrow, fmt::Formatter};
 
 /// Reference to the text of a SyntaxToken without having to worry about the lifetime of `&str`.
 #[derive(Eq, Clone)]
+#[repr(C)]
 pub struct TokenText {
     // Using a green token to ensure this type is Send + Sync.
     token: GreenToken,

--- a/crates/biome_text_size/src/range.rs
+++ b/crates/biome_text_size/src/range.rs
@@ -14,6 +14,7 @@ use {
 ///
 /// It is a logic error for `start` to be greater than `end`.
 #[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(C)]
 pub struct TextRange {
     // Invariant: start <= end
     start: TextSize,


### PR DESCRIPTION
## Summary

Shrinks `Text` from 24 bytes to 16. Given that `Text` is getting used increasingly, including quite pervasively inside the module graph, I figured it might be a good candidate to squeeze a bit further.

Seems to give a ~1-3% improvement on the module graph benchmarks.

## Test Plan

Everything should stay green.