### PR TITLE
ci: make it so windows devs don't get lints that don't show up on linux/macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,7 +33,7 @@ documentation = """
     --no-deps
 """
 format = "fmt --all --verbose"
-lint = "clippy --workspace --all-targets -- --deny warnings"
+lint = "clippy --workspace --all-features --all-targets -- --deny warnings"
 new-crate = "run -p xtask_codegen -- new-crate"
 
 [profile.release]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,14 @@ jobs:
 
   lint:
     name: Lint project
-    runs-on: depot-ubuntu-24.04-arm-16
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # we have to also lint on windows because sometimes lints appear only on windows.
+          # this particularly occurs when code is conditionally compiled depending on the target os.
+          - os: depot-windows-2022
+          - os: depot-ubuntu-24.04-arm-16
     steps:
       - name: Checkout PR Branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/xtask/codegen/src/generate_bindings.rs
+++ b/xtask/codegen/src/generate_bindings.rs
@@ -207,7 +207,7 @@ pub(crate) fn generate_workspace_bindings(mode: Mode) -> Result<()> {
     items.extend(declarations.into_iter().map(|(decl, description)| {
         let mut export = make::token(T![export]);
         if let Some(description) = description {
-            let comment = format!("/**\n\t* {} \n\t */\n", description);
+            let comment = format!("/**\n\t* {description} \n\t */\n");
             let trivia = vec![
                 (TriviaPieceKind::Newline, "\n"),
                 (TriviaPieceKind::MultiLineComment, comment.as_str()),

--- a/xtask/codegen/src/generate_license.rs
+++ b/xtask/codegen/src/generate_license.rs
@@ -33,8 +33,8 @@ const URL: &str =
     "https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json";
 pub(crate) fn generate_license(mode: Mode) -> Result<()> {
     let request = get(URL);
-    let result = request.call()?;
-    let license_list = result.into_json::<LicenseList>()?;
+    let mut result = request.call()?;
+    let license_list = result.body_mut().read_json::<LicenseList>()?;
     let config_root = project_root().join("crates/biome_package/src/license");
 
     let tokens = create_data(license_list).expect("To write data into file");


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This makes it so that all our code also gets linted on a windows machine in CI.

The reason for this is that it seems `--all-targets` does not make `cargo clippy` evaluate lints from the context of all platforms. This means that if a lint appears on windows from conditional os-specific code, then that lint won't appear when running clippy on linux, for example.

https://github.com/biomejs/biome/pull/6923#discussion_r2230962772

We also weren't linting with `--all-features`, so I added that too.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
