### PR TITLE
feat: execute JS plugin in the Boa engine

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests on ${{ matrix.os }}
-        run: cargo test --workspace
+        run: cargo test --workspace --features=js_plugin
 
   coverage:
     name: Test262 Coverage

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -73,7 +73,7 @@ jobs:
 
       # Build the CLI binary
       - name: Build binaries
-        run: cargo build -p biome_cli --release --target ${{ matrix.target }}
+        run: cargo build -p biome_cli --release --target=${{ matrix.target }} --features=js_plugin
         env:
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols -C codegen-units=1"
@@ -129,7 +129,7 @@ jobs:
 
       # Build the CLI binary
       - name: Build binaries
-        run: cargo build -p biome_cli --release --target ${{ matrix.target }}
+        run: cargo build -p biome_cli --release --target=${{ matrix.target }} --features=js_plugin
         env:
           # Strip all debug symbols from the resulting binaries
           RUSTFLAGS: "-C strip=symbols -C codegen-units=1"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --features=js_plugin
 
   e2e-tests:
     name: End-to-end tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii_table"
@@ -933,6 +945,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "biome_js_runtime"
+version = "0.0.1"
+dependencies = [
+ "biome_analyze",
+ "biome_diagnostics",
+ "biome_resolver",
+ "biome_text_size",
+ "boa_engine",
+ "camino",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
 name = "biome_js_semantic"
 version = "0.5.7"
 dependencies = [
@@ -1337,10 +1362,13 @@ dependencies = [
  "biome_diagnostics",
  "biome_fs",
  "biome_grit_patterns",
+ "biome_js_parser",
+ "biome_js_runtime",
  "biome_json_parser",
  "biome_parser",
  "biome_resolver",
  "biome_rowan",
+ "boa_engine",
  "camino",
  "grit-pattern-matcher",
  "grit-util",
@@ -1672,9 +1700,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bitvec"
@@ -1686,6 +1714,145 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "boa_ast"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c340fe0f0b267787095cbe35240c6786ff19da63ec7b69367ba338eace8169b"
+dependencies = [
+ "bitflags 2.9.3",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap",
+ "num-bigint",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f620c3f06f51e65c0504ddf04978be1b814ac6586f0b45f6019801ab5efd37f9"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.9.3",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_profiler",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
+ "dashmap 6.1.0",
+ "fast-float2",
+ "hashbrown 0.15.5",
+ "icu_normalizer",
+ "indexmap",
+ "intrusive-collections",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "once_cell",
+ "pollster",
+ "portable-atomic",
+ "rand",
+ "regress",
+ "rustc-hash 2.1.1",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "sptr",
+ "static_assertions",
+ "tap",
+ "thin-vec",
+ "thiserror 2.0.16",
+ "time",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2425c0b7720d42d73eaa6a883fbb77a5c920da8694964a3d79a67597ac55cce2"
+dependencies = [
+ "boa_macros",
+ "boa_profiler",
+ "boa_string",
+ "hashbrown 0.15.5",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42407a3b724cfaecde8f7d4af566df4b56af32a2f11f0956f5570bb974e7f749"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "once_cell",
+ "phf",
+ "rustc-hash 2.1.1",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cc142dac798cdc6e2dbccfddeb50f36d2523bb977a976e19bdb3ae19b740804"
+dependencies = [
+ "bitflags 2.9.3",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "boa_profiler",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint",
+ "num-traits",
+ "regress",
+ "rustc-hash 2.1.1",
+]
+
+[[package]]
+name = "boa_profiler"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4064908e7cdf9b6317179e9b04dcb27f1510c1c144aeab4d0394014f37a0f922"
+
+[[package]]
+name = "boa_string"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
+dependencies = [
+ "fast-float2",
+ "paste",
+ "rustc-hash 2.1.1",
+ "sptr",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1729,9 +1896,23 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "byteorder"
@@ -2186,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -2372,6 +2553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2591,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -2564,7 +2757,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "libc",
  "libgit2-sys",
  "log",
@@ -2596,7 +2789,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "ignore",
  "walkdir",
 ]
@@ -2644,6 +2837,11 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2866,7 +3064,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "inotify-sys",
  "libc",
 ]
@@ -2894,6 +3092,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2909,7 +3116,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -2943,6 +3150,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2952,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -3041,7 +3257,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "libc",
 ]
 
@@ -3126,6 +3342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,7 +3396,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3183,7 +3408,7 @@ version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "crossbeam-channel",
  "fsevent-sys",
  "inotify",
@@ -3222,10 +3447,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3234,6 +3479,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3309,6 +3585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "path-absolutize"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3613,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pico-args"
@@ -3385,10 +3709,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.6.0"
+name = "pollster"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -3457,7 +3787,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -3481,7 +3811,7 @@ dependencies = [
  "newtype-uuid",
  "quick-xml",
  "strip-ansi-escapes",
- "thiserror 2.0.3",
+ "thiserror 2.0.16",
  "uuid",
 ]
 
@@ -3593,7 +3923,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3604,7 +3934,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.3",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -3658,6 +3988,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "regress"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145bb27393fe455dd64d6cbc8d059adfa392590a45eadf079c01b11857e7b010"
+dependencies = [
+ "hashbrown 0.15.5",
+ "memchr",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f79304aff09c245934bb9558a215e53a4cfbbe6aa8ac2a79847be551264979"
+checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -3767,7 +4107,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
@@ -3826,6 +4166,12 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
 name = "same-file"
@@ -4019,6 +4365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,6 +4403,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4199,6 +4557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,11 +4573,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -4229,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4270,13 +4634,16 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4285,15 +4652,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5215,7 +5582,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "biome_parser",
  "biome_resolver",
  "biome_rowan",
+ "biome_text_size",
  "boa_engine",
  "camino",
  "grit-pattern-matcher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,9 +1373,11 @@ dependencies = [
  "grit-pattern-matcher",
  "grit-util",
  "insta",
+ "libc",
  "papaya",
  "rustc-hash 2.1.1",
  "serde",
+ "windows",
 ]
 
 [[package]]
@@ -3225,9 +3227,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libgit2-sys"
@@ -4604,12 +4606,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -5266,6 +5267,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5385,6 +5488,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ biome_js_analyze             = { version = "0.5.7", path = "./crates/biome_js_an
 biome_js_factory             = { version = "0.5.7", path = "./crates/biome_js_factory" }
 biome_js_formatter           = { version = "0.5.7", path = "./crates/biome_js_formatter" }
 biome_js_parser              = { version = "0.5.7", path = "./crates/biome_js_parser" }
+biome_js_runtime             = { version = "0.0.1", path = "./crates/biome_js_runtime" }
 biome_js_semantic            = { version = "0.5.7", path = "./crates/biome_js_semantic" }
 biome_js_syntax              = { version = "0.5.7", path = "./crates/biome_js_syntax" }
 biome_js_type_info           = { version = "0.0.1", path = "./crates/biome_js_type_info" }
@@ -188,6 +189,7 @@ tests_macros         = { path = "./crates/tests_macros" }
 
 # Crates needed in the workspace
 anyhow               = "1.0.99"
+boa_engine           = "0.20.0"
 bpaf                 = { version = "0.9.20", features = ["derive"] }
 camino               = "1.1.11"
 cfg-if               = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ hashbrown            = { version = "0.15.5", default-features = false }
 ignore               = "0.4.23"
 indexmap             = { version = "2.10.0" }
 insta                = "1.43.1"
+libc                 = "0.2.175"
 mimalloc             = "0.1.47"
 papaya               = "0.2.3"
 path-absolutize      = { version = "3.1.1", optional = false, features = ["use_unix_paths_on_wasm"] }
@@ -239,6 +240,7 @@ ureq                 = "3.0.12"
 url                  = "2.5.4"
 walkdir              = "2.5.0"
 web-time             = "1.1.0"
+windows              = "0.61.3"
 
 [profile.dev.package.biome_wasm]
 debug     = true

--- a/biome.json
+++ b/biome.json
@@ -82,8 +82,7 @@
     }
   },
   "plugins": [
-    "plugins/no-object-assign.grit",
-    "plugins/plugin.js"
+    "plugins/no-object-assign.grit"
   ],
   "vcs": {
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,7 @@
       "**/packages/@biomejs/**",
       "**/packages/tailwindcss-config-analyzer/**",
       "**/benchmark/**",
+      "plugins/*.js",
       "scripts/**",
       "!**/crates",
       "!**/dist",
@@ -81,7 +82,8 @@
     }
   },
   "plugins": [
-    "plugins/no-object-assign.grit"
+    "plugins/no-object-assign.grit",
+    "plugins/plugin.js"
   ],
   "vcs": {
     "clientKind": "git",

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -90,6 +90,7 @@ tokio                = { workspace = true, features = ["io-util"] }
 
 [features]
 docgen = ["bpaf/docgen"]
+js_plugin = ["biome_service/js_plugin"]
 
 [lints]
 workspace = true

--- a/crates/biome_cli/Cargo.toml
+++ b/crates/biome_cli/Cargo.toml
@@ -89,7 +89,7 @@ regex                = { workspace = true }
 tokio                = { workspace = true, features = ["io-util"] }
 
 [features]
-docgen = ["bpaf/docgen"]
+docgen    = ["bpaf/docgen"]
 js_plugin = ["biome_service/js_plugin"]
 
 [lints]

--- a/crates/biome_js_analyze/Cargo.toml
+++ b/crates/biome_js_analyze/Cargo.toml
@@ -40,7 +40,7 @@ camino                   = { workspace = true }
 enumflags2               = { workspace = true }
 globset                  = { workspace = true }
 regex                    = { workspace = true }
-roaring                  = "0.11.1"
+roaring                  = "0.11.2"
 rustc-hash               = { workspace = true }
 schemars                 = { workspace = true, optional = true }
 serde                    = { workspace = true, features = ["derive"] }

--- a/crates/biome_js_runtime/Cargo.toml
+++ b/crates/biome_js_runtime/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors.workspace    = true
+categories.workspace = true
+description          = "ECMAScript runtime for JS plugins"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_js_runtime"
+repository.workspace = true
+version              = "0.0.1"
+
+[dependencies]
+biome_analyze     = { workspace = true }
+biome_diagnostics = { workspace = true }
+biome_resolver    = { workspace = true }
+biome_text_size   = { workspace = true }
+boa_engine        = { workspace = true }
+camino            = { workspace = true }
+rustc-hash        = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -45,10 +45,9 @@ impl JsExecContext {
     pub fn import_module(&mut self, path: impl AsRef<Utf8Path>) -> JsResult<Module> {
         let ctx = &mut self.ctx;
         let path = path.as_ref();
-        let source = self
-            .fs
-            .read_file_from_path(path)
-            .map_err(|err| JsNativeError::error().with_message(err.to_string()))?;
+        let source = self.fs.read_file_from_path(path).map_err(|err| {
+            JsNativeError::error().with_message(format!("Failed to read {path}: {err}"))
+        })?;
         let source = Source::from_bytes(source.as_bytes()).with_path(path.as_std_path());
         let module = Module::parse(source, None, ctx)?;
 

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -82,13 +82,13 @@ impl JsExecContext {
                     let opaque = JsError::from_opaque(err);
                     break match opaque.try_native(ctx) {
                         Some(native) => Err(native.into()),
-                        None => Err(opaque)
+                        None => Err(opaque),
                     };
                 }
                 PromiseState::Pending => {
                     // Drive the job queue until the promise settles.
                     ctx.run_jobs();
-                },
+                }
             }
         }
     }

