### PR TITLE
fix(parse/css): let `@utility` parse declarations and rules

### DIFF
--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -2513,7 +2513,7 @@ impl TwThemeAtRuleBuilder {
 pub fn tw_utility_at_rule(
     utility_token: SyntaxToken,
     name: AnyTwUtilityName,
-    block: AnyCssDeclarationBlock,
+    block: AnyCssDeclarationOrRuleBlock,
 ) -> TwUtilityAtRule {
     TwUtilityAtRule::unwrap_cast(SyntaxNode::new_detached(
         CssSyntaxKind::TW_UTILITY_AT_RULE,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -5157,7 +5157,7 @@ impl SyntaxFactory for CssSyntaxFactory {
                 }
                 slots.next_slot();
                 if let Some(element) = &current_element
-                    && AnyCssDeclarationBlock::can_cast(element.kind())
+                    && AnyCssDeclarationOrRuleBlock::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
+++ b/crates/biome_css_parser/src/syntax/at_rule/tailwind.rs
@@ -1,8 +1,6 @@
 use crate::lexer::CssLexContext;
 use crate::parser::CssParser;
-use crate::syntax::block::{
-    parse_declaration_block, parse_declaration_or_rule_list_block, parse_rule_block,
-};
+use crate::syntax::block::{parse_declaration_or_rule_list_block, parse_rule_block};
 use crate::syntax::parse_error::{expected_identifier, expected_selector, expected_string};
 use crate::syntax::selector::parse_selector;
 use crate::syntax::{is_at_identifier, parse_identifier, parse_regular_identifier, parse_string};
@@ -47,7 +45,7 @@ pub(crate) fn parse_utility_at_rule(p: &mut CssParser) -> ParsedSyntax {
 
     parse_utility_name(p).ok();
 
-    parse_declaration_block(p);
+    parse_declaration_or_rule_list_block(p);
 
     Present(m.complete(p, TW_UTILITY_AT_RULE))
 }

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/utility.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/utility.css.snap
@@ -24,9 +24,9 @@ CssRoot {
                     CssIdentifier {
                         value_token: IDENT@9..20 "empty-util" [] [Whitespace(" ")],
                     },
-                    CssDeclarationBlock {
+                    CssDeclarationOrRuleBlock {
                         l_curly_token: L_CURLY@20..21 "{" [] [],
-                        declarations: CssDeclarationList [],
+                        items: CssDeclarationOrRuleList [],
                         r_curly_token: R_CURLY@21..22 "}" [] [],
                     },
                 ],
@@ -49,9 +49,9 @@ CssRoot {
         0: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@9..20
           0: IDENT@9..20 "empty-util" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@20..22
+        2: CSS_DECLARATION_OR_RULE_BLOCK@20..22
           0: L_CURLY@20..21 "{" [] []
-          1: CSS_DECLARATION_LIST@21..21
+          1: CSS_DECLARATION_OR_RULE_LIST@21..21
           2: R_CURLY@21..22 "}" [] []
   2: EOF@22..23 "" [Newline("\n")] []
 

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/value-arbitrary.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/value-arbitrary.css.snap
@@ -29,56 +29,49 @@ CssRoot {
                     minus_token: MINUS@12..13 "-" [] [],
                     star_token: STAR@13..15 "*" [] [Whitespace(" ")],
                 },
-                block: CssBogusBlock {
-                    items: [
-                        L_CURLY@15..16 "{" [] [],
-                        CssDeclarationList [
-                            CssDeclarationWithSemicolon {
-                                declaration: CssDeclaration {
-                                    property: CssGenericProperty {
-                                        name: CssIdentifier {
-                                            value_token: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] [],
-                                        },
-                                        colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
-                                        value: CssGenericComponentValueList [
-                                            CssFunction {
-                                                name: CssIdentifier {
-                                                    value_token: IDENT@25..32 "--value" [] [],
-                                                },
-                                                l_paren_token: L_PAREN@32..33 "(" [] [],
-                                                items: CssParameterList [
-                                                    CssParameter {
-                                                        any_css_expression: CssListOfComponentValuesExpression {
-                                                            css_component_value_list: CssComponentValueList [
-                                                                CssBracketedValue {
-                                                                    l_brack_token: L_BRACK@33..34 "[" [] [],
-                                                                    items: CssBracketedValueList [
-                                                                        CssCustomIdentifier {
-                                                                            value_token: IDENT@34..40 "length" [] [],
-                                                                        },
-                                                                        CssBogusCustomIdentifier {
-                                                                            items: [
-                                                                                R_PAREN@40..41 ")" [] [],
-                                                                                R_CURLY@41..43 "}" [Newline("\n")] [],
-                                                                            ],
-                                                                        },
-                                                                    ],
-                                                                    r_brack_token: missing (required),
-                                                                },
-                                                            ],
-                                                        },
-                                                    },
-                                                ],
-                                                r_paren_token: missing (required),
-                                            },
-                                        ],
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@15..16 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] [],
                                     },
-                                    important: missing (optional),
+                                    colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@25..32 "--value" [] [],
+                                            },
+                                            l_paren_token: L_PAREN@32..33 "(" [] [],
+                                            items: CssParameterList [
+                                                CssParameter {
+                                                    any_css_expression: CssListOfComponentValuesExpression {
+                                                        css_component_value_list: CssComponentValueList [
+                                                            CssBracketedValue {
+                                                                l_brack_token: L_BRACK@33..34 "[" [] [],
+                                                                items: CssBracketedValueList [
+                                                                    CssCustomIdentifier {
+                                                                        value_token: IDENT@34..40 "length" [] [],
+                                                                    },
+                                                                ],
+                                                                r_brack_token: missing (required),
+                                                            },
+                                                        ],
+                                                    },
+                                                },
+                                            ],
+                                            r_paren_token: R_PAREN@40..41 ")" [] [],
+                                        },
+                                    ],
                                 },
-                                semicolon_token: missing (optional),
+                                important: missing (optional),
                             },
-                        ],
+                            semicolon_token: missing (optional),
+                        },
                     ],
+                    r_curly_token: R_CURLY@41..43 "}" [Newline("\n")] [],
                 },
             },
         },
