### PR TITLE
fix(core): resolve aliased imports

### DIFF
--- a/.changeset/aliased-antilopes-acknowledge.md
+++ b/.changeset/aliased-antilopes-acknowledge.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7111](https://github.com/biomejs/biome/issues/7111): Imported symbols using aliases are now correctly recognised.

--- a/crates/biome_js_analyze/tests/quick_test.rs
+++ b/crates/biome_js_analyze/tests/quick_test.rs
@@ -26,22 +26,20 @@ fn project_layout_with_top_level_dependencies(dependencies: Dependencies) -> Arc
 #[test]
 fn quick_test() {
     const FILENAME: &str = "dummyFile.ts";
-    const SOURCE: &str = r#"function head<T>(items: T[]) {
-  if (items) {  // This check is unnecessary
-    return items[0].toUpperCase();
-  }
-}"#;
+    const SOURCE: &str = r#"import { sleep as alias } from "./sleep.ts";
+alias(100);"#;
 
     let parsed = parse(SOURCE, JsFileSource::tsx(), JsParserOptions::default());
 
     let mut fs = TemporaryFs::new("quick_test");
+    fs.create_file("sleep.ts", "export const sleep = async (ms = 1000): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));");
     fs.create_file(FILENAME, SOURCE);
 
     let file_path = Utf8PathBuf::from(format!("{}/{FILENAME}", fs.cli_path()));
 
     let mut error_ranges: Vec<TextRange> = Vec::new();
     let options = AnalyzerOptions::default().with_file_path(file_path.clone());
-    let rule_filter = RuleFilter::Rule("nursery", "noUnnecessaryConditions");
+    let rule_filter = RuleFilter::Rule("nursery", "noFloatingPromises");
 
     let dependencies = Dependencies(Box::new([("buffer".into(), "latest".into())]));
 

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts
@@ -1,4 +1,5 @@
 import { returnPromiseResult } from "./returnPromiseResult.ts";
+import { returnPromiseResult as returnAliasedPromiseResult } from "./returnPromiseResult.ts";
 
 async function returnsPromise(): Promise<string> {
 	return "value";
@@ -335,6 +336,7 @@ async function testDestructuringAndCallingReturnsPromiseFromRest({
 import("some-module").then(() => {});
 
 returnPromiseResult();
+returnAliasedPromiseResult();
 
 function returnMaybePromise(): Promise<void> | undefined {
 	if (!false) {

--- a/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noFloatingPromises/invalid.ts.snap
@@ -5,6 +5,7 @@ expression: invalid.ts
 # Input
 ```ts
 import { returnPromiseResult } from "./returnPromiseResult.ts";
+import { returnPromiseResult as returnAliasedPromiseResult } from "./returnPromiseResult.ts";
 
 async function returnsPromise(): Promise<string> {
 	return "value";
@@ -341,6 +342,7 @@ async function testDestructuringAndCallingReturnsPromiseFromRest({
 import("some-module").then(() => {});
 
 returnPromiseResult();
+returnAliasedPromiseResult();
 
 function returnMaybePromise(): Promise<void> | undefined {
 	if (!false) {
@@ -356,36 +358,16 @@ returnMaybePromise();
 
 # Diagnostics
 ```
-invalid.ts:6:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    4 │ 	return "value";
-    5 │ }
-  > 6 │ returnsPromise();
-      │ ^^^^^^^^^^^^^^^^^
-    7 │ returnsPromise()
-    8 │ 	.then(() => {})
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
 invalid.ts:7:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-     5 │ }
-     6 │ returnsPromise();
-   > 7 │ returnsPromise()
-       │ ^^^^^^^^^^^^^^^^
-   > 8 │ 	.then(() => {})
-   > 9 │ 	.finally(() => {});
-       │ 	^^^^^^^^^^^^^^^^^^^
-    10 │ 
-    11 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
+    5 │ 	return "value";
+    6 │ }
+  > 7 │ returnsPromise();
+      │ ^^^^^^^^^^^^^^^^^
+    8 │ returnsPromise()
+    9 │ 	.then(() => {})
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -393,80 +375,100 @@ invalid.ts:7:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━
 ```
 
 ```
-invalid.ts:12:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:8:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    11 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
-  > 12 │ 	returnsPromise();
+     6 │ }
+     7 │ returnsPromise();
+   > 8 │ returnsPromise()
+       │ ^^^^^^^^^^^^^^^^
+   > 9 │ 	.then(() => {})
+  > 10 │ 	.finally(() => {});
+       │ 	^^^^^^^^^^^^^^^^^^^
+    11 │ 
+    12 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:13:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    12 │ async function returnsPromiseInAsyncFunction(): Promise<void> {
+  > 13 │ 	returnsPromise();
        │ 	^^^^^^^^^^^^^^^^^
-    13 │ }
-    14 │ 
+    14 │ }
+    15 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    12 │ → await·returnsPromise();
+    13 │ → await·returnsPromise();
        │   ++++++                 
 
 ```
 
 ```
-invalid.ts:16:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:17:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    15 │ const returnsPromiseInAsyncArrowFunction = async (): Promise<void> => {
-  > 16 │ 	returnsPromise()
+    16 │ const returnsPromiseInAsyncArrowFunction = async (): Promise<void> => {
+  > 17 │ 	returnsPromise()
        │ 	^^^^^^^^^^^^^^^^
-  > 17 │ 		.then(() => {})
-  > 18 │ 		.finally(() => {});
+  > 18 │ 		.then(() => {})
+  > 19 │ 		.finally(() => {});
        │ 		^^^^^^^^^^^^^^^^^^^
-    19 │ };
-    20 │ 
+    20 │ };
+    21 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    16 │ → await·returnsPromise()
+    17 │ → await·returnsPromise()
        │   ++++++                
 
 ```
 
 ```
-invalid.ts:23:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:24:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    21 │ class Test {
-    22 │ 	async returnsPromiseInAsyncClassMethod(): Promise<void> {
-  > 23 │ 		returnsPromise();
+    22 │ class Test {
+    23 │ 	async returnsPromiseInAsyncClassMethod(): Promise<void> {
+  > 24 │ 		returnsPromise();
        │ 		^^^^^^^^^^^^^^^^^
-    24 │ 	}
-    25 │ }
+    25 │ 	}
+    26 │ }
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    23 │ → → await·returnsPromise();
+    24 │ → → await·returnsPromise();
        │     ++++++                 
 
 ```
 
 ```
-invalid.ts:31:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:32:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    29 │ }
-    30 │ 
-  > 31 │ returnsPromiseWithoutAsync();
+    30 │ }
+    31 │ 
+  > 32 │ returnsPromiseWithoutAsync();
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    32 │ 
-    33 │ const returnsPromiseAssignedArrowFunction = async (): Promise<string> => {
+    33 │ 
+    34 │ const returnsPromiseAssignedArrowFunction = async (): Promise<string> => {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -474,16 +476,16 @@ invalid.ts:31:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:37:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:38:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    35 │ };
-    36 │ 
-  > 37 │ returnsPromiseAssignedArrowFunction();
+    36 │ };
+    37 │ 
+  > 38 │ returnsPromiseAssignedArrowFunction();
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    38 │ 
-    39 │ const returnsPromiseAssignedFunction = async function (): Promise<string> {
+    39 │ 
+    40 │ const returnsPromiseAssignedFunction = async function (): Promise<string> {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -491,36 +493,36 @@ invalid.ts:37:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:44:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:45:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    43 │ async function returnsPromiseAssignedFunctionInAsyncFunction(): Promise<void> {
-  > 44 │ 	returnsPromiseAssignedFunction().then(() => {});
+    44 │ async function returnsPromiseAssignedFunctionInAsyncFunction(): Promise<void> {
+  > 45 │ 	returnsPromiseAssignedFunction().then(() => {});
        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    45 │ }
-    46 │ 
+    46 │ }
+    47 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    44 │ → await·returnsPromiseAssignedFunction().then(()·=>·{});
+    45 │ → await·returnsPromiseAssignedFunction().then(()·=>·{});
        │   ++++++                                                
 
 ```
 
 ```
-invalid.ts:52:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:53:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    50 │ 	};
-    51 │ 
-  > 52 │ returnsPromiseAssignedArrowFunctionAnnotatedType();
+    51 │ 	};
+    52 │ 
+  > 53 │ returnsPromiseAssignedArrowFunctionAnnotatedType();
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    53 │ 
-    54 │ const promise = new Promise((resolve) => resolve("value"));
+    54 │ 
+    55 │ const promise = new Promise((resolve) => resolve("value"));
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -528,32 +530,15 @@ invalid.ts:52:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:55:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:56:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    54 │ const promise = new Promise((resolve) => resolve("value"));
-  > 55 │ promise.then(() => {}).finally(() => {});
+    55 │ const promise = new Promise((resolve) => resolve("value"));
+  > 56 │ promise.then(() => {}).finally(() => {});
        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    56 │ 
