### PR TITLE
Fix GritQL misnomer in configuration_schema.json

### DIFF
--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -48,7 +48,7 @@
 			]
 		},
 		"grit": {
-			"description": "Specific configuration for the GraphQL language",
+			"description": "Specific configuration for the GritQL language",
 			"anyOf": [
 				{ "$ref": "#/definitions/GritConfiguration" },
 				{ "type": "null" }


### PR DESCRIPTION
## Summary
I was inspecting the configuration schema and noticed a typo

## Test Plan
Seems this would self-evidently fix, I'm not sure if this JSON Schema is generated from some other place where the incorrect copy still exists
