### PR TITLE
fix: consider type-only imports as dev dependency

### DIFF
--- a/.changeset/two-badgers-cut.md
+++ b/.changeset/two-badgers-cut.md
@@ -1,0 +1,23 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7162](https://github.com/biomejs/biome/7162): The `noUndeclaredDependencies` now considers a type-only import as a dev dependency.
+
+For example, the following code is no longer reported:
+
+**`package.json`**:
+```json
+{
+  "devDependencies": {
+    "type-fest": "*"
+  }
+}
+```
+
+**`foo.ts`**:
+```ts
+import type { SetRequired } from "type-fest";
+```
+
+Note that you still need to declare the package in the `devDependencies` section in `package.json`.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.package.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.package.json
@@ -10,7 +10,8 @@
 	},
 	"devDependencies": {
 		"@testing-library/react": "1.0.0",
-		"@types/lodash": "1.0.0"
+		"@types/lodash": "1.0.0",
+    "type-fest": "1.0.0"
 	},
 	"peerDependencies": {
 		"peer-dep": "1.0.0"

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
@@ -37,3 +37,6 @@ import "path";
 import "process";
 
 import "dep.js"
+
+// Type-only imports
+import type {} from "type-fest";

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
@@ -43,4 +43,8 @@ import "path";
 import "process";
 
 import "dep.js"
+
+// Type-only imports
+import type {} from "type-fest";
+
 ```


### PR DESCRIPTION
## Summary

Fixed #7162 

Type-only imports are no longer required to be declared in the `dependencies` section.

## Test Plan

Added a snapshot test.

## Docs

Updated the doc comment.
