### PR TITLE
feat(json/analyze): rule `noQuickfixBiome`

### DIFF
--- a/.changeset/dark-states-speak.md
+++ b/.changeset/dark-states-speak.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added a new JSON rule called `noQuickfixBiome`, which disallow the use of code action `quickfix.biome` inside code editor settings.

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -227,6 +227,7 @@ pub enum RuleName {
     NoProcessEnv,
     NoProcessGlobal,
     NoPrototypeBuiltins,
+    NoQuickfixBiome,
     NoReExportAll,
     NoReactPropAssign,
     NoReactSpecificProps,
@@ -568,6 +569,7 @@ impl RuleName {
             Self::NoProcessEnv => "noProcessEnv",
             Self::NoProcessGlobal => "noProcessGlobal",
             Self::NoPrototypeBuiltins => "noPrototypeBuiltins",
+            Self::NoQuickfixBiome => "noQuickfixBiome",
             Self::NoReExportAll => "noReExportAll",
             Self::NoReactPropAssign => "noReactPropAssign",
             Self::NoReactSpecificProps => "noReactSpecificProps",
@@ -905,6 +907,7 @@ impl RuleName {
             Self::NoProcessEnv => RuleGroup::Style,
             Self::NoProcessGlobal => RuleGroup::Nursery,
             Self::NoPrototypeBuiltins => RuleGroup::Suspicious,
+            Self::NoQuickfixBiome => RuleGroup::Nursery,
             Self::NoReExportAll => RuleGroup::Performance,
             Self::NoReactPropAssign => RuleGroup::Nursery,
             Self::NoReactSpecificProps => RuleGroup::Suspicious,
@@ -1060,7 +1063,7 @@ impl RuleName {
             Self::UseMediaCaption => RuleGroup::A11y,
             Self::UseNamedOperation => RuleGroup::Nursery,
             Self::UseNamespaceKeyword => RuleGroup::Suspicious,
-            Self::UseNamingConvention => RuleGroup::Style,
+            Self::UseNamingConvention => RuleGroup::Nursery,
             Self::UseNodeAssertStrict => RuleGroup::Style,
             Self::UseNodejsImportProtocol => RuleGroup::Style,
             Self::UseNumberNamespace => RuleGroup::Style,
@@ -1251,6 +1254,7 @@ impl std::str::FromStr for RuleName {
             "noProcessEnv" => Ok(Self::NoProcessEnv),
             "noProcessGlobal" => Ok(Self::NoProcessGlobal),
             "noPrototypeBuiltins" => Ok(Self::NoPrototypeBuiltins),
+            "noQuickfixBiome" => Ok(Self::NoQuickfixBiome),
             "noReExportAll" => Ok(Self::NoReExportAll),
             "noReactPropAssign" => Ok(Self::NoReactPropAssign),
             "noReactSpecificProps" => Ok(Self::NoReactSpecificProps),
@@ -4254,7 +4258,7 @@ impl From<GroupPlainConfiguration> for Correctness {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
-pub struct Nursery { # [doc = r" It enables the recommended rules for this group"] # [serde (skip_serializing_if = "Option::is_none")] pub recommended : Option < bool > , # [doc = "Disallow await inside loops."] # [serde (skip_serializing_if = "Option::is_none")] pub no_await_in_loop : Option < RuleConfiguration < biome_rule_options :: no_await_in_loop :: NoAwaitInLoopOptions >> , # [doc = "Disallow bitwise operators."] # [serde (skip_serializing_if = "Option::is_none")] pub no_bitwise_operators : Option < RuleConfiguration < biome_rule_options :: no_bitwise_operators :: NoBitwiseOperatorsOptions >> , # [doc = "Disallow expressions where the operation doesn't affect the value"] # [serde (skip_serializing_if = "Option::is_none")] pub no_constant_binary_expression : Option < RuleConfiguration < biome_rule_options :: no_constant_binary_expression :: NoConstantBinaryExpressionOptions >> , # [doc = "Disallow destructuring props inside JSX components in Solid projects."] # [serde (skip_serializing_if = "Option::is_none")] pub no_destructured_props : Option < RuleConfiguration < biome_rule_options :: no_destructured_props :: NoDestructuredPropsOptions >> , # [doc = "Restrict the number of lines of code in a function."] # [serde (skip_serializing_if = "Option::is_none")] pub no_excessive_lines_per_function : Option < RuleConfiguration < biome_rule_options :: no_excessive_lines_per_function :: NoExcessiveLinesPerFunctionOptions >> , # [doc = "Require Promise-like statements to be handled appropriately."] # [serde (skip_serializing_if = "Option::is_none")] pub no_floating_promises : Option < RuleFixConfiguration < biome_rule_options :: no_floating_promises :: NoFloatingPromisesOptions >> , # [doc = "Disallow the use of __dirname and __filename in the global scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_global_dirname_filename : Option < RuleFixConfiguration < biome_rule_options :: no_global_dirname_filename :: NoGlobalDirnameFilenameOptions >> , # [doc = "Disallow shorthand type conversions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_implicit_coercion : Option < RuleFixConfiguration < biome_rule_options :: no_implicit_coercion :: NoImplicitCoercionOptions >> , # [doc = "Prevent import cycles."] # [serde (skip_serializing_if = "Option::is_none")] pub no_import_cycles : Option < RuleConfiguration < biome_rule_options :: no_import_cycles :: NoImportCyclesOptions >> , # [doc = "Disallow the use of the !important style."] # [serde (skip_serializing_if = "Option::is_none")] pub no_important_styles : Option < RuleFixConfiguration < biome_rule_options :: no_important_styles :: NoImportantStylesOptions >> , # [doc = "Reports usage of \"magic numbers\" — numbers used directly instead of being assigned to named constants."] # [serde (skip_serializing_if = "Option::is_none")] pub no_magic_numbers : Option < RuleConfiguration < biome_rule_options :: no_magic_numbers :: NoMagicNumbersOptions >> , # [doc = "Disallow Promises to be used in places where they are almost certainly a mistake."] # [serde (skip_serializing_if = "Option::is_none")] pub no_misused_promises : Option < RuleFixConfiguration < biome_rule_options :: no_misused_promises :: NoMisusedPromisesOptions >> , # [doc = "Disallows defining React components inside other components."] # [serde (skip_serializing_if = "Option::is_none")] pub no_nested_component_definitions : Option < RuleConfiguration < biome_rule_options :: no_nested_component_definitions :: NoNestedComponentDefinitionsOptions >> , # [doc = "Disallow use event handlers on non-interactive elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_noninteractive_element_interactions : Option < RuleConfiguration < biome_rule_options :: no_noninteractive_element_interactions :: NoNoninteractiveElementInteractionsOptions >> , # [doc = "Disallow the use of process global."] # [serde (skip_serializing_if = "Option::is_none")] pub no_process_global : Option < RuleFixConfiguration < biome_rule_options :: no_process_global :: NoProcessGlobalOptions >> , # [doc = "Disallow assigning to React component props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_react_prop_assign : Option < RuleConfiguration < biome_rule_options :: no_react_prop_assign :: NoReactPropAssignOptions >> , # [doc = "Disallow the use of configured elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_restricted_elements : Option < RuleConfiguration < biome_rule_options :: no_restricted_elements :: NoRestrictedElementsOptions >> , # [doc = "Disallow usage of sensitive data such as API keys and tokens."] # [serde (skip_serializing_if = "Option::is_none")] pub no_secrets : Option < RuleConfiguration < biome_rule_options :: no_secrets :: NoSecretsOptions >> , # [doc = "Disallow variable declarations from shadowing variables declared in the outer scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_shadow : Option < RuleConfiguration < biome_rule_options :: no_shadow :: NoShadowOptions >> , # [doc = "Prevents the use of the TypeScript directive @ts-ignore."] # [serde (skip_serializing_if = "Option::is_none")] pub no_ts_ignore : Option < RuleFixConfiguration < biome_rule_options :: no_ts_ignore :: NoTsIgnoreOptions >> , # [doc = "Disallow let or var variables that are read but never assigned."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unassigned_variables : Option < RuleConfiguration < biome_rule_options :: no_unassigned_variables :: NoUnassignedVariablesOptions >> , # [doc = "Disallow unknown at-rules."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unknown_at_rule : Option < RuleConfiguration < biome_rule_options :: no_unknown_at_rule :: NoUnknownAtRuleOptions >> , # [doc = "Warn when importing non-existing exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unresolved_imports : Option < RuleConfiguration < biome_rule_options :: no_unresolved_imports :: NoUnresolvedImportsOptions >> , # [doc = "Prevent duplicate polyfills from Polyfill.io."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unwanted_polyfillio : Option < RuleConfiguration < biome_rule_options :: no_unwanted_polyfillio :: NoUnwantedPolyfillioOptions >> , # [doc = "Disallow useless backreferences in regular expression literals that always match an empty string."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_backref_in_regex : Option < RuleConfiguration < biome_rule_options :: no_useless_backref_in_regex :: NoUselessBackrefInRegexOptions >> , # [doc = "Disallow unnecessary escapes in string literals."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_escape_in_string : Option < RuleFixConfiguration < biome_rule_options :: no_useless_escape_in_string :: NoUselessEscapeInStringOptions >> , # [doc = "Disallow the use of useless undefined."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_undefined : Option < RuleFixConfiguration < biome_rule_options :: no_useless_undefined :: NoUselessUndefinedOptions >> , # [doc = "Disallow reserved names to be used as props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_props : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_props :: NoVueReservedPropsOptions >> , # [doc = "Enforce that getters and setters for the same property are adjacent in class and object definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_adjacent_getter_setter : Option < RuleConfiguration < biome_rule_options :: use_adjacent_getter_setter :: UseAdjacentGetterSetterOptions >> , # [doc = "Require the consistent declaration of object literals. Defaults to explicit definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_object_definition : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_object_definition :: UseConsistentObjectDefinitionOptions >> , # [doc = "Use static Response methods instead of new Response() constructor when possible."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_response : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_response :: UseConsistentResponseOptions >> , # [doc = "Require switch-case statements to be exhaustive."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exhaustive_switch_cases : Option < RuleFixConfiguration < biome_rule_options :: use_exhaustive_switch_cases :: UseExhaustiveSwitchCasesOptions >> , # [doc = "Enforce types in functions, methods, variables, and parameters."] # [serde (skip_serializing_if = "Option::is_none")] pub use_explicit_type : Option < RuleConfiguration < biome_rule_options :: use_explicit_type :: UseExplicitTypeOptions >> , # [doc = "Require that all exports are declared after all non-export statements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exports_last : Option < RuleConfiguration < biome_rule_options :: use_exports_last :: UseExportsLastOptions >> , # [doc = "Enforce using Solid's \\<For /> component for mapping an array to JSX elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_for_component : Option < RuleConfiguration < biome_rule_options :: use_for_component :: UseForComponentOptions >> , # [doc = "Ensure the preconnect attribute is used when using Google Fonts."] # [serde (skip_serializing_if = "Option::is_none")] pub use_google_font_preconnect : Option < RuleFixConfiguration < biome_rule_options :: use_google_font_preconnect :: UseGoogleFontPreconnectOptions >> , # [doc = "Prefer Array#{indexOf,lastIndexOf}() over Array#{findIndex,findLastIndex}() when looking for the index of an item."] # [serde (skip_serializing_if = "Option::is_none")] pub use_index_of : Option < RuleFixConfiguration < biome_rule_options :: use_index_of :: UseIndexOfOptions >> , # [doc = "Enforce consistent return values in iterable callbacks."] # [serde (skip_serializing_if = "Option::is_none")] pub use_iterable_callback_return : Option < RuleConfiguration < biome_rule_options :: use_iterable_callback_return :: UseIterableCallbackReturnOptions >> , # [doc = "Enforces the use of with { type: \"json\" } for JSON module imports."] # [serde (skip_serializing_if = "Option::is_none")] pub use_json_import_attribute : Option < RuleFixConfiguration < biome_rule_options :: use_json_import_attribute :: UseJsonImportAttributeOptions >> , # [doc = "Enforce specifying the name of GraphQL operations."] # [serde (skip_serializing_if = "Option::is_none")] pub use_named_operation : Option < RuleFixConfiguration < biome_rule_options :: use_named_operation :: UseNamedOperationOptions >> , # [doc = "Validates that all enum values are capitalized."] # [serde (skip_serializing_if = "Option::is_none")] pub use_naming_convention : Option < RuleConfiguration < biome_rule_options :: use_naming_convention :: UseNamingConventionOptions >> , # [doc = "Enforce the use of numeric separators in numeric literals."] # [serde (skip_serializing_if = "Option::is_none")] pub use_numeric_separators : Option < RuleFixConfiguration < biome_rule_options :: use_numeric_separators :: UseNumericSeparatorsOptions >> , # [doc = "Prefer object spread over Object.assign() when constructing new objects."] # [serde (skip_serializing_if = "Option::is_none")] pub use_object_spread : Option < RuleFixConfiguration < biome_rule_options :: use_object_spread :: UseObjectSpreadOptions >> , # [doc = "Enforce the consistent use of the radix argument when using parseInt()."] # [serde (skip_serializing_if = "Option::is_none")] pub use_parse_int_radix : Option < RuleFixConfiguration < biome_rule_options :: use_parse_int_radix :: UseParseIntRadixOptions >> , # [doc = "Enforce marking members as readonly if they are never modified outside the constructor."] # [serde (skip_serializing_if = "Option::is_none")] pub use_readonly_class_properties : Option < RuleFixConfiguration < biome_rule_options :: use_readonly_class_properties :: UseReadonlyClassPropertiesOptions >> , # [doc = "Enforce JSDoc comment lines to start with a single asterisk, except for the first one."] # [serde (skip_serializing_if = "Option::is_none")] pub use_single_js_doc_asterisk : Option < RuleFixConfiguration < biome_rule_options :: use_single_js_doc_asterisk :: UseSingleJsDocAsteriskOptions >> , # [doc = "Enforce the sorting of CSS utility classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_sorted_classes : Option < RuleFixConfiguration < biome_rule_options :: use_sorted_classes :: UseSortedClassesOptions >> , # [doc = "Require a description parameter for the Symbol()."] # [serde (skip_serializing_if = "Option::is_none")] pub use_symbol_description : Option < RuleConfiguration < biome_rule_options :: use_symbol_description :: UseSymbolDescriptionOptions >> , # [doc = "Disallow overload signatures that can be unified into a single signature."] # [serde (skip_serializing_if = "Option::is_none")] pub use_unified_type_signature : Option < RuleFixConfiguration < biome_rule_options :: use_unified_type_signature :: UseUnifiedTypeSignatureOptions >> , # [doc = "Prevent the usage of static string literal id attribute on elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_unique_element_ids : Option < RuleConfiguration < biome_rule_options :: use_unique_element_ids :: UseUniqueElementIdsOptions >> }
+pub struct Nursery { # [doc = r" It enables the recommended rules for this group"] # [serde (skip_serializing_if = "Option::is_none")] pub recommended : Option < bool > , # [doc = "Disallow await inside loops."] # [serde (skip_serializing_if = "Option::is_none")] pub no_await_in_loop : Option < RuleConfiguration < biome_rule_options :: no_await_in_loop :: NoAwaitInLoopOptions >> , # [doc = "Disallow bitwise operators."] # [serde (skip_serializing_if = "Option::is_none")] pub no_bitwise_operators : Option < RuleConfiguration < biome_rule_options :: no_bitwise_operators :: NoBitwiseOperatorsOptions >> , # [doc = "Disallow expressions where the operation doesn't affect the value"] # [serde (skip_serializing_if = "Option::is_none")] pub no_constant_binary_expression : Option < RuleConfiguration < biome_rule_options :: no_constant_binary_expression :: NoConstantBinaryExpressionOptions >> , # [doc = "Disallow destructuring props inside JSX components in Solid projects."] # [serde (skip_serializing_if = "Option::is_none")] pub no_destructured_props : Option < RuleConfiguration < biome_rule_options :: no_destructured_props :: NoDestructuredPropsOptions >> , # [doc = "Restrict the number of lines of code in a function."] # [serde (skip_serializing_if = "Option::is_none")] pub no_excessive_lines_per_function : Option < RuleConfiguration < biome_rule_options :: no_excessive_lines_per_function :: NoExcessiveLinesPerFunctionOptions >> , # [doc = "Require Promise-like statements to be handled appropriately."] # [serde (skip_serializing_if = "Option::is_none")] pub no_floating_promises : Option < RuleFixConfiguration < biome_rule_options :: no_floating_promises :: NoFloatingPromisesOptions >> , # [doc = "Disallow the use of __dirname and __filename in the global scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_global_dirname_filename : Option < RuleFixConfiguration < biome_rule_options :: no_global_dirname_filename :: NoGlobalDirnameFilenameOptions >> , # [doc = "Disallow shorthand type conversions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_implicit_coercion : Option < RuleFixConfiguration < biome_rule_options :: no_implicit_coercion :: NoImplicitCoercionOptions >> , # [doc = "Prevent import cycles."] # [serde (skip_serializing_if = "Option::is_none")] pub no_import_cycles : Option < RuleConfiguration < biome_rule_options :: no_import_cycles :: NoImportCyclesOptions >> , # [doc = "Disallow the use of the !important style."] # [serde (skip_serializing_if = "Option::is_none")] pub no_important_styles : Option < RuleFixConfiguration < biome_rule_options :: no_important_styles :: NoImportantStylesOptions >> , # [doc = "Reports usage of \"magic numbers\" — numbers used directly instead of being assigned to named constants."] # [serde (skip_serializing_if = "Option::is_none")] pub no_magic_numbers : Option < RuleConfiguration < biome_rule_options :: no_magic_numbers :: NoMagicNumbersOptions >> , # [doc = "Disallow Promises to be used in places where they are almost certainly a mistake."] # [serde (skip_serializing_if = "Option::is_none")] pub no_misused_promises : Option < RuleFixConfiguration < biome_rule_options :: no_misused_promises :: NoMisusedPromisesOptions >> , # [doc = "Disallows defining React components inside other components."] # [serde (skip_serializing_if = "Option::is_none")] pub no_nested_component_definitions : Option < RuleConfiguration < biome_rule_options :: no_nested_component_definitions :: NoNestedComponentDefinitionsOptions >> , # [doc = "Disallow use event handlers on non-interactive elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_noninteractive_element_interactions : Option < RuleConfiguration < biome_rule_options :: no_noninteractive_element_interactions :: NoNoninteractiveElementInteractionsOptions >> , # [doc = "Disallow the use of process global."] # [serde (skip_serializing_if = "Option::is_none")] pub no_process_global : Option < RuleFixConfiguration < biome_rule_options :: no_process_global :: NoProcessGlobalOptions >> , # [doc = "Disallow the use if quickfix.biome inside editor settings file."] # [serde (skip_serializing_if = "Option::is_none")] pub no_quickfix_biome : Option < RuleFixConfiguration < biome_rule_options :: no_quickfix_biome :: NoQuickfixBiomeOptions >> , # [doc = "Disallow assigning to React component props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_react_prop_assign : Option < RuleConfiguration < biome_rule_options :: no_react_prop_assign :: NoReactPropAssignOptions >> , # [doc = "Disallow the use of configured elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_restricted_elements : Option < RuleConfiguration < biome_rule_options :: no_restricted_elements :: NoRestrictedElementsOptions >> , # [doc = "Disallow usage of sensitive data such as API keys and tokens."] # [serde (skip_serializing_if = "Option::is_none")] pub no_secrets : Option < RuleConfiguration < biome_rule_options :: no_secrets :: NoSecretsOptions >> , # [doc = "Disallow variable declarations from shadowing variables declared in the outer scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_shadow : Option < RuleConfiguration < biome_rule_options :: no_shadow :: NoShadowOptions >> , # [doc = "Prevents the use of the TypeScript directive @ts-ignore."] # [serde (skip_serializing_if = "Option::is_none")] pub no_ts_ignore : Option < RuleFixConfiguration < biome_rule_options :: no_ts_ignore :: NoTsIgnoreOptions >> , # [doc = "Disallow let or var variables that are read but never assigned."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unassigned_variables : Option < RuleConfiguration < biome_rule_options :: no_unassigned_variables :: NoUnassignedVariablesOptions >> , # [doc = "Disallow unknown at-rules."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unknown_at_rule : Option < RuleConfiguration < biome_rule_options :: no_unknown_at_rule :: NoUnknownAtRuleOptions >> , # [doc = "Warn when importing non-existing exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unresolved_imports : Option < RuleConfiguration < biome_rule_options :: no_unresolved_imports :: NoUnresolvedImportsOptions >> , # [doc = "Prevent duplicate polyfills from Polyfill.io."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unwanted_polyfillio : Option < RuleConfiguration < biome_rule_options :: no_unwanted_polyfillio :: NoUnwantedPolyfillioOptions >> , # [doc = "Disallow useless backreferences in regular expression literals that always match an empty string."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_backref_in_regex : Option < RuleConfiguration < biome_rule_options :: no_useless_backref_in_regex :: NoUselessBackrefInRegexOptions >> , # [doc = "Disallow unnecessary escapes in string literals."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_escape_in_string : Option < RuleFixConfiguration < biome_rule_options :: no_useless_escape_in_string :: NoUselessEscapeInStringOptions >> , # [doc = "Disallow the use of useless undefined."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_undefined : Option < RuleFixConfiguration < biome_rule_options :: no_useless_undefined :: NoUselessUndefinedOptions >> , # [doc = "Disallow reserved names to be used as props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_props : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_props :: NoVueReservedPropsOptions >> , # [doc = "Enforce that getters and setters for the same property are adjacent in class and object definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_adjacent_getter_setter : Option < RuleConfiguration < biome_rule_options :: use_adjacent_getter_setter :: UseAdjacentGetterSetterOptions >> , # [doc = "Require the consistent declaration of object literals. Defaults to explicit definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_object_definition : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_object_definition :: UseConsistentObjectDefinitionOptions >> , # [doc = "Use static Response methods instead of new Response() constructor when possible."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_response : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_response :: UseConsistentResponseOptions >> , # [doc = "Require switch-case statements to be exhaustive."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exhaustive_switch_cases : Option < RuleFixConfiguration < biome_rule_options :: use_exhaustive_switch_cases :: UseExhaustiveSwitchCasesOptions >> , # [doc = "Enforce types in functions, methods, variables, and parameters."] # [serde (skip_serializing_if = "Option::is_none")] pub use_explicit_type : Option < RuleConfiguration < biome_rule_options :: use_explicit_type :: UseExplicitTypeOptions >> , # [doc = "Require that all exports are declared after all non-export statements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exports_last : Option < RuleConfiguration < biome_rule_options :: use_exports_last :: UseExportsLastOptions >> , # [doc = "Enforce using Solid's \\<For /> component for mapping an array to JSX elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_for_component : Option < RuleConfiguration < biome_rule_options :: use_for_component :: UseForComponentOptions >> , # [doc = "Ensure the preconnect attribute is used when using Google Fonts."] # [serde (skip_serializing_if = "Option::is_none")] pub use_google_font_preconnect : Option < RuleFixConfiguration < biome_rule_options :: use_google_font_preconnect :: UseGoogleFontPreconnectOptions >> , # [doc = "Prefer Array#{indexOf,lastIndexOf}() over Array#{findIndex,findLastIndex}() when looking for the index of an item."] # [serde (skip_serializing_if = "Option::is_none")] pub use_index_of : Option < RuleFixConfiguration < biome_rule_options :: use_index_of :: UseIndexOfOptions >> , # [doc = "Enforce consistent return values in iterable callbacks."] # [serde (skip_serializing_if = "Option::is_none")] pub use_iterable_callback_return : Option < RuleConfiguration < biome_rule_options :: use_iterable_callback_return :: UseIterableCallbackReturnOptions >> , # [doc = "Enforces the use of with { type: \"json\" } for JSON module imports."] # [serde (skip_serializing_if = "Option::is_none")] pub use_json_import_attribute : Option < RuleFixConfiguration < biome_rule_options :: use_json_import_attribute :: UseJsonImportAttributeOptions >> , # [doc = "Enforce specifying the name of GraphQL operations."] # [serde (skip_serializing_if = "Option::is_none")] pub use_named_operation : Option < RuleFixConfiguration < biome_rule_options :: use_named_operation :: UseNamedOperationOptions >> , # [doc = "Validates that all enum values are capitalized."] # [serde (skip_serializing_if = "Option::is_none")] pub use_naming_convention : Option < RuleConfiguration < biome_rule_options :: use_naming_convention :: UseNamingConventionOptions >> , # [doc = "Enforce the use of numeric separators in numeric literals."] # [serde (skip_serializing_if = "Option::is_none")] pub use_numeric_separators : Option < RuleFixConfiguration < biome_rule_options :: use_numeric_separators :: UseNumericSeparatorsOptions >> , # [doc = "Prefer object spread over Object.assign() when constructing new objects."] # [serde (skip_serializing_if = "Option::is_none")] pub use_object_spread : Option < RuleFixConfiguration < biome_rule_options :: use_object_spread :: UseObjectSpreadOptions >> , # [doc = "Enforce the consistent use of the radix argument when using parseInt()."] # [serde (skip_serializing_if = "Option::is_none")] pub use_parse_int_radix : Option < RuleFixConfiguration < biome_rule_options :: use_parse_int_radix :: UseParseIntRadixOptions >> , # [doc = "Enforce marking members as readonly if they are never modified outside the constructor."] # [serde (skip_serializing_if = "Option::is_none")] pub use_readonly_class_properties : Option < RuleFixConfiguration < biome_rule_options :: use_readonly_class_properties :: UseReadonlyClassPropertiesOptions >> , # [doc = "Enforce JSDoc comment lines to start with a single asterisk, except for the first one."] # [serde (skip_serializing_if = "Option::is_none")] pub use_single_js_doc_asterisk : Option < RuleFixConfiguration < biome_rule_options :: use_single_js_doc_asterisk :: UseSingleJsDocAsteriskOptions >> , # [doc = "Enforce the sorting of CSS utility classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_sorted_classes : Option < RuleFixConfiguration < biome_rule_options :: use_sorted_classes :: UseSortedClassesOptions >> , # [doc = "Require a description parameter for the Symbol()."] # [serde (skip_serializing_if = "Option::is_none")] pub use_symbol_description : Option < RuleConfiguration < biome_rule_options :: use_symbol_description :: UseSymbolDescriptionOptions >> , # [doc = "Disallow overload signatures that can be unified into a single signature."] # [serde (skip_serializing_if = "Option::is_none")] pub use_unified_type_signature : Option < RuleFixConfiguration < biome_rule_options :: use_unified_type_signature :: UseUnifiedTypeSignatureOptions >> , # [doc = "Prevent the usage of static string literal id attribute on elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_unique_element_ids : Option < RuleConfiguration < biome_rule_options :: use_unique_element_ids :: UseUniqueElementIdsOptions >> }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
     pub(crate) const GROUP_RULES: &'static [&'static str] = &[
@@ -4273,6 +4277,7 @@ impl Nursery {
         "noNestedComponentDefinitions",
         "noNoninteractiveElementInteractions",
         "noProcessGlobal",
+        "noQuickfixBiome",
         "noReactPropAssign",
         "noRestrictedElements",
         "noSecrets",
@@ -4311,14 +4316,15 @@ impl Nursery {
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
@@ -4371,6 +4377,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]),
     ];
 }
 impl RuleGroupExt for Nursery {
@@ -4457,179 +4464,184 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_react_prop_assign.as_ref() {
+        if let Some(rule) = self.no_quickfix_biome.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_restricted_elements.as_ref() {
+        if let Some(rule) = self.no_react_prop_assign.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_elements.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_shadow.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_ts_ignore.as_ref() {
+        if let Some(rule) = self.no_shadow.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_unassigned_variables.as_ref() {
+        if let Some(rule) = self.no_ts_ignore.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_unassigned_variables.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_unresolved_imports.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
+        if let Some(rule) = self.no_unresolved_imports.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_useless_backref_in_regex.as_ref() {
+        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_string.as_ref() {
+        if let Some(rule) = self.no_useless_backref_in_regex.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_string.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_vue_reserved_props.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_adjacent_getter_setter.as_ref() {
+        if let Some(rule) = self.no_vue_reserved_props.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_consistent_object_definition.as_ref() {
+        if let Some(rule) = self.use_adjacent_getter_setter.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_consistent_response.as_ref() {
+        if let Some(rule) = self.use_consistent_object_definition.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref() {
+        if let Some(rule) = self.use_consistent_response.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_for_component.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_for_component.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_index_of.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.use_iterable_callback_return.as_ref() {
+        if let Some(rule) = self.use_index_of.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.use_json_import_attribute.as_ref() {
+        if let Some(rule) = self.use_iterable_callback_return.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_json_import_attribute.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_numeric_separators.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_object_spread.as_ref() {
+        if let Some(rule) = self.use_numeric_separators.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_object_spread.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_readonly_class_properties.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_single_js_doc_asterisk.as_ref() {
+        if let Some(rule) = self.use_readonly_class_properties.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_single_js_doc_asterisk.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_symbol_description.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_unified_type_signature.as_ref() {
+        if let Some(rule) = self.use_symbol_description.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_unique_element_ids.as_ref() {
+        if let Some(rule) = self.use_unified_type_signature.as_ref() {
             if rule.is_enabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
+            }
+        }
+        if let Some(rule) = self.use_unique_element_ids.as_ref() {
+            if rule.is_enabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
         index_set
@@ -4711,179 +4723,184 @@ impl RuleGroupExt for Nursery {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
             }
         }
-        if let Some(rule) = self.no_react_prop_assign.as_ref() {
+        if let Some(rule) = self.no_quickfix_biome.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
             }
         }
-        if let Some(rule) = self.no_restricted_elements.as_ref() {
+        if let Some(rule) = self.no_react_prop_assign.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
             }
         }
-        if let Some(rule) = self.no_secrets.as_ref() {
+        if let Some(rule) = self.no_restricted_elements.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
             }
         }
-        if let Some(rule) = self.no_shadow.as_ref() {
+        if let Some(rule) = self.no_secrets.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
             }
         }
-        if let Some(rule) = self.no_ts_ignore.as_ref() {
+        if let Some(rule) = self.no_shadow.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
             }
         }
-        if let Some(rule) = self.no_unassigned_variables.as_ref() {
+        if let Some(rule) = self.no_ts_ignore.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
             }
         }
-        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
+        if let Some(rule) = self.no_unassigned_variables.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
             }
         }
-        if let Some(rule) = self.no_unresolved_imports.as_ref() {
+        if let Some(rule) = self.no_unknown_at_rule.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
             }
         }
-        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
+        if let Some(rule) = self.no_unresolved_imports.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
             }
         }
-        if let Some(rule) = self.no_useless_backref_in_regex.as_ref() {
+        if let Some(rule) = self.no_unwanted_polyfillio.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
             }
         }
-        if let Some(rule) = self.no_useless_escape_in_string.as_ref() {
+        if let Some(rule) = self.no_useless_backref_in_regex.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
             }
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref() {
+        if let Some(rule) = self.no_useless_escape_in_string.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
             }
         }
-        if let Some(rule) = self.no_vue_reserved_props.as_ref() {
+        if let Some(rule) = self.no_useless_undefined.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
             }
         }
-        if let Some(rule) = self.use_adjacent_getter_setter.as_ref() {
+        if let Some(rule) = self.no_vue_reserved_props.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
             }
         }
-        if let Some(rule) = self.use_consistent_object_definition.as_ref() {
+        if let Some(rule) = self.use_adjacent_getter_setter.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
             }
         }
-        if let Some(rule) = self.use_consistent_response.as_ref() {
+        if let Some(rule) = self.use_consistent_object_definition.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
             }
         }
-        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref() {
+        if let Some(rule) = self.use_consistent_response.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
             }
         }
-        if let Some(rule) = self.use_explicit_type.as_ref() {
+        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
             }
         }
-        if let Some(rule) = self.use_exports_last.as_ref() {
+        if let Some(rule) = self.use_explicit_type.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
             }
         }
-        if let Some(rule) = self.use_for_component.as_ref() {
+        if let Some(rule) = self.use_exports_last.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
             }
         }
-        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
+        if let Some(rule) = self.use_for_component.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[35]));
             }
         }
