### PR TITLE
ci: use `github.sha` for dispatch event on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,7 @@ jobs:
           repository: ${{ env.BIOME_WEBSITE_REPO }}
           event-type: ${{ env.BIOME_RELEASE_CLI_EVENT }}
           client-payload: |
-            { "sha": "${{ env.GITHUB_SHA }}", "tag": "@biomejs/biome@${{ needs.build-binaries.outputs.version }}", "version": "${{ needs.build-binaries.outputs.version }}" }
+            { "sha": "${{ github.sha }}", "tag": "@biomejs/biome@${{ needs.build-binaries.outputs.version }}", "version": "${{ needs.build-binaries.outputs.version }}" }
 
   publish-js-api:
     name: Publish JS API


### PR DESCRIPTION
## Summary

Replaced `env.GITHUB_SHA` with `github.sha`.

<img width="743" height="199" alt="image" src="https://github.com/user-attachments/assets/658fdf38-2ba2-44c0-b798-83bfe667a1f2" />

## Test Plan

Pray for success in the next release :)

## Docs

N/A
