### PR TITLE
feat(core): add support for  `.graphqls` files

### DIFF
--- a/.changeset/legal-mugs-care.md
+++ b/.changeset/legal-mugs-care.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added support for `.graphqls` files. Biome can now format and lint GraphQL files that have the extension `.graphqls`

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -159,6 +159,31 @@ const APPLY_BRACKET_SAME_LINE_AFTER: &str = r#"<Foo
 </Foo>;
 "#;
 
+const SPACING_GRAPHQLS_SANITY_BEFORE: &str = r#"  scalar Time
+  scalar UUID
+
+
+ type   User   {
+  id:  UUID!
+   name: String!
+    updatedAt: Time!
+ }
+
+
+
+
+"#;
+
+const SPACING_GRAPHQLS_SANITY_BEFORE: &str = r#"scalar Time
+scalar UUID
+
+type User {
+    id: UUID!
+    name: String!
+    updatedAt: Time!
+}
+"#;
+
 const APPLY_ATTRIBUTE_POSITION_BEFORE: &str = r#"<Foo className={style}	reallyLongAttributeName1={longComplexValue}
 reallyLongAttributeName2={anotherLongValue} />;
 
@@ -3363,6 +3388,44 @@ fn should_error_if_unchanged_files_only_with_changed_flag() {
         result,
     ));
 }
+
+#[test]
+fn spacing_graphql_sanity() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let file_path = Utf8Path::new("file.graphqls");
+    fs.insert(
+        file_path.into(),
+        SPACING_GRAPHQLS_SANITY_BEFORE.as_bytes(),
+    );
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(
+            [
+                "format",
+                "--write",
+                file_path.as_str(),
+            ]
+            .as_slice(),
+        ),
+    );
+
+    assert!(result.is_ok(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, file_path, SPACING_GRAPHQLS_SANITY_AFTER);
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "spacing_graphql_sanity",
+        fs,
+        console,
+        result,
+    ));
+}
+
 
 #[test]
 fn applies_custom_bracket_spacing_for_graphql() {

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -3547,29 +3547,3 @@ fn format_skip_parse_errors_continues_with_valid_files() {
         result,
     ));
 }
