### PR TITLE
ci: sync `next` branch to the website repo

### DIFF
--- a/.github/workflows/repository_dispatch.yml
+++ b/.github/workflows/repository_dispatch.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 permissions:
   contents: read
@@ -91,7 +92,7 @@ jobs:
           token: ${{ secrets.BIOME_REPOSITORY_DISPATCH }}
           repository: ${{ env.BIOME_WEBSITE_REPO }}
           event-type: ${{ env.BIOME_PUSH_ON_MAIN_EVENT_TYPE }}
-          client-payload: '{"event": ${{ toJson(github.event) }}}'
+          client-payload: '{"event": ${{ toJSON(github.event) }}}'
       # For testing only, the payload is mocked
       - name: Dispatch event on workflow dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -100,4 +101,4 @@ jobs:
           token: ${{ secrets.BIOME_REPOSITORY_DISPATCH }}
           repository: ${{ env.BIOME_WEBSITE_REPO }}
           event-type: ${{ env.BIOME_PUSH_ON_MAIN_EVENT_TYPE }}
-          client-payload: '{"event": {"head_commit": {"id": "${{ env.GITHUB_SHA }}"}}}'
+          client-payload: '{"event": {"head_commit": {"id": "${{ github.sha }}"}, "ref": "${{ github.ref }}"}}'


### PR DESCRIPTION
## Summary

Added a `push` trigger to the `next` branch to sync it to the website repository.
See also https://github.com/biomejs/website/pull/2779

## Test Plan

The `next` branch in the website repo will be updated once this PR was merged

## Docs

N/A