-    57 │ Promise.resolve("value").then(() => {});
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
-invalid.ts:57:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    55 │ promise.then(() => {}).finally(() => {});
-    56 │ 
-  > 57 │ Promise.resolve("value").then(() => {});
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    58 │ Promise.all([p1, p2, p3]);
-    59 │ 
+    57 │ 
+    58 │ Promise.resolve("value").then(() => {});
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -565,11 +550,12 @@ invalid.ts:58:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    57 │ Promise.resolve("value").then(() => {});
-  > 58 │ Promise.all([p1, p2, p3]);
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-    59 │ 
-    60 │ const promiseWithParentheses = new Promise((resolve, reject) =>
+    56 │ promise.then(() => {}).finally(() => {});
+    57 │ 
+  > 58 │ Promise.resolve("value").then(() => {});
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    59 │ Promise.all([p1, p2, p3]);
+    60 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -577,16 +563,15 @@ invalid.ts:58:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:63:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:59:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    61 │ 	resolve("value")
-    62 │ );
-  > 63 │ promiseWithParentheses;
-       │ ^^^^^^^^^^^^^^^^^^^^^^^
-    64 │ returnsPromise();
-    65 │ 
+    58 │ Promise.resolve("value").then(() => {});
+  > 59 │ Promise.all([p1, p2, p3]);
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    60 │ 
+    61 │ const promiseWithParentheses = new Promise((resolve, reject) =>
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -598,12 +583,12 @@ invalid.ts:64:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    62 │ );
-    63 │ promiseWithParentheses;
-  > 64 │ returnsPromise();
-       │ ^^^^^^^^^^^^^^^^^
-    65 │ 
-    66 │ const promiseWithGlobalIdentifier = new window.Promise((resolve, reject) =>
+    62 │ 	resolve("value")
+    63 │ );
+  > 64 │ promiseWithParentheses;
+       │ ^^^^^^^^^^^^^^^^^^^^^^^
+    65 │ returnsPromise();
+    66 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -611,16 +596,16 @@ invalid.ts:64:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:69:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:65:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    67 │ 	resolve("value")
-    68 │ );
-  > 69 │ promiseWithGlobalIdentifier.then(() => {}).finally(() => {});
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    70 │ globalThis.Promise.reject("value").finally();
-    71 │ 
+    63 │ );
+    64 │ promiseWithParentheses;
+  > 65 │ returnsPromise();
+       │ ^^^^^^^^^^^^^^^^^
+    66 │ 
+    67 │ const promiseWithGlobalIdentifier = new window.Promise((resolve, reject) =>
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -632,12 +617,12 @@ invalid.ts:70:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    68 │ );
-    69 │ promiseWithGlobalIdentifier.then(() => {}).finally(() => {});
-  > 70 │ globalThis.Promise.reject("value").finally();
-       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    71 │ 
-    72 │ class InvalidTestClassParent {
+    68 │ 	resolve("value")
+    69 │ );
+  > 70 │ promiseWithGlobalIdentifier.then(() => {}).finally(() => {});
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    71 │ globalThis.Promise.reject("value").finally();
+    72 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -645,188 +630,188 @@ invalid.ts:70:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:90:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:71:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    88 │ 	}
-    89 │ 	async someMethod() {
-  > 90 │ 		this.returnsPromiseMethod();
+    69 │ );
+    70 │ promiseWithGlobalIdentifier.then(() => {}).finally(() => {});
+  > 71 │ globalThis.Promise.reject("value").finally();
+       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    72 │ 
+    73 │ class InvalidTestClassParent {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:91:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    89 │ 	}
+    90 │ 	async someMethod() {
+  > 91 │ 		this.returnsPromiseMethod();
        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    91 │ 	}
