### PR TITLE
fix(core): return type inference no longer picks up nested returns

### DIFF
--- a/.changeset/returned-raisins-reciprocate.md
+++ b/.changeset/returned-raisins-reciprocate.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6985](https://github.com/biomejs/biome/issues/6985): Inference of return types no longer mistakenly picks up return types of nested functions.

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue6985Valid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue6985Valid.ts
@@ -1,0 +1,10 @@
+/* should not generate diagnostics */
+
+function doSth() {
+    const innerFn = () => {
+        return Promise.resolve(1);
+    }
+    return 'hah'
+}
+
+doSth()

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue6985Valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/issue6985Valid.ts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6985Valid.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+function doSth() {
+    const innerFn = () => {
+        return Promise.resolve(1);
+    }
+    return 'hah'
+}
+
+doSth()
+
+```

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -5,9 +5,9 @@ use biome_js_syntax::{
     AnyJsArrayBindingPatternElement, AnyJsArrayElement, AnyJsArrowFunctionParameters,
     AnyJsBindingPattern, AnyJsCallArgument, AnyJsClass, AnyJsClassMember, AnyJsDeclaration,
     AnyJsDeclarationClause, AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsFormalParameter,
-    AnyJsFunctionBody, AnyJsLiteralExpression, AnyJsName, AnyJsObjectBindingPatternMember,
-    AnyJsObjectMember, AnyJsObjectMemberName, AnyJsParameter, AnyTsModuleName, AnyTsName,
-    AnyTsReturnType, AnyTsTupleTypeElement, AnyTsType, AnyTsTypeMember,
+    AnyJsFunction, AnyJsFunctionBody, AnyJsLiteralExpression, AnyJsName,
+    AnyJsObjectBindingPatternMember, AnyJsObjectMember, AnyJsObjectMemberName, AnyJsParameter,
+    AnyTsModuleName, AnyTsName, AnyTsReturnType, AnyTsTupleTypeElement, AnyTsType, AnyTsTypeMember,
     AnyTsTypePredicateParameterName, ClassMemberName, JsArrayBindingPattern,
     JsArrowFunctionExpression, JsBinaryExpression, JsBinaryOperator, JsCallArguments,
     JsClassDeclaration, JsClassExportDefaultDeclaration, JsClassExpression, JsForInStatement,
@@ -2548,7 +2548,7 @@ fn type_from_function_body(
 ) -> TypeData {
     let mut return_types: Vec<_> = body
         .syntax()
-        .descendants()
+        .pruned_descendents(|node| !AnyJsFunction::can_cast(node.kind()))
         .filter_map(JsReturnStatement::cast)
         .map(|return_statement| {
             return_statement.argument().map_or(

--- a/crates/biome_js_type_info/src/local_inference.rs
+++ b/crates/biome_js_type_info/src/local_inference.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use biome_js_syntax::{
     AnyJsArrayBindingPatternElement, AnyJsArrayElement, AnyJsArrowFunctionParameters,
-    AnyJsBindingPattern, AnyJsCallArgument, AnyJsClass, AnyJsClassMember, AnyJsDeclaration,
+    AnyJsBindingPattern, AnyJsCallArgument, AnyJsClassMember, AnyJsDeclaration,
     AnyJsDeclarationClause, AnyJsExportDefaultDeclaration, AnyJsExpression, AnyJsFormalParameter,
     AnyJsFunction, AnyJsFunctionBody, AnyJsLiteralExpression, AnyJsName,
     AnyJsObjectBindingPatternMember, AnyJsObjectMember, AnyJsObjectMemberName, AnyJsParameter,
@@ -12,14 +12,15 @@ use biome_js_syntax::{
     JsArrowFunctionExpression, JsBinaryExpression, JsBinaryOperator, JsCallArguments,
     JsClassDeclaration, JsClassExportDefaultDeclaration, JsClassExpression, JsForInStatement,
     JsForOfStatement, JsForVariableDeclaration, JsFormalParameter, JsFunctionBody,
-    JsFunctionDeclaration, JsFunctionExpression, JsGetterObjectMember, JsLogicalExpression,
-    JsLogicalOperator, JsMethodObjectMember, JsNewExpression, JsObjectBindingPattern,
-    JsObjectExpression, JsParameters, JsReferenceIdentifier, JsReturnStatement,
-    JsSetterObjectMember, JsSyntaxNode, JsSyntaxToken, JsUnaryExpression, JsUnaryOperator,
-    JsVariableDeclaration, JsVariableDeclarator, TsDeclareFunctionDeclaration,
-    TsExternalModuleDeclaration, TsInterfaceDeclaration, TsModuleDeclaration, TsReferenceType,
-    TsReturnTypeAnnotation, TsTypeAliasDeclaration, TsTypeAnnotation, TsTypeArguments, TsTypeList,
-    TsTypeParameter, TsTypeParameters, TsTypeofType, inner_string_text, unescape_js_string,
+    JsFunctionDeclaration, JsFunctionExpression, JsGetterObjectMember, JsInitializerClause,
+    JsLogicalExpression, JsLogicalOperator, JsMethodObjectMember, JsNewExpression,
+    JsObjectBindingPattern, JsObjectExpression, JsParameters, JsPropertyClassMember,
+    JsPropertyObjectMember, JsReferenceIdentifier, JsReturnStatement, JsSetterObjectMember,
+    JsSyntaxNode, JsSyntaxToken, JsUnaryExpression, JsUnaryOperator, JsVariableDeclaration,
+    JsVariableDeclarator, TsDeclareFunctionDeclaration, TsExternalModuleDeclaration,
+    TsInterfaceDeclaration, TsModuleDeclaration, TsReferenceType, TsReturnTypeAnnotation,
+    TsTypeAliasDeclaration, TsTypeAnnotation, TsTypeArguments, TsTypeList, TsTypeParameter,
+    TsTypeParameters, TsTypeofType, inner_string_text, unescape_js_string,
 };
 use biome_rowan::{AstNode, SyntaxResult, Text, TokenText};
 
@@ -2292,16 +2293,16 @@ fn is_direct_class_or_object_member(node: &JsSyntaxNode) -> bool {
                 ) {
                     None
                 } else {
-                    Some(matches!(
-                        node,
-                        AnyJsExpression::JsObjectExpression(_)
-                            | AnyJsExpression::JsClassExpression(_)
-                    ))
+                    Some(false)
                 }
-            } else if AnyJsClass::can_cast(node.kind()) {
-                Some(true)
             } else {
-                None
+                Some(
+                    JsInitializerClause::can_cast(node.kind())
+                        && node
+                            .parent()
+                            .is_some_and(|parent| JsPropertyClassMember::can_cast(parent.kind()))
+                        || JsPropertyObjectMember::can_cast(node.kind()),
+                )
             }
         })
         .unwrap_or_default()

--- a/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_this_in_class_wrong_scope.snap
+++ b/crates/biome_module_graph/tests/snapshots/test_resolve_type_of_this_in_class_wrong_scope.snap
@@ -71,109 +71,111 @@ Imports {
 ## Registered types
 
 ```
-Module TypeId(0) => instanceof Module(0) TypeId(37)
+Module TypeId(0) => value: foo
 
-Module TypeId(1) => Module(0) TypeId(4)
+Module TypeId(1) => unknown
 
 Module TypeId(2) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(1)
+  returns: Module(0) TypeId(20)
 }
 