-        if let Some(rule) = self.use_index_of.as_ref() {
+        if let Some(rule) = self.use_google_font_preconnect.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[36]));
             }
         }
-        if let Some(rule) = self.use_iterable_callback_return.as_ref() {
+        if let Some(rule) = self.use_index_of.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[37]));
             }
         }
-        if let Some(rule) = self.use_json_import_attribute.as_ref() {
+        if let Some(rule) = self.use_iterable_callback_return.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[38]));
             }
         }
-        if let Some(rule) = self.use_named_operation.as_ref() {
+        if let Some(rule) = self.use_json_import_attribute.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[39]));
             }
         }
-        if let Some(rule) = self.use_naming_convention.as_ref() {
+        if let Some(rule) = self.use_named_operation.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[40]));
             }
         }
-        if let Some(rule) = self.use_numeric_separators.as_ref() {
+        if let Some(rule) = self.use_naming_convention.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[41]));
             }
         }
-        if let Some(rule) = self.use_object_spread.as_ref() {
+        if let Some(rule) = self.use_numeric_separators.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[42]));
             }
         }
-        if let Some(rule) = self.use_parse_int_radix.as_ref() {
+        if let Some(rule) = self.use_object_spread.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[43]));
             }
         }
-        if let Some(rule) = self.use_readonly_class_properties.as_ref() {
+        if let Some(rule) = self.use_parse_int_radix.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[44]));
             }
         }
