### PR TITLE
fix: always use statically linked musl build on linux

### DIFF
--- a/packages/@biomejs/biome/bin/biome
+++ b/packages/@biomejs/biome/bin/biome
@@ -2,21 +2,6 @@
 const { platform, arch, env, version, release } = process;
 const { execSync } = require("child_process");
 
-function isMusl() {
-	let stderr;
-	try {
-		stderr = execSync("ldd --version", {
-			stdio: ['pipe', 'pipe', 'pipe']
-		});
-	} catch (err) {
-		stderr = err.stderr;
-	}
-	if (stderr.indexOf("musl") > -1) {
-		return true;
-	}
-	return false;
-}
-
 const PLATFORMS = {
 	win32: {
 		x64: "@biomejs/cli-win32-x64/biome.exe",
@@ -37,7 +22,7 @@ const PLATFORMS = {
 };
 
 const binPath = env.BIOME_BINARY ||
-	(platform === "linux" && isMusl()
+	(platform === "linux"
 		? PLATFORMS?.["linux-musl"]?.[arch]
 		: PLATFORMS?.[platform]?.[arch]
 	);


### PR DESCRIPTION
## Summary

Not all Linux systems can run the dynamically linked build of Biome (e.g. NixOS). The statically linked build that you already provide is a slightly smaller file size, and will work on all Linux systems. So then it is only a question of making it the default.

This PR removes inaccurate logic that was attempting to use the statically linked build in as few cases as possible, and instead uses the static build for *all* Linux systems.

See previous [discussion here](https://github.com/biomejs/biome-vscode/issues/295) for when the same change was merged for your vscode extension.

You might consider removing your dynamically linked Linux build altogether. For now it is still present, just not used by the CLI.

## Test Plan

The change is trivial. I have verified that the  @biomejs/biome script, which used to be unable to run on my Linux system that does not support dynamic linking, now executes just fine after my change.

## Docs

I believe no documentation is needed here, since this change should not impact existing users. Though it will enable more users to now use biome on their systems.