### PR TITLE
docs: update documentation for `useForOf`; fix typos

### DIFF
--- a/crates/biome_js_analyze/src/lint/style/use_for_of.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_for_of.rs
@@ -16,8 +16,16 @@ use biome_rule_options::use_for_of::UseForOfOptions;
 use crate::{services::semantic::Semantic, utils::is_node_equal};
 
 declare_lint_rule! {
-    /// This rule recommends a `for-of` loop when in a `for` loop, the index used to extract an item from the iterated array.
+    /// Prefer using `for...of` loops over standard `for` loops where possible.
     ///
+    /// This rule recommends using a `for...of` loop in place of a `for` loop 
+    /// when the loop index is solely used to read from the iterated array.
+    /// 
+    /// ### Exceptions for Index Usage
+    /// When the loop index is declared within the outer scope or used anywhere within the loop body,
+    /// it is acceptable to use a `for` loop.
+    /// (`Array.entries()` can be used to a similar effect.)
+    /// 
     /// ## Examples
     ///
     /// ### Invalid
@@ -38,6 +46,7 @@ declare_lint_rule! {
     ///
     /// ```js
     /// for (let i = 0; i < array.length; i++) {
+    ///    // `i` is used, so for loop is OK
     ///    console.log(i, array[i]);
     ///  }
     /// ```
@@ -45,6 +54,13 @@ declare_lint_rule! {
     /// ```js
     /// for (let i = 0, j = 0; i < array.length; i++) {
     ///    console.log(i, array[i]);
+    ///  }
+    /// ```
+    ///
+    /// ```js
+    /// let i = 0;
+    /// for (; i < array.length; i++) {
+    ///    console.log(array[i]);
     ///  }
     /// ```
     ///


### PR DESCRIPTION
## Rationale

There was a typo in the rules desc, as well as it being generally nondescript and lacking docs for examples.

See [this issue on the documentation site](<https://github.com/biomejs/website/issues/2919>) for more context

## Summary

The description was reworked with less typo and more clarity. 
I based the content off the rule text from the original rule sources (`typescript-eslint` & `unicorn`), using wording similar to other lint rules in the existing docs.

(As an aside, we might want to look into adding an option to replace `for` loops which use indices & values solely in the loop body with `for [i, v] of array.entries()`.

## Test Plan

I'd presume I don't need to add tests for a documentation-only PR whose sole job is to edit a rust doc comment.
(I'd hope so at least)

## Docs

I was told to make a PR to here instead of the docs site since it pulls the rule documentation from main.

## Questions

Is a changeset required for a minor doc fix?
This is my first pr, so a little nervous