-        if let Some(rule) = self.use_single_js_doc_asterisk.as_ref() {
+        if let Some(rule) = self.use_readonly_class_properties.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[45]));
             }
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref() {
+        if let Some(rule) = self.use_single_js_doc_asterisk.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[46]));
             }
         }
-        if let Some(rule) = self.use_symbol_description.as_ref() {
+        if let Some(rule) = self.use_sorted_classes.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[47]));
             }
         }
-        if let Some(rule) = self.use_unified_type_signature.as_ref() {
+        if let Some(rule) = self.use_symbol_description.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[48]));
             }
         }
-        if let Some(rule) = self.use_unique_element_ids.as_ref() {
+        if let Some(rule) = self.use_unified_type_signature.as_ref() {
             if rule.is_disabled() {
                 index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[49]));
+            }
+        }
+        if let Some(rule) = self.use_unique_element_ids.as_ref() {
+            if rule.is_disabled() {
+                index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[50]));
             }
         }
         index_set
@@ -4974,6 +4991,10 @@ impl RuleGroupExt for Nursery {
                 .map(|conf| (conf.level(), conf.get_options())),
             "noProcessGlobal" => self
                 .no_process_global
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noQuickfixBiome" => self
+                .no_quickfix_biome
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noReactPropAssign" => self
@@ -5139,6 +5160,7 @@ impl From<GroupPlainConfiguration> for Nursery {
             no_nested_component_definitions: Some(value.into()),
             no_noninteractive_element_interactions: Some(value.into()),
             no_process_global: Some(value.into()),
+            no_quickfix_biome: Some(value.into()),
             no_react_prop_assign: Some(value.into()),
             no_restricted_elements: Some(value.into()),
             no_secrets: Some(value.into()),

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -170,6 +170,7 @@ define_categories! {
     "lint/nursery/noNestedComponentDefinitions": "https://biomejs.dev/linter/rules/no-nested-component-definitions",
     "lint/nursery/noNoninteractiveElementInteractions": "https://biomejs.dev/linter/rules/no-noninteractive-element-interactions",
     "lint/nursery/noProcessGlobal": "https://biomejs.dev/linter/rules/no-process-global",
+    "lint/nursery/noQuickfixBiome": "https://biomejs.dev/linter/rules/no-quickfix-biome",
     "lint/nursery/noReactPropAssign": "https://biomejs.dev/linter/rules/no-react-prop-assign",
     "lint/nursery/noReactSpecificProps": "https://biomejs.dev/linter/rules/no-react-specific-props",
     "lint/nursery/noRestrictedElements": "https://biomejs.dev/linter/rules/no-restricted-elements",

--- a/crates/biome_json_analyze/src/lint.rs
+++ b/crates/biome_json_analyze/src/lint.rs
@@ -2,5 +2,6 @@
 
 //! Generated file, do not edit by hand, see `xtask/codegen`
 
+pub mod nursery;
 pub mod suspicious;
-::biome_analyze::declare_category! { pub Lint { kind : Lint , groups : [self :: suspicious :: Suspicious ,] } }
+::biome_analyze::declare_category! { pub Lint { kind : Lint , groups : [self :: nursery :: Nursery , self :: suspicious :: Suspicious ,] } }

--- a/crates/biome_json_analyze/src/lint/nursery.rs
+++ b/crates/biome_json_analyze/src/lint/nursery.rs
@@ -1,0 +1,7 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use biome_analyze::declare_lint_group;
+pub mod no_quickfix_biome;
+declare_lint_group! { pub Nursery { name : "nursery" , rules : [self :: no_quickfix_biome :: NoQuickfixBiome ,] } }

--- a/crates/biome_json_analyze/src/lint/nursery/no_quickfix_biome.rs
+++ b/crates/biome_json_analyze/src/lint/nursery/no_quickfix_biome.rs
@@ -1,0 +1,200 @@
+use crate::JsonRuleAction;
+use biome_analyze::{Ast, FixKind, Rule, RuleDiagnostic, context::RuleContext, declare_lint_rule};
+use biome_console::markup;
+use biome_json_factory::make::{
+    json_boolean_value, json_member, json_member_list, json_member_name, json_string_literal,
+    json_string_value, token,
+};
+use biome_json_syntax::{AnyJsonValue, JsonMember, JsonObjectValue, T, inner_string_text};
+use biome_rowan::{AstNode, AstSeparatedList, BatchMutationExt, TextRange, TriviaPieceKind};
+use biome_rule_options::no_quickfix_biome::NoQuickfixBiomeOptions;
+
+declare_lint_rule! {
+    /// Disallow the use if `quickfix.biome` inside editor settings file.
+    ///
+    /// The code action `quickfix.biome` can be harmful because it instructs the editors
+    /// to apply the code fix of lint rules and code actions atomically. If multiple rules or
+    /// actions apply a code fix to the same code span, the editor will emit invalid code.
+    ///
+    /// The rule targets specifically VSCode settings and Zed settings. Specifically, paths that end with:
+    /// - `.vscode/settings.json`
+    /// - `Code/User/settings.json`
+    /// - `.zed/settings.json`
+    /// - `zed/settings.json`
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```json,ignore
+    /// {
+    ///     "quickfix.biome": "explicit"
+    /// }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```json,ignore
+    /// {
+    ///     "source.fixAll.biome": "explicit"
+    /// }
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// The following options are available
+    ///
+    /// ### `additionalPaths`
+    ///
+    /// It's possible to specify a list of JSON paths, if your editor uses a JSON file setting that isn't supported natively by the rule.
+    ///
+    /// If your editor uses, for example, a file called `.myEditor/file.json`, you can add `".myEditor/file.json"` to the list.
+    /// **The rule checks if the file ends with the given paths**.
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "additionalPaths": [".myEditor/file.json"]
+    ///     }
+    /// }
+    /// ```
+    ///
+    pub NoQuickfixBiome {
+        version: "next",
+        name: "noQuickfixBiome",
+        language: "json",
+        recommended: true,
+        fix_kind: FixKind::Safe,
+    }
+}
+
+const DEFAULT_PATHS: &[&str] = &[
+    ".vscode/settings.json",
+    "Code/User/settings.json",
+    ".zed/settings.json",
+    "zed/settings.json",
+];
+
+impl Rule for NoQuickfixBiome {
+    type Query = Ast<JsonMember>;
+    type State = TextRange;
+    type Signals = Option<Self::State>;
+    type Options = NoQuickfixBiomeOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        let node = ctx.query();
+        let path = ctx.file_path();
+        let options = ctx.options();
+        for default_path in DEFAULT_PATHS {
+            if path.ends_with(default_path) {
+                let name = node.name().ok()?;
+                let value = name.value_token().ok()?;
+                if inner_string_text(&value) == "quickfix.biome" {
+                    return Some(name.range());
+                }
+            }
+        }
+
+        for default_path in options.additional_paths.iter() {
+            if path.ends_with(default_path) {
+                let name = node.name().ok()?;
+                let value = name.value_token().ok()?;
+                if inner_string_text(&value) == "quickfix.biome" {
+                    return Some(name.range());
+                }
+            }
+        }
+
+        None
+    }
+
+    fn diagnostic(_ctx: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                state,
+                markup! {
+                    "The use of "<Emphasis>"quickfix.biome"</Emphasis>" is deprecated."
+                },
+            )
+            .note(markup! {
+                    "The code action "<Emphasis>"quickfix.biome"</Emphasis>" applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code."
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _: &Self::State) -> Option<JsonRuleAction> {
+        let quick_fix_node = ctx.query();
+        let path = ctx.file_path();
+        let mut mutation = ctx.root().begin();
+        let parent = quick_fix_node
+            .syntax()
+            .ancestors()
+            .find_map(JsonObjectValue::cast)?;
+
+        let parent_list = parent.json_member_list();
+        let has_fix_all = parent_list.iter().flatten().any(|member| {
+            member
+                .name()
+                .map(|name| {
+                    name.value_token()
+                        .map(|token| inner_string_text(&token) == "source.fixAll.biome")
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        });
+
+        let new_list = parent_list
+            .iter()
+            .flatten()
+            .filter(|node| node != quick_fix_node)
+            .collect::<Vec<_>>();
+        if has_fix_all {
+            let mut separators = vec![];
+
+            for _ in 0..(new_list.len() - 1) {
+                separators.push(token(T![,]));
+            }
+
+            let new_list = json_member_list(new_list, separators);
+            mutation.replace_node(parent_list, new_list);
+            Some(JsonRuleAction::new(
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
+                ctx.metadata().applicability(),
+                markup! {
+                    "Remove the code action."
+                },
+                mutation,
+            ))
+        } else {
+            let mut new_list = vec![];
+            new_list.push(json_member(
+                json_member_name(json_string_literal("source.fixAll.biome")),
+                token(T![:]).with_trailing_trivia(vec![(TriviaPieceKind::Whitespace, " ")]),
+                if path.as_str().contains("zed") || path.as_str().contains(".zed") {
+                    AnyJsonValue::JsonBooleanValue(json_boolean_value(token(T![true])))
+                } else {
+                    AnyJsonValue::JsonStringValue(json_string_value(json_string_literal(
+                        "explicit",
+                    )))
+                },
+            ));
+            let mut separators = vec![];
+
+            for _ in 0..(new_list.len() - 1) {
+                separators.push(token(T![,]));
+            }
+
+            let new_list = json_member_list(new_list, separators);
+            mutation.replace_node(parent_list, new_list);
+            Some(JsonRuleAction::new(
+                ctx.metadata().action_category(ctx.category(), ctx.group()),
+                ctx.metadata().applicability(),
+                markup! {
+                    "Remove the code action."
+                },
+                mutation,
+            ))
+        }
+    }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.vscode/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "source.fixAll.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.vscode/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.vscode/settings.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "source.fixAll.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:5:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    3 │     "source.organizeImports.biome": "explicit",
+    4 │     "source.fixAll.biome": "explicit",
+  > 5 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    6 │   }
+    7 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    2 2 │     "editor.codeActionsOnSave": {
+    3 3 │       "source.organizeImports.biome": "explicit",
+    4   │ - ····"source.fixAll.biome":·"explicit",
+    5   │ - ····"quickfix.biome":·"explicit"
+      4 │ + ····"source.fixAll.biome":·"explicit"
+    6 5 │     }
+    7 6 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.zed/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true,
+    "source.fixAll.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/.zed/settings.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true,
+    "source.fixAll.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true,
+      │     ^^^^^^^^^^^^^^^^
+    4 │     "source.organizeImports.biome": true,
+    5 │     "source.fixAll.biome": true
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true,
+    4   │ - ····"source.organizeImports.biome":·true,
+      3 │ + ····"source.organizeImports.biome":·true,
+    5 4 │       "source.fixAll.biome": true
+    6 5 │     }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/Code/User/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/Code/User/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "source.fixAll.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/Code/User/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/Code/User/settings.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "source.fixAll.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:5:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    3 │     "source.organizeImports.biome": "explicit",
+    4 │     "source.fixAll.biome": "explicit",
+  > 5 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    6 │   }
+    7 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    2 2 │     "editor.codeActionsOnSave": {
+    3 3 │       "source.organizeImports.biome": "explicit",
+    4   │ - ····"source.fixAll.biome":·"explicit",
+    5   │ - ····"quickfix.biome":·"explicit"
+      4 │ + ····"source.fixAll.biome":·"explicit"
+    6 5 │     }
+    7 6 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/zed/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true,
+    "source.fixAll.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/has_fix_all/zed/settings.json.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true,
+    "source.fixAll.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true,
+      │     ^^^^^^^^^^^^^^^^
+    4 │     "source.organizeImports.biome": true,
+    5 │     "source.fixAll.biome": true
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true,
+    4   │ - ····"source.organizeImports.biome":·true,
+      3 │ + ····"source.organizeImports.biome":·true,
+    5 4 │       "source.fixAll.biome": true
+    6 5 │     }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.vscode/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.vscode/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.vscode/settings.json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:4:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    2 │   "editor.codeActionsOnSave": {
+    3 │     "source.organizeImports.biome": "explicit",
+  > 4 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    5 │   }
+    6 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.codeActionsOnSave": {
+    3   │ - ····"source.organizeImports.biome":·"explicit",
+    4   │ - ····"quickfix.biome":·"explicit"
+      3 │ + ····"source.fixAll.biome":·"explicit"
+    5 4 │     }
+    6 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.zed/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/.zed/settings.json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true,
+      │     ^^^^^^^^^^^^^^^^
+    4 │     "source.organizeImports.biome": true
+    5 │   }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true,
+    4   │ - ····"source.organizeImports.biome":·true
+      3 │ + ····"source.fixAll.biome":·true
+    5 4 │     }
+    6 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/Code/User/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/Code/User/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/Code/User/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/Code/User/settings.json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:4:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    2 │   "editor.codeActionsOnSave": {
+    3 │     "source.organizeImports.biome": "explicit",
+  > 4 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    5 │   }
+    6 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.codeActionsOnSave": {
+    3   │ - ····"source.organizeImports.biome":·"explicit",
+    4   │ - ····"quickfix.biome":·"explicit"
+      3 │ + ····"source.fixAll.biome":·"explicit"
+    5 4 │     }
+    6 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/zed/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/more_items/zed/settings.json.snap
@@ -1,0 +1,42 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true,
+    "source.organizeImports.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true,
+      │     ^^^^^^^^^^^^^^^^
+    4 │     "source.organizeImports.biome": true
+    5 │   }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true,
+    4   │ - ····"source.organizeImports.biome":·true
+      3 │ + ····"source.fixAll.biome":·true
+    5 4 │     }
+    6 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.vscode/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.vscode/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.vscode/settings.json.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.codeActionsOnSave": {
+  > 3 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    4 │   }
+    5 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.codeActionsOnSave": {
+    3   │ - ····"quickfix.biome":·"explicit"
+      3 │ + ····"source.fixAll.biome":·"explicit"
+    4 4 │     }
+    5 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.zed/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/.zed/settings.json.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true
+      │     ^^^^^^^^^^^^^^^^
+    4 │   }
+    5 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true
+      3 │ + ····"source.fixAll.biome":·true
+    4 4 │     }
+    5 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/Code/User/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/Code/User/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit"
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/Code/User/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/Code/User/settings.json.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit"
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.codeActionsOnSave": {
+  > 3 │     "quickfix.biome": "explicit"
+      │     ^^^^^^^^^^^^^^^^
+    4 │   }
+    5 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.codeActionsOnSave": {
+    3   │ - ····"quickfix.biome":·"explicit"
+      3 │ + ····"source.fixAll.biome":·"explicit"
+    4 4 │     }
+    5 5 │   }
+  
+
+```

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/zed/settings.json
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/zed/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true
+  }
+}

--- a/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/zed/settings.json.snap
+++ b/crates/biome_json_analyze/tests/specs/nursery/noQuickfixBiome/simple/zed/settings.json.snap
@@ -1,0 +1,40 @@
+---
+source: crates/biome_json_analyze/tests/spec_tests.rs
+expression: settings.json
+---
+# Input
+```json
+{
+  "editor.code_action_on_format": {
+    "quickfix.biome": true
+  }
+}
+
+```
+
+# Diagnostics
+```
+settings.json:3:5 lint/nursery/noQuickfixBiome  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i The use of quickfix.biome is deprecated.
+  
+    1 │ {
+    2 │   "editor.code_action_on_format": {
+  > 3 │     "quickfix.biome": true
+      │     ^^^^^^^^^^^^^^^^
+    4 │   }
+    5 │ }
+  
+  i The code action quickfix.biome applies the code fix of rules and actions without being aware of each other. This might cause the emission of malformed code, especially if the code fixes are applied to the same code.
+  
+  i Safe fix: Remove the code action.
+  
+    1 1 │   {
+    2 2 │     "editor.code_action_on_format": {
+    3   │ - ····"quickfix.biome":·true
+      3 │ + ····"source.fixAll.biome":·true
+    4 4 │     }
+    5 5 │   }
+  
+
+```

--- a/crates/biome_rule_options/src/lib.rs
+++ b/crates/biome_rule_options/src/lib.rs
@@ -140,6 +140,7 @@ pub mod no_private_imports;
 pub mod no_process_env;
 pub mod no_process_global;
 pub mod no_prototype_builtins;
+pub mod no_quickfix_biome;
 pub mod no_re_export_all;
 pub mod no_react_prop_assign;
 pub mod no_react_specific_props;

--- a/crates/biome_rule_options/src/no_quickfix_biome.rs
+++ b/crates/biome_rule_options/src/no_quickfix_biome.rs
@@ -1,0 +1,9 @@
+use biome_deserialize_macros::Deserializable;
+use serde::{Deserialize, Serialize};
+#[derive(Default, Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NoQuickfixBiomeOptions {
+    /// A list of additional JSON files that should be checked.
+    pub additional_paths: Vec<String>,
+}

--- a/justfile
+++ b/justfile
@@ -79,6 +79,11 @@ new-json-assistrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=json --category=assist --name={{rulename}}
   just gen-analyzer
 
+# Creates a new json lint rule with the given name. Name has to be camel case.
+new-json-lintrule rulename:
+  cargo run -p xtask_codegen -- new-lintrule --kind=json --category=lint --name={{rulename}}
+  just gen-analyzer
+
 # Creates a new css lint rule with the given name. Name has to be camel case.
 new-css-lintrule rulename:
   cargo run -p xtask_codegen -- new-lintrule --kind=css --category=lint --name={{rulename}}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1610,6 +1610,10 @@ export interface Nursery {
 	 */
 	noProcessGlobal?: RuleFixConfiguration_for_NoProcessGlobalOptions;
 	/**
+	 * Succinct description of the rule.
+	 */
+	noQuickfixBiome?: RuleConfiguration_for_NoQuickfixBiomeOptions;
+	/**
 	 * Disallow assigning to React component props.
 	 */
 	noReactPropAssign?: RuleConfiguration_for_NoReactPropAssignOptions;
@@ -2883,6 +2887,9 @@ export type RuleConfiguration_for_NoNoninteractiveElementInteractionsOptions =
 export type RuleFixConfiguration_for_NoProcessGlobalOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_NoProcessGlobalOptions;
+export type RuleConfiguration_for_NoQuickfixBiomeOptions =
+	| RulePlainConfiguration
+	| RuleWithOptions_for_NoQuickfixBiomeOptions;
 export type RuleConfiguration_for_NoReactPropAssignOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoReactPropAssignOptions;
@@ -5167,6 +5174,16 @@ export interface RuleWithFixOptions_for_NoProcessGlobalOptions {
 	 * Rule's options
 	 */
 	options: NoProcessGlobalOptions;
+}
+export interface RuleWithOptions_for_NoQuickfixBiomeOptions {
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: NoQuickfixBiomeOptions;
 }
 export interface RuleWithOptions_for_NoReactPropAssignOptions {
 	/**
@@ -7666,6 +7683,12 @@ export interface NoMisusedPromisesOptions {}
 export interface NoNestedComponentDefinitionsOptions {}
 export interface NoNoninteractiveElementInteractionsOptions {}
 export interface NoProcessGlobalOptions {}
+export interface NoQuickfixBiomeOptions {
+	/**
+	 * A list of additional JSON files that should be checked.
+	 */
+	additionalPaths?: string[];
+}
 export interface NoReactPropAssignOptions {}
 export interface NoRestrictedElementsOptions {
 	/**
@@ -8352,6 +8375,7 @@ export type Category =
 	| "lint/nursery/noNestedComponentDefinitions"
 	| "lint/nursery/noNoninteractiveElementInteractions"
 	| "lint/nursery/noProcessGlobal"
+	| "lint/nursery/noQuickfixBiome"
 	| "lint/nursery/noReactPropAssign"
 	| "lint/nursery/noReactSpecificProps"
 	| "lint/nursery/noRestrictedElements"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3770,6 +3770,24 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoQuickfixBiomeConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoQuickfixBiomeOptions" }
+			]
+		},
+		"NoQuickfixBiomeOptions": {
+			"type": "object",
+			"properties": {
+				"additionalPaths": {
+					"description": "A list of additional JSON files that should be checked.",
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"NoReExportAllConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
@@ -4791,6 +4809,13 @@
 					"description": "Disallow the use of process global.",
 					"anyOf": [
 						{ "$ref": "#/definitions/NoProcessGlobalConfiguration" },
+						{ "type": "null" }
+					]
+				},
+				"noQuickfixBiome": {
+					"description": "Succinct description of the rule.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoQuickfixBiomeConfiguration" },
 						{ "type": "null" }
 					]
 				},
@@ -7848,6 +7873,21 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/NoPrototypeBuiltinsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoQuickfixBiomeOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoQuickfixBiomeOptions" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a new rule called `noQuickfixBiome` and bans the use of `quickfix.biome` in specific files: mainly VSCode and Zed settings.

The use of `quickfix.biome` is deprecated and should be removed, which is why I created this rule.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

Added

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