-    92 │ 
+    92 │ 	}
+    93 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    90 │ → → await·this.returnsPromiseMethod();
+    91 │ → → await·this.returnsPromiseMethod();
        │     ++++++                            
 
 ```
 
 ```
-invalid.ts:94:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:95:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    93 │ 	async someMethod2() {
-  > 94 │ 		this.returnsPromiseFromParent()
+    94 │ 	async someMethod2() {
+  > 95 │ 		this.returnsPromiseFromParent()
        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 95 │ 			.then(() => {})
-  > 96 │ 			.finally(() => {});
+  > 96 │ 			.then(() => {})
+  > 97 │ 			.finally(() => {});
        │ 			^^^^^^^^^^^^^^^^^^^
-    97 │ 	}
-    98 │ 
+    98 │ 	}
+    99 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    94 │ → → await·this.returnsPromiseFromParent()
+    95 │ → → await·this.returnsPromiseFromParent()
        │     ++++++                               
 
 ```
 
 ```
-invalid.ts:100:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:101:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-     99 │ 	async someMethod3() {
-  > 100 │ 		this.returnsPromiseFunctionProperty();
+    100 │ 	async someMethod3() {
+  > 101 │ 		this.returnsPromiseFunctionProperty();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    101 │ 	}
-    102 │ 
+    102 │ 	}
+    103 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    100 │ → → await·this.returnsPromiseFunctionProperty();
+    101 │ → → await·this.returnsPromiseFunctionProperty();
         │     ++++++                                      
 
 ```
 
 ```
-invalid.ts:104:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:105:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    103 │ 	async someMethod4() {
-  > 104 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
+    104 │ 	async someMethod4() {
+  > 105 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    105 │ 	}
-    106 │ 
+    106 │ 	}
+    107 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    104 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
+    105 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
         │     ++++++                                                             
 
 ```
 
 ```
-invalid.ts:111:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:112:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    109 │ 	}
-    110 │ 	async someMethod5() {
-  > 111 │ 		this.#returnsPromisePrivateMethod()
+    110 │ 	}
+    111 │ 	async someMethod5() {
+  > 112 │ 		this.#returnsPromisePrivateMethod()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 112 │ 			.then(() => {})
-  > 113 │ 			.finally(() => {});
+  > 113 │ 			.then(() => {})
+  > 114 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    114 │ 	}
-    115 │ 
+    115 │ 	}
+    116 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    111 │ → → await·this.#returnsPromisePrivateMethod()
+    112 │ → → await·this.#returnsPromisePrivateMethod()
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:124:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:125:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    123 │ 	async someMetho3() {
-  > 124 │ 		this.returnsPromiseFunction()
+    124 │ 	async someMetho3() {
+  > 125 │ 		this.returnsPromiseFunction()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 125 │ 			.then(() => {})
-  > 126 │ 			.finally(() => {});
+  > 126 │ 			.then(() => {})
+  > 127 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    127 │ 		this.returnsPromiseArrowFunction();
-    128 │ 	}
+    128 │ 		this.returnsPromiseArrowFunction();
+    129 │ 	}
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    124 │ → → await·this.returnsPromiseFunction()
+    125 │ → → await·this.returnsPromiseFunction()
         │     ++++++                             
 
 ```
 
 ```
-invalid.ts:127:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:128:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    125 │ 			.then(() => {})
-    126 │ 			.finally(() => {});
-  > 127 │ 		this.returnsPromiseArrowFunction();
+    126 │ 			.then(() => {})
+    127 │ 			.finally(() => {});
+  > 128 │ 		this.returnsPromiseArrowFunction();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    128 │ 	}
-    129 │ }
+    129 │ 	}
+    130 │ }
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    127 │ → → await·this.returnsPromiseArrowFunction();
+    128 │ → → await·this.returnsPromiseArrowFunction();
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:132:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:133:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    131 │ const invalidTestClass = new InvalidTestClass();
-  > 132 │ invalidTestClass
+    132 │ const invalidTestClass = new InvalidTestClass();
+  > 133 │ invalidTestClass
         │ ^^^^^^^^^^^^^^^^