--- a/crates/biome_js_runtime/src/context.rs
+++ b/crates/biome_js_runtime/src/context.rs
@@ -1,0 +1,106 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use boa_engine::builtins::promise::PromiseState;
+use boa_engine::module::ModuleLoader;
+use boa_engine::object::builtins::JsFunction;
+use boa_engine::{Context, JsError, JsResult, JsValue, Module, NativeFunction, Source, js_string};
+use camino::Utf8Path;
+
+use biome_analyze::RuleDiagnostic;
+use biome_resolver::FsWithResolverProxy;
+
+use crate::JsModuleLoader;
+use crate::plugin_api::JsPluginApi;
+
+pub struct JsExecContext {
+    inner: Context,
+    fs: Arc<dyn FsWithResolverProxy>,
+    api: JsPluginApi,
+}
+
+impl JsExecContext {
+    pub fn new(fs: Arc<dyn FsWithResolverProxy>) -> JsResult<Self> {
+        let module_loader = Rc::new(JsModuleLoader::new(fs.clone()));
+        let api = JsPluginApi::new();
+        let mut inner = Context::builder()
+            .module_loader(Rc::clone(&module_loader))
+            .build()?;
+
+        module_loader.register_module(
+            js_string!("@biomejs/plugin-api"),
+            api.create_module(&mut inner),
+        );
+
+        Ok(Self { inner, fs, api })
+    }
+
+    #[inline]
+    pub fn pull_diagnostics(&mut self) -> Vec<RuleDiagnostic> {
+        self.api.pull_diagnostics()
+    }
+
+    pub fn import_module(&mut self, path: impl AsRef<Utf8Path>) -> JsResult<Module> {
+        let ctx = &mut self.inner;
+        let path = path.as_ref();
+        let source = self.fs.read_file_from_path(path).unwrap();
+        let source = Source::from_bytes(source.as_bytes()).with_path(path.as_std_path());
+        let module = Module::parse(source, None, ctx)?;
+
+        let promise_result = module
+            .load(ctx)
+            .then(
+                Some(
+                    NativeFunction::from_copy_closure_with_captures(
+                        |_, _, module, context| {
+                            module.link(context)?;
+                            Ok(JsValue::undefined())
+                        },
+                        module.clone(),
+                    )
+                    .to_js_function(ctx.realm()),
+                ),
+                None,
+                ctx,
+            )
+            .then(
+                Some(
+                    NativeFunction::from_copy_closure_with_captures(
+                        |_, _, module, context| Ok(module.evaluate(context).into()),
+                        module.clone(),
+                    )
+                    .to_js_function(ctx.realm()),
+                ),
+                None,
+                ctx,
+            );
+
+        ctx.run_jobs();
+
+        match promise_result.state() {
+            PromiseState::Pending => unreachable!(),
+            PromiseState::Fulfilled(_) => {}
+            PromiseState::Rejected(err) => {
+                return Err(JsError::from_opaque(err).try_native(ctx).unwrap().into());
+            }
+        }
+
+        Ok(module)
+    }
+
+    pub fn get_default_export(&mut self, module: &Module) -> JsResult<JsValue> {
+        let ctx = &mut self.inner;
+        let namespace = module.namespace(ctx);
+
+        namespace.get(js_string!("default"), ctx)
+    }
+
+    pub fn call_function(
+        &mut self,
+        function: &JsFunction,
+        this: &JsValue,
+        args: &[JsValue],
+    ) -> JsResult<JsValue> {
+        function.call(this, args, &mut self.inner)
+    }
+}

