### PR TITLE
fix(core): ignored files by scanner

### DIFF
--- a/.changeset/sharp-numbers-end.md
+++ b/.changeset/sharp-numbers-end.md
@@ -1,0 +1,6 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where when using project rules, the file scanner incorrectly indexed ignored files, when those
+files were part of other ignored folders/files.


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

I was testing v2.2, and when enabling project rules, the scanner was still indexing ignored files.

The case was caused by the fact that there some test files that import modules that are generated and stored inside ignored folders (e.g. `fixtures` or `dist` folders).

I changed the logic of the scanner to fallback to `IgnoreKind::Ancestors` only when the `path` **isn't** a dependency. 

## Test Plan

Tested locally on a real project

I tested it manually. The performance are reasonable even with a debug build

<!-- What demonstrates that your implementation is correct? -->

## Docs

N/A

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