-  > 133 │ 	.returnsPromiseMethod()
-  > 134 │ 	.then(() => {})
-  > 135 │ 	.finally(() => {});
+  > 134 │ 	.returnsPromiseMethod()
+  > 135 │ 	.then(() => {})
+  > 136 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    136 │ invalidTestClass.returnsPromiseFunctionProperty();
-    137 │ invalidTestClass.returnsPromiseProperty;
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
-invalid.ts:136:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    134 │ 	.then(() => {})
-    135 │ 	.finally(() => {});
-  > 136 │ invalidTestClass.returnsPromiseFunctionProperty();
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    137 │ invalidTestClass.returnsPromiseProperty;
-    138 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
+    137 │ invalidTestClass.returnsPromiseFunctionProperty();
+    138 │ invalidTestClass.returnsPromiseProperty;
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -838,12 +823,12 @@ invalid.ts:137:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    135 │ 	.finally(() => {});
-    136 │ invalidTestClass.returnsPromiseFunctionProperty();
-  > 137 │ invalidTestClass.returnsPromiseProperty;
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    138 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
-    139 │ 
+    135 │ 	.then(() => {})
+    136 │ 	.finally(() => {});
+  > 137 │ invalidTestClass.returnsPromiseFunctionProperty();
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    138 │ invalidTestClass.returnsPromiseProperty;
+    139 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -855,12 +840,12 @@ invalid.ts:138:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    136 │ invalidTestClass.returnsPromiseFunctionProperty();
-    137 │ invalidTestClass.returnsPromiseProperty;
-  > 138 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    139 │ 
-    140 │ const InvalidTestClassInitializedExpression = class InvalidTestClass extends InvalidTestClassParent {
+    136 │ 	.finally(() => {});
+    137 │ invalidTestClass.returnsPromiseFunctionProperty();
+  > 138 │ invalidTestClass.returnsPromiseProperty;
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    139 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
+    140 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -868,188 +853,188 @@ invalid.ts:138:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:153:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:139:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    151 │ 	}
-    152 │ 	async someMethod() {
-  > 153 │ 		this.returnsPromiseMethod();
+    137 │ invalidTestClass.returnsPromiseFunctionProperty();
+    138 │ invalidTestClass.returnsPromiseProperty;
+  > 139 │ invalidTestClass.returnsPromiseProperty.then(() => {}).finally(() => {});
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    140 │ 
+    141 │ const InvalidTestClassInitializedExpression = class InvalidTestClass extends InvalidTestClassParent {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:154:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    152 │ 	}
+    153 │ 	async someMethod() {
+  > 154 │ 		this.returnsPromiseMethod();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    154 │ 	}
-    155 │ 
+    155 │ 	}
+    156 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    153 │ → → await·this.returnsPromiseMethod();
+    154 │ → → await·this.returnsPromiseMethod();
         │     ++++++                            
 
 ```
 
 ```
-invalid.ts:157:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:158:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    156 │ 	async someMethod2() {
-  > 157 │ 		this.returnsPromiseFromParent()
+    157 │ 	async someMethod2() {
+  > 158 │ 		this.returnsPromiseFromParent()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 158 │ 			.then(() => {})
-  > 159 │ 			.finally(() => {});
+  > 159 │ 			.then(() => {})
+  > 160 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    160 │ 	}
-    161 │ 
+    161 │ 	}
+    162 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    157 │ → → await·this.returnsPromiseFromParent()
+    158 │ → → await·this.returnsPromiseFromParent()
         │     ++++++                               
 
 ```
 
 ```
-invalid.ts:163:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:164:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    162 │ 	async someMethod3() {
-  > 163 │ 		this.returnsPromiseFunctionProperty();
+    163 │ 	async someMethod3() {
+  > 164 │ 		this.returnsPromiseFunctionProperty();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    164 │ 	}
-    165 │ 
+    165 │ 	}
+    166 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    163 │ → → await·this.returnsPromiseFunctionProperty();
+    164 │ → → await·this.returnsPromiseFunctionProperty();
         │     ++++++                                      
 
 ```
 
 ```
-invalid.ts:167:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:168:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    166 │ 	async someMethod4() {
-  > 167 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
+    167 │ 	async someMethod4() {
+  > 168 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    168 │ 	}
-    169 │ 
+    169 │ 	}
+    170 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    167 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
+    168 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
         │     ++++++                                                             
 
 ```
 
 ```
-invalid.ts:174:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:175:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    172 │ 	}
-    173 │ 	async someMethod5() {
-  > 174 │ 		this.#returnsPromisePrivateMethod()
+    173 │ 	}
+    174 │ 	async someMethod5() {
+  > 175 │ 		this.#returnsPromisePrivateMethod()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 175 │ 			.then(() => {})
-  > 176 │ 			.finally(() => {});
+  > 176 │ 			.then(() => {})
+  > 177 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    177 │ 	}
-    178 │ 
+    178 │ 	}
+    179 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    174 │ → → await·this.#returnsPromisePrivateMethod()
+    175 │ → → await·this.#returnsPromisePrivateMethod()
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:187:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:188:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    186 │ 	async someMetho3() {
-  > 187 │ 		this.returnsPromiseFunction()
+    187 │ 	async someMetho3() {
+  > 188 │ 		this.returnsPromiseFunction()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 188 │ 			.then(() => {})
-  > 189 │ 			.finally(() => {});
+  > 189 │ 			.then(() => {})
+  > 190 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    190 │ 		this.returnsPromiseArrowFunction();
-    191 │ 	}
+    191 │ 		this.returnsPromiseArrowFunction();
+    192 │ 	}
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    187 │ → → await·this.returnsPromiseFunction()
+    188 │ → → await·this.returnsPromiseFunction()
         │     ++++++                             
 
 ```
 
 ```
-invalid.ts:190:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:191:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    188 │ 			.then(() => {})
-    189 │ 			.finally(() => {});
-  > 190 │ 		this.returnsPromiseArrowFunction();
+    189 │ 			.then(() => {})
+    190 │ 			.finally(() => {});
+  > 191 │ 		this.returnsPromiseArrowFunction();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    191 │ 	}
-    192 │ };
+    192 │ 	}
+    193 │ };
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    190 │ → → await·this.returnsPromiseArrowFunction();
+    191 │ → → await·this.returnsPromiseArrowFunction();
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:195:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:196:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    194 │ const invalidTestClassExpression = new InvalidTestClassInitializedExpression();
-  > 195 │ invalidTestClassExpression
+    195 │ const invalidTestClassExpression = new InvalidTestClassInitializedExpression();
+  > 196 │ invalidTestClassExpression
         │ ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 196 │ 	.returnsPromiseMethod()