@@ -102,36 +95,34 @@ CssRoot {
             0: IDENT@9..12 "foo" [] []
           1: MINUS@12..13 "-" [] []
           2: STAR@13..15 "*" [] [Whitespace(" ")]
-        2: CSS_BOGUS_BLOCK@15..43
+        2: CSS_DECLARATION_OR_RULE_BLOCK@15..43
           0: L_CURLY@15..16 "{" [] []
-          1: CSS_DECLARATION_LIST@16..43
-            0: CSS_DECLARATION_WITH_SEMICOLON@16..43
-              0: CSS_DECLARATION@16..43
-                0: CSS_GENERIC_PROPERTY@16..43
+          1: CSS_DECLARATION_OR_RULE_LIST@16..41
+            0: CSS_DECLARATION_WITH_SEMICOLON@16..41
+              0: CSS_DECLARATION@16..41
+                0: CSS_GENERIC_PROPERTY@16..41
                   0: CSS_IDENTIFIER@16..23
                     0: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] []
                   1: COLON@23..25 ":" [] [Whitespace(" ")]
-                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@25..43
-                    0: CSS_FUNCTION@25..43
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@25..41
+                    0: CSS_FUNCTION@25..41
                       0: CSS_IDENTIFIER@25..32
                         0: IDENT@25..32 "--value" [] []
                       1: L_PAREN@32..33 "(" [] []
-                      2: CSS_PARAMETER_LIST@33..43
-                        0: CSS_PARAMETER@33..43
-                          0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@33..43
-                            0: CSS_COMPONENT_VALUE_LIST@33..43
-                              0: CSS_BRACKETED_VALUE@33..43
+                      2: CSS_PARAMETER_LIST@33..40
+                        0: CSS_PARAMETER@33..40
+                          0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@33..40
+                            0: CSS_COMPONENT_VALUE_LIST@33..40
+                              0: CSS_BRACKETED_VALUE@33..40
                                 0: L_BRACK@33..34 "[" [] []
-                                1: CSS_BRACKETED_VALUE_LIST@34..43
+                                1: CSS_BRACKETED_VALUE_LIST@34..40
                                   0: CSS_CUSTOM_IDENTIFIER@34..40
                                     0: IDENT@34..40 "length" [] []
-                                  1: CSS_BOGUS_CUSTOM_IDENTIFIER@40..43
-                                    0: R_PAREN@40..41 ")" [] []
-                                    1: R_CURLY@41..43 "}" [Newline("\n")] []
                                 2: (empty)
-                      3: (empty)
+                      3: R_PAREN@40..41 ")" [] []
                 1: (empty)
               1: (empty)
+          2: R_CURLY@41..43 "}" [Newline("\n")] []
   2: EOF@43..44 "" [Newline("\n")] []
 
 ```
@@ -141,14 +132,12 @@ CssRoot {
 ```
 value-arbitrary.css:2:24 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  × Expected an identifier but instead found ')
-    }'.
+  × Expected an identifier but instead found ')'.
   
     1 │ @utility foo-* {
   > 2 │ 	width: --value([length)
       │ 	                      ^
-  > 3 │ }
-      │ ^
+    3 │ }
     4 │ 
   
   i Expected an identifier here.
@@ -156,24 +145,7 @@ value-arbitrary.css:2:24 parse ━━━━━━━━━━━━━━━━�
     1 │ @utility foo-* {
   > 2 │ 	width: --value([length)
       │ 	                      ^
-  > 3 │ }
-      │ ^
+    3 │ }
     4 │ 
