### PR TITLE
fix(lint/noUnassignedVariables): handle JSX ref attribute assignments

### DIFF
--- a/.changeset/five-ghosts-wave.md
+++ b/.changeset/five-ghosts-wave.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6795](https://github.com/biomejs/biome/issues/6795): `noUnassignedVariables` now correctly recognizes variables used in JSX `ref` attributes.

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx
@@ -1,0 +1,6 @@
+/* should not generate diagnostics */
+export const Component = () => {
+    let value;
+    return <div ref={value} />
+  }
+  

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+export const Component = () => {
+    let value;
+    return <div ref={value} />
+  }
+  
+```


### PR DESCRIPTION
## Summary
Closes #6795

The `noUnassignedVariables` rule was incorrectly flagging variables used in JSX `ref` attributes as
unassigned. This occurred because JSX ref attributes were not being recognized as write references in the
semantic analyzer.

This PR fixes the issue by adding proper detection for JSX ref attribute usage, ensuring that variables
assigned to `ref` props are correctly tracked as write references.


## Test Plan
Added test cases in `crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx` to verify
that JSX ref attributes are correctly handled:

```jsx
export const Bug = () => {
    let value;
    return <div ref={value} />
}
```

The snapshot test confirms that no diagnostic is generated for this valid usage pattern.

## Docs
[no-unassigned-variables](https://biomejs.dev/linter/rules/no-unassigned-variables/)