-Module TypeId(3) => Module(0) TypeId(2)
+Module TypeId(3) => Module(0) TypeId(30)
 
-Module TypeId(4) => value: foo
-
-Module TypeId(5) => unknown
-
-Module TypeId(6) => Module(0) TypeId(38)
-
-Module TypeId(7) => Object {
+Module TypeId(4) => Object {
   prototype: No prototype
-  members: ["fn": Module(0) TypeId(8)]
+  members: ["fn": Module(0) TypeId(5)]
 }
 
-Module TypeId(8) => sync Function {
+Module TypeId(5) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(11)
+  returns: Module(0) TypeId(22)
 }
 
-Module TypeId(9) => Module(0) TypeId(7)
+Module TypeId(6) => Module(0) TypeId(4)
+
+Module TypeId(7) => Module(0) TypeId(5)
+
+Module TypeId(8) => Object {
+  prototype: No prototype
+  members: ["fn": Module(0) TypeId(9)]
+}
+
+Module TypeId(9) => sync Function "fn" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(12)
+}
 
 Module TypeId(10) => Module(0) TypeId(8)
 
-Module TypeId(11) => Module(0) TypeId(7).x
+Module TypeId(11) => Module(0) TypeId(9)
 
-Module TypeId(12) => Object {
-  prototype: No prototype
-  members: ["fn": Module(0) TypeId(13)]
-}
+Module TypeId(12) => Module(0) TypeId(8).x
 