--- a/crates/biome_js_runtime/src/lib.rs
+++ b/crates/biome_js_runtime/src/lib.rs
@@ -1,0 +1,6 @@
+mod context;
+mod module_loader;
+mod plugin_api;
+
+pub use context::JsExecContext;
+pub use module_loader::JsModuleLoader;

--- a/crates/biome_js_runtime/src/module_loader.rs
+++ b/crates/biome_js_runtime/src/module_loader.rs
@@ -1,0 +1,81 @@
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use boa_engine::module::{ModuleLoader, Referrer};
+use boa_engine::{Context, JsNativeError, JsResult, JsString, Module, Source};
+use camino::Utf8Path;
+use rustc_hash::FxHashMap;
+
+use biome_resolver::{FsWithResolverProxy, ResolveOptions, resolve};
+
+pub struct JsModuleLoader {
+    fs: Arc<dyn FsWithResolverProxy>,
+    modules: RefCell<FxHashMap<JsString, Module>>,
+}
+
+impl JsModuleLoader {
+    pub fn new(fs: Arc<dyn FsWithResolverProxy>) -> Self {
+        Self {
+            fs,
+            modules: Default::default(),
+        }
+    }
+}
+
+impl ModuleLoader for JsModuleLoader {
+    fn load_imported_module(
+        &self,
+        referrer: Referrer,
+        specifier: JsString,
+        finish_load: Box<dyn FnOnce(JsResult<Module>, &mut Context)>,
+        context: &mut Context,
+    ) {
+        if let Some(module) = self.modules.borrow().get(&specifier) {
+            finish_load(Ok(module.clone()), context);
+            return;
+        }
+
+        let specifier = specifier.to_std_string_lossy();
+
+        let base_dir = referrer
+            .path()
+            .and_then(|path| path.parent())
+            .and_then(Utf8Path::from_path)
+            .map(Utf8Path::to_path_buf)
+            .or_else(|| self.fs.working_directory())
+            .unwrap_or_default();
+
+        let options = ResolveOptions {
+            ..Default::default()
+        };
+
+        match resolve(&specifier, &base_dir, self.fs.as_ref(), &options) {
+            Ok(path) => {
+                let source = self.fs.read_file_from_path(&path);
+                match source {
+                    Ok(source) => {
+                        let source = Source::from_bytes(source.as_bytes());
+                        let module = Module::parse(source, None, context);
+                        finish_load(module, context);
+                    }
+                    Err(err) => finish_load(
+                        Err(JsNativeError::error().with_message(err.to_string()).into()),
+                        context,
+                    ),
+                }
+            }
+            Err(err) => finish_load(
+                Err(JsNativeError::error().with_message(err.to_string()).into()),
+                context,
+            ),
+        }
+    }
+
+    fn register_module(&self, specifier: JsString, module: Module) {
+        self.modules.borrow_mut().insert(specifier, module);
+    }
+
+    fn get_module(&self, specifier: JsString) -> Option<Module> {
+        self.modules.borrow().get(&specifier).cloned()
+    }
+}

