### PR TITLE
fix: update documentation URL for `noUnknownPseudoClass`

### DIFF
--- a/.changeset/fast-bottles-guess.md
+++ b/.changeset/fast-bottles-guess.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed the documentation URL for `lint/correctness/noUnknownPseudoClass`

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -120,7 +120,7 @@ define_categories! {
     "lint/correctness/noUnknownFunction": "https://biomejs.dev/linter/rules/no-unknown-function",
     "lint/correctness/noUnknownMediaFeatureName": "https://biomejs.dev/linter/rules/no-unknown-media-feature-name",
     "lint/correctness/noUnknownProperty": "https://biomejs.dev/linter/rules/no-unknown-property",
-    "lint/correctness/noUnknownPseudoClass": "https://biomejs.dev/linter/rules/no-unknown-pseudo-class-selector",
+    "lint/correctness/noUnknownPseudoClass": "https://biomejs.dev/linter/rules/no-unknown-pseudo-class",
     "lint/correctness/noUnknownPseudoClassSelector": "https://biomejs.dev/linter/rules/no-unknown-pseudo-class-selector",
     "lint/correctness/noUnknownPseudoElement": "https://biomejs.dev/linter/rules/no-unknown-selector-pseudo-element",
     "lint/correctness/noUnknownTypeSelector": "https://biomejs.dev/linter/rules/no-unknown-type-selector",


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

This fixes the documentation URL for `lint/correctness/noUnknownPseudoClass`, that was pointing to a 404 page.

I noticed there's also a `lint/correctness/noUnknownPseudoClassSelector` rule [here](https://github.com/biomejs/biome/blob/main/crates/biome_diagnostics_categories/src/categories.rs#L124), but hesitated to update that URL too, cause I'm not sure how to approach this. It seems like `noUnknownPseudoClassSelector` has been renamed to `noUnknownPseudoClass`, but before removing I want to make sure it's not there for backwards compatibility.

Let me know if I should either update that URL too, or remove the reference to `noUnknownPseudoClassSelector`.



<!-- ## Test Plan What demonstrates that your implementation is correct? -->

<!-- ## Docs If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
