### PR TITLE
chore: fix typos in biome css analyze crates

### DIFF
--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -5946,42 +5946,42 @@ mod tests {
     }
 
     #[test]
-    fn test_kown_edge_properties_order() {
+    fn test_known_edge_properties_order() {
         for items in KNOWN_EDGE_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }
     }
 
     #[test]
-    fn test_kown_explorer_properties_order() {
+    fn test_known_explorer_properties_order() {
         for items in KNOWN_EXPLORER_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }
     }
 
     #[test]
-    fn test_kown_firefox_properties_order() {
+    fn test_known_firefox_properties_order() {
         for items in KNOWN_FIREFOX_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }
     }
 
     #[test]
-    fn test_kown_safari_properties_order() {
+    fn test_known_safari_properties_order() {
         for items in KNOWN_SAFARI_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }
     }
 
     #[test]
-    fn test_kown_sumsung_internet_properties_order() {
+    fn test_known_samsung_internet_properties_order() {
         for items in KNOWN_SAMSUNG_INTERNET_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }
     }
 
     #[test]
-    fn test_kown_us_browser_properties_order() {
+    fn test_known_us_browser_properties_order() {
         for items in KNOWN_US_BROWSER_PROPERTIES.windows(2) {
             assert!(items[0] < items[1], "{} < {}", items[0], items[1]);
         }

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css
@@ -69,7 +69,7 @@
 }
 
 .example-from-doc-comment {
-  transition: opactity 1s ease;
+  transition: opacity 1s ease;
   border: 1px solid black;
   pointer-events: none;
   color: black;

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/invalid.css.snap
@@ -75,7 +75,7 @@ expression: invalid.css
 }
 
 .example-from-doc-comment {
-  transition: opactity 1s ease;
+  transition: opacity 1s ease;
   border: 1px solid black;
   pointer-events: none;
   color: black;
@@ -411,7 +411,7 @@ invalid.css:71:27 assist/source/useSortedProperties  FIXABLE  ━━━━━━
     70 │ 
   > 71 │ .example-from-doc-comment {
        │                           ^
-  > 72 │   transition: opactity 1s ease;
+  > 72 │   transition: opacity 1s ease;
         ...
   > 77 │   display: block;
   > 78 │   --custom: 100;
@@ -423,7 +423,7 @@ invalid.css:71:27 assist/source/useSortedProperties  FIXABLE  ━━━━━━
   
     70 70 │   
     71 71 │   .example-from-doc-comment {
-    72    │ - ··transition:·opactity·1s·ease;
+    72    │ - ··transition:·opacity·1s·ease;
     73    │ - ··border:·1px·solid·black;
     74    │ - ··pointer-events:·none;
        72 │ + ··--custom:·100;
@@ -435,7 +435,7 @@ invalid.css:71:27 assist/source/useSortedProperties  FIXABLE  ━━━━━━
     78    │ - ··--custom:·100;
        76 │ + ··pointer-events:·none;
        77 │ + ··border:·1px·solid·black;
-       78 │ + ··transition:·opactity·1s·ease;
+       78 │ + ··transition:·opacity·1s·ease;
     79 79 │   }
     80 80 │   
   

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css
@@ -76,7 +76,7 @@
   color: black;
   pointer-events:·none;
   border:·1px·solid·black;
-  transition:·opactity·1s·ease;
+  transition:·opacity·1s·ease;
 }
 
 

--- a/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/source/useSortedProperties/valid.css.snap
@@ -82,7 +82,7 @@ expression: valid.css
   color: black;
   pointer-events:·none;
   border:·1px·solid·black;
-  transition:·opactity·1s·ease;
+  transition:·opacity·1s·ease;
 }
 
 
@@ -110,4 +110,5 @@ expression: valid.css
   box-sizing: border-box;
   position-anchor: --position-anchor;
 }
+
 ```


### PR DESCRIPTION
## Summary

Fix typos in biome_css_analyze tests and CSS fixtures

Tests:
- Correct test function name typos from 'kown' to 'known' in several KNOWN_* properties order tests
- Change `sumsung` to `samsung`
- Fix typo in CSS test fixtures by replacing 'opactity' with 'opacity' in valid and invalid sortedProperties cases

## Test Plan

```bash
cargo test
```