-  > 197 │ 	.then(() => {})
-  > 198 │ 	.finally(() => {});
+  > 197 │ 	.returnsPromiseMethod()
+  > 198 │ 	.then(() => {})
+  > 199 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    199 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
-    200 │ invalidTestClassExpression.returnsPromiseProperty;
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
-invalid.ts:199:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    197 │ 	.then(() => {})
-    198 │ 	.finally(() => {});
-  > 199 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    200 │ invalidTestClassExpression.returnsPromiseProperty;
-    201 │ invalidTestClassExpression.returnsPromiseProperty
+    200 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
+    201 │ invalidTestClassExpression.returnsPromiseProperty;
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1061,12 +1046,12 @@ invalid.ts:200:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    198 │ 	.finally(() => {});
-    199 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
-  > 200 │ invalidTestClassExpression.returnsPromiseProperty;
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    201 │ invalidTestClassExpression.returnsPromiseProperty
-    202 │ 	.then(() => {})
+    198 │ 	.then(() => {})
+    199 │ 	.finally(() => {});
+  > 200 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    201 │ invalidTestClassExpression.returnsPromiseProperty;
+    202 │ invalidTestClassExpression.returnsPromiseProperty
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1078,15 +1063,12 @@ invalid.ts:201:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    199 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
-    200 │ invalidTestClassExpression.returnsPromiseProperty;
-  > 201 │ invalidTestClassExpression.returnsPromiseProperty
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 202 │ 	.then(() => {})
-  > 203 │ 	.finally(() => {});
-        │ 	^^^^^^^^^^^^^^^^^^^
-    204 │ 
-    205 │ const InvalidTestUnnamedClassInitializedExpression = class extends InvalidTestClassParent {
+    199 │ 	.finally(() => {});
+    200 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
+  > 201 │ invalidTestClassExpression.returnsPromiseProperty;
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    202 │ invalidTestClassExpression.returnsPromiseProperty
+    203 │ 	.then(() => {})
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1094,189 +1076,192 @@ invalid.ts:201:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:218:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:202:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    216 │ 	}
-    217 │ 	async someMethod() {
-  > 218 │ 		this.returnsPromiseMethod();
+    200 │ invalidTestClassExpression.returnsPromiseFunctionProperty();
+    201 │ invalidTestClassExpression.returnsPromiseProperty;
+  > 202 │ invalidTestClassExpression.returnsPromiseProperty
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  > 203 │ 	.then(() => {})
+  > 204 │ 	.finally(() => {});
+        │ 	^^^^^^^^^^^^^^^^^^^
+    205 │ 
+    206 │ const InvalidTestUnnamedClassInitializedExpression = class extends InvalidTestClassParent {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:219:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    217 │ 	}
+    218 │ 	async someMethod() {
+  > 219 │ 		this.returnsPromiseMethod();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    219 │ 	}
-    220 │ 
+    220 │ 	}
+    221 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    218 │ → → await·this.returnsPromiseMethod();
+    219 │ → → await·this.returnsPromiseMethod();
         │     ++++++                            
 
 ```
 
 ```
-invalid.ts:222:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:223:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    221 │ 	async someMethod2() {
-  > 222 │ 		this.returnsPromiseFromParent()
+    222 │ 	async someMethod2() {
+  > 223 │ 		this.returnsPromiseFromParent()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 223 │ 			.then(() => {})
-  > 224 │ 			.finally(() => {});
+  > 224 │ 			.then(() => {})
+  > 225 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    225 │ 	}
-    226 │ 
+    226 │ 	}
+    227 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    222 │ → → await·this.returnsPromiseFromParent()
+    223 │ → → await·this.returnsPromiseFromParent()
         │     ++++++                               
 
 ```
 
 ```
-invalid.ts:228:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:229:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    227 │ 	async someMethod3() {
-  > 228 │ 		this.returnsPromiseFunctionProperty();
+    228 │ 	async someMethod3() {
+  > 229 │ 		this.returnsPromiseFunctionProperty();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    229 │ 	}
-    230 │ 
+    230 │ 	}
+    231 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    228 │ → → await·this.returnsPromiseFunctionProperty();
+    229 │ → → await·this.returnsPromiseFunctionProperty();
         │     ++++++                                      
 
 ```
 
 ```
-invalid.ts:232:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:233:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    231 │ 	async someMethod4() {
-  > 232 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
+    232 │ 	async someMethod4() {
+  > 233 │ 		this.returnsPromiseProperty.then(() => {}).finally(() => {});
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    233 │ 	}
-    234 │ 
+    234 │ 	}
+    235 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    232 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
+    233 │ → → await·this.returnsPromiseProperty.then(()·=>·{}).finally(()·=>·{});
         │     ++++++                                                             
 
 ```
 
 ```
-invalid.ts:239:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:240:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    237 │ 	}
-    238 │ 	async someMethod5() {
-  > 239 │ 		this.#returnsPromisePrivateMethod()
+    238 │ 	}
+    239 │ 	async someMethod5() {
+  > 240 │ 		this.#returnsPromisePrivateMethod()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 240 │ 			.then(() => {})
-  > 241 │ 			.finally(() => {});
+  > 241 │ 			.then(() => {})
+  > 242 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    242 │ 	}
-    243 │ 
+    243 │ 	}
+    244 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    239 │ → → await·this.#returnsPromisePrivateMethod()
+    240 │ → → await·this.#returnsPromisePrivateMethod()
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:252:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:253:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    251 │ 	async someMetho3() {
-  > 252 │ 		this.returnsPromiseFunction()
+    252 │ 	async someMetho3() {
+  > 253 │ 		this.returnsPromiseFunction()
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 253 │ 			.then(() => {})
-  > 254 │ 			.finally(() => {});
+  > 254 │ 			.then(() => {})
+  > 255 │ 			.finally(() => {});
         │ 			^^^^^^^^^^^^^^^^^^^
-    255 │ 		this.returnsPromiseArrowFunction();
-    256 │ 	}
+    256 │ 		this.returnsPromiseArrowFunction();
+    257 │ 	}
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    252 │ → → await·this.returnsPromiseFunction()
+    253 │ → → await·this.returnsPromiseFunction()
         │     ++++++                             
 
 ```
 
 ```
-invalid.ts:255:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:256:3 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    253 │ 			.then(() => {})
-    254 │ 			.finally(() => {});
-  > 255 │ 		this.returnsPromiseArrowFunction();
+    254 │ 			.then(() => {})
+    255 │ 			.finally(() => {});
+  > 256 │ 		this.returnsPromiseArrowFunction();
         │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    256 │ 	}
