### PR TITLE
fix: correct error message in useIndexOf rule

### DIFF
--- a/.changeset/slimy-zoos-search.md
+++ b/.changeset/slimy-zoos-search.md
@@ -2,4 +2,6 @@
 "@biomejs/biome": patch
 ---
 
-Fixed incorrect error message in useIndexOf rule that suggested preferring findIndex over indexOf
+Fixed #7233: The useIndexOf rule now correctly suggests using indexOf() instead of findIndex().
+
+The diagnostic message was incorrectly recommending Array#findIndex() over Array#indexOf(), when it should recommend the opposite for simple equality checks.

--- a/.changeset/slimy-zoos-search.md
+++ b/.changeset/slimy-zoos-search.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed incorrect error message in useIndexOf rule that suggested preferring findIndex over indexOf

--- a/.changeset/slimy-zoos-search.md
+++ b/.changeset/slimy-zoos-search.md
@@ -2,6 +2,6 @@
 "@biomejs/biome": patch
 ---
 
-Fixed #7233: The useIndexOf rule now correctly suggests using indexOf() instead of findIndex().
+Fixed [#7233](https://github.com/biomejs/biome/issues/7233): The useIndexOf rule now correctly suggests using indexOf() instead of findIndex().
 
 The diagnostic message was incorrectly recommending Array#findIndex() over Array#indexOf(), when it should recommend the opposite for simple equality checks.

--- a/crates/biome_js_analyze/src/lint/complexity/use_index_of.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/use_index_of.rs
@@ -175,7 +175,7 @@ impl Rule for UseIndexOf {
                 rule_category!(),
                 node.range(),
                 markup! {
-                    "Prefer "<Emphasis>"Array#"{old_member_name}"()"</Emphasis>" over "<Emphasis>"Array#"{new_member_name}"()"</Emphasis>" when looking for the index of an item.`"
+                    "Prefer "<Emphasis>"Array#"{new_member_name}"()"</Emphasis>" over "<Emphasis>"Array#"{old_member_name}"()"</Emphasis>" when looking for the index of an item."
                 },
             ).note(markup! {
                 "This callback only tests for equality against a single value. This value can be passed directly to "<Emphasis>""{new_member_name}"()"</Emphasis>" instead."

--- a/crates/biome_js_analyze/tests/specs/complexity/useIndexOf/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useIndexOf/invalid.js.snap
@@ -29,7 +29,7 @@ list.findLastIndex(x => x === undefined);
 ```
 invalid.js:2:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findIndex() over Array#indexOf() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
   
     1 │ const list = ['foo', 'bar', 'baz'];
   > 2 │ list.findIndex(bar => bar === 'foo');
@@ -53,7 +53,7 @@ invalid.js:2:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:3:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findIndex() over Array#indexOf() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
   
     1 │ const list = ['foo', 'bar', 'baz'];
     2 │ list.findIndex(bar => bar === 'foo');
@@ -79,7 +79,7 @@ invalid.js:3:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:4:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findIndex() over Array#indexOf() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
   
     2 │ list.findIndex(bar => bar === 'foo');
     3 │ list.findIndex((x) => x === 'foo');
@@ -105,7 +105,7 @@ invalid.js:4:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:5:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findIndex() over Array#indexOf() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
   
     3 │ list.findIndex((x) => x === 'foo');
     4 │ list.findIndex(x => 'foo' === x);
@@ -136,7 +136,7 @@ invalid.js:5:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:9:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findIndex() over Array#indexOf() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
   
      7 │ });
      8 │ list.findIndex((x, y) => x === 'foo');
@@ -162,7 +162,7 @@ invalid.js:9:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:11:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findLastIndex() over Array#lastIndexOf() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
   
      9 │ list.findIndex(x => x === undefined);
     10 │ 
@@ -188,7 +188,7 @@ invalid.js:11:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:12:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findLastIndex() over Array#lastIndexOf() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
   
     11 │ list.findLastIndex(bar => bar === 'foo');
   > 12 │ list.findLastIndex((x) => x === 'foo');
@@ -213,7 +213,7 @@ invalid.js:12:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:13:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findLastIndex() over Array#lastIndexOf() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
   
     11 │ list.findLastIndex(bar => bar === 'foo');
     12 │ list.findLastIndex((x) => x === 'foo');
@@ -239,7 +239,7 @@ invalid.js:13:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:14:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findLastIndex() over Array#lastIndexOf() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
   
     12 │ list.findLastIndex((x) => x === 'foo');
     13 │ list.findLastIndex(x => 'foo' === x);
@@ -270,7 +270,7 @@ invalid.js:14:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:18:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#findLastIndex() over Array#lastIndexOf() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
   
     16 │ });
     17 │ list.findLastIndex((x, y) => x === 'foo');

--- a/crates/biome_js_analyze/tests/specs/complexity/useIndexOf/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/useIndexOf/invalid.js.snap
@@ -29,7 +29,7 @@ list.findLastIndex(x => x === undefined);
 ```
 invalid.js:2:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.
   
     1 │ const list = ['foo', 'bar', 'baz'];
   > 2 │ list.findIndex(bar => bar === 'foo');
@@ -53,7 +53,7 @@ invalid.js:2:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:3:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.
   
     1 │ const list = ['foo', 'bar', 'baz'];
     2 │ list.findIndex(bar => bar === 'foo');
@@ -79,7 +79,7 @@ invalid.js:3:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:4:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.
   
     2 │ list.findIndex(bar => bar === 'foo');
     3 │ list.findIndex((x) => x === 'foo');
@@ -105,7 +105,7 @@ invalid.js:4:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:5:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.
   
     3 │ list.findIndex((x) => x === 'foo');
     4 │ list.findIndex(x => 'foo' === x);
@@ -136,7 +136,7 @@ invalid.js:5:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:9:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.`
+  i Prefer Array#indexOf() over Array#findIndex() when looking for the index of an item.
   
      7 │ });
      8 │ list.findIndex((x, y) => x === 'foo');
@@ -162,7 +162,7 @@ invalid.js:9:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━�
 ```
 invalid.js:11:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.
   
      9 │ list.findIndex(x => x === undefined);
     10 │ 
@@ -188,7 +188,7 @@ invalid.js:11:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:12:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.
   
     11 │ list.findLastIndex(bar => bar === 'foo');
   > 12 │ list.findLastIndex((x) => x === 'foo');
@@ -213,7 +213,7 @@ invalid.js:12:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:13:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.
   
     11 │ list.findLastIndex(bar => bar === 'foo');
     12 │ list.findLastIndex((x) => x === 'foo');
@@ -239,7 +239,7 @@ invalid.js:13:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:14:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.
   
     12 │ list.findLastIndex((x) => x === 'foo');
     13 │ list.findLastIndex(x => 'foo' === x);
@@ -270,7 +270,7 @@ invalid.js:14:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━
 ```
 invalid.js:18:1 lint/complexity/useIndexOf  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.`
+  i Prefer Array#lastIndexOf() over Array#findLastIndex() when looking for the index of an item.
   
     16 │ });
     17 │ list.findLastIndex((x, y) => x === 'foo');


### PR DESCRIPTION
Fixes #7233

The error message was incorrectly suggesting to prefer findIndex() over indexOf(), when it should suggest the opposite. Updated the diagnostic message to correctly recommend using indexOf()/lastIndexOf() over findIndex()/findLastIndex().

## Summary

Fixed incorrect error message in the `useIndexOf` lint rule. The diagnostic was showing "Prefer Array#findIndex() over Array#indexOf()" when it should show "Prefer Array#indexOf() over Array#findIndex()". This was a simple variable swap in the diagnostic message template.

## Test Plan

The fix swaps two variables in the diagnostic message string. The existing test snapshots will catch this change and verify the message is now correct. GitHub CI will validate the build and tests.