### PR TITLE
fix(core): consider extended configs for scan kind

### DIFF
--- a/.changeset/skating-scanner-skips.md
+++ b/.changeset/skating-scanner-skips.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7062](https://github.com/biomejs/biome/issues/7062): Biome now correctly considers extended configs when determining the mode for the scanner.

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/linter_enables_project_domain_based_on_extended_config.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/linter_enables_project_domain_based_on_extended_config.snap
@@ -1,0 +1,62 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "extends": ["biome.base.json"] }
+```
+
+## `biome.base.json`
+
+```json
+{
+    "linter": {
+        "rules": {
+            "nursery": {
+                "noFloatingPromises": "on"
+            }
+        }
+    }
+}
+```
+
+## `src/foo.ts`
+
+```ts
+export function foo(): Foo {}
+
+export async function bar() {}
+```
+
+## `src/index.ts`
+
+```ts
+import { foo, bar } from "./foo.ts";
+
+fn(foo());
+
+bar();
+```
+
+# Emitted Messages
+
+```block
+src/index.ts:5:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    3 │ fn(foo());
+    4 │ 
+  > 5 │ bar();
+      │ ^^^^^^
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```block
+Checked 1 file in <TIME>. No fixes applied.
+```

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -50,13 +50,11 @@ impl<'a> SpecTestFile<'a> {
             "The input '{spec_input_file}' must exist and be a file.",
         );
 
-        let OpenProjectResult { project_key, .. } = app
+        let OpenProjectResult { project_key } = app
             .workspace
             .open_project(OpenProjectParams {
                 path: BiomePath::new(""),
                 open_uninitialized: true,
-                only_rules: None,
-                skip_rules: None,
             })
             .unwrap();
 

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -3,11 +3,10 @@ use std::sync::Arc;
 use crate::diagnostics::LspError;
 use crate::utils::apply_document_changes;
 use crate::{documents::Document, session::Session};
-use biome_fs::BiomePath;
+use biome_configuration::ConfigurationPathHint;
 use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DocumentFileSource, FeaturesBuilder, FileContent,
-    GetFileContentParams, IgnoreKind, IsPathIgnoredParams, OpenFileParams, OpenProjectParams,
-    ScanKind,
+    GetFileContentParams, IgnoreKind, IsPathIgnoredParams, OpenFileParams,
 };
 use tower_lsp_server::lsp_types;
 use tracing::{debug, error, field, info};
@@ -35,26 +34,28 @@ pub(crate) async fn did_open(
         Some(project_key) => project_key,
         None => {
             info!("No open project for path: {path:?}. Opening new project.");
-            let parent_path = BiomePath::new(
-                path.parent()
-                    .map(|parent| parent.to_path_buf())
-                    .unwrap_or_default(),
-            );
-            let result = session.workspace.open_project(OpenProjectParams {
-                path: parent_path.clone(),
-                open_uninitialized: true,
-                skip_rules: None,
-                only_rules: None,
-            })?;
-            let scan_kind = if result.scan_kind.is_none() {
-                ScanKind::KnownFiles
-            } else {
-                result.scan_kind
-            };
-            session
-                .insert_and_scan_project(result.project_key, parent_path, scan_kind)
+            let parent_path = path
+                .parent()
+                .map(|parent| parent.to_path_buf())
+                .unwrap_or_default();
+            let status = session
+                .load_biome_configuration_file(ConfigurationPathHint::FromLsp(parent_path))
                 .await;
-            result.project_key
+            debug!("Configuration status: {status:?}");
+            session.set_configuration_status(status);
+
+            if status.is_loaded() {
+                match session.project_for_path(&path) {
+                    Some(project_key) => project_key,
+                    None => {
+                        error!("Could not find project for {path}");
+                        return Ok(());
+                    }
+                }
+            } else {
+                error!("Configuration could not be loaded for {path}");
+                return Ok(());
+            }
         }
     };
 

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -6,13 +6,13 @@ use crate::session::{
 };
 use crate::utils::{into_lsp_error, panic_to_lsp_error};
 use crate::{handlers, requests};