-    257 │ };
+    257 │ 	}
+    258 │ };
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    255 │ → → await·this.returnsPromiseArrowFunction();
+    256 │ → → await·this.returnsPromiseArrowFunction();
         │     ++++++                                   
 
 ```
 
 ```
-invalid.ts:261:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:262:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    259 │ const invalidTestUnnamedClassInitializedExpression =
-    260 │ 	new InvalidTestUnnamedClassInitializedExpression();
-  > 261 │ invalidTestUnnamedClassInitializedExpression
+    260 │ const invalidTestUnnamedClassInitializedExpression =
+    261 │ 	new InvalidTestUnnamedClassInitializedExpression();
+  > 262 │ invalidTestUnnamedClassInitializedExpression
         │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 262 │ 	.returnsPromiseMethod()
-  > 263 │ 	.then(() => {})
-  > 264 │ 	.finally(() => {});
+  > 263 │ 	.returnsPromiseMethod()
+  > 264 │ 	.then(() => {})
+  > 265 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    265 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
-    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
-invalid.ts:265:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    263 │ 	.then(() => {})
-    264 │ 	.finally(() => {});
-  > 265 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
-    267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
+    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
+    267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1288,12 +1273,12 @@ invalid.ts:266:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    264 │ 	.finally(() => {});
-    265 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
-  > 266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
-        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
-    268 │ 	.then(() => {})
+    264 │ 	.then(() => {})
+    265 │ 	.finally(() => {});
+  > 266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
+    268 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1305,15 +1290,32 @@ invalid.ts:267:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    265 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
-    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
-  > 267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
+    265 │ 	.finally(() => {});
+    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
+  > 267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    268 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
+    269 │ 	.then(() => {})
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:268:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    266 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseFunctionProperty();
+    267 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty;
+  > 268 │ invalidTestUnnamedClassInitializedExpression.returnsPromiseProperty
         │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 268 │ 	.then(() => {})
-  > 269 │ 	.finally(() => {});
+  > 269 │ 	.then(() => {})
+  > 270 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    270 │ invalidTestClassExpression.returnsPromiseProperty
-    271 │ 	.then(() => {})
+    271 │ invalidTestClassExpression.returnsPromiseProperty
+    272 │ 	.then(() => {})
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1321,35 +1323,19 @@ invalid.ts:267:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:270:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:271:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    268 │ 	.then(() => {})
-    269 │ 	.finally(() => {});
-  > 270 │ invalidTestClassExpression.returnsPromiseProperty
+    269 │ 	.then(() => {})
+    270 │ 	.finally(() => {});
+  > 271 │ invalidTestClassExpression.returnsPromiseProperty
         │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  > 271 │ 	.then(() => {})
-  > 272 │ 	.finally(() => {});
+  > 272 │ 	.then(() => {})
+  > 273 │ 	.finally(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^
-    273 │ 
-    274 │ const invalidTestObject = {
-  
-  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
-  
-
-```
-
-```
-invalid.ts:288:3 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
-  
-    287 │ 	someMethod() {
-  > 288 │ 		this.returnsPromiseArrowFunction();
-        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    289 │ 		this.returnsPromiseFunction().then(() => {});
-    290 │ 		this["returnsPromiseMethod"]();
+    274 │ 
+    275 │ const invalidTestObject = {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1361,12 +1347,11 @@ invalid.ts:289:3 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    287 │ 	someMethod() {
-    288 │ 		this.returnsPromiseArrowFunction();
-  > 289 │ 		this.returnsPromiseFunction().then(() => {});
-        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    290 │ 		this["returnsPromiseMethod"]();
-    291 │ 	},
+    288 │ 	someMethod() {
+  > 289 │ 		this.returnsPromiseArrowFunction();
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    290 │ 		this.returnsPromiseFunction().then(() => {});
+    291 │ 		this["returnsPromiseMethod"]();
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1378,12 +1363,12 @@ invalid.ts:290:3 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    288 │ 		this.returnsPromiseArrowFunction();
-    289 │ 		this.returnsPromiseFunction().then(() => {});
-  > 290 │ 		this["returnsPromiseMethod"]();
-        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    291 │ 	},
-    292 │ };
+    288 │ 	someMethod() {
+    289 │ 		this.returnsPromiseArrowFunction();
+  > 290 │ 		this.returnsPromiseFunction().then(() => {});
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    291 │ 		this["returnsPromiseMethod"]();
+    292 │ 	},
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1391,23 +1376,19 @@ invalid.ts:290:3 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:294:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:291:3 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    292 │ };
-    293 │ async function testInvalidObejctMethodCalls(): Promise<void> {
-  > 294 │ 	invalidTestObject.returnsPromiseArrowFunction();
-        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    295 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
-    296 │ 	invalidTestObject
+    289 │ 		this.returnsPromiseArrowFunction();
+    290 │ 		this.returnsPromiseFunction().then(() => {});
+  > 291 │ 		this["returnsPromiseMethod"]();
+        │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    292 │ 	},
+    293 │ };
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
-  i Unsafe fix: Add await operator.
-  
-    294 │ → await·invalidTestObject.returnsPromiseArrowFunction();
-        │   ++++++                                                
 
 ```
 
@@ -1416,19 +1397,19 @@ invalid.ts:295:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    293 │ async function testInvalidObejctMethodCalls(): Promise<void> {
-    294 │ 	invalidTestObject.returnsPromiseArrowFunction();
-  > 295 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
-        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    296 │ 	invalidTestObject
-    297 │ 		.returnsPromiseMethod()
+    293 │ };
+    294 │ async function testInvalidObejctMethodCalls(): Promise<void> {
+  > 295 │ 	invalidTestObject.returnsPromiseArrowFunction();
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    296 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+    297 │ 	invalidTestObject
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    295 │ → await·invalidTestObject.returnsPromiseFunction().then(()·=>·{});
-        │   ++++++                                                          
+    295 │ → await·invalidTestObject.returnsPromiseArrowFunction();
+        │   ++++++                                                
 
 ```
 
@@ -1437,167 +1418,188 @@ invalid.ts:296:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    294 │ 	invalidTestObject.returnsPromiseArrowFunction();
-    295 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
-  > 296 │ 	invalidTestObject
-        │ 	^^^^^^^^^^^^^^^^^
-  > 297 │ 		.returnsPromiseMethod()
-  > 298 │ 		.then(() => {})
-  > 299 │ 		.finally(() => {});
-        │ 		^^^^^^^^^^^^^^^^^^^
-    300 │ 	invalidTestObject["returnsPromiseMethod"]();
-    301 │ }
+    294 │ async function testInvalidObejctMethodCalls(): Promise<void> {
+    295 │ 	invalidTestObject.returnsPromiseArrowFunction();
+  > 296 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    297 │ 	invalidTestObject
+    298 │ 		.returnsPromiseMethod()
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    296 │ → await·invalidTestObject
+    296 │ → await·invalidTestObject.returnsPromiseFunction().then(()·=>·{});
+        │   ++++++                                                          
+
+```
+
+```
+invalid.ts:297:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    295 │ 	invalidTestObject.returnsPromiseArrowFunction();
+    296 │ 	invalidTestObject.returnsPromiseFunction().then(() => {});
+  > 297 │ 	invalidTestObject
+        │ 	^^^^^^^^^^^^^^^^^
+  > 298 │ 		.returnsPromiseMethod()
+  > 299 │ 		.then(() => {})
+  > 300 │ 		.finally(() => {});
+        │ 		^^^^^^^^^^^^^^^^^^^
+    301 │ 	invalidTestObject["returnsPromiseMethod"]();
+    302 │ }
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+  i Unsafe fix: Add await operator.
+  
+    297 │ → await·invalidTestObject
         │   ++++++                 
 
 ```
 
 ```
