### PR TITLE
chore: update generated code from analyzer codegen

### DIFF
--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1610,9 +1610,9 @@ export interface Nursery {
 	 */
 	noProcessGlobal?: RuleFixConfiguration_for_NoProcessGlobalOptions;
 	/**
-	 * Succinct description of the rule.
+	 * Disallow the use if quickfix.biome inside editor settings file.
 	 */
-	noQuickfixBiome?: RuleConfiguration_for_NoQuickfixBiomeOptions;
+	noQuickfixBiome?: RuleFixConfiguration_for_NoQuickfixBiomeOptions;
 	/**
 	 * Disallow assigning to React component props.
 	 */
@@ -2887,9 +2887,9 @@ export type RuleConfiguration_for_NoNoninteractiveElementInteractionsOptions =
 export type RuleFixConfiguration_for_NoProcessGlobalOptions =
 	| RulePlainConfiguration
 	| RuleWithFixOptions_for_NoProcessGlobalOptions;
-export type RuleConfiguration_for_NoQuickfixBiomeOptions =
+export type RuleFixConfiguration_for_NoQuickfixBiomeOptions =
 	| RulePlainConfiguration
-	| RuleWithOptions_for_NoQuickfixBiomeOptions;
+	| RuleWithFixOptions_for_NoQuickfixBiomeOptions;
 export type RuleConfiguration_for_NoReactPropAssignOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoReactPropAssignOptions;
@@ -5175,7 +5175,11 @@ export interface RuleWithFixOptions_for_NoProcessGlobalOptions {
 	 */
 	options: NoProcessGlobalOptions;
 }
-export interface RuleWithOptions_for_NoQuickfixBiomeOptions {
+export interface RuleWithFixOptions_for_NoQuickfixBiomeOptions {
+	/**
+	 * The kind of the code actions emitted by the rule
+	 */
+	fix?: FixKind;
 	/**
 	 * The severity of the emitted diagnostics by the rule
 	 */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -4813,7 +4813,7 @@
 					]
 				},
 				"noQuickfixBiome": {
-					"description": "Succinct description of the rule.",
+					"description": "Disallow the use if quickfix.biome inside editor settings file.",
 					"anyOf": [
 						{ "$ref": "#/definitions/NoQuickfixBiomeConfiguration" },
 						{ "type": "null" }
@@ -7881,6 +7881,10 @@
 			"type": "object",
 			"required": ["level"],
 			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
 				"level": {
 					"description": "The severity of the emitted diagnostics by the rule",
 					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]


### PR DESCRIPTION
## Summary
This PR updates the generated code by running `just gen-analyzer`. While working on PR #7000, I noticed that the CI was failing due to outdated generated code.

## Test Plan
pass ci 

## Docs
