### PR TITLE
fix(lint/noUnusedPrivateClassMembers): handle class members declared in constructor parameters correctly

### DIFF
--- a/.changeset/rotten-knives-brush.md
+++ b/.changeset/rotten-knives-brush.md
@@ -1,0 +1,9 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7101](https://github.com/biomejs/biome/issues/7101)
+
+1. If a class member defined in a constructor argument is only used within the constructor, remove the private modifier and make it a plain method argument.
+
+2. If it is not used within the constructor, prefix it with an underscore, as with no_unused_function_parameter.

--- a/.changeset/rotten-knives-brush.md
+++ b/.changeset/rotten-knives-brush.md
@@ -2,8 +2,7 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#7101](https://github.com/biomejs/biome/issues/7101)
+Fixed [#7101](https://github.com/biomejs/biome/issues/7101): [`noUnusedPrivateClassMembers`](https://biomejs.dev/linter/rules/no-unused-private-class-members/) now handles members declared as part of constructor arguments:
 
-1. If a class member defined in a constructor argument is only used within the constructor, remove the private modifier and make it a plain method argument.
-
-2. If it is not used within the constructor, prefix it with an underscore, as with no_unused_function_parameter.
+1. If a class member defined in a constructor argument is only used within the constructor, it removes the `private` modifier and makes it a plain method argument.
+1. If it is not used at all, it will prefix it with an underscore, similar to `noUnusedFunctionParameter`.

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -135,13 +135,37 @@ impl Rule for NoUnusedPrivateClassMembers {
     }
 
     fn diagnostic(_: &RuleContext<Self>, state: &Self::State) -> Option<RuleDiagnostic> {
-        Some(RuleDiagnostic::new(
-            rule_category!(),
-            state.property_range(),
-            markup! {
-                "This private class member is defined but never used."
-            },
-        ))
+        match state {
+            UnusedMemberAction::RemoveMember(_) => Some(RuleDiagnostic::new(
+                rule_category!(),
+                state.property_range(),
+                markup! {
+                    "This private class member is defined but never used."
+                },
+            )),
+            UnusedMemberAction::RemovePrivateModifier {
+                rename_with_underscore,
+                ..
+            } => {
+                if *rename_with_underscore {
+                    Some(RuleDiagnostic::new(
+                        rule_category!(),
+                        state.property_range(),
+                        markup! {
+                            "This private class member is defined but never used."
+                        },
+                    ))
+                } else {
+                    Some(RuleDiagnostic::new(
+                        rule_category!(),
+                        state.property_range(),
+                        markup! {
+                            "This parameter is never used outside of the constructor."
+                        },
+                    ))
+                }
+            }
+        }
     }
 
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -1,8 +1,14 @@
+use crate::{
+    JsRuleAction,
+    services::semantic::Semantic,
+    utils::{is_node_equal, rename::RenameSymbolExtensions},
+};
 use biome_analyze::{
-    Ast, FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+    FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
+use biome_js_semantic::ReferencesExtensions;
 use biome_js_syntax::{
     AnyJsClassMember, AnyJsClassMemberName, AnyJsFormalParameter, AnyJsName,
     JsAssignmentExpression, JsAssignmentOperator, JsClassDeclaration, JsSyntaxKind, JsSyntaxNode,
@@ -14,8 +20,6 @@ use biome_rowan::{
 };
 use biome_rule_options::no_unused_private_class_members::NoUnusedPrivateClassMembersOptions;
 use rustc_hash::FxHashSet;
-
-use crate::{JsRuleAction, utils::is_node_equal};
 
 declare_lint_rule! {
     /// Disallow unused private class members
@@ -76,9 +80,27 @@ declare_node_union! {
     pub AnyMember = AnyJsClassMember | TsPropertyParameter
 }
 
+#[derive(Debug, Clone)]
+pub enum UnusedMemberAction {
+    Remove(AnyMember),
+    RemovePrivateModifier {
+        member: AnyMember,
+        rename_with_underscore: bool,
+    },
+}
+
+impl UnusedMemberAction {
+    fn property_range(&self) -> Option<TextRange> {
+        match self {
+            Self::Remove(member) => member.property_range(),
+            Self::RemovePrivateModifier { member, .. } => member.property_range(),
+        }
+    }
+}
+
 impl Rule for NoUnusedPrivateClassMembers {
-    type Query = Ast<JsClassDeclaration>;
-    type State = AnyMember;
+    type Query = Semantic<JsClassDeclaration>;
+    type State = UnusedMemberAction;
     type Signals = Box<[Self::State]>;
     type Options = NoUnusedPrivateClassMembersOptions;
 
@@ -88,7 +110,26 @@ impl Rule for NoUnusedPrivateClassMembers {
         if private_members.is_empty() {
             Vec::new()
         } else {
-            traverse_members_usage(node.syntax(), private_members)
+            let mut results = Vec::new();
+            let unused_members = traverse_members_usage(node.syntax(), private_members);
+
+            for member in unused_members {
+                match &member {
+                    AnyMember::AnyJsClassMember(_) => {
+                        results.push(UnusedMemberAction::Remove(member));
+                    }
+                    AnyMember::TsPropertyParameter(ts_property_param) => {
+                        // Check if the parameter is also unused in constructor body using semantic analysis
+                        let should_rename =
+                            check_ts_property_parameter_usage(ctx, ts_property_param);
+                        results.push(UnusedMemberAction::RemovePrivateModifier {
+                            member,
+                            rename_with_underscore: should_rename,
+                        });
+                    }
+                }
+            }
+            results
         }
         .into_boxed_slice()
     }
@@ -106,14 +147,62 @@ impl Rule for NoUnusedPrivateClassMembers {
     fn action(ctx: &RuleContext<Self>, state: &Self::State) -> Option<JsRuleAction> {
         let mut mutation = ctx.root().begin();
 
-        mutation.remove_node(state.clone());
-
-        Some(JsRuleAction::new(
-            ctx.metadata().action_category(ctx.category(), ctx.group()),
-            ctx.metadata().applicability(),
-            markup! { "Remove unused declaration." }.to_owned(),
-            mutation,
-        ))
+        match state {
+            UnusedMemberAction::Remove(member) => {
+                mutation.remove_node(member.clone());
+                Some(JsRuleAction::new(
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
+                    ctx.metadata().applicability(),
+                    markup! { "Remove unused declaration." }.to_owned(),
+                    mutation,
+                ))
+            }
+            UnusedMemberAction::RemovePrivateModifier {
+                member,
+                rename_with_underscore,
+            } => {
+                if let AnyMember::TsPropertyParameter(ts_property_param) = member {
+                    // Remove the private modifier
+                    let modifiers = ts_property_param.modifiers();
+                    for modifier in modifiers.iter() {
+                        if let Some(accessibility_modifier) =
+                            TsAccessibilityModifier::cast(modifier.into_syntax())
+                        {
+                            if accessibility_modifier.is_private() {
+                                mutation.remove_node(accessibility_modifier);
+                                break;
+                            }
+                        }
+                    }
+                    // If needed, rename with underscore prefix
+                    if *rename_with_underscore {
+                        if let Ok(AnyJsFormalParameter::JsFormalParameter(param)) =
+                            ts_property_param.formal_parameter()
+                        {
+                            let binding = param.binding().ok()?;
+                            let identifier_binding =
+                                binding.as_any_js_binding()?.as_js_identifier_binding()?;
+                            let name_token = identifier_binding.name_token().ok()?;
+                            let name_trimmed = name_token.text_trimmed();
+                            let new_name = format!("_{name_trimmed}");
+                            if !mutation.rename_node_declaration(
+                                ctx.model(),
+                                identifier_binding,
+                                &new_name,
+                            ) {
+                                return None;
+                            }
+                        }
+                    }
+                }
+                Some(JsRuleAction::new(
+                    ctx.metadata().action_category(ctx.category(), ctx.group()),
+                    ctx.metadata().applicability(),
+                    markup! { "Remove private modifier" }.to_owned(),
+                    mutation,
+                ))
+            }
+        }
     }
 }
 
@@ -158,6 +247,45 @@ fn traverse_members_usage(
     }
 
     private_members.into_iter().collect()
+}
+
+/// Check if a TsPropertyParameter is also unused as a function parameter
+fn check_ts_property_parameter_usage(
+    ctx: &RuleContext<NoUnusedPrivateClassMembers>,
+    ts_property_param: &TsPropertyParameter,
+) -> bool {
+    if let Ok(AnyJsFormalParameter::JsFormalParameter(param)) = ts_property_param.formal_parameter()
+    {
+        if let Ok(binding) = param.binding() {
+            if let Some(identifier_binding) = binding
+                .as_any_js_binding()
+                .and_then(|b| b.as_js_identifier_binding())
+            {
+                let name_token = match identifier_binding.name_token() {
+                    Ok(token) => token,
+                    Err(_) => return false,
+                };
+
+                let name = name_token.text_trimmed();
+
+                if name.starts_with('_') {
+                    return false;
+                }
+
+                if identifier_binding
+                    .all_references(ctx.model())
+                    .next()
+                    .is_some()
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 fn get_all_declared_private_members(

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 146
 expression: invalid.ts
 ---
 # Input
@@ -113,10 +114,15 @@ invalid.ts:10:22 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━�
     11 │ 
     12 │ 	}
   
-  i Unsafe fix: Remove unused declaration.
+  i Unsafe fix: Remove private modifier
   
-    10 │ → constructor(private·nusedProperty·=·3){
-       │               -------------------------  
+     8  8 │   
+     9  9 │   class TSUnusedPrivateConstructor {
+    10    │ - → constructor(private·nusedProperty·=·3){
+       10 │ + → constructor(_nusedProperty·=·3){
+    11 11 │   
+    12 12 │   	}
+  
 
 ```
 

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts
@@ -1,0 +1,12 @@
+class TSDoubleUnusedPrivateConstructor {
+	constructor(private unusedProperty = 3, private anotherUnusedProperty = 4) {
+		// This constructor has two unused private properties
+
+	}
+}
+
+class TSPartiallyUsedPrivateConstructor {
+  constructor(private param: number) {
+    foo(param)
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts.snap
@@ -1,0 +1,83 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 146
+expression: invalid_issue_7101.ts
+---
+# Input
+```ts
+class TSDoubleUnusedPrivateConstructor {
+	constructor(private unusedProperty = 3, private anotherUnusedProperty = 4) {
+		// This constructor has two unused private properties
+
+	}
+}
+
+class TSPartiallyUsedPrivateConstructor {
+  constructor(private param: number) {
+    foo(param)
+  }
+}
+```
+
+# Diagnostics
+```
+invalid_issue_7101.ts:2:22 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━
+
+  ! This private class member is defined but never used.
+  
+    1 │ class TSDoubleUnusedPrivateConstructor {
+  > 2 │ 	constructor(private unusedProperty = 3, private anotherUnusedProperty = 4) {
+      │ 	                    ^^^^^^^^^^^^^^^
+    3 │ 		// This constructor has two unused private properties
+    4 │ 
+  
+  i Unsafe fix: Remove private modifier
+  
+     1  1 │   class TSDoubleUnusedPrivateConstructor {
+     2    │ - → constructor(private·unusedProperty·=·3,·private·anotherUnusedProperty·=·4)·{
+        2 │ + → constructor(_unusedProperty·=·3,·private·anotherUnusedProperty·=·4)·{
+     3  3 │   		// This constructor has two unused private properties
+     4  4 │   
+  
+
+```
+
+```
+invalid_issue_7101.ts:2:50 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━
+
+  ! This private class member is defined but never used.
+  
+    1 │ class TSDoubleUnusedPrivateConstructor {
+  > 2 │ 	constructor(private unusedProperty = 3, private anotherUnusedProperty = 4) {
+      │ 	                                                ^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 		// This constructor has two unused private properties
+    4 │ 
+  
+  i Unsafe fix: Remove private modifier
+  
+     1  1 │   class TSDoubleUnusedPrivateConstructor {
+     2    │ - → constructor(private·unusedProperty·=·3,·private·anotherUnusedProperty·=·4)·{
+        2 │ + → constructor(private·unusedProperty·=·3,·_anotherUnusedProperty·=·4)·{
+     3  3 │   		// This constructor has two unused private properties
+     4  4 │   
+  
+
+```
+
+```
+invalid_issue_7101.ts:9:23 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━
+
+  ! This private class member is defined but never used.
+  
+     8 │ class TSPartiallyUsedPrivateConstructor {
+   > 9 │   constructor(private param: number) {
+       │                       ^^^^^
+    10 │     foo(param)
+    11 │   }
+  
+  i Unsafe fix: Remove private modifier
+  
+    9 │ ··constructor(private·param:·number)·{
+      │               --------                
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_issue_7101.ts.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 146
 expression: invalid_issue_7101.ts
 ---
 # Input
@@ -67,7 +66,7 @@ invalid_issue_7101.ts:2:50 lint/correctness/noUnusedPrivateClassMembers  FIXABLE
 ```
 invalid_issue_7101.ts:9:23 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━
 
-  ! This private class member is defined but never used.
+  ! This parameter is never used outside of the constructor.
   
      8 │ class TSPartiallyUsedPrivateConstructor {
    > 9 │   constructor(private param: number) {

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1015,6 +1015,28 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
                         range: Range {
                             start: Position {
                                 line: 0,
+                                character: 16,
+                            },
+                            end: Position {
+                                line: 0,
+                                character: 20,
+                            },
+                        },
+                        severity: Some(lsp::DiagnosticSeverity::ERROR),
+                        code: Some(lsp::NumberOrString::String(String::from(
+                            "syntax/correctness/noDuplicatePrivateClassMembers",
+                        ))),
+                        code_description: None,
+                        source: Some(String::from("biome")),
+                        message: String::from("Duplicate private class member \"#foo\"",),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    },
+                    lsp::Diagnostic {
+                        range: Range {
+                            start: Position {
+                                line: 0,
                                 character: 10,
                             },
                             end: Position {
@@ -1065,28 +1087,6 @@ async fn pull_diagnostics_of_syntax_rules() -> Result<()> {
                         message: String::from(
                             "This private class member is defined but never used.",
                         ),
-                        related_information: None,
-                        tags: None,
-                        data: None,
-                    },
-                    lsp::Diagnostic {
-                        range: Range {
-                            start: Position {
-                                line: 0,
-                                character: 16,
-                            },
-                            end: Position {
-                                line: 0,
-                                character: 20,
-                            },
-                        },
-                        severity: Some(lsp::DiagnosticSeverity::ERROR),
-                        code: Some(lsp::NumberOrString::String(String::from(
-                            "syntax/correctness/noDuplicatePrivateClassMembers",
-                        ))),
-                        code_description: None,
-                        source: Some(String::from("biome")),
-                        message: String::from("Duplicate private class member \"#foo\"",),
                         related_information: None,
                         tags: None,
                         data: None,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

This PR fixes #7101

1. If a class member defined in a constructor argument is only used within the constructor, remove the `private` modifier and make it a plain method argument.
2. If it is not used within the constructor, prefix it with an underscore, as with `no_unused_function_parameter`.

Note:
Previously, unused class members defined as constructor arguments were completely removed from the constructor arguments. However, this changed the constructor signature and was inconsistent with the behavior of `no_unused_function_parameter`.

As a side effect of this bug fix, the constructor signature is no longer changed, which has caused some existing tests to produce different results. (check changed files)

## Test Plan

New test file has been added.