### PR TITLE
chore: fix various typos across codebase

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -39,7 +39,7 @@ All members must follow the [Code of Conduct](CODE_OF_CONDUCT.md). Consequences 
 
 ### Lead
 
-Leads are the owners of the organisation.
+Leads are the owners of the organization.
 
 Leads have additional privileges over core contributors. Leads control and maintain sensitive project assets and act as tiebreakers in the event of disagreements. In case of disagreements, only **one** lead must be involved in the resolution.
 
@@ -75,7 +75,7 @@ In the event of a rejection, the nominated person will be privately given the re
 
 ### Core Contributor
 
-Core Contributors are outstanding [maintainers](#maintainer), are ambassadors of Biome organisation and lead by example the community.
+Core Contributors are outstanding [maintainers](#maintainer), are ambassadors of Biome organization and lead by example the community.
 
 - Push access to the [Biome GitHub org][gh-org], this includes all repositories
 - `Core contributor` status on the [Biome Discord server][discord]

--- a/packages/@biomejs/biome/CHANGELOG.md
+++ b/packages/@biomejs/biome/CHANGELOG.md
@@ -3824,7 +3824,7 @@
     }
   ```
 
-- Fix a parsing error when a `JsxElementName` is `JsxMemberExpression`, and a `JsLogicalExpreesion` before it without a semicolon.
+- Fix a parsing error when a `JsxElementName` is `JsxMemberExpression`, and a `JsLogicalExpression` before it without a semicolon.
 
   The following case will now not throw error:
 

--- a/packages/@biomejs/js-api/tests/lintContent.test.ts
+++ b/packages/@biomejs/js-api/tests/lintContent.test.ts
@@ -23,7 +23,7 @@ describe("Biome WebAssembly lintContent", () => {
 	});
 
 	describe("fixFileMode is undefined/omitted", () => {
-		it("should emit diagnotics", () => {
+		it("should emit diagnostics", () => {
 			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 			});
@@ -43,7 +43,7 @@ describe("Biome WebAssembly lintContent", () => {
 	});
 
 	describe("fixFileMode is SafeFixes", () => {
-		it("should emit diagnotics", () => {
+		it("should emit diagnostics", () => {
 			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeFixes",
@@ -64,7 +64,7 @@ describe("Biome WebAssembly lintContent", () => {
 	});
 
 	describe("fixFileMode is SafeAndUnsafeFixes", () => {
-		it("should emit diagnotics", () => {
+		it("should emit diagnostics", () => {
 			const result = biome.lintContent(projectKey, inputCode, {
 				filePath: "example.js",
 				fixFileMode: "safeAndUnsafeFixes",

--- a/packages/@biomejs/js-api/tests/nodejs.test.ts
+++ b/packages/@biomejs/js-api/tests/nodejs.test.ts
@@ -23,7 +23,7 @@ describe("Biome for Node.js", () => {
 		expect(result.diagnostics).toEqual([]);
 	});
 
-	it("should emit diagnotics", () => {
+	it("should emit diagnostics", () => {
 		const result = biome.lintContent(projectKey, "a { font-color: red }", {
 			filePath: "example.css",
 		});

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1831,7 +1831,7 @@ CssUnicodeRangeInterval =
 	end: CssUnicodeCodepoint
 
 
-// Any identifier. Case insensitve, used for standard property names, values, type selectors, etc.
+// Any identifier. Case insensitive, used for standard property names, values, type selectors, etc.
 CssIdentifier = value: 'ident'
 // Any non-standard identifier. Case sensitive, used for class names, ids, etc. Custom identifiers
 // _may_ overlap with standard identifiers defined by CSS (e.g., `color`).

--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -320,7 +320,7 @@ where
 {
     let path = BiomePath::new(Utf8PathBuf::from(&file_path));
     let file_source = &test.document_file_source();
-    let supression_reason = None;
+    let suppression_reason = None;
 
     let Some(settings) = workspace_settings.get_root_settings(project_key) else {
         return AnalyzerOptions::default();
@@ -335,7 +335,7 @@ where
         environment,
         &path,
         file_source,
-        supression_reason,
+        suppression_reason,
     )
 }
 


### PR DESCRIPTION
## Summary

Apply spelling corrections across the codebase

Chores:
- Fix misspelling of "diagnostics" in test descriptions
- Correct "organisation" to "organization" in governance documentation
- Fix typo in variable name from "supression_reason" to "suppression_reason" in rules_check
- Correct typo in CHANGELOG from "JsLogicalExpreesion" to "JsLogicalExpression"