--- a/crates/biome_js_runtime/src/module_loader.rs
+++ b/crates/biome_js_runtime/src/module_loader.rs
@@ -53,8 +53,8 @@ impl ModuleLoader for JsModuleLoader {
 
         match resolve(&specifier, &base_dir, self.fs.as_ref(), &options) {
             Ok(path) => {
-                if let Some(module) = self.modules.borrow().get(&path) {
-                    finish_load(Ok(module.clone()), context);
+                if let Some(module) = self.modules.borrow().get(&path).cloned() {
+                    finish_load(Ok(module), context);
                     return;
                 }
 

--- a/crates/biome_js_runtime/src/module_loader.rs
+++ b/crates/biome_js_runtime/src/module_loader.rs
@@ -56,6 +56,14 @@ impl ModuleLoader for JsModuleLoader {
                     Ok(source) => {
                         let source = Source::from_bytes(source.as_bytes());
                         let module = Module::parse(source, None, context);
+
+                        // Insert the parsed module into the cache.
+                        if let Ok(module) = &module {
+                            self.modules
+                                .borrow_mut()
+                                .insert(specifier.into(), module.clone());
+                        }
+
                         finish_load(module, context);
                     }
                     Err(err) => finish_load(

--- a/crates/biome_js_runtime/src/plugin_api.rs
+++ b/crates/biome_js_runtime/src/plugin_api.rs
@@ -1,0 +1,85 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use boa_engine::module::SyntheticModuleInitializer;
+use boa_engine::object::FunctionObjectBuilder;
+use boa_engine::{Context, JsValue, Module, NativeFunction, js_string};
+
+use biome_analyze::RuleDiagnostic;
+use biome_diagnostics::location::AsSpan;
+use biome_diagnostics::{Severity, category};
+use biome_text_size::TextRange;
+
+pub(crate) struct JsPluginApi {
+    diagnostics: Rc<RefCell<Vec<RuleDiagnostic>>>,
+}
+
+impl JsPluginApi {
+    pub(crate) fn new() -> Self {
+        Self {
+            diagnostics: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    pub(crate) fn create_module(&self, context: &mut Context) -> Module {
+        let diagnostics = self.diagnostics.clone();
+        let add_diagnostic = FunctionObjectBuilder::new(context.realm(), unsafe {
+            NativeFunction::from_closure(move |_this, args, _context| {
+                let [JsValue::String(severity), JsValue::String(message)] = args else {
+                    todo!()
+                };
+
+                let severity = match severity.to_std_string_lossy().as_str() {
+                    "fatal" => Severity::Fatal,
+                    "error" => Severity::Error,
+                    "warning" => Severity::Warning,
+                    "information" => Severity::Information,
+                    "hint" => Severity::Hint,
+                    _ => todo!(),
+                };
+
+                let diagnostic = RuleDiagnostic::new(
+                    category!("plugin"),
+                    EmptySpan, // TODO: retrieve a span from the AST
+                    message.to_std_string_lossy(),
+                )
+                .with_severity(severity);
+
+                diagnostics.borrow_mut().push(diagnostic);
+
+                Ok(JsValue::undefined())
+            })
+        })
+        .length(2)
+        .name("addDiagnostic")
+        .build();
+
+        // TODO: auto-generate AST classes and insert into the runtime
+        // TODO: more runtime APIs?
+
+        Module::synthetic(
+            &[js_string!("addDiagnostic")],
+            SyntheticModuleInitializer::from_copy_closure_with_captures(
+                |module, fns, _| {
+                    module.set_export(&js_string!("addDiagnostic"), fns.0.clone().into())
+                },
+                (add_diagnostic,),
+            ),
+            None,
+            None,
+            context,
+        )
+    }
+
+    pub(crate) fn pull_diagnostics(&self) -> Vec<RuleDiagnostic> {
+        std::mem::take(&mut self.diagnostics.borrow_mut())
+    }
+}
+
+struct EmptySpan;
+
+impl AsSpan for EmptySpan {
+    fn as_span(&self) -> Option<TextRange> {
+        None
+    }
+}

--- a/crates/biome_js_runtime/src/plugin_api.rs
+++ b/crates/biome_js_runtime/src/plugin_api.rs
@@ -6,7 +6,6 @@ use boa_engine::object::FunctionObjectBuilder;
 use boa_engine::{Context, JsValue, Module, NativeFunction, js_string};
 
 use biome_analyze::RuleDiagnostic;
-use biome_diagnostics::location::AsSpan;
 use biome_diagnostics::{Severity, category};
 use biome_text_size::TextRange;
 
@@ -40,7 +39,7 @@ impl JsPluginApi {
 
                 let diagnostic = RuleDiagnostic::new(
                     category!("plugin"),
-                    EmptySpan, // TODO: retrieve a span from the AST
+                    None::<TextRange>, // TODO: retrieve a span from the AST
                     message.to_std_string_lossy(),
                 )
                 .with_severity(severity);
@@ -73,13 +72,5 @@ impl JsPluginApi {
 
     pub(crate) fn pull_diagnostics(&self) -> Vec<RuleDiagnostic> {
         std::mem::take(&mut self.diagnostics.borrow_mut())
-    }
-}
-
-struct EmptySpan;
-
-impl AsSpan for EmptySpan {
-    fn as_span(&self) -> Option<TextRange> {
-        None
     }
 }

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -33,6 +33,12 @@ serde                    = { workspace = true }
 biome_js_runtime         = { workspace = true, optional = true }
 boa_engine               = { workspace = true, optional = true }
 
+[target.'cfg(windows)'.dependencies]
+windows = { workspace = true, optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true, optional = true }
+
 [dev-dependencies]
 biome_js_parser = { workspace = true }
 insta           = { workspace = true }
@@ -42,4 +48,4 @@ workspace = true
 
 [features]
 default = ["js_plugin"]
-js_plugin = ["dep:biome_js_runtime", "dep:boa_engine"]
+js_plugin = ["dep:biome_js_runtime", "dep:boa_engine", "dep:libc", "dep:windows"]

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -30,8 +30,16 @@ papaya                   = { workspace = true }
 rustc-hash               = { workspace = true }
 serde                    = { workspace = true }
 
+biome_js_runtime         = { workspace = true, optional = true }
+boa_engine               = { workspace = true, optional = true }
+
 [dev-dependencies]
-insta = { workspace = true }
+biome_js_parser = { workspace = true }
+insta           = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = ["js_plugin"]
+js_plugin = ["dep:biome_js_runtime", "dep:boa_engine"]

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -23,6 +23,7 @@ biome_json_parser        = { workspace = true }
 biome_parser             = { workspace = true }
 biome_resolver           = { workspace = true }
 biome_rowan              = { workspace = true }
+biome_text_size          = { workspace = true }
 camino                   = { workspace = true }
 grit-pattern-matcher     = { workspace = true }
 grit-util                = { workspace = true }

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -34,7 +34,7 @@ biome_js_runtime = { workspace = true, optional = true }
 boa_engine       = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { workspace = true, optional = true }
+windows = { workspace = true, optional = true, features = ["Win32_System_Threading"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true, optional = true }
@@ -47,5 +47,5 @@ insta           = { workspace = true }
 workspace = true
 
 [features]
-default   = ["js_plugin"]
+default   = []
 js_plugin = ["dep:biome_js_runtime", "dep:boa_engine", "dep:libc", "dep:windows"]

--- a/crates/biome_plugin_loader/Cargo.toml
+++ b/crates/biome_plugin_loader/Cargo.toml
@@ -30,8 +30,8 @@ papaya                   = { workspace = true }
 rustc-hash               = { workspace = true }
 serde                    = { workspace = true }
 
-biome_js_runtime         = { workspace = true, optional = true }
-boa_engine               = { workspace = true, optional = true }
+biome_js_runtime = { workspace = true, optional = true }
+boa_engine       = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { workspace = true, optional = true }
@@ -47,5 +47,5 @@ insta           = { workspace = true }
 workspace = true
 
 [features]
-default = ["js_plugin"]
+default   = ["js_plugin"]
 js_plugin = ["dep:biome_js_runtime", "dep:boa_engine", "dep:libc", "dep:windows"]

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -8,11 +8,11 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use biome_analyze::{AnalyzerPlugin, RuleDiagnostic};
 use biome_console::markup;
-use biome_deserialize::TextRange;
 use biome_diagnostics::category;
 use biome_js_runtime::JsExecContext;
 use biome_parser::AnyParse;
 use biome_resolver::FsWithResolverProxy;
+use biome_text_size::TextRange;
 
 use crate::PluginDiagnostic;
 use crate::thread_local::ThreadLocalCell;
@@ -59,7 +59,7 @@ impl AnalyzerJsPlugin {
         path: &Utf8Path,
     ) -> Result<Self, PluginDiagnostic> {
         // Load the plugin in the main thread here to catch errors while loading.
-        let _ = load_plugin(fs.clone(), path);
+        load_plugin(fs.clone(), path)?;
 
         Ok(Self {
             fs,
@@ -146,9 +146,9 @@ mod tests {
         fs.insert("/bar.js".into(), "let bar;");
         fs.insert(
             "/plugin.js".into(),
-            r#"import { addDiagnostic } from "@biomejs/plugin-api";
+            r#"import { registerDiagnostic } from "@biomejs/plugin-api";
             export default function useMyPlugin() {
-                addDiagnostic("information", "Hello, world!");
+                registerDiagnostic("information", "Hello, world!");
             }"#,
         );
 

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -49,7 +49,9 @@ pub struct AnalyzerJsPlugin {
 
 impl Debug for AnalyzerJsPlugin {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AnalyzerJsPlugin").finish_non_exhaustive()
+        f.debug_struct("AnalyzerJsPlugin")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+++ b/crates/biome_plugin_loader/src/analyzer_js_plugin.rs
@@ -1,0 +1,245 @@
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use boa_engine::object::builtins::JsFunction;
+use boa_engine::{JsNativeError, JsResult, JsString, JsValue};
+use camino::{Utf8Path, Utf8PathBuf};
+use rustc_hash::FxHashMap;
+
+use biome_analyze::{AnalyzerPlugin, RuleDiagnostic};
+use biome_console::markup;
+use biome_deserialize::TextRange;
+use biome_diagnostics::category;
+use biome_js_runtime::JsExecContext;
+use biome_parser::AnyParse;
+use biome_resolver::FsWithResolverProxy;
+
+use crate::PluginDiagnostic;
+
+/// The global atomic store to generate a unique plugin ID.
+static PLUGIN_ID: AtomicUsize = AtomicUsize::new(0);
+
+/// A unique ID of the JS plugin across threads.
+/// The same plugin will have the same ID, even in the different threads.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct JsPluginId(usize);
+
+impl JsPluginId {
+    /// Generate a unique plugin ID.
+    fn new() -> Self {
+        Self(PLUGIN_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// Parameters for initialising a plugin in a thread.
+struct JsPluginInit {
+    id: JsPluginId,
+    fs: Arc<dyn FsWithResolverProxy>,
+    path: Utf8PathBuf,
+}
+
+impl Debug for JsPluginInit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entry(&"id", &self.id)
+            .entry(&"path", &self.path)
+            .finish()
+    }
+}
+
+/// Already loaded plugin in a thread.
+/// These values can't be shared with another threads.
+struct LoadedPlugin {
+    ctx: JsExecContext,
+    entrypoint: JsFunction,
+}
+
+thread_local! {
+    static PLUGINS: RefCell<FxHashMap<JsPluginId, LoadedPlugin>> = RefCell::new(FxHashMap::default());
+}
+
+fn load_plugin(init: &JsPluginInit) -> JsResult<LoadedPlugin> {
+    let mut ctx = JsExecContext::new(init.fs.clone())?;
+    let module = ctx.import_module(&init.path)?;
+    let entrypoint = ctx.get_default_export(&module)?;
+
+    let Some(entrypoint) = entrypoint.as_function() else {
+        return Err(JsNativeError::typ()
+            .with_message("The plugin entrypoint must be a function")
+            .into());
+    };
+
+    Ok(LoadedPlugin { ctx, entrypoint })
+}
+
+/// Execute a function after loaded a plugin, or re-use the instance if the plugin is already loaded
+/// in the thread.
+fn with_plugin<F, R>(init: &JsPluginInit, f: F) -> JsResult<R>
+where
+    F: FnOnce(&mut LoadedPlugin) -> JsResult<R>,
+{
+    PLUGINS.with_borrow_mut(|plugins| {
+        let plugin = match plugins.entry(init.id) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(load_plugin(init)?),
+        };
+
+        f(plugin)
+    })
+}
+
+/// Unload all loaded plugin in the current thread.
+#[allow(dead_code)]
+fn unload_plugins() {
+    PLUGINS.with_borrow_mut(|plugins| std::mem::take(plugins));
+}
+
+/// A JS analyzer plugin.
+/// As the JS engine is intended to run in single thread, plugins are lazily loaded in each thread
+/// just before executing it.
+#[derive(Debug)]
+pub struct AnalyzerJsPlugin {
+    init: JsPluginInit,
+}
+
+impl AnalyzerJsPlugin {
+    pub fn load(
+        fs: Arc<dyn FsWithResolverProxy>,
+        path: &Utf8Path,
+    ) -> Result<Self, PluginDiagnostic> {
+        let id = JsPluginId::new();
+        let init = JsPluginInit {
+            id,
+            fs,
+            path: path.to_owned(),
+        };
+
+        // Load the plugin in the main thread here to catch errors while loading.
+        let _ = load_plugin(&init);
+
+        Ok(Self { init })
+    }
+}
+
+impl AnalyzerPlugin for AnalyzerJsPlugin {
+    fn evaluate(&self, _root: AnyParse, path: Arc<Utf8PathBuf>) -> Vec<RuleDiagnostic> {
+        let result = with_plugin(&self.init, |plugin| {
+            // TODO: pass the AST to the plugin
+            let _ = plugin.ctx.call_function(
+                &plugin.entrypoint,
+                &JsValue::undefined(),
+                &[JsValue::String(JsString::from(path.as_str()))],
+            )?;
+
+            Ok(plugin.ctx.pull_diagnostics())
+        });
+
+        result.unwrap_or_else(|err| {
+            vec![RuleDiagnostic::new(
+                category!("plugin"),
+                None::<TextRange>,
+                markup!("Plugin errored: "<Error>{err.to_string()}</Error>),
+            )]
+        })
+    }
+
+    fn supports_css(&self) -> bool {
+        false
+    }
+
+    fn supports_js(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biome_diagnostics::{Error, print_diagnostic_to_string};
+    use biome_fs::MemoryFileSystem;
+    use biome_js_parser::{JsFileSource, JsParserOptions};
+
+    fn snap_diagnostics(test_name: &str, diagnostics: Vec<Error>) {
+        let content = diagnostics
+            .iter()
+            .map(|err| print_diagnostic_to_string(err))
+            .collect::<Vec<_>>()
+            .join("");
+
+        // Normalize Windows paths...
+        let content = content.replace('\\', "/");
+
+        insta::with_settings!({
+            prepend_module_to_snapshot => false,
+        }, {
+            insta::assert_snapshot!(test_name, content);
+        });
+    }
+
+    #[test]
+    fn evaluate_in_worker_threads() {
+        let fs = MemoryFileSystem::default();
+        fs.insert("/foo.js".into(), "let foo;");
+        fs.insert("/bar.js".into(), "let bar;");
+        fs.insert(
+            "/plugin.js".into(),
+            r#"import { addDiagnostic } from "@biomejs/plugin-api";
+            export default function useMyPlugin() {
+                addDiagnostic("information", "Hello, world!");
+            }"#,
+        );
+
+        let fs = Arc::new(fs) as Arc<dyn FsWithResolverProxy>;
+        let plugin = Arc::new(AnalyzerJsPlugin::load(fs.clone(), "/plugin.js".into()).unwrap());
+
+        let worker1 = {
+            let plugin = plugin.clone();
+
+            std::thread::spawn(move || {
+                let parse = biome_js_parser::parse(
+                    "let foo;",
+                    JsFileSource::js_module(),
+                    JsParserOptions::default(),
+                );
+
+                let diagnostics = plugin.evaluate(parse.into(), Arc::new("/foo.js".into()));
+
+                // FIXME: Unload plugins before exiting the thread to avoid heap corruption.
+                unload_plugins();
+
+                diagnostics
+            })
+        };
+
+        let worker2 = {
+            let plugin = plugin.clone();
+
+            std::thread::spawn(move || {
+                let parse = biome_js_parser::parse(
+                    "let bar;",
+                    JsFileSource::js_module(),
+                    JsParserOptions::default(),
+                );
+
+                let diagnostics = plugin.evaluate(parse.into(), Arc::new("/bar.js".into()));
+
+                // FIXME: Unload plugins before exiting the thread to avoid heap corruption.
+                unload_plugins();
+
+                diagnostics
+            })
+        };
+
+        let mut diagnostics = worker1.join().unwrap();
+        diagnostics.extend(worker2.join().unwrap());
+
+        assert_eq!(diagnostics.len(), 2);
+        snap_diagnostics(
+            "evaluate_in_worker_threads",
+            diagnostics.into_iter().map(|diag| diag.into()).collect(),
+        );
+    }
+}

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -7,6 +7,7 @@ mod plugin_manifest;
 
 #[cfg(feature = "js_plugin")]
 mod analyzer_js_plugin;
+mod thread_local;
 
 #[cfg(feature = "js_plugin")]
 pub use analyzer_js_plugin::AnalyzerJsPlugin;

--- a/crates/biome_plugin_loader/src/lib.rs
+++ b/crates/biome_plugin_loader/src/lib.rs
@@ -7,6 +7,7 @@ mod plugin_manifest;
 
 #[cfg(feature = "js_plugin")]
 mod analyzer_js_plugin;
+#[cfg(feature = "js_plugin")]
 mod thread_local;
 
 #[cfg(feature = "js_plugin")]

--- a/crates/biome_plugin_loader/src/snapshots/evaluate_in_worker_threads.snap
+++ b/crates/biome_plugin_loader/src/snapshots/evaluate_in_worker_threads.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_plugin_loader/src/analyzer_js_plugin.rs
+expression: content
+---
+plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Hello, world!
+  
+
+plugin ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Hello, world!

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -99,7 +99,10 @@ pub(crate) struct ThreadLocalCell<T> {
     key: platform::Key<RefCell<T>>,
 }
 
-impl<T> ThreadLocalCell<T> {
+impl<T> ThreadLocalCell<T>
+where
+    T: 'static,
+{
     pub(crate) fn new() -> Self {
         Self {
             key: unsafe { platform::Key::new() },

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -14,13 +14,17 @@ mod platform {
     impl<T> Key<T> {
         pub(super) unsafe fn new() -> Self {
             let inner = unsafe { win32::FlsAlloc(None) };
+            // FlsAlloc returns FLS_OUT_OF_INDEXES (u32::MAX) on failure.
+            assert!(
+                inner != u32::MAX,
+                "FlsAlloc failed: out of FLS indexes"
+            );
 
             Self {
                 inner,
                 _phantom: PhantomData,
             }
         }
-
         pub(super) unsafe fn get(&self) -> *mut T {
             unsafe { win32::FlsGetValue(self.inner) as *mut T }
         }

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -28,13 +28,15 @@ mod platform {
         pub(super) unsafe fn set(&self, value: *mut T) {
             let result = unsafe { win32::FlsSetValue(self.inner, Some(value as *const c_void)) };
 
-            assert!(result.is_ok());
+            debug_assert!(result.is_ok());
         }
     }
 
     impl<T> Drop for Key<T> {
         fn drop(&mut self) {
-            unsafe { win32::FlsFree(self.inner) };
+            let result = unsafe { win32::FlsFree(self.inner) };
+
+            debug_assert!(result.is_ok());
         }
     }
 }

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -1,0 +1,153 @@
+use std::cell::{RefCell, RefMut};
+
+#[cfg(windows)]
+mod platform {
+    use std::ffi::c_void;
+    use std::marker::PhantomData;
+    use windows::Win32::System::Threading as win32;
+
+    pub(super) struct Key<T> {
+        inner: u32,
+        _phantom: PhantomData<fn() -> T>,
+    }
+
+    impl<T> Key<T> {
+        pub(super) unsafe fn new() -> Self {
+            let inner = unsafe { win32::FlsAlloc(Some(dtor::<T>)) };
+
+            Self {
+                inner,
+                _phantom: PhantomData,
+            }
+        }
+
+        pub(super) unsafe fn get(&self) -> *mut T {
+            unsafe { win32::FlsGetValue(self.inner) as *mut T }
+        }
+
+        pub(super) unsafe fn set(&self, value: *mut T) {
+            let result = unsafe { win32::FlsSetValue(self.inner, value as *const c_void) };
+
+            assert!(result.is_ok());
+        }
+    }
+
+    impl<T> Drop for Key<T> {
+        fn drop(&mut self) {
+            unsafe { win32::FlsFree(self.inner) };
+        }
+    }
+
+    unsafe extern "system" fn dtor<T>(ptr: *mut c_void) {
+        unsafe {
+            if !ptr.is_null() {
+                std::ptr::drop_in_place(ptr as *mut T);
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+mod platform {
+    use std::ffi::c_void;
+    use std::marker::PhantomData;
+    use std::mem::MaybeUninit;
+
+    pub(super) struct Key<T> {
+        inner: libc::pthread_key_t,
+        _phantom: PhantomData<fn() -> T>,
+    }
+
+    impl<T> Key<T> {
+        pub(super) unsafe fn new() -> Self {
+            let inner = unsafe {
+                let mut inner = MaybeUninit::uninit();
+                let result = libc::pthread_key_create(inner.as_mut_ptr(), Some(dtor::<T>));
+
+                assert_eq!(result, 0);
+
+                inner.assume_init()
+            };
+
+            Self {
+                inner,
+                _phantom: PhantomData,
+            }
+        }
+
+        pub(super) unsafe fn get(&self) -> *mut T {
+            unsafe { libc::pthread_getspecific(self.inner) as *mut T }
+        }
+
+        pub(super) unsafe fn set(&self, value: *mut T) {
+            let result = unsafe { libc::pthread_setspecific(self.inner, value as *mut c_void) };
+
+            debug_assert_eq!(result, 0);
+        }
+    }
+
+    impl<T> Drop for Key<T> {
+        fn drop(&mut self) {
+            let result = unsafe { libc::pthread_key_delete(self.inner) };
+
+            debug_assert_eq!(result, 0);
+        }
+    }
+
+    unsafe extern "C" fn dtor<T>(ptr: *mut c_void) {
+        if !ptr.is_null() {
+            // FIXME: Dropping the value here will break Boa's GC
+            // std::ptr::drop_in_place(ptr as *mut T);
+            let _ = ptr as *mut T;
+        }
+    }
+}
+
+/// Thread-local storage.
+/// It uses [`Fiber Local Storage`](https://learn.microsoft.com/en-us/windows/win32/procthread/fibers#fiber-local-storage) on Windows,
+/// or [`pthread_setspecific(3)`](https://linux.die.net/man/3/pthread_setspecific) on Unix.
+pub(crate) struct ThreadLocalCell<T> {
+    key: platform::Key<RefCell<T>>,
+}
+
+impl<T> ThreadLocalCell<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            key: unsafe { platform::Key::new() },
+        }
+    }
+
+    pub(crate) fn get_mut_or_try_init<F, E>(&self, default: F) -> Result<RefMut<'_, T>, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        match self.get_mut() {
+            Some(r) => Ok(r),
+            _ => match default() {
+                Ok(value) => {
+                    self.set(value);
+                    Ok(self.get_mut().unwrap())
+                }
+                Err(err) => Err(err),
+            },
+        }
+    }
+
+    fn get_mut(&self) -> Option<RefMut<'_, T>> {
+        unsafe {
+            let ptr = self.key.get();
+            if ptr.is_null() {
+                None
+            } else {
+                Some((&*ptr).borrow_mut())
+            }
+        }
+    }
+
+    fn set(&self, value: T) {
+        let cell = Box::into_raw(Box::new(RefCell::new(value)));
+        unsafe {
+            self.key.set(cell);
+        }
+    }
+}

--- a/crates/biome_plugin_loader/src/thread_local.rs
+++ b/crates/biome_plugin_loader/src/thread_local.rs
@@ -15,10 +15,7 @@ mod platform {
         pub(super) unsafe fn new() -> Self {
             let inner = unsafe { win32::FlsAlloc(None) };
             // FlsAlloc returns FLS_OUT_OF_INDEXES (u32::MAX) on failure.
-            assert!(
-                inner != u32::MAX,
-                "FlsAlloc failed: out of FLS indexes"
-            );
+            assert!(inner != u32::MAX, "FlsAlloc failed: out of FLS indexes");
 
             Self {
                 inner,

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -98,6 +98,7 @@ schema = [
   "biome_fs/schema",
   "biome_module_graph/schema",
 ]
+js_plugin = ["biome_plugin_loader/js_plugin"]
 
 [lints]
 workspace = true

--- a/crates/biome_service/Cargo.toml
+++ b/crates/biome_service/Cargo.toml
@@ -80,6 +80,7 @@ web-time                = { workspace = true }
 insta = { workspace = true }
 
 [features]
+js_plugin = ["biome_plugin_loader/js_plugin"]
 schema = [
   "dep:schemars",
   "biome_configuration/schema",
@@ -98,7 +99,6 @@ schema = [
   "biome_fs/schema",
   "biome_module_graph/schema",
 ]
-js_plugin = ["biome_plugin_loader/js_plugin"]
 
 [lints]
 workspace = true

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -488,7 +488,7 @@ impl WorkspaceServer {
         for plugin_config in plugins.iter() {
             match plugin_config {
                 PluginConfiguration::Path(plugin_path) => {
-                    match BiomePlugin::load(self.fs.as_ref(), plugin_path, base_path) {
+                    match BiomePlugin::load(self.fs.clone(), plugin_path, base_path) {
                         Ok((plugin, _)) => {
                             plugin_cache.insert_plugin(plugin_path.clone().into(), plugin);
                         }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@biomejs/plugin-api": "workspace:",
     "@changesets/changelog-github": "0.5.1",
     "@changesets/cli": "2.29.6",
     "@types/node": "22.17.2"

--- a/packages/@biomejs/plugin-api/LICENSE-APACHE
+++ b/packages/@biomejs/plugin-api/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright (c) 2023 Biome Developers and Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/@biomejs/plugin-api/LICENSE-MIT
+++ b/packages/@biomejs/plugin-api/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Biome Developers and Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/@biomejs/plugin-api/index.d.ts
+++ b/packages/@biomejs/plugin-api/index.d.ts
@@ -1,3 +1,3 @@
 export type Severity = "fatal" | "error" | "warning" | "information" | "hint";
 
-export function addDiagnostic(severity: Severity, message: string): void;
+export function registerDiagnostic(severity: Severity, message: string): void;

--- a/packages/@biomejs/plugin-api/index.d.ts
+++ b/packages/@biomejs/plugin-api/index.d.ts
@@ -1,0 +1,3 @@
+export type Severity = "fatal" | "error" | "warning" | "information" | "hint";
+
+export function addDiagnostic(severity: Severity, message: string): void;

--- a/packages/@biomejs/plugin-api/index.js
+++ b/packages/@biomejs/plugin-api/index.js
@@ -1,0 +1,3 @@
+throw new Error(
+	"This package is intended to be used in Biome JS plugins, did you mean `@biomejs/js-api`?",
+);

--- a/packages/@biomejs/plugin-api/package.json
+++ b/packages/@biomejs/plugin-api/package.json
@@ -1,0 +1,36 @@
+{
+  "private": true,
+  "name": "@biomejs/plugin-api",
+  "version": "0.0.0",
+  "description": "JavaScript APIs for Biome JS plugins",
+  "files": [
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "index.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "license": "MIT OR Apache-2.0",
+  "homepage": "https://biomejs.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/biomejs/biome.git",
+    "directory": "packages/@biomejs/plugin-api"
+  },
+  "author": "Biome Developers and Contributors",
+  "bugs": "https://github.com/biomejs/biome/issues",
+  "devDependencies": {},
+  "peerDependencies": {
+    "@biomejs/biome": "*"
+  },
+  "publishConfig": {
+    "provenance": true
+  }
+}

--- a/plugins/plugin.js
+++ b/plugins/plugin.js
@@ -1,0 +1,8 @@
+import { addDiagnostic } from "@biomejs/plugin-api";
+
+/** @param {string} path */
+export default function useMyPlugin(path) {
+	if (path.endsWith("plugin.js")) {
+		addDiagnostic("warning", "Hello, world!");
+	}
+}

--- a/plugins/plugin.js
+++ b/plugins/plugin.js
@@ -1,8 +1,8 @@
-import { addDiagnostic } from "@biomejs/plugin-api";
+import { registerDiagnostic } from "@biomejs/plugin-api";
 
 /** @param {string} path */
 export default function useMyPlugin(path) {
 	if (path.endsWith("plugin.js")) {
-		addDiagnostic("warning", "Hello, world!");
+		registerDiagnostic("warning", "Hello, world!");
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/plugin-api':
+        specifier: 'workspace:'
+        version: link:packages/@biomejs/plugin-api
       '@changesets/changelog-github':
         specifier: 0.5.1
         version: 0.5.1
@@ -145,6 +148,12 @@ importers:
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@22.17.2)(happy-dom@18.0.1)(jiti@1.21.6)
+
+  packages/@biomejs/plugin-api:
+    dependencies:
+      '@biomejs/biome':
+        specifier: '*'
+        version: link:../biome
 
   packages/@biomejs/wasm-bundler: {}
 


### PR DESCRIPTION
## Summary

Part of #2469

This pull request integrates the Boa engine to Biome for JS plugins. It runs the default exported function and pulls diagnostics from the plugin. JS APIs for Biome's AST/CST aren't implemented yet.

Support for JS plugins is gated behind the `js_plugin` feature and it will be enabled only in preview releases. Thus I think we can merge this to the main branch.

## Test Plan

Added a simple test using multiple threads.

## Docs

TODO