-invalid.ts:300:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:301:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    298 │ 		.then(() => {})
-    299 │ 		.finally(() => {});
-  > 300 │ 	invalidTestObject["returnsPromiseMethod"]();
+    299 │ 		.then(() => {})
+    300 │ 		.finally(() => {});
+  > 301 │ 	invalidTestObject["returnsPromiseMethod"]();
         │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    301 │ }
-    302 │ 
+    302 │ }
+    303 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    300 │ → await·invalidTestObject["returnsPromiseMethod"]();
+    301 │ → await·invalidTestObject["returnsPromiseMethod"]();
         │   ++++++                                            
 
 ```
 
 ```
-invalid.ts:308:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:309:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    306 │ };
-    307 │ async function testCallingReturnsPromise(props: Props) {
-  > 308 │ 	props.returnsPromise().then(() => {});
+    307 │ };
+    308 │ async function testCallingReturnsPromise(props: Props) {
+  > 309 │ 	props.returnsPromise().then(() => {});
         │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    309 │ }
-    310 │ const testDestructuringAndCallingReturnsPromise = async ({
+    310 │ }
+    311 │ const testDestructuringAndCallingReturnsPromise = async ({
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    308 │ → await·props.returnsPromise().then(()·=>·{});
+    309 │ → await·props.returnsPromise().then(()·=>·{});
         │   ++++++                                      
 
 ```
 
 ```
-invalid.ts:313:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:314:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    311 │ 	returnsPromise,
-    312 │ }: Props) => {
-  > 313 │ 	returnsPromise();
+    312 │ 	returnsPromise,
+    313 │ }: Props) => {
+  > 314 │ 	returnsPromise();
         │ 	^^^^^^^^^^^^^^^^^
-    314 │ };
-    315 │ async function testPassingReturnsPromiseDirectly(
+    315 │ };
+    316 │ async function testPassingReturnsPromiseDirectly(
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    313 │ → await·returnsPromise();
+    314 │ → await·returnsPromise();
         │   ++++++                 
 
 ```
 
 ```
-invalid.ts:318:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:319:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    316 │ 	returnsPromise: () => Promise<void>
-    317 │ ) {
-  > 318 │ 	returnsPromise();
+    317 │ 	returnsPromise: () => Promise<void>
+    318 │ ) {
+  > 319 │ 	returnsPromise();
         │ 	^^^^^^^^^^^^^^^^^
-    319 │ }
-    320 │ async function testCallingReturnsPromiseFromObject(props: {
+    320 │ }
+    321 │ async function testCallingReturnsPromiseFromObject(props: {
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    318 │ → await·returnsPromise();
+    319 │ → await·returnsPromise();
         │   ++++++                 
 
 ```
 
 ```
-invalid.ts:323:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:324:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    321 │ 	returnsPromise: () => Promise<void>;
-    322 │ }) {
-  > 323 │ 	props.returnsPromise();
+    322 │ 	returnsPromise: () => Promise<void>;
+    323 │ }) {
+  > 324 │ 	props.returnsPromise();
         │ 	^^^^^^^^^^^^^^^^^^^^^^^
-    324 │ }
-    325 │ async function testDestructuringAndCallingReturnsPromiseFromRest({
+    325 │ }
+    326 │ async function testDestructuringAndCallingReturnsPromiseFromRest({
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    323 │ → await·props.returnsPromise();
+    324 │ → await·props.returnsPromise();
         │   ++++++                       
 
 ```
 
 ```
-invalid.ts:329:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:330:2 lint/nursery/noFloatingPromises  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    327 │ 	...rest
-    328 │ }: Props) {
-  > 329 │ 	rest
+    328 │ 	...rest
+    329 │ }: Props) {
+  > 330 │ 	rest
         │ 	^^^^
-  > 330 │ 		.returnsPromise()
-  > 331 │ 		.then(() => {})
-  > 332 │ 		.finally(() => {});
+  > 331 │ 		.returnsPromise()
+  > 332 │ 		.then(() => {})
+  > 333 │ 		.finally(() => {});
         │ 		^^^^^^^^^^^^^^^^^^^
-    333 │ }
-    334 │ 
+    334 │ }
+    335 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
   i Unsafe fix: Add await operator.
   