-Module TypeId(13) => sync Function "fn" {
+Module TypeId(13) => Module(0) TypeId(2)
+
+Module TypeId(14) => sync Function {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(16)
+  returns: Module(0) TypeId(20)
 }
 
-Module TypeId(14) => Module(0) TypeId(12)
+Module TypeId(15) => Module(0) TypeId(29)
 
-Module TypeId(15) => Module(0) TypeId(13)
+Module TypeId(16) => instanceof Module(0) TypeId(15)
 
-Module TypeId(16) => Module(0) TypeId(12).x
+Module TypeId(17) => Module(0) TypeId(25)
 
-Module TypeId(17) => sync Function {
+Module TypeId(18) => Module(0) TypeId(26)
+
+Module TypeId(19) => Module(0) TypeId(14)
+
+Module TypeId(20) => Module(0) TypeId(1).x
+
+Module TypeId(21) => Module(0) TypeId(27)
+
+Module TypeId(22) => Module(0) TypeId(4).x
+
+Module TypeId(23) => Module(0) TypeId(28)
+
+Module TypeId(24) => Module(0) TypeId(12) | Module(0) TypeId(12)
+
+Module TypeId(25) => sync Function "nested" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(19)
+  returns: Module(0) TypeId(20)
 }
 
-Module TypeId(18) => Module(0) TypeId(17)
-
-Module TypeId(19) => Module(0) TypeId(5).x
-
-Module TypeId(20) => sync Function {
+Module TypeId(26) => sync Function "nested2" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(28)
+  returns: Module(0) TypeId(20)
 }
 
-Module TypeId(21) => Module(0) TypeId(37)
+Module TypeId(27) => sync Function "nestedObject" {
+  accepts: {
+    params: []
+    type_args: []
+  }
+  returns: Module(0) TypeId(22)
+}
 
-Module TypeId(22) => instanceof Module(0) TypeId(21)
-
-Module TypeId(23) => Module(0) TypeId(33)
-
-Module TypeId(24) => Module(0) TypeId(1) | Module(0) TypeId(4)
-
-Module TypeId(25) => Module(0) TypeId(34)
-
-Module TypeId(26) => Module(0) TypeId(19) | Module(0) TypeId(19)
-
-Module TypeId(27) => Module(0) TypeId(20)
-
-Module TypeId(28) => Module(0) TypeId(19) | Module(0) TypeId(19)
-
-Module TypeId(29) => Module(0) TypeId(35)
-
-Module TypeId(30) => Module(0) TypeId(11) | Module(0) TypeId(11)
-
-Module TypeId(31) => Module(0) TypeId(36)
-
-Module TypeId(32) => Module(0) TypeId(16) | Module(0) TypeId(16)
-
-Module TypeId(33) => sync Function "nested" {
+Module TypeId(28) => sync Function "nestedObject2" {
   accepts: {
     params: []
     type_args: []
@@ -181,41 +183,17 @@ Module TypeId(33) => sync Function "nested" {
   returns: Module(0) TypeId(24)
 }
 
-Module TypeId(34) => sync Function "nested2" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(26)
-}
-
-Module TypeId(35) => sync Function "nestedObject" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(30)
-}
-
-Module TypeId(36) => sync Function "nestedObject2" {
-  accepts: {
-    params: []
-    type_args: []
-  }
-  returns: Module(0) TypeId(32)
-}
-
-Module TypeId(37) => class "Foo" {
+Module TypeId(29) => class "Foo" {
   extends: none
   implements: []
   type_args: []
 }
 
-Module TypeId(38) => sync Function "fn" {
+Module TypeId(30) => sync Function "fn" {
   accepts: {
     params: []
     type_args: []
   }
-  returns: Module(0) TypeId(19)
+  returns: Module(0) TypeId(20)
 }
 ```


### PR DESCRIPTION
## Summary

Fixed [#6985](https://github.com/biomejs/biome/issues/6985): Inference of return types no longer mistakenly picks up return types of nested functions.

For all Biome devs: This PR introduces a nice utility that makes it easier to prune subtrees during node traversal: look for the `pruned_descendents()` method.

## Test Plan

Test added.

## Docs

N/A