### PR TITLE
fix(lint/noUnusedPrivateClassMembers): improve member usage check

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_private_class_members.rs
@@ -5,7 +5,7 @@ use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
     AnyJsClassMember, AnyJsClassMemberName, AnyJsFormalParameter, AnyJsName,
-    JsAssignmentExpression, JsAssignmentOperator, JsClassDeclaration, JsSyntaxKind, JsSyntaxNode,
+    JsAssignmentExpression, JsClassDeclaration, JsSyntaxKind, JsSyntaxNode,
     TsAccessibilityModifier, TsPropertyParameter,
 };
 use biome_rowan::{
@@ -215,6 +215,13 @@ fn get_constructor_params(class_declaration: &JsClassDeclaration) -> FxHashSet<A
 /// this.usedOnlyInWrite = this.usedOnlyInWrite;
 /// ```
 ///
+/// # Examples of expressions that are NOT write-only
+///
+/// ```js
+/// return this.#val++;  // increment expression used as return value
+/// return this.#val = 1; //assignment used as expression
+/// ```
+///
 fn is_write_only(js_name: &AnyJsName) -> Option<bool> {
     let parent = js_name.syntax().parent()?;
     let grand_parent = parent.parent()?;
@@ -225,28 +232,26 @@ fn is_write_only(js_name: &AnyJsName) -> Option<bool> {
         return Some(false);
     }
 
-    if !matches!(
-        assignment_expression.operator(),
-        Ok(JsAssignmentOperator::Assign)
-    ) {
-        let kind = assignment_expression.syntax().parent().kind();
-        return Some(
-            kind.is_some_and(|kind| matches!(kind, JsSyntaxKind::JS_EXPRESSION_STATEMENT)),
-        );
-    }
-
-    Some(true)
+    // If it's not a direct child of expression statement, its result is being used
+    let kind = assignment_expression.syntax().parent().kind();
+    Some(kind.is_some_and(|kind| matches!(kind, JsSyntaxKind::JS_EXPRESSION_STATEMENT)))
 }
 
 fn is_in_update_expression(js_name: &AnyJsName) -> bool {
-    let grand_parent = js_name.syntax().grand_parent();
+    let Some(grand_parent) = js_name.syntax().grand_parent() else {
+        return false;
+    };
 
-    grand_parent.kind().is_some_and(|kind| {
-        matches!(
-            kind,
-            JsSyntaxKind::JS_POST_UPDATE_EXPRESSION | JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION
-        )
-    })
+    // If it's not a direct child of expression statement, its result is being used
+    let kind = grand_parent.parent().kind();
+    if !kind.is_some_and(|kind| matches!(kind, JsSyntaxKind::JS_EXPRESSION_STATEMENT)) {
+        return false;
+    }
+
+    matches!(
+        grand_parent.kind(),
+        JsSyntaxKind::JS_POST_UPDATE_EXPRESSION | JsSyntaxKind::JS_PRE_UPDATE_EXPRESSION
+    )
 }
 
 impl AnyMember {

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js
@@ -179,3 +179,27 @@ class C {
 			this.#x = 1;
 	}
 }
+
+// issue #6994
+class UsedAssignmentExpr {
+  #val = 0;
+  method() {
+    return this.#val = 1
+  }
+}
+
+// issue #6933
+class UsedPreUpdateExpr {
+  #val = 0;
+  method() {
+    return ++this.#val;
+  }
+}
+
+// issue #6933
+class UsedPostUpdateExpr {
+  #val = 0;
+  method() {
+    return this.#val++;
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
 expression: valid.js
-snapshot_kind: text
 ---
 # Input
 ```js
@@ -185,6 +184,28 @@ class C {
 	foo() {
 			this.#x = 1;
 	}
+}
+
+class UsedAssignmentExpr {
+  #val = 0;
+  method() {
+    return this.#val = 1
+  }
+}
+
+class UsedPreUpdateExpr {
+  #val = 0;
+  method() {
+    return ++this.#val;
+  }
+}
+
+
+class UsedPostUpdateExpr {
+  #val = 0;
+  method() {
+    return this.#val++;
+  }
 }
 
 ```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

This PR fixes #6933 and #6994.

When the values of private member assignment expressions, increment expressions, etc. are used, those private members are no longer marked as unused.

## Test Plan

<!-- What demonstrates that your implementation is correct? -->

Additional test cases have been added.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
