### PR TITLE
fix: typo `perfer-for` → `prefer-for`

### DIFF
--- a/.changeset/eleven-years-act.md
+++ b/.changeset/eleven-years-act.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed `prefer-for` rule name of `eslint-plugin-solid`.

--- a/.changeset/eleven-years-act.md
+++ b/.changeset/eleven-years-act.md
@@ -2,4 +2,4 @@
 "@biomejs/biome": patch
 ---
 
-Fixed `prefer-for` rule name of `eslint-plugin-solid`.
+Fixed ESLint migration for the rule `prefer-for` from `eslint-plugin-solid` to Biome's `useForComponent`.

--- a/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
+++ b/crates/biome_cli/src/execute/migrate/eslint_any_rule_to_biome.rs
@@ -2341,7 +2341,7 @@ pub(crate) fn migrate_eslint_any_rule(
                 .get_or_insert(Default::default());
             rule.set_level(rule.level().max(rule_severity.into()));
         }
-        "solidjs/perfer-for" => {
+        "solidjs/prefer-for" => {
             if !options.include_inspired {
                 results.add(eslint_name, eslint_to_biome::RuleMigrationResult::Inspired);
                 return false;

--- a/crates/biome_js_analyze/src/lint/nursery/use_for_component.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_for_component.rs
@@ -58,7 +58,7 @@ declare_lint_rule! {
         language: "js",
         domains: &[RuleDomain::Solid],
         recommended: false,
-        sources: &[RuleSource::EslintSolid("perfer-for").inspired()],
+        sources: &[RuleSource::EslintSolid("prefer-for").inspired()],
     }
 }
 


### PR DESCRIPTION
## Summary

Fix typo in [Solid.js ESLint rule](https://github.com/solidjs-community/eslint-plugin-solid) name from “perfer-for” to “prefer-for” and add a corresponding changeset

Bug Fixes:
- Correct rule key in migrate_eslint_any_rule from “solidjs/perfer-for” to “solidjs/prefer-for”
- Update lint rule declaration to reference “prefer-for” instead of misspelled “perfer-for”

Chores:
- Add changeset entry for the ESLint plugin fix

## Test Plan

| Before | After |
|--------|--------|
| https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/perfer-for.md | https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-for.md | 

## Docs

[eslint-plugin-solid](https://biomejs.dev/linter/javascript/sources/#eslint-plugin-solid)