+use biome_configuration::ConfigurationPathHint;
 use biome_console::markup;
 use biome_diagnostics::panic::PanicError;
 use biome_fs::{ConfigName, MemoryFileSystem, OsFileSystem};
 use biome_resolver::FsWithResolverProxy;
 use biome_service::workspace::{
-    CloseProjectParams, OpenProjectParams, RageEntry, RageParams, RageResult, ScanKind,
-    ServiceDataNotification,
+    CloseProjectParams, RageEntry, RageParams, RageResult, ServiceDataNotification,
 };
 use biome_service::{WatcherInstruction, WorkspaceServer};
 use crossbeam::channel::{Sender, bounded};
@@ -412,39 +412,14 @@ impl LanguageServer for LSPServer {
 
         for added in &params.event.added {
             if let Ok(project_path) = self.session.file_path(&added.uri) {
-                let result = self
+                let status = self
                     .session
-                    .workspace
-                    .open_project(OpenProjectParams {
-                        path: project_path.clone(),
-                        open_uninitialized: true,
-                        only_rules: None,
-                        skip_rules: None,
-                    })
-                    .map_err(LspError::from);
-
-                match result {
-                    Ok(result) => {
-                        let scan_kind = if result.scan_kind.is_none() {
-                            ScanKind::KnownFiles
-                        } else {
-                            result.scan_kind
-                        };
-                        self.session
-                            .insert_and_scan_project(
-                                result.project_key,
-                                project_path.clone(),
-                                scan_kind,
-                            )
-                            .await;
-
-                        self.session.update_all_diagnostics().await;
-                    }
-                    Err(err) => {
-                        error!("Failed to add project to the workspace: {err}");
-                        self.notify_error(err).await;
-                    }
-                }
+                    .load_biome_configuration_file(ConfigurationPathHint::FromWorkspace(
+                        project_path.to_path_buf(),
+                    ))
+                    .await;
+                debug!("Configuration status: {status:?}");
+                self.session.set_configuration_status(status);
             }
         }
     }

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -604,15 +604,13 @@ async fn document_lifecycle() -> Result<()> {
 
     // `open_project()` will return an existing key if called with a path
     // for an existing project.
-    let OpenProjectResult { project_key, .. } = server
+    let OpenProjectResult { project_key } = server
         .request(
             "biome/open_project",
             "open_project",
             OpenProjectParams {
                 path: BiomePath::new(""),
                 open_uninitialized: true,
-                only_rules: None,
-                skip_rules: None,
             },
         )
         .await?
@@ -666,15 +664,13 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
 
         // `open_project()` will return an existing key if called with a path
         // for an existing project.
-        let OpenProjectResult { project_key, .. } = server
+        let OpenProjectResult { project_key } = server
             .request(
                 "biome/open_project",
                 "open_project",
                 OpenProjectParams {
                     path: BiomePath::new(""),
                     open_uninitialized: true,
-                    only_rules: None,
-                    skip_rules: None,
                 },
             )
             .await?
@@ -712,15 +708,13 @@ async fn lifecycle_with_multiple_connections() -> Result<()> {
 
         // `open_project()` will return an existing key if called with a path
         // for an existing project.
-        let OpenProjectResult { project_key, .. } = server
+        let OpenProjectResult { project_key } = server
             .request(
                 "biome/open_project",
                 "open_project",
                 OpenProjectParams {
                     path: BiomePath::new(""),
                     open_uninitialized: true,
-                    only_rules: None,
-                    skip_rules: None,
                 },
             )
             .await?
@@ -2561,15 +2555,13 @@ isSpreadAssignment;
 
     // `open_project()` will return an existing key if called with a path
     // for an existing project.
-    let OpenProjectResult { project_key, .. } = server
+    let OpenProjectResult { project_key } = server
         .request(
             "biome/open_project",
             "open_project",
             OpenProjectParams {
                 path: BiomePath::new(""),
                 open_uninitialized: true,
-                skip_rules: None,
-                only_rules: None,
             },
         )
         .await?
@@ -3383,15 +3375,13 @@ export function bar() {
 
     server.initialize().await?;
 
-    let OpenProjectResult { project_key, .. } = server
+    let OpenProjectResult { project_key } = server
         .request(
             "biome/open_project",
             "open_project",
             OpenProjectParams {
                 path: fs.working_directory.clone().into(),
                 open_uninitialized: true,
-                skip_rules: None,
-                only_rules: None,
             },
         )
         .await?
@@ -3581,15 +3571,13 @@ export function bar() {
 
     server.initialize().await?;
 
-    let OpenProjectResult { project_key, .. } = server
+    let OpenProjectResult { project_key } = server
         .request(
             "biome/open_project",
             "open_project",
             OpenProjectParams {
                 path: fs.working_directory.clone().into(),
                 open_uninitialized: true,
-                only_rules: None,
-                skip_rules: None,
             },
         )
         .await?
@@ -3739,15 +3727,13 @@ async fn should_open_and_update_nested_files() -> Result<()> {
     server.initialize().await?;
 
     // ARRANGE: Open project.
-    let OpenProjectResult { project_key, .. } = server
+    let OpenProjectResult { project_key } = server
         .request(
             "biome/open_project",
             "open_project",
             OpenProjectParams {
                 path: fs.working_directory.clone().into(),
                 open_uninitialized: true,
-                only_rules: None,
-                skip_rules: None,
             },
         )
         .await?

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -13,7 +13,9 @@ use biome_line_index::WideEncoding;
 use biome_lsp_converters::{PositionEncoding, negotiated_encoding};
 use biome_service::Workspace;
 use biome_service::WorkspaceError;
-use biome_service::configuration::{LoadedConfiguration, load_configuration, load_editorconfig};
+use biome_service::configuration::{
+    LoadedConfiguration, ProjectScanComputer, load_configuration, load_editorconfig,
+};
 use biome_service::file_handlers::{AstroFileHandler, SvelteFileHandler, VueFileHandler};
 use biome_service::projects::ProjectKey;
 use biome_service::workspace::{
@@ -105,7 +107,7 @@ struct InitializeParams {
     workspace_folders: Option<Vec<WorkspaceFolder>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[repr(u8)]
 pub(crate) enum ConfigurationStatus {
     /// The configuration file was properly loaded
@@ -712,7 +714,7 @@ impl Session {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn load_biome_configuration_file(
+    pub(super) async fn load_biome_configuration_file(
         self: &Arc<Self>,
         base_path: ConfigurationPathHint,
     ) -> ConfigurationStatus {
@@ -790,13 +792,8 @@ impl Session {
         let register_result = self.workspace.open_project(OpenProjectParams {
             path: path.as_path().into(),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         });
-        let OpenProjectResult {
-            project_key,
-            scan_kind,
-        } = match register_result {
+        let OpenProjectResult { project_key } = match register_result {
             Ok(result) => result,
             Err(error) => {
                 error!("Failed to register the project folder: {error}");
@@ -805,6 +802,7 @@ impl Session {
             }
         };
 
+        let scan_kind = ProjectScanComputer::new(&configuration).compute();
         let scan_kind = if scan_kind.is_none() {
             ScanKind::KnownFiles
         } else {
@@ -899,7 +897,7 @@ impl Session {
     }
 
     /// Updates the status of the configuration
-    fn set_configuration_status(&self, status: ConfigurationStatus) {
+    pub(super) fn set_configuration_status(&self, status: ConfigurationStatus) {
         self.notified_broken_configuration
             .store(false, Ordering::Relaxed);
         self.configuration_status

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -468,12 +468,20 @@ pub trait ConfigurationExt {
 }
 
 impl ConfigurationExt for Configuration {
-    /// Mutates the configuration so that any fields that have not been configured explicitly are
-    /// filled in with their values from configs listed in the `extends` field.
+    /// Mutates the configuration so that any fields that have not been
+    /// configured explicitly are filled in with their values from configs
+    /// listed in the `extends` field.
     ///
     /// The `extends` configs are applied from left to right.
     ///
-    /// If a configuration can't be resolved from the file system, the operation will fail.
+    /// If a configuration can't be resolved from the file system, the operation
+    /// will fail.
+    ///
+    /// `file_path` is the path to the configuration file and is used for
+    /// resolving relative paths in the `extends` field.
+    ///
+    /// `external_resolution_base_path` is used for resolving non-relative
+    /// `extends` entries.
     fn apply_extends(
         &mut self,
         fs: &dyn FsWithResolverProxy,
@@ -696,19 +704,25 @@ pub struct ProjectScanComputer<'a> {
 }
 
 impl<'a> ProjectScanComputer<'a> {
-    pub fn new(
-        configuration: &'a Configuration,
-        skip: &'a [RuleSelector],
-        only: &'a [RuleSelector],
-    ) -> Self {
+    pub fn new(configuration: &'a Configuration) -> Self {
         let enabled_rules = configuration.get_linter_rules().as_enabled_rules();
         Self {
             enabled_rules,
             requires_project_scan: false,
-            skip,
-            only,
             configuration,
+            skip: &[],
+            only: &[],
         }
+    }
+
+    pub fn with_rule_selectors(
+        mut self,
+        skip: &'a [RuleSelector],
+        only: &'a [RuleSelector],
+    ) -> Self {
+        self.skip = skip;
+        self.only = only;
+        self
     }
 
     /// Computes and return the [ScanKind] required by this project
@@ -821,7 +835,7 @@ mod tests {
         };
 
         assert_eq!(
-            ProjectScanComputer::new(&configuration, &[], &[]).compute(),
+            ProjectScanComputer::new(&configuration).compute(),
             ScanKind::NoScanner
         );
     }
@@ -840,7 +854,7 @@ mod tests {
         };
 
         assert_eq!(
-            ProjectScanComputer::new(&configuration, &[], &[]).compute(),
+            ProjectScanComputer::new(&configuration).compute(),
             ScanKind::Project
         );
     }
@@ -864,7 +878,7 @@ mod tests {
         };
 
         assert_eq!(
-            ProjectScanComputer::new(&configuration, &[], &[]).compute(),
+            ProjectScanComputer::new(&configuration).compute(),
             ScanKind::Project
         );
     }
@@ -888,12 +902,12 @@ mod tests {
         };
 
         assert_eq!(
-            ProjectScanComputer::new(
-                &configuration,
-                &[RuleSelector::Rule("correctness", "noPrivateImports")],
-                &[]
-            )
-            .compute(),
+            ProjectScanComputer::new(&configuration)
+                .with_rule_selectors(
+                    &[RuleSelector::Rule("correctness", "noPrivateImports")],
+                    &[]
+                )
+                .compute(),
             ScanKind::NoScanner
         );
     }
@@ -917,12 +931,12 @@ mod tests {
         };
 
         assert_eq!(
-            ProjectScanComputer::new(
-                &configuration,
-                &[],
-                &[RuleSelector::Rule("correctness", "noPrivateImports")]
-            )
-            .compute(),
+            ProjectScanComputer::new(&configuration)
+                .with_rule_selectors(
+                    &[],
+                    &[RuleSelector::Rule("correctness", "noPrivateImports")]
+                )
+                .compute(),
             ScanKind::Project
         );
     }

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -1207,13 +1207,6 @@ pub struct OpenProjectParams {
     /// Whether the folder should be opened as a project, even if no
     /// `biome.json` can be found.
     pub open_uninitialized: bool,
-
-    /// Whether the client wants to run only certain rules. This is needed to compute the kind of [ScanKind].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub only_rules: Option<Vec<RuleSelector>>,
-    /// Whether the client wants to skip some lint rule. This is needed to compute the kind of [ScanKind].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub skip_rules: Option<Vec<RuleSelector>>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -1222,9 +1215,6 @@ pub struct OpenProjectParams {
 pub struct OpenProjectResult {
     /// A unique identifier for this project
     pub project_key: ProjectKey,
-
-    /// How to scan this project
-    pub scan_kind: ScanKind,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -27,12 +27,10 @@ use super::{
 
 fn create_server() -> (Box<dyn Workspace>, ProjectKey) {
     let workspace = server(Arc::new(MemoryFileSystem::default()), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Default::default(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -322,12 +320,10 @@ fn files_loaded_by_the_scanner_are_only_unloaded_when_the_project_is_unregistere
     fs.insert(Utf8PathBuf::from("/project/b.ts"), FILE_B_CONTENT);
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -401,12 +397,10 @@ fn too_large_files_are_tracked_but_not_parsed() {
     fs.insert(Utf8PathBuf::from("/project/a.ts"), FILE_CONTENT);
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -463,12 +457,10 @@ fn plugins_are_loaded_and_used_during_analysis() {
     fs.insert(Utf8PathBuf::from("/project/a.ts"), FILE_CONTENT);
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -533,12 +525,10 @@ language css;
     fs.insert(Utf8PathBuf::from("/project/a.css"), FILE_CONTENT);
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -599,12 +589,10 @@ fn plugins_may_use_invalid_span() {
     fs.insert(Utf8PathBuf::from("/project/a.ts"), FILE_CONTENT);
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -699,12 +687,10 @@ const hasOwn = Object.hasOwn({ foo: 'bar' }, 'foo');"#,
     }
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: Utf8PathBuf::from("/project").into(),
             open_uninitialized: true,
-            only_rules: Some(Vec::new()),
-            skip_rules: None,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/scanner.tests.rs
+++ b/crates/biome_service/src/workspace/scanner.tests.rs
@@ -32,8 +32,6 @@ fn scanner_doesnt_show_errors_for_inaccessible_files() {
         .open_project(OpenProjectParams {
             path: BiomePath::new(fs.cli_path()),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .unwrap();
     let project_key = result.project_key;

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -21,8 +21,6 @@ fn commonjs_file_rejects_import_statement() {
         .open_project(OpenProjectParams {
             path: BiomePath::new("/"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .unwrap();
 
@@ -84,8 +82,6 @@ fn store_embedded_nodes_with_corrent_ranges() {
         .open_project(OpenProjectParams {
             path: BiomePath::new("/"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .unwrap();
 

--- a/crates/biome_service/src/workspace/watcher.tests.rs
+++ b/crates/biome_service/src/workspace/watcher.tests.rs
@@ -30,12 +30,10 @@ fn should_not_open_an_ignored_file_inside_vcs_ignore_file() {
     let (watcher_tx, _) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 
@@ -78,12 +76,10 @@ fn should_not_open_an_ignored_file_inside_file_includes() {
     let (watcher_tx, _) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 
@@ -126,12 +122,10 @@ fn close_file_through_watcher_before_client() {
     let (watcher_tx, _) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 
@@ -192,12 +186,10 @@ fn close_file_from_client_before_watcher() {
     let (watcher_tx, _) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 
@@ -259,12 +251,10 @@ fn close_modified_file_from_client_before_watcher() {
     let (watcher_tx, rx) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 
@@ -339,12 +329,10 @@ fn should_not_open_a_source_file_with_scan_kind_known_files() {
     let (watcher_tx, watcher_rx) = unbounded();
     let (service_data_tx, _) = watch::channel(ServiceDataNotification::Updated);
     let workspace = WorkspaceServer::new(Arc::new(fs), watcher_tx, service_data_tx, None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: BiomePath::new("/project"),
             open_uninitialized: true,
-            skip_rules: None,
-            only_rules: None,
         })
         .expect("can open project");
 

--- a/crates/biome_service/tests/spec_tests.rs
+++ b/crates/biome_service/tests/spec_tests.rs
@@ -31,12 +31,10 @@ fn test_scanner_only_loads_type_definitions_from_node_modules() {
     let fs = OsFileSystem::new(fixtures_path.clone());
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: fixtures_path.clone().into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -108,12 +106,10 @@ fn test_scanner_ignored_files_are_not_loaded() {
     let fs = OsFileSystem::new(fixtures_path.clone());
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: fixtures_path.clone().into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 
@@ -177,12 +173,10 @@ fn test_scanner_required_files_are_only_ignored_in_ignored_directories() {
     let fs = OsFileSystem::new(fixtures_path.clone());
 
     let workspace = server(Arc::new(fs), None);
-    let OpenProjectResult { project_key, .. } = workspace
+    let OpenProjectResult { project_key } = workspace
         .open_project(OpenProjectParams {
             path: fixtures_path.clone().into(),
             open_uninitialized: true,
-            only_rules: None,
-            skip_rules: None,
         })
         .unwrap();
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8842,10 +8842,6 @@ export interface BacktraceSymbol {
 }
 export interface OpenProjectParams {
 	/**
-	 * Whether the client wants to run only certain rules. This is needed to compute the kind of [ScanKind].
-	 */
-	onlyRules?: RuleCode[];
-	/**
 	 * Whether the folder should be opened as a project, even if no `biome.json` can be found.
 	 */
 	openUninitialized: boolean;
@@ -8853,42 +8849,13 @@ export interface OpenProjectParams {
 	 * The path to open
 	 */
 	path: BiomePath;
-	/**
-	 * Whether the client wants to skip some lint rule. This is needed to compute the kind of [ScanKind].
-	 */
-	skipRules?: RuleCode[];
 }
-export type RuleCode = string;
 export interface OpenProjectResult {
 	/**
 	 * A unique identifier for this project
 	 */
 	projectKey: ProjectKey;
-	/**
-	 * How to scan this project
-	 */
-	scanKind: ScanKind;
 }
-export type ScanKind =
-	| "noScanner"
-	| "knownFiles"
-	| {
-			targetedKnownFiles: {
-				/**
-				 * Determines whether the file scanner should descend into subdirectories of the target paths.
-				 */
-				descendFromTargets: boolean;
-				/**
-	* The paths to target by the scanner.
-
-If a target path indicates a folder, all files within are scanned as well.
-
-Target paths must be absolute. 
-	 */
-				targetPaths: BiomePath[];
-			};
-	  }
-	| "project";
 export interface OpenFileParams {
 	content: FileContent;
 	documentFileSource?: DocumentFileSource;
@@ -9041,6 +9008,7 @@ export interface PullDiagnosticsParams {
 	skip?: RuleCode[];
 }
 export type RuleCategories = RuleCategory[];
+export type RuleCode = string;
 export type RuleCategory = "syntax" | "lint" | "action" | "transformation";
 export interface PullDiagnosticsResult {
 	diagnostics: Diagnostic[];

--- a/packages/@biomejs/js-api/src/wasm.ts
+++ b/packages/@biomejs/js-api/src/wasm.ts
@@ -20,31 +20,7 @@ export interface OpenProjectResult {
 	 * A unique identifier for this project
 	 */
 	projectKey: ProjectKey;
-	/**
-	 * How to scan this project
-	 */
-	scanKind: ScanKind;
 }
-type ScanKind =
-	| "noScanner"
-	| "knownFiles"
-	| {
-			targetedKnownFiles: {
-				/**
-				 * Determines whether the file scanner should descend into subdirectories of the target paths.
-				 */
-				descendFromTargets: boolean;
-				/**
-* The paths to target by the scanner.
-
-If a target path indicates a folder, all files within are scanned as well.
-
-Target paths must be absolute. 
-	*/
-				targetPaths: BiomePath[];
-			};
-	  }
-	| "project";
 interface OpenFileParams {
 	content: FileContent;
 	path: BiomePath;


### PR DESCRIPTION
## Summary

Fixed [#7062](https://github.com/biomejs/biome/issues/7062): Biome now correctly considers extended configs when determining the mode for the scanner.

The caller of `openProject()` already has a configuration, which has correctly applied extended configurations, so we use that instead of handling it inside the workspace. We already have `ScanKindComputer` to keep CLI and LSP implementations in sync.

## Test Plan

Test added. Existing tests should remain green.

## Docs

N/A