### PR TITLE
fix(lsp): unsafe fixes when pulling code actions

### DIFF
--- a/.changeset/fancy-plants-exist.md
+++ b/.changeset/fancy-plants-exist.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#748](https://github.com/biomejs/biome-vscode/issues/748), where Biome Language Server didn't show the unsafe fixes when requesting the quick fixes. Now all LSP editors will show also opt-in, unsafe fixes.

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -8,7 +8,7 @@ use biome_analyze::{
     SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY, SourceActionKind,
 };
 use biome_configuration::analyzer::RuleSelector;
-use biome_diagnostics::{Applicability, Error};
+use biome_diagnostics::Error;
 use biome_fs::BiomePath;
 use biome_line_index::LineIndex;
 use biome_lsp_converters::from_proto;
@@ -100,16 +100,12 @@ pub(crate) fn code_actions(
     }
 
     let mut has_fix_all = false;
-    let mut has_quick_fix = false;
     let mut filters = Vec::new();
     if let Some(filter) = &params.context.only {
         for kind in filter {
             let kind = kind.as_str();
             if FIX_ALL_CATEGORY.matches(kind) {
                 has_fix_all = true;
-            }
-            if kind == "quickfix.biome" {
-                has_quick_fix = true;
             }
             filters.push(kind);
         }
@@ -202,16 +198,6 @@ pub(crate) fn code_actions(
                 &action.category, &action.suggestion.applicability
             );
 
-            // Skip quick fixes that have unsafe code fixes
-            if has_quick_fix && action.suggestion.applicability == Applicability::MaybeIncorrect {
-                return None;
-            }
-
-            if action.category.matches("quickfix.biome")
-                && action.suggestion.applicability == Applicability::MaybeIncorrect
-            {
-                return None;
-            }
             // Filter out source.organizeImports.biome action when assist is not supported.
             if action.category.matches("source.organizeImports.biome")
                 && !file_features.supports_assist()

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -1495,7 +1495,7 @@ async fn pull_biome_quick_fixes() -> Result<()> {
 }
 
 #[tokio::test]
-async fn pull_quick_fixes_not_include_unsafe() -> Result<()> {
+async fn pull_quick_fixes_include_unsafe() -> Result<()> {
     let factory = ServerFactory::default();
     let (service, client) = factory.create().into_inner();
     let (stream, sink) = client.split();
@@ -1647,9 +1647,43 @@ async fn pull_quick_fixes_not_include_unsafe() -> Result<()> {
     let expected_toplevel_suppression_action = CodeActionOrCommand::CodeAction(CodeAction {
         title: String::from("Suppress rule lint/suspicious/noDoubleEquals for the whole file."),
         kind: Some(CodeActionKind::new("quickfix.suppressRule.topLevel.biome")),
-        diagnostics: Some(vec![unsafe_fixable]),
+        diagnostics: Some(vec![unsafe_fixable.clone()]),
         edit: Some(WorkspaceEdit {
             changes: Some(top_level_changes),
+            document_changes: None,
+            change_annotations: None,
+        }),
+        command: None,
+        is_preferred: None,
+        disabled: None,
+        data: None,
+    });
+
+    let mut unsafe_action_changes = HashMap::default();
+    unsafe_action_changes.insert(
+        uri!("document.js"),
+        vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: 0,
+                    character: 7,
+                },
+                end: Position {
+                    line: 0,
+                    character: 7,
+                },
+            },
+            new_text: String::from("="),
+        }],
+    );
+    let unsafe_action = CodeActionOrCommand::CodeAction(CodeAction {
+        title: String::from("Use === instead."),
+        kind: Some(CodeActionKind::new(
+            "quickfix.biome.suspicious.noDoubleEquals",
+        )),
+        diagnostics: Some(vec![unsafe_fixable]),
+        edit: Some(WorkspaceEdit {
+            changes: Some(unsafe_action_changes),
             document_changes: None,
             change_annotations: None,
         }),
@@ -1662,6 +1696,7 @@ async fn pull_quick_fixes_not_include_unsafe() -> Result<()> {
     assert_eq!(
         res,
         vec![
+            unsafe_action,
             expected_inline_suppression_action,
             expected_toplevel_suppression_action,
         ]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome-vscode/issues/748

Now that we officially deprecated the use of `quickfix.biome`, we shouldn't use it anymore internally. The code we had was preventing the editors from opting for unsafe fixes. 

This PR fixes it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Updated existing test 

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