-    329 │ → await·rest
+    330 │ → await·rest
         │   ++++++    
 
 ```
 
 ```
-invalid.ts:335:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:336:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    333 │ }
-    334 │ 
-  > 335 │ import("some-module").then(() => {});
+    334 │ }
+    335 │ 
+  > 336 │ import("some-module").then(() => {});
         │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    336 │ 
-    337 │ returnPromiseResult();
+    337 │ 
+    338 │ returnPromiseResult();
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1605,16 +1607,16 @@ invalid.ts:335:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:337:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:338:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    335 │ import("some-module").then(() => {});
-    336 │ 
-  > 337 │ returnPromiseResult();
+    336 │ import("some-module").then(() => {});
+    337 │ 
+  > 338 │ returnPromiseResult();
         │ ^^^^^^^^^^^^^^^^^^^^^^
-    338 │ 
-    339 │ function returnMaybePromise(): Promise<void> | undefined {
+    339 │ returnAliasedPromiseResult();
+    340 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   
@@ -1622,15 +1624,31 @@ invalid.ts:337:1 lint/nursery/noFloatingPromises ━━━━━━━━━━�
 ```
 
 ```
-invalid.ts:347:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:339:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
   
-    345 │ }
-    346 │ 
-  > 347 │ returnMaybePromise();
-        │ ^^^^^^^^^^^^^^^^^^^^^
+    338 │ returnPromiseResult();
+  > 339 │ returnAliasedPromiseResult();
+        │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    340 │ 
+    341 │ function returnMaybePromise(): Promise<void> | undefined {
+  
+  i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
+  
+
+```
+
+```
+invalid.ts:349:1 lint/nursery/noFloatingPromises ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i A "floating" Promise was found, meaning it is not properly handled and could lead to ignored errors or unexpected behavior.
+  
+    347 │ }
     348 │ 
+  > 349 │ returnMaybePromise();
+        │ ^^^^^^^^^^^^^^^^^^^^^
+    350 │ 
   
   i This happens when a Promise is not awaited, lacks a `.catch` or `.then` rejection handler, or is not explicitly ignored using the `void` operator.
   

--- a/crates/biome_js_syntax/src/import_ext.rs
+++ b/crates/biome_js_syntax/src/import_ext.rs
@@ -189,13 +189,15 @@ impl AnyJsNamedImportSpecifier {
     /// ```
     pub fn imported_name(&self) -> Option<JsSyntaxToken> {
         match self {
-            specifier @ (Self::JsNamedImportSpecifier(_)
-            | Self::JsShorthandNamedImportSpecifier(_)) => specifier
-                .local_name()?
-                .as_js_identifier_binding()?
-                .name_token()
-                .ok(),
             Self::JsBogusNamedImportSpecifier(_) => None,
+            Self::JsNamedImportSpecifier(specifier) => {
+                specifier.name().and_then(|name| name.value()).ok()
+            }
+            Self::JsShorthandNamedImportSpecifier(specifier) => {
+                let imported_name = specifier.local_name().ok()?;
+                let imported_name = imported_name.as_js_identifier_binding()?;
+                imported_name.name_token().ok()
+            }
         }
     }
 

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.cjs
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.cjs
@@ -1,0 +1,2 @@
+"use strict";Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});const s=async(e=1e3)=>new Promise(t=>setTimeout(t,e));exports.sleep=s;
+//# sourceMappingURL=index.cjs.map

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.d.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.d.ts
@@ -1,0 +1,2 @@
+export * from './src/index'
+export {}

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.js
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/index.js
@@ -1,0 +1,5 @@
+const o = async (e = 1e3) => new Promise((s) => setTimeout(s, e));
+export {
+  o as sleep
+};
+//# sourceMappingURL=index.js.map

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/src/index.d.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/src/index.d.ts
@@ -1,0 +1,1 @@
+export { sleep } from './sleep';

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/src/sleep.d.ts
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/dist/src/sleep.d.ts
@@ -1,0 +1,1 @@
+export declare const sleep: (ms?: number) => Promise<void>;

--- a/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/package.json
+++ b/crates/biome_resolver/tests/fixtures/resolver_cases_5/node_modules/sleep/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "sleep",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "dist/index.cjs",
+	"module": "dist/index.js",
+	"exports": {
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	]
+}

--- a/crates/biome_resolver/tests/spec_tests.rs
+++ b/crates/biome_resolver/tests/spec_tests.rs
@@ -498,3 +498,38 @@ fn test_resolve_type_definitions_with_custom_type_roots() {
         )))
     );
 }
+
+#[test]
+fn test_resolve_type_definitions_without_type_specification() {
+    let base_dir = get_fixtures_path("resolver_cases_5");
+    let fs = OsFileSystem::new(base_dir.clone());
+
+    let options = ResolveOptions {
+        condition_names: &["types", "import", "default"],
+        default_files: &["index"],
+        extensions: &["ts", "js"],
+        resolve_types: true,
+        type_roots: TypeRoots::Auto, // auto-detected from `tsconfig.json`
+        ..Default::default()
+    };
+
+    assert_eq!(
+        resolve("sleep", &base_dir, &fs, &options),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/node_modules/sleep/dist/index.d.ts"
+        )))
+    );
+
+    // Make sure the re-export is resolvable too:
+    assert_eq!(
+        resolve(
+            "./src/index",
+            Utf8Path::new(&format!("{base_dir}/node_modules/sleep/dist")),
+            &fs,
+            &options
+        ),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/node_modules/sleep/dist/src/index.d.ts"
+        )))
+    );
+}


### PR DESCRIPTION
## Summary

Fixed [#7111](https://github.com/biomejs/biome/issues/7111): Imported symbols using aliases are now correctly recognised.

Also squeezed in a tiny optimisation for the resolver, to avoid allocations when someone has `typeRoots` in their `tsconfig.json`.

## Test Plan

Test added.