-
-#[test]
-fn should_not_format_file_with_syntax_errors() {
-    let fs = MemoryFileSystem::default();
-    let mut console = BufferConsole::default();
-
-    let invalid = Utf8Path::new("invalid.js");
-    fs.insert(invalid.into(), "while ) {}".as_bytes());
-
-    let (fs, result) = run_cli(
-        fs,
-        &mut console,
-        Args::from(["format", "--write", invalid.as_str()].as_slice()),
-    );
-
-    assert!(result.is_err(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, invalid, "while ) {}");
-    assert_cli_snapshot(SnapshotPayload::new(
-        module_path!(),
-        "should_not_format_file_with_syntax_errors",
-        fs,
-        console,
-        result,
-    ));
-}

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -174,16 +174,6 @@ const SPACING_GRAPHQLS_SANITY_BEFORE: &str = r#"  scalar Time
 
 "#;
 
-const SPACING_GRAPHQLS_SANITY_AFTER: &str = r#"scalar Time
-scalar UUID
-
-type User {
-    id: UUID!
-    name: String!
-    updatedAt: Time!
-}
-"#;
-
 const APPLY_ATTRIBUTE_POSITION_BEFORE: &str = r#"<Foo className={style}	reallyLongAttributeName1={longComplexValue}
 reallyLongAttributeName2={anotherLongValue} />;
 
@@ -3390,42 +3380,29 @@ fn should_error_if_unchanged_files_only_with_changed_flag() {
 }
 
 #[test]
-fn spacing_graphql_sanity() {
+fn can_format_graphphs_files() {
     let fs = MemoryFileSystem::default();
     let mut console = BufferConsole::default();
 
     let file_path = Utf8Path::new("file.graphqls");
-    fs.insert(
-        file_path.into(),
-        SPACING_GRAPHQLS_SANITY_BEFORE.as_bytes(),
-    );
+    fs.insert(file_path.into(), SPACING_GRAPHQLS_SANITY_BEFORE.as_bytes());
 
     let (fs, result) = run_cli(
         fs,
         &mut console,
-        Args::from(
-            [
-                "format",
-                "--write",
-                file_path.as_str(),
-            ]
-            .as_slice(),
-        ),
+        Args::from(["format", "--write", file_path.as_str()].as_slice()),
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
-    assert_file_contents(&fs, file_path, SPACING_GRAPHQLS_SANITY_AFTER);
-
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
-        "spacing_graphql_sanity",
+        "can_format_graphphs_files",
         fs,
         console,
         result,
     ));
 }
-
 
 #[test]
 fn applies_custom_bracket_spacing_for_graphql() {
@@ -3565,6 +3542,32 @@ fn format_skip_parse_errors_continues_with_valid_files() {
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_skip_parse_errors_continues_with_valid_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
+fn should_not_format_file_with_syntax_errors() {
+    let fs = MemoryFileSystem::default();
+    let mut console = BufferConsole::default();
+
+    let invalid = Utf8Path::new("invalid.js");
+    fs.insert(invalid.into(), "while ) {}".as_bytes());
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["format", "--write", invalid.as_str()].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_file_contents(&fs, invalid, "while ) {}");
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_not_format_file_with_syntax_errors",
         fs,
         console,
         result,

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -174,7 +174,7 @@ const SPACING_GRAPHQLS_SANITY_BEFORE: &str = r#"  scalar Time
 
 "#;
 
-const SPACING_GRAPHQLS_SANITY_BEFORE: &str = r#"scalar Time
+const SPACING_GRAPHQLS_SANITY_AFTER: &str = r#"scalar Time
 scalar UUID
 
 type User {

--- a/crates/biome_cli/tests/snapshots/main_commands_format/can_format_graphphs_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/can_format_graphphs_files.snap
@@ -1,0 +1,23 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `file.graphqls`
+
+```graphqls
+scalar Time
+scalar UUID
+
+type User {
+	id: UUID!
+	name: String!
+	updatedAt: Time!
+}
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_graphql_syntax/src/file_source.rs
+++ b/crates/biome_graphql_syntax/src/file_source.rs
@@ -39,7 +39,7 @@ impl GraphqlFileSource {
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         // We assume the file extension is normalized to lowercase
         match extension {
-            "graphql" | "gql" => Ok(Self::default()),
+            "graphqls" | "graphql" | "gql" => Ok(Self::default()),
             _ => Err(FileSourceError::UnknownExtension),
         }
     }
@@ -52,7 +52,7 @@ impl GraphqlFileSource {
     /// [VS Code spec]: https://code.visualstudio.com/docs/languages/identifiers
     pub fn try_from_language_id(language_id: &str) -> Result<Self, FileSourceError> {
         match language_id {
-            "graphql" | "gql" => Ok(Self::default()),
+            "graphqls" | "graphql" | "gql" => Ok(Self::default()),
             _ => Err(FileSourceError::UnknownLanguageId),
         }
     }

--- a/crates/biome_graphql_syntax/src/file_source.rs
+++ b/crates/biome_graphql_syntax/src/file_source.rs
@@ -36,6 +36,9 @@ impl GraphqlFileSource {
     }
 
     /// Try to return the GraphQL file source corresponding to this file extension
+    /// See the difference between .graphql and .graphqls files here:
+    /// https://www.apollographql.com/docs/kotlin/essentials/file-types#sdl-schemas-graphqls
+    /// https://graphql.com/learn/schema/#inspecting-the-schema
     pub fn try_from_extension(extension: &str) -> Result<Self, FileSourceError> {
         // We assume the file extension is normalized to lowercase
         match extension {


### PR DESCRIPTION
## Summary
We use `.graphqls` files for GraphQL definition files that contain only types ([SDL](https://www.apollographql.com/docs/kotlin/essentials/file-types#sdl-schemas-graphqls)), like this:
```graphql
scalar Time
scalar UUID

type Tenant {
  id: UUID!
  name: String!
  isActive: Boolean!
  createdAt: Time!
  updatedAt: Time!
}

type DashboardUser {
  name: String!
  givenName: String
  familyName: String
  email: String!
  createdAt: Time
}

type Query {
  tenants: [Tenant!]!
  dashboardUsers(tenantId: UUID): [DashboardUser!]!
}
```

We want `biome` to format those, and as we seen that [you already have tests](https://github.com/biomejs/biome/blob/main/crates/biome_graphql_formatter/tests/specs/graphql/definitions/object.graphql) that parse this format, the format we use in `.graphqls` types, we thought that it will be easy and correct to just detect `.graphqls` files as matching the already existing GraphQL syntax.

## Test Plan
The `.graphqls` (SDL) syntax is as the one you currently parse as `.graphql`, so I just added a sanity test that verifies the current behavior, with the `.graphqls` file extension.

## Docs
I didn't find any documentation about what file extensions are matched to what syntax, so assuming they don't exist, I don't see a reason for any documentation change.
Added a reference in a comment to describe the file different file extensions.