### PR TITLE
feat(wasm): expose Workspace::scan_project_folder

### DIFF
--- a/.changeset/six-corners-lay.md
+++ b/.changeset/six-corners-lay.md
@@ -1,5 +1,8 @@
 ---
 "@biomejs/biome": minor
+"@biomejs/wasm-bundler": minor
+"@biomejs/wasm-nodejs": minor
+"@biomejs/wasm-web": minor
 ---
 
 Added new functions to the `@biomejs/wasm-*` packages:
@@ -7,3 +10,4 @@ Added new functions to the `@biomejs/wasm-*` packages:
 - `isPathIgnored`: returns whether the input path is ignored.
 - `updateModuleGraph`: updates the internal module graph of the input path.
 - `getModuleGraph`: it returns a serialized version of the internal module graph.
+- `scanProjectFolder`: scans the files and directories in the project to build the internal module graph.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ unicode-width        = "0.1.12"
 ureq                 = "3.0.12"
 url                  = "2.5.4"
 walkdir              = "2.5.0"
+web-time             = "1.1.0"
 
 [profile.dev.package.biome_wasm]
 debug     = true

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -74,6 +74,7 @@ serde_json              = { workspace = true, features = ["raw_value"] }
 smallvec                = { workspace = true, features = ["serde"] }
 tokio                   = { workspace = true, features = ["sync"] }
 tracing                 = { workspace = true, features = ["attributes", "log"] }
+web-time                = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/biome_service/src/workspace_types.rs
+++ b/crates/biome_service/src/workspace_types.rs
@@ -548,11 +548,12 @@ macro_rules! workspace_method {
 }
 
 /// Returns a list of signature for all the methods in the [Workspace] trait
-pub fn methods() -> [WorkspaceMethod; 29] {
+pub fn methods() -> [WorkspaceMethod; 30] {
     [
         workspace_method!(file_features),
         workspace_method!(update_settings),
         workspace_method!(open_project),
+        workspace_method!(scan_project_folder),
         workspace_method!(open_file),
         workspace_method!(change_file),
         workspace_method!(close_file),

--- a/crates/biome_wasm/src/lib.rs
+++ b/crates/biome_wasm/src/lib.rs
@@ -8,8 +8,8 @@ use biome_service::workspace::{
     FormatOnTypeParams, FormatRangeParams, GetControlFlowGraphParams, GetFileContentParams,
     GetFormatterIRParams, GetModuleGraphParams, GetRegisteredTypesParams, GetSemanticModelParams,
     GetSyntaxTreeParams, GetTypeInfoParams, OpenProjectParams, PathIsIgnoredParams,
-    PullActionsParams, PullDiagnosticsParams, RenameParams, UpdateModuleGraphParams,
-    UpdateSettingsParams,
+    PullActionsParams, PullDiagnosticsParams, RenameParams, ScanProjectFolderParams,
+    UpdateModuleGraphParams, UpdateSettingsParams,
 };
 use biome_service::workspace::{OpenFileParams, SupportsFeatureParams};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -110,6 +110,20 @@ impl Workspace {
 
         to_value(&result)
             .map(IOpenProjectResult::from)
+            .map_err(into_error)
+    }
+
+    #[wasm_bindgen(js_name = scanProjectFolder)]
+    pub fn scan_project_folder(
+        &self,
+        params: IScanProjectFolderParams,
+    ) -> Result<IScanProjectFolderResult, Error> {
+        let params: ScanProjectFolderParams =
+            serde_wasm_bindgen::from_value(params.into()).map_err(into_error)?;
+        let result = self.inner.scan_project_folder(params).map_err(into_error)?;
+
+        to_value(&result)
+            .map(IScanProjectFolderResult::from)
             .map_err(into_error)
     }
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8774,6 +8774,47 @@ Target paths must be absolute.
 			};
 	  }
 	| "project";
+export interface ScanProjectFolderParams {
+	/**
+	 * Forces scanning of the folder, even if it is already being watched.
+	 */
+	force: boolean;
+	/**
+	* Optional path within the project to scan.
+
+If omitted, the project is scanned from its root folder.
+
+This is a potential optimization that allows scanning to be limited to a subset of the full project. Clients should specify it to indicate which part of the project they are interested in. The server may or may not use this to avoid scanning parts that are irrelevant to clients. 
+	 */
+	path?: BiomePath;
+	projectKey: ProjectKey;
+	scanKind: ScanKind;
+	verbose: boolean;
+	/**
+	* Whether the watcher should watch this path.
+
+Does nothing if the watcher is already watching this path. 
+	 */
+	watch: boolean;
+}
+export interface ScanProjectFolderResult {
+	/**
+	 * A list of child configuration files found inside the project
+	 */
+	configurationFiles: BiomePath[];
+	/**
+	 * Diagnostics reported while scanning the project.
+	 */
+	diagnostics: Diagnostic[];
+	/**
+	 * Duration of the scan.
+	 */
+	duration: Duration;
+}
+export interface Duration {
+	nanos: number;
+	secs: number;
+}
 export interface OpenFileParams {
 	content: FileContent;
 	documentFileSource?: DocumentFileSource;
@@ -9162,6 +9203,9 @@ export interface Workspace {
 	fileFeatures(params: SupportsFeatureParams): Promise<FileFeaturesResult>;
 	updateSettings(params: UpdateSettingsParams): Promise<UpdateSettingsResult>;
 	openProject(params: OpenProjectParams): Promise<OpenProjectResult>;
+	scanProjectFolder(
+		params: ScanProjectFolderParams,
+	): Promise<ScanProjectFolderResult>;
 	openFile(params: OpenFileParams): Promise<void>;
 	changeFile(params: ChangeFileParams): Promise<void>;
 	closeFile(params: CloseFileParams): Promise<void>;
@@ -9202,6 +9246,9 @@ export function createWorkspace(transport: Transport): Workspace {
 		},
 		openProject(params) {
 			return transport.request("biome/open_project", params);
+		},
+		scanProjectFolder(params) {
+			return transport.request("biome/scan_project_folder", params);
 		},
 		openFile(params) {
 			return transport.request("biome/open_file", params);


### PR DESCRIPTION
## Summary

Exposes a workspace method `scan_project_folder` via the WASM API. This will enable use of type inference and project rules in the playground.

## Test Plan

Manually tested with the playground locally.

## Docs

N/A