### PR TITLE
feat(linter): auto add Svelte globals for .svelte.test/spec files

### DIFF
--- a/.changeset/tame-dolls-serve.md
+++ b/.changeset/tame-dolls-serve.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Added support for automatically recognizing Svelte globals ($state and so on) inside `.svelte.test.ts/js` `.svelte.spec.ts/js` files.

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -325,6 +325,10 @@ impl ServiceLanguage for JsLanguage {
             } else if filename.ends_with(".svelte")
                 || filename.ends_with(".svelte.js")
                 || filename.ends_with(".svelte.ts")
+                || filename.ends_with(".svelte.test.ts")
+                || filename.ends_with(".svelte.test.js")
+                || filename.ends_with(".svelte.spec.ts")
+                || filename.ends_with(".svelte.spec.js")
             {
                 // Svelte 5 runes
                 globals.extend(


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Svelte allows using [runes](https://svelte.dev/docs/svelte/testing#Unit-and-integration-testing-using-Vitest-Using-runes-inside-your-test-files) in test/spec files. Automatically add Svelte globals for those files, like we do for regular files.

## Test Plan

n/a

## Docs

No doc changes needed.