-  
-value-arbitrary.css:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `]` but instead the file ends
-  
-    2 │ 	width: --value([length)
-    3 │ }
-  > 4 │ 
-      │ 
-  
-  i the file ends here
-  
-    2 │ 	width: --value([length)
-    3 │ }
-  > 4 │ 
-      │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/value-incomplete.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/value-incomplete.css.snap
@@ -29,62 +29,43 @@ CssRoot {
                     minus_token: MINUS@12..13 "-" [] [],
                     star_token: STAR@13..15 "*" [] [Whitespace(" ")],
                 },
-                block: CssBogusBlock {
-                    items: [
-                        L_CURLY@15..16 "{" [] [],
-                        CssDeclarationList [
-                            CssDeclarationWithSemicolon {
-                                declaration: CssDeclaration {
-                                    property: CssBogusProperty {
-                                        items: [
-                                            CssIdentifier {
-                                                value_token: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] [],
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@15..16 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@23..25 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssFunction {
+                                            name: CssIdentifier {
+                                                value_token: IDENT@25..32 "--value" [] [],
                                             },
-                                            COLON@23..25 ":" [] [Whitespace(" ")],
-                                            CssBogus {
-                                                items: [
-                                                    CssBogusSupportsCondition {
-                                                        items: [
+                                            l_paren_token: L_PAREN@32..33 "(" [] [],
+                                            items: CssParameterList [
+                                                CssParameter {
+                                                    any_css_expression: CssListOfComponentValuesExpression {
+                                                        css_component_value_list: CssComponentValueList [
                                                             CssIdentifier {
-                                                                value_token: IDENT@25..32 "--value" [] [],
-                                                            },
-                                                            L_PAREN@32..33 "(" [] [],
-                                                            CssBogus {
-                                                                items: [
-                                                                    CssBogus {
-                                                                        items: [
-                                                                            CssBogus {
-                                                                                items: [
-                                                                                    CssBogus {
-                                                                                        items: [
-                                                                                            CssIdentifier {
-                                                                                                value_token: IDENT@33..39 "length" [] [],
-                                                                                            },
-                                                                                            CssBogus {
-                                                                                                items: [
-                                                                                                    R_CURLY@39..41 "}" [Newline("\n")] [],
-                                                                                                ],
-                                                                                            },
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    },
-                                                                ],
+                                                                value_token: IDENT@33..39 "length" [] [],
                                                             },
                                                         ],
                                                     },
-                                                ],
-                                            },
-                                        ],
-                                    },
-                                    important: missing (optional),
+                                                },
+                                            ],
+                                            r_paren_token: missing (required),
+                                        },
+                                    ],
                                 },
-                                semicolon_token: missing (optional),
+                                important: missing (optional),
                             },
-                        ],
+                            semicolon_token: missing (optional),
+                        },
                     ],
+                    r_curly_token: R_CURLY@39..41 "}" [Newline("\n")] [],
                 },
             },
         },
@@ -108,30 +89,30 @@ CssRoot {
             0: IDENT@9..12 "foo" [] []
           1: MINUS@12..13 "-" [] []
           2: STAR@13..15 "*" [] [Whitespace(" ")]
-        2: CSS_BOGUS_BLOCK@15..41
+        2: CSS_DECLARATION_OR_RULE_BLOCK@15..41
           0: L_CURLY@15..16 "{" [] []
-          1: CSS_DECLARATION_LIST@16..41
-            0: CSS_DECLARATION_WITH_SEMICOLON@16..41
-              0: CSS_DECLARATION@16..41
-                0: CSS_BOGUS_PROPERTY@16..41
+          1: CSS_DECLARATION_OR_RULE_LIST@16..39
+            0: CSS_DECLARATION_WITH_SEMICOLON@16..39
+              0: CSS_DECLARATION@16..39
+                0: CSS_GENERIC_PROPERTY@16..39
                   0: CSS_IDENTIFIER@16..23
                     0: IDENT@16..23 "width" [Newline("\n"), Whitespace("\t")] []
                   1: COLON@23..25 ":" [] [Whitespace(" ")]
-                  2: CSS_BOGUS@25..41
-                    0: CSS_BOGUS_SUPPORTS_CONDITION@25..41
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@25..39
+                    0: CSS_FUNCTION@25..39
                       0: CSS_IDENTIFIER@25..32
                         0: IDENT@25..32 "--value" [] []
                       1: L_PAREN@32..33 "(" [] []
-                      2: CSS_BOGUS@33..41
-                        0: CSS_BOGUS@33..41
-                          0: CSS_BOGUS@33..41
-                            0: CSS_BOGUS@33..41
+                      2: CSS_PARAMETER_LIST@33..39
+                        0: CSS_PARAMETER@33..39
+                          0: CSS_LIST_OF_COMPONENT_VALUES_EXPRESSION@33..39
+                            0: CSS_COMPONENT_VALUE_LIST@33..39
                               0: CSS_IDENTIFIER@33..39
                                 0: IDENT@33..39 "length" [] []
-                              1: CSS_BOGUS@39..41
-                                0: R_CURLY@39..41 "}" [Newline("\n")] []
+                      3: (empty)
                 1: (empty)
               1: (empty)
+          2: R_CURLY@39..41 "}" [Newline("\n")] []
   2: EOF@41..42 "" [Newline("\n")] []
 
 ```
@@ -158,21 +139,5 @@ value-incomplete.css:3:1 parse ━━━━━━━━━━━━━━━━�
   - ratio
   - custom property
   - function
-  
-value-incomplete.css:4:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  × expected `)` but instead the file ends
-  
-    2 │ 	width: --value(length
-    3 │ }
-  > 4 │ 
-      │ 
-  
-  i the file ends here
-  
-    2 │ 	width: --value(length
-    3 │ }
-  > 4 │ 
-      │ 
   
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/simple.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/simple.css.snap
@@ -97,9 +97,9 @@ CssRoot {
                 name: CssIdentifier {
                     value_token: IDENT@121..128 "center" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@128..129 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -397,9 +397,9 @@ CssRoot {
         0: UTILITY_KW@113..121 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@121..128
           0: IDENT@121..128 "center" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@128..198
+        2: CSS_DECLARATION_OR_RULE_BLOCK@128..198
           0: L_CURLY@128..129 "{" [] []
-          1: CSS_DECLARATION_LIST@129..196
+          1: CSS_DECLARATION_OR_RULE_LIST@129..196
             0: CSS_DECLARATION_WITH_SEMICOLON@129..146
               0: CSS_DECLARATION@129..145
                 0: CSS_GENERIC_PROPERTY@129..145

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/arbitrary-star.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/arbitrary-star.css.snap
@@ -29,9 +29,9 @@ CssRoot {
                     minus_token: MINUS@12..13 "-" [] [],
                     star_token: STAR@13..15 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@15..16 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -95,9 +95,9 @@ CssRoot {
             0: IDENT@9..12 "tab" [] []
           1: MINUS@12..13 "-" [] []
           2: STAR@13..15 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@15..43
+        2: CSS_DECLARATION_OR_RULE_BLOCK@15..43
           0: L_CURLY@15..16 "{" [] []
-          1: CSS_DECLARATION_LIST@16..41
+          1: CSS_DECLARATION_OR_RULE_LIST@16..41
             0: CSS_DECLARATION_WITH_SEMICOLON@16..41
               0: CSS_DECLARATION@16..40
                 0: CSS_GENERIC_PROPERTY@16..40

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/enhanced-value-function.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/enhanced-value-function.css.snap
@@ -59,9 +59,9 @@ CssRoot {
                     minus_token: MINUS@76..77 "-" [] [],
                     star_token: STAR@77..79 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@79..80 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -116,9 +116,9 @@ CssRoot {
                     minus_token: MINUS@131..132 "-" [] [],
                     star_token: STAR@132..134 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@134..135 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -173,9 +173,9 @@ CssRoot {
                     minus_token: MINUS@180..181 "-" [] [],
                     star_token: STAR@181..183 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@183..184 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -230,9 +230,9 @@ CssRoot {
                     minus_token: MINUS@291..292 "-" [] [],
                     star_token: STAR@292..294 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@294..295 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -285,9 +285,9 @@ CssRoot {
                     minus_token: MINUS@344..345 "-" [] [],
                     star_token: STAR@345..347 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@347..348 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -340,9 +340,9 @@ CssRoot {
                     minus_token: MINUS@448..449 "-" [] [],
                     star_token: STAR@449..451 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@451..452 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -391,9 +391,9 @@ CssRoot {
                     minus_token: MINUS@567..568 "-" [] [],
                     star_token: STAR@568..570 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@570..571 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -585,9 +585,9 @@ CssRoot {
             0: IDENT@69..76 "opacity" [] []
           1: MINUS@76..77 "-" [] []
           2: STAR@77..79 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@79..115
+        2: CSS_DECLARATION_OR_RULE_BLOCK@79..115
           0: L_CURLY@79..80 "{" [] []
-          1: CSS_DECLARATION_LIST@80..113
+          1: CSS_DECLARATION_OR_RULE_LIST@80..113
             0: CSS_DECLARATION_WITH_SEMICOLON@80..113
               0: CSS_DECLARATION@80..112
                 0: CSS_GENERIC_PROPERTY@80..112
@@ -622,9 +622,9 @@ CssRoot {
             0: IDENT@126..131 "width" [] []
           1: MINUS@131..132 "-" [] []
           2: STAR@132..134 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@134..164
+        2: CSS_DECLARATION_OR_RULE_BLOCK@134..164
           0: L_CURLY@134..135 "{" [] []
-          1: CSS_DECLARATION_LIST@135..162
+          1: CSS_DECLARATION_OR_RULE_LIST@135..162
             0: CSS_DECLARATION_WITH_SEMICOLON@135..162
               0: CSS_DECLARATION@135..161
                 0: CSS_GENERIC_PROPERTY@135..161
@@ -659,9 +659,9 @@ CssRoot {
             0: IDENT@175..180 "color" [] []
           1: MINUS@180..181 "-" [] []
           2: STAR@181..183 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@183..212
+        2: CSS_DECLARATION_OR_RULE_BLOCK@183..212
           0: L_CURLY@183..184 "{" [] []
-          1: CSS_DECLARATION_LIST@184..210
+          1: CSS_DECLARATION_OR_RULE_LIST@184..210
             0: CSS_DECLARATION_WITH_SEMICOLON@184..210
               0: CSS_DECLARATION@184..209
                 0: CSS_GENERIC_PROPERTY@184..209
@@ -696,9 +696,9 @@ CssRoot {
             0: IDENT@284..291 "spacing" [] []
           1: MINUS@291..292 "-" [] []
           2: STAR@292..294 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@294..328
+        2: CSS_DECLARATION_OR_RULE_BLOCK@294..328
           0: L_CURLY@294..295 "{" [] []
-          1: CSS_DECLARATION_LIST@295..326
+          1: CSS_DECLARATION_OR_RULE_LIST@295..326
             0: CSS_DECLARATION_WITH_SEMICOLON@295..326
               0: CSS_DECLARATION@295..325
                 0: CSS_GENERIC_PROPERTY@295..325
@@ -732,9 +732,9 @@ CssRoot {
             0: IDENT@339..344 "color" [] []
           1: MINUS@344..345 "-" [] []
           2: STAR@345..347 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@347..378
+        2: CSS_DECLARATION_OR_RULE_BLOCK@347..378
           0: L_CURLY@347..348 "{" [] []
-          1: CSS_DECLARATION_LIST@348..376
+          1: CSS_DECLARATION_OR_RULE_LIST@348..376
             0: CSS_DECLARATION_WITH_SEMICOLON@348..376
               0: CSS_DECLARATION@348..375
                 0: CSS_GENERIC_PROPERTY@348..375
@@ -768,9 +768,9 @@ CssRoot {
             0: IDENT@444..448 "flex" [] []
           1: MINUS@448..449 "-" [] []
           2: STAR@449..451 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@451..479
+        2: CSS_DECLARATION_OR_RULE_BLOCK@451..479
           0: L_CURLY@451..452 "{" [] []
-          1: CSS_DECLARATION_LIST@452..477
+          1: CSS_DECLARATION_OR_RULE_LIST@452..477
             0: CSS_DECLARATION_WITH_SEMICOLON@452..477
               0: CSS_DECLARATION@452..476
                 0: CSS_GENERIC_PROPERTY@452..476
@@ -801,9 +801,9 @@ CssRoot {
             0: IDENT@560..567 "complex" [] []
           1: MINUS@567..568 "-" [] []
           2: STAR@568..570 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@570..711
+        2: CSS_DECLARATION_OR_RULE_BLOCK@570..711
           0: L_CURLY@570..571 "{" [] []
-          1: CSS_DECLARATION_LIST@571..709
+          1: CSS_DECLARATION_OR_RULE_LIST@571..709
             0: CSS_DECLARATION_WITH_SEMICOLON@571..625
               0: CSS_DECLARATION@571..624
                 0: CSS_GENERIC_PROPERTY@571..624

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/modifier.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/modifier.css.snap
@@ -29,9 +29,9 @@ CssRoot {
                     minus_token: MINUS@13..14 "-" [] [],
                     star_token: STAR@14..16 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@16..17 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -109,9 +109,9 @@ CssRoot {
             0: IDENT@9..13 "text" [] []
           1: MINUS@13..14 "-" [] []
           2: STAR@14..16 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@16..68
+        2: CSS_DECLARATION_OR_RULE_BLOCK@16..68
           0: L_CURLY@16..17 "{" [] []
-          1: CSS_DECLARATION_LIST@17..66
+          1: CSS_DECLARATION_OR_RULE_LIST@17..66
             0: CSS_DECLARATION_WITH_SEMICOLON@17..66
               0: CSS_DECLARATION@17..65
                 0: CSS_GENERIC_PROPERTY@17..65

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/simple-utility.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/simple-utility.css.snap
@@ -45,9 +45,9 @@ CssRoot {
                 name: CssIdentifier {
                     value_token: IDENT@9..21 "center-flex" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@21..22 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -111,9 +111,9 @@ CssRoot {
                 name: CssIdentifier {
                     value_token: IDENT@99..107 "sr-only" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@107..108 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -327,9 +327,9 @@ CssRoot {
                 name: CssIdentifier {
                     value_token: IDENT@275..281 "tab-4" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@281..282 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -359,9 +359,9 @@ CssRoot {
                 name: CssIdentifier {
                     value_token: IDENT@309..320 "empty-util" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@320..321 "{" [] [],
-                    declarations: CssDeclarationList [],
+                    items: CssDeclarationOrRuleList [],
                     r_curly_token: R_CURLY@321..322 "}" [] [],
                 },
             },
@@ -383,9 +383,9 @@ CssRoot {
         0: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@9..21
           0: IDENT@9..21 "center-flex" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@21..88
+        2: CSS_DECLARATION_OR_RULE_BLOCK@21..88
           0: L_CURLY@21..22 "{" [] []
-          1: CSS_DECLARATION_LIST@22..86
+          1: CSS_DECLARATION_OR_RULE_LIST@22..86
             0: CSS_DECLARATION_WITH_SEMICOLON@22..38
               0: CSS_DECLARATION@22..37
                 0: CSS_GENERIC_PROPERTY@22..37
@@ -426,9 +426,9 @@ CssRoot {
         0: UTILITY_KW@91..99 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@99..107
           0: IDENT@99..107 "sr-only" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@107..264
+        2: CSS_DECLARATION_OR_RULE_BLOCK@107..264
           0: L_CURLY@107..108 "{" [] []
-          1: CSS_DECLARATION_LIST@108..262
+          1: CSS_DECLARATION_OR_RULE_LIST@108..262
             0: CSS_DECLARATION_WITH_SEMICOLON@108..129
               0: CSS_DECLARATION@108..128
                 0: CSS_GENERIC_PROPERTY@108..128
@@ -565,9 +565,9 @@ CssRoot {
         0: UTILITY_KW@267..275 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@275..281
           0: IDENT@275..281 "tab-4" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@281..298
+        2: CSS_DECLARATION_OR_RULE_BLOCK@281..298
           0: L_CURLY@281..282 "{" [] []
-          1: CSS_DECLARATION_LIST@282..296
+          1: CSS_DECLARATION_OR_RULE_LIST@282..296
             0: CSS_DECLARATION_WITH_SEMICOLON@282..296
               0: CSS_DECLARATION@282..295
                 0: CSS_GENERIC_PROPERTY@282..295
@@ -586,9 +586,9 @@ CssRoot {
         0: UTILITY_KW@301..309 "utility" [] [Whitespace(" ")]
         1: CSS_IDENTIFIER@309..320
           0: IDENT@309..320 "empty-util" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@320..322
+        2: CSS_DECLARATION_OR_RULE_BLOCK@320..322
           0: L_CURLY@320..321 "{" [] []
-          1: CSS_DECLARATION_LIST@321..321
+          1: CSS_DECLARATION_OR_RULE_LIST@321..321
           2: R_CURLY@321..322 "}" [] []
   2: EOF@322..323 "" [Newline("\n")] []
 

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/value-literals.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/value-literals.css.snap
@@ -29,9 +29,9 @@ CssRoot {
                     minus_token: MINUS@12..13 "-" [] [],
                     star_token: STAR@13..15 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@15..16 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -109,9 +109,9 @@ CssRoot {
             0: IDENT@9..12 "tab" [] []
           1: MINUS@12..13 "-" [] []
           2: STAR@13..15 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@15..69
+        2: CSS_DECLARATION_OR_RULE_BLOCK@15..69
           0: L_CURLY@15..16 "{" [] []
-          1: CSS_DECLARATION_LIST@16..67
+          1: CSS_DECLARATION_OR_RULE_LIST@16..67
             0: CSS_DECLARATION_WITH_SEMICOLON@16..67
               0: CSS_DECLARATION@16..66
                 0: CSS_GENERIC_PROPERTY@16..66

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-param.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-param.css.snap
@@ -29,9 +29,9 @@ CssRoot {
                     minus_token: MINUS@12..13 "-" [] [],
                     star_token: STAR@13..15 "*" [] [Whitespace(" ")],
                 },
-                block: CssDeclarationBlock {
+                block: CssDeclarationOrRuleBlock {
                     l_curly_token: L_CURLY@15..16 "{" [] [],
-                    declarations: CssDeclarationList [
+                    items: CssDeclarationOrRuleList [
                         CssDeclarationWithSemicolon {
                             declaration: CssDeclaration {
                                 property: CssGenericProperty {
@@ -93,9 +93,9 @@ CssRoot {
             0: IDENT@9..12 "tab" [] []
           1: MINUS@12..13 "-" [] []
           2: STAR@13..15 "*" [] [Whitespace(" ")]
-        2: CSS_DECLARATION_BLOCK@15..52
+        2: CSS_DECLARATION_OR_RULE_BLOCK@15..52
           0: L_CURLY@15..16 "{" [] []
-          1: CSS_DECLARATION_LIST@16..50
+          1: CSS_DECLARATION_OR_RULE_LIST@16..50
             0: CSS_DECLARATION_WITH_SEMICOLON@16..50
               0: CSS_DECLARATION@16..49
                 0: CSS_GENERIC_PROPERTY@16..49

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-sub-block.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-sub-block.css
@@ -1,0 +1,7 @@
+@utility border-overlay-* {
+	position: relative;
+
+	&::after {
+		border-width: 1px;
+	}
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-sub-block.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/utility/with-sub-block.css.snap
@@ -1,0 +1,178 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@utility border-overlay-* {
+	position: relative;
+
+	&::after {
+		border-width: 1px;
+	}
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwUtilityAtRule {
+                utility_token: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")],
+                name: TwFunctionalUtilityName {
+                    identifier: CssIdentifier {
+                        value_token: IDENT@9..23 "border-overlay" [] [],
+                    },
+                    minus_token: MINUS@23..24 "-" [] [],
+                    star_token: STAR@24..26 "*" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@26..27 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@27..37 "position" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@37..39 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@39..47 "relative" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@47..48 ";" [] [],
+                        },
+                        CssNestedQualifiedRule {
+                            prelude: CssRelativeSelectorList [
+                                CssRelativeSelector {
+                                    combinator: missing (optional),
+                                    selector: CssCompoundSelector {
+                                        nesting_selectors: CssNestedSelectorList [
+                                            CssNestedSelector {
+                                                amp_token: AMP@48..52 "&" [Newline("\n"), Newline("\n"), Whitespace("\t")] [],
+                                            },
+                                        ],
+                                        simple_selector: missing (optional),
+                                        sub_selectors: CssSubSelectorList [
+                                            CssPseudoElementSelector {
+                                                double_colon_token: COLON2@52..54 "::" [] [],
+                                                element: CssPseudoElementIdentifier {
+                                                    name: CssIdentifier {
+                                                        value_token: IDENT@54..60 "after" [] [Whitespace(" ")],
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                            block: CssDeclarationOrRuleBlock {
+                                l_curly_token: L_CURLY@60..61 "{" [] [],
+                                items: CssDeclarationOrRuleList [
+                                    CssDeclarationWithSemicolon {
+                                        declaration: CssDeclaration {
+                                            property: CssGenericProperty {
+                                                name: CssIdentifier {
+                                                    value_token: IDENT@61..76 "border-width" [Newline("\n"), Whitespace("\t\t")] [],
+                                                },
+                                                colon_token: COLON@76..78 ":" [] [Whitespace(" ")],
+                                                value: CssGenericComponentValueList [
+                                                    CssRegularDimension {
+                                                        value_token: CSS_NUMBER_LITERAL@78..79 "1" [] [],
+                                                        unit_token: IDENT@79..81 "px" [] [],
+                                                    },
+                                                ],
+                                            },
+                                            important: missing (optional),
+                                        },
+                                        semicolon_token: SEMICOLON@81..82 ";" [] [],
+                                    },
+                                ],
+                                r_curly_token: R_CURLY@82..85 "}" [Newline("\n"), Whitespace("\t")] [],
+                            },
+                        },
+                    ],
+                    r_curly_token: R_CURLY@85..87 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@87..88 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..88
+  0: (empty)
+  1: CSS_RULE_LIST@0..87
+    0: CSS_AT_RULE@0..87
+      0: AT@0..1 "@" [] []
+      1: TW_UTILITY_AT_RULE@1..87
+        0: UTILITY_KW@1..9 "utility" [] [Whitespace(" ")]
+        1: TW_FUNCTIONAL_UTILITY_NAME@9..26
+          0: CSS_IDENTIFIER@9..23
+            0: IDENT@9..23 "border-overlay" [] []
+          1: MINUS@23..24 "-" [] []
+          2: STAR@24..26 "*" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_OR_RULE_BLOCK@26..87
+          0: L_CURLY@26..27 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@27..85
+            0: CSS_DECLARATION_WITH_SEMICOLON@27..48
+              0: CSS_DECLARATION@27..47
+                0: CSS_GENERIC_PROPERTY@27..47
+                  0: CSS_IDENTIFIER@27..37
+                    0: IDENT@27..37 "position" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@37..39 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@39..47
+                    0: CSS_IDENTIFIER@39..47
+                      0: IDENT@39..47 "relative" [] []
+                1: (empty)
+              1: SEMICOLON@47..48 ";" [] []
+            1: CSS_NESTED_QUALIFIED_RULE@48..85
+              0: CSS_RELATIVE_SELECTOR_LIST@48..60
+                0: CSS_RELATIVE_SELECTOR@48..60
+                  0: (empty)
+                  1: CSS_COMPOUND_SELECTOR@48..60
+                    0: CSS_NESTED_SELECTOR_LIST@48..52
+                      0: CSS_NESTED_SELECTOR@48..52
+                        0: AMP@48..52 "&" [Newline("\n"), Newline("\n"), Whitespace("\t")] []
+                    1: (empty)
+                    2: CSS_SUB_SELECTOR_LIST@52..60
+                      0: CSS_PSEUDO_ELEMENT_SELECTOR@52..60
+                        0: COLON2@52..54 "::" [] []
+                        1: CSS_PSEUDO_ELEMENT_IDENTIFIER@54..60
+                          0: CSS_IDENTIFIER@54..60
+                            0: IDENT@54..60 "after" [] [Whitespace(" ")]
+              1: CSS_DECLARATION_OR_RULE_BLOCK@60..85
+                0: L_CURLY@60..61 "{" [] []
+                1: CSS_DECLARATION_OR_RULE_LIST@61..82
+                  0: CSS_DECLARATION_WITH_SEMICOLON@61..82
+                    0: CSS_DECLARATION@61..81
+                      0: CSS_GENERIC_PROPERTY@61..81
+                        0: CSS_IDENTIFIER@61..76
+                          0: IDENT@61..76 "border-width" [Newline("\n"), Whitespace("\t\t")] []
+                        1: COLON@76..78 ":" [] [Whitespace(" ")]
+                        2: CSS_GENERIC_COMPONENT_VALUE_LIST@78..81
+                          0: CSS_REGULAR_DIMENSION@78..81
+                            0: CSS_NUMBER_LITERAL@78..79 "1" [] []
+                            1: IDENT@79..81 "px" [] []
+                      1: (empty)
+                    1: SEMICOLON@81..82 ";" [] []
+                2: R_CURLY@82..85 "}" [Newline("\n"), Whitespace("\t")] []
+          2: R_CURLY@85..87 "}" [Newline("\n")] []
+  2: EOF@87..88 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/quick_test.rs
+++ b/crates/biome_css_parser/tests/quick_test.rs
@@ -1,0 +1,30 @@
+use biome_css_parser::{CssParserOptions, parse_css};
+use biome_test_utils::has_bogus_nodes_or_empty_slots;
+
+#[ignore]
+#[test]
+pub fn quick_test() {
+    let code = r#"
+@utility border-overlay-* {
+    position: relative;
+
+    &::after {
+        border-width: 1px;
+    }
+}
+"#;
+
+    let root = parse_css(
+        code,
+        CssParserOptions::default()
+            .allow_wrong_line_comments()
+            .allow_css_modules()
+            .allow_metavariables()
+            .allow_tailwind_directives(),
+    );
+    let syntax = root.syntax();
+    dbg!(&syntax, root.diagnostics(), root.has_errors());
+    if has_bogus_nodes_or_empty_slots(&syntax) {
+        panic!("modified tree has bogus nodes or empty slots:\n{syntax:#?} \n\n {syntax}")
+    }
+}

--- a/crates/biome_css_parser/tests/spec_test.rs
+++ b/crates/biome_css_parser/tests/spec_test.rs
@@ -179,26 +179,3 @@ pub fn run(test_case: &str, _snapshot_name: &str, test_directory: &str, outcome_
         insta::assert_snapshot!(file_name, snapshot);
     });
 }
-
-#[ignore]
-#[test]
-pub fn quick_test() {
-    let code = r#"
-html:active-view-transition-type(backwards forwards backwards forwards) {
-}
-
-    "#;
-
-    let root = parse_css(
-        code,
-        CssParserOptions::default()
-            .allow_wrong_line_comments()
-            .allow_css_modules()
-            .allow_metavariables(),
-    );
-    let syntax = root.syntax();
-    dbg!(&syntax, root.diagnostics(), root.has_errors());
-    if has_bogus_nodes_or_empty_slots(&syntax) {
-        panic!("modified tree has bogus nodes or empty slots:\n{syntax:#?} \n\n {syntax}")
-    }
-}

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -7269,7 +7269,7 @@ impl TwUtilityAtRule {
     pub fn name(&self) -> SyntaxResult<AnyTwUtilityName> {
         support::required_node(&self.syntax, 1usize)
     }
-    pub fn block(&self) -> SyntaxResult<AnyCssDeclarationBlock> {
+    pub fn block(&self) -> SyntaxResult<AnyCssDeclarationOrRuleBlock> {
         support::required_node(&self.syntax, 2usize)
     }
 }
@@ -7285,7 +7285,7 @@ impl Serialize for TwUtilityAtRule {
 pub struct TwUtilityAtRuleFields {
     pub utility_token: SyntaxResult<SyntaxToken>,
     pub name: SyntaxResult<AnyTwUtilityName>,
-    pub block: SyntaxResult<AnyCssDeclarationBlock>,
+    pub block: SyntaxResult<AnyCssDeclarationOrRuleBlock>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TwValueThemeReference {

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -2952,7 +2952,7 @@ impl TwUtilityAtRule {
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_block(self, element: AnyCssDeclarationBlock) -> Self {
+    pub fn with_block(self, element: AnyCssDeclarationOrRuleBlock) -> Self {
         Self::unwrap_cast(
             self.syntax
                 .splice_slots(2usize..=2usize, once(Some(element.into_syntax().into()))),

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1875,7 +1875,7 @@ TwValueThemeReference =
 TwUtilityAtRule =
   'utility'
   name: AnyTwUtilityName
-  block: AnyCssDeclarationBlock
+  block: AnyCssDeclarationOrRuleBlock
 
 // Support both simple utility names and functional utility names
 AnyTwUtilityName =


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
This lets `@utility` at-rules parse both declarations and rules instead of just declarations.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
Fixes issue reported in this thread: https://github.com/biomejs/biome/issues/7223#issuecomment-3217516731

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan
Added a snapshot test

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
