### PR TITLE
feat(lint): add `ignoreTypes` option to the `noImportCycles` rule

### DIFF
--- a/.changeset/shaky-experts-sit.md
+++ b/.changeset/shaky-experts-sit.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6799](https://github.com/biomejs/biome/issues/6799): The [`noImportCycles`](https://biomejs.dev/linter/rules/no-import-cycles/) rule now ignores type-only imports if the new `ignoreTypes` option is enabled (enabled by default).

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -9,7 +9,7 @@ use biome_js_syntax::{
     AnyJsImportClause, AnyJsImportLike, AnyJsNamedImportSpecifier, JsModuleSource, JsSyntaxToken,
 };
 use biome_jsdoc_comment::JsdocComment;
-use biome_module_graph::{JsModuleInfo, ModuleGraph, ResolvedPath};
+use biome_module_graph::{JsImportPath, JsModuleInfo, ModuleGraph};
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange};
 use biome_rule_options::no_private_imports::{NoPrivateImportsOptions, Visibility};
 use camino::{Utf8Path, Utf8PathBuf};
@@ -180,7 +180,7 @@ impl Rule for NoPrivateImports {
             .then(|| node.inner_string_text())
             .flatten()
             .and_then(|specifier| module_info.static_import_paths.get(specifier.text()))
-            .and_then(ResolvedPath::as_path)
+            .and_then(JsImportPath::as_path)
             .filter(|path| !BiomePath::new(path).is_dependency())
         else {
             return Vec::new();

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -1,5 +1,5 @@
 use biome_diagnostics::Severity;
-use biome_module_graph::ResolvedPath;
+use biome_module_graph::JsImportPath;
 use camino::{Utf8Component, Utf8Path};
 use serde::{Deserialize, Serialize};
 
@@ -145,7 +145,7 @@ impl Rule for UseImportExtensions {
         let node = ctx.query();
         let resolved_path = module_info
             .get_import_path_by_js_node(node)
-            .and_then(ResolvedPath::as_path)?;
+            .and_then(JsImportPath::as_path)?;
 
         get_extensionless_import(node, resolved_path, force_js_extensions)
     }

--- a/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
@@ -5,7 +5,7 @@ use biome_console::markup;
 use biome_js_syntax::{
     AnyJsImportClause, AnyJsImportLike, AnyJsNamedImportSpecifier, JsModuleSource, JsSyntaxToken,
 };
-use biome_module_graph::{JsModuleInfo, ModuleGraph, SUPPORTED_EXTENSIONS};
+use biome_module_graph::{JsImportPath, JsModuleInfo, ModuleGraph, SUPPORTED_EXTENSIONS};
 use biome_resolver::ResolveError;
 use biome_rowan::{AstNode, SyntaxResult, Text, TextRange, TokenText};
 use biome_rule_options::no_unresolved_imports::NoUnresolvedImportsOptions;
@@ -99,7 +99,8 @@ impl Rule for NoUnresolvedImports {
         };
 
         let node = ctx.query();
-        let Some(resolved_path) = module_info.get_import_path_by_js_node(node) else {
+        let Some(JsImportPath { resolved_path, .. }) = module_info.get_import_path_by_js_node(node)
+        else {
             return Vec::new();
         };
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/a.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/a.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+import type { Foo } from "./b.ts";
+import type { Baz } from "./c.ts";
+
+export type Bar = {};
+
+export const baz: Baz = {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/a.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/a.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: a.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import type { Foo } from "./b.ts";
+import type { Baz } from "./c.ts";
+
+export type Bar = {};
+
+export const baz: Baz = {};
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/b.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/b.ts
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+import type { Bar } from "./a.ts";
+
+export type Foo = {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/b.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/b.ts.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: b.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import type { Bar } from "./a.ts";
+
+export type Foo = {};
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/c.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/c.ts
@@ -1,0 +1,7 @@
+/* should not generate diagnostics */
+
+// This is not a type-only import, but a.ts imports c.ts as type-only.
+// It does not make an import cycle after the compiler erased type-only imports.
+import { baz } from "./a.ts";
+
+export type Baz = {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/c.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/ignoreTypes/c.ts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: c.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+// This is not a type-only import, but a.ts imports c.ts as type-only.
+// It does not make an import cycle after the compiler erased type-only imports.
+import { baz } from "./a.ts";
+
+export type Baz = {};
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noImportCycles": {
+          "level": "on",
+          "options": {
+            "ignoreTypes": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.ts
@@ -1,0 +1,2 @@
+/* should generate diagnostics */
+import type { Foo } from "./types.ts";

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/includeTypes.ts.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: includeTypes.ts
+---
+# Input
+```ts
+/* should generate diagnostics */
+import type { Foo } from "./types.ts";
+
+```
+
+# Diagnostics
+```
+includeTypes.ts:2:26 lint/nursery/noImportCycles ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! This import is part of a cycle.
+  
+    1 │ /* should generate diagnostics */
+  > 2 │ import type { Foo } from "./types.ts";
+      │                          ^^^^^^^^^^^^
+    3 │ 
+  
+  i This import resolves to tests/specs/nursery/noImportCycles/types.ts
+        ... which imports tests/specs/nursery/noImportCycles/includeTypes.ts
+        ... which is the file we're importing from.
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/types.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/types.ts
@@ -1,0 +1,5 @@
+/* should not generate diagnostics */
+import type {} from "./ignoreTypes.ts";
+import type {} from "./includeTypes.ts";
+
+export type Foo = {};

--- a/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/types.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noImportCycles/types.ts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: types.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+import type {} from "./ignoreTypes.ts";
+import type {} from "./includeTypes.ts";
+
+export type Foo = {};
+
+```

--- a/crates/biome_module_graph/src/js_module_info.rs
+++ b/crates/biome_module_graph/src/js_module_info.rs
@@ -3,11 +3,13 @@ mod collector;
 mod module_resolver;
 mod scope;
 mod visitor;
+
 use biome_js_syntax::AnyJsImportLike;
 use biome_js_type_info::{BindingId, ImportSymbol, ResolvedTypeId, ScopeId, TypeData};
 use biome_jsdoc_comment::JsdocComment;
 use biome_resolver::ResolvedPath;
 use biome_rowan::{Text, TextRange};
+use camino::Utf8Path;
 use indexmap::IndexMap;
 use rust_lapper::Lapper;
 use rustc_hash::FxHashMap;
@@ -37,7 +39,7 @@ impl Deref for JsModuleInfo {
 impl JsModuleInfo {
     /// Returns an iterator over all the static and dynamic imports in this
     /// module.
-    pub fn all_import_paths(&self) -> impl Iterator<Item = ResolvedPath> + use<> {
+    pub fn all_import_paths(&self) -> impl Iterator<Item = JsImportPath> + use<> {
         ImportPathIterator {
             module_info: self.clone(),
             index: 0,
@@ -96,10 +98,10 @@ impl JsModuleInfo {
             static_import_paths: self
                 .static_import_paths
                 .iter()
-                .map(|(specifier, resolved)| {
+                .map(|(specifier, JsImportPath { resolved_path, .. })| {
                     (
                         specifier.to_string(),
-                        resolved
+                        resolved_path
                             .as_ref()
                             .map_or_else(|_| specifier.to_string(), ToString::to_string),
                     )
@@ -138,11 +140,11 @@ pub struct JsModuleInfoInner {
 
     /// Map of all the paths from static imports in the module.
     ///
-    /// Maps from the source specifier name to a [JsResolvedPath] with the
+    /// Maps from the source specifier name to a [JsImportPath] with the
     /// absolute path it resolves to. The resolved path may be looked up as key
     /// in the [ModuleGraph::data] map, although it is not required to exist
     /// (for instance, if the path is outside the project's scope).
-    pub static_import_paths: IndexMap<Text, ResolvedPath>,
+    pub static_import_paths: IndexMap<Text, JsImportPath>,
 
     /// Map of all dynamic import paths found in the module for which the import
     /// specifier could be statically determined.
@@ -151,14 +153,14 @@ pub struct JsModuleInfoInner {
     /// (for instance, because a template string with variables is used) will be
     /// omitted from this map.
     ///
-    /// Maps from the source specifier name to a [JsResolvedPath] with the
+    /// Maps from the source specifier name to a [JsImportPath] with the
     /// absolute path it resolves to. The resolved path may be looked up as key
     /// in the [ModuleGraph::data] map, although it is not required to exist
     /// (for instance, if the path is outside the project's scope).
     ///
     /// Paths found in `require()` expressions in CommonJS sources are also
     /// included with the dynamic import paths.
-    pub dynamic_import_paths: IndexMap<Text, ResolvedPath>,
+    pub dynamic_import_paths: IndexMap<Text, JsImportPath>,
 
     /// Map of exports from the module.
     ///
@@ -214,6 +216,31 @@ impl Deref for Imports {
     }
 }
 
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub enum JsImportPhase {
+    #[default]
+    Default,
+    /// https://tc39.es/proposal-defer-import-eval/
+    Defer,
+    /// https://tc39.es/proposal-source-phase-imports/
+    Source,
+    /// Technically this is not an import phase defined in ECMAScript, but type-only imports in
+    /// TypeScript cannot be imported in other phases.
+    Type,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JsImportPath {
+    pub resolved_path: ResolvedPath,
+    pub phase: JsImportPhase,
+}
+
+impl JsImportPath {
+    pub fn as_path(&self) -> Option<&Utf8Path> {
+        self.resolved_path.as_path()
+    }
+}
+
 static_assertions::assert_impl_all!(JsModuleInfo: Send, Sync);
 
 impl JsModuleInfoInner {
@@ -245,7 +272,7 @@ impl JsModuleInfoInner {
     }
 
     /// Returns the information about a given import by its syntax node.
-    pub fn get_import_path_by_js_node(&self, node: &AnyJsImportLike) -> Option<&ResolvedPath> {
+    pub fn get_import_path_by_js_node(&self, node: &AnyJsImportLike) -> Option<&JsImportPath> {
         let specifier_text = node.inner_string_text()?;
         let specifier = specifier_text.text();
         if node.is_static_import() {
@@ -350,7 +377,7 @@ struct ImportPathIterator {
 }
 
 impl Iterator for ImportPathIterator {
-    type Item = ResolvedPath;
+    type Item = JsImportPath;
 
     fn next(&mut self) -> Option<Self::Item> {
         let num_static_imports = self.module_info.static_import_paths.len();

--- a/crates/biome_module_graph/src/js_module_info/module_resolver.rs
+++ b/crates/biome_module_graph/src/js_module_info/module_resolver.rs
@@ -12,7 +12,7 @@ use biome_rowan::{AstNode, RawSyntaxKind, Text, TextRange, TokenText};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    JsExport, JsOwnExport, ModuleGraph,
+    JsExport, JsImportPath, JsOwnExport, ModuleGraph,
     js_module_info::{JsModuleInfoInner, scope::TsBindingReference},
 };
 
@@ -184,7 +184,7 @@ impl ModuleResolver {
         let mut i = 0;
         while i < self.modules.len() {
             let module = self.modules[i].clone();
-            for resolved_path in module.static_import_paths.values() {
+            for JsImportPath { resolved_path, .. } in module.static_import_paths.values() {
                 self.register_module(resolved_path.clone());
             }
 

--- a/crates/biome_module_graph/src/lib.rs
+++ b/crates/biome_module_graph/src/lib.rs
@@ -8,7 +8,7 @@ pub use biome_js_type_info::ImportSymbol;
 pub use biome_resolver::ResolvedPath;
 
 pub use js_module_info::{
-    JsExport, JsImport, JsModuleInfo, JsOwnExport, JsReexport, ModuleResolver,
-    SerializedJsModuleInfo,
+    JsExport, JsImport, JsImportPath, JsImportPhase, JsModuleInfo, JsOwnExport, JsReexport,
+    ModuleResolver, SerializedJsModuleInfo,
 };
 pub use module_graph::{ModuleDependencies, ModuleGraph, SUPPORTED_EXTENSIONS};

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -13,10 +13,10 @@ use biome_js_type_info::{ScopeId, TypeData, TypeResolver};
 use biome_jsdoc_comment::JsdocComment;
 use biome_json_parser::{JsonParserOptions, parse_json};
 use biome_json_value::{JsonObject, JsonString};
-use biome_module_graph::JsExport;
 use biome_module_graph::{
     ImportSymbol, JsImport, JsReexport, ModuleGraph, ModuleResolver, ResolvedPath,
 };
+use biome_module_graph::{JsExport, JsImportPath, JsImportPhase};
 use biome_package::{Dependencies, PackageJson};
 use biome_project_layout::ProjectLayout;
 use biome_rowan::Text;
@@ -1976,9 +1976,10 @@ fn test_resolve_swr_types() {
         .expect("module must exist");
     assert_eq!(
         index_module.static_import_paths.get("swr"),
-        Some(&ResolvedPath::from_path(format!(
-            "{swr_path}/dist/index/index.d.mts"
-        )))
+        Some(&JsImportPath {
+            resolved_path: ResolvedPath::from_path(format!("{swr_path}/dist/index/index.d.mts")),
+            phase: JsImportPhase::Default,
+        })
     );
 
     let swr_index_module = module_graph
@@ -1988,9 +1989,12 @@ fn test_resolve_swr_types() {
         swr_index_module
             .static_import_paths
             .get("../_internal/index.mjs"),
-        Some(&ResolvedPath::from_path(format!(
-            "{swr_path}/dist/_internal/index.d.mts"
-        )))
+        Some(&JsImportPath {
+            resolved_path: ResolvedPath::from_path(format!(
+                "{swr_path}/dist/_internal/index.d.mts"
+            )),
+            phase: JsImportPhase::Default,
+        })
     );
 
     let resolver = Arc::new(ModuleResolver::for_module(

--- a/crates/biome_rule_options/src/no_import_cycles.rs
+++ b/crates/biome_rule_options/src/no_import_cycles.rs
@@ -1,6 +1,27 @@
 use biome_deserialize_macros::Deserializable;
 use serde::{Deserialize, Serialize};
-#[derive(Default, Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+
+#[derive(Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-pub struct NoImportCyclesOptions {}
+pub struct NoImportCyclesOptions {
+    /// Ignores type-only imports when finding an import cycle. A type-only import (`import type`)
+    /// will be removed by the compiler, so it cuts an import cycle at runtime. Note that named type
+    /// imports (`import { type Foo }`) aren't considered as type-only because it's not removed by
+    /// the compiler if the `verbatimModuleSyntax` option is enabled. Enabled by default.
+    #[serde(default = "ignore_types_default")]
+    pub ignore_types: bool,
+}
+
+impl Default for NoImportCyclesOptions {
+    fn default() -> Self {
+        Self {
+            ignore_types: ignore_types_default(),
+        }
+    }
+}
+
+#[inline]
+fn ignore_types_default() -> bool {
+    true
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -7850,7 +7850,12 @@ export interface NoExcessiveLinesPerFunctionOptions {
 export interface NoFloatingPromisesOptions {}
 export interface NoGlobalDirnameFilenameOptions {}
 export interface NoImplicitCoercionOptions {}
-export interface NoImportCyclesOptions {}
+export interface NoImportCyclesOptions {
+	/**
+	 * Ignores type-only imports when finding an import cycle. A type-only import (`import type`) will be removed by the compiler, so it cuts an import cycle at runtime. Note that named type imports (`import { type Foo }`) aren't considered as type-only because it's not removed by the compiler if the `verbatimModuleSyntax` option is enabled. Enabled by default.
+	 */
+	ignoreTypes?: boolean;
+}
 export interface NoImportantStylesOptions {}
 export interface NoMagicNumbersOptions {}
 export interface NoMisusedPromisesOptions {}

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -3315,6 +3315,13 @@
 		},
 		"NoImportCyclesOptions": {
 			"type": "object",
+			"properties": {
+				"ignoreTypes": {
+					"description": "Ignores type-only imports when finding an import cycle. A type-only import (`import type`) will be removed by the compiler, so it cuts an import cycle at runtime. Note that named type imports (`import { type Foo }`) aren't considered as type-only because it's not removed by the compiler if the `verbatimModuleSyntax` option is enabled. Enabled by default.",
+					"default": true,
+					"type": "boolean"
+				}
+			},
 			"additionalProperties": false
 		},
 		"NoImportantInKeyframeConfiguration": {


### PR DESCRIPTION
## Summary

Fixes #6799 

Added a new option `ignoreTypes`, enabled by default, to ignore type-only imports in the `noImportCycle` rule.

## Test Plan

Added snapshot tests.

## Docs

Added the options section to the rule doc.