### PR TITLE
fix(noDuplicateObjectKeys): correct grammatical error in JSON diagnostic message

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
@@ -43,7 +43,7 @@ test.json:1:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━━�
   > 1 │ { "foo": true, "foo": true }
       │   ^^^^^
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
   > 1 │ { "foo": true, "foo": true }
       │                ^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
@@ -43,7 +43,7 @@ test.json:1:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━━�
   > 1 │ { "foo": true, "foo": true }
       │   ^^^^^
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
   > 1 │ { "foo": true, "foo": true }
       │                ^^^^^

--- a/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -83,7 +83,7 @@ impl Rule for NoDuplicateObjectKeys {
             diagnostic = diagnostic.detail(
                 range,
                 markup! {
-                    "This where a duplicated key was declared again."
+                    "This is where a duplicated key was declared again."
                 },
             );
         }

--- a/crates/biome_json_analyze/tests/specs/suspicious/noDuplicateObjectKeys/invalid.json.snap
+++ b/crates/biome_json_analyze/tests/specs/suspicious/noDuplicateObjectKeys/invalid.json.snap
@@ -31,7 +31,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     3 │ 	"foo": "",
     4 │ 	"foo": "",
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     1 │ {
     2 │ 	"foo": "",
@@ -40,7 +40,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     4 │ 	"foo": "",
     5 │ 	"foo": "",
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     2 │ 	"foo": "",
     3 │ 	"foo": "",
@@ -49,7 +49,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     5 │ 	"foo": "",
     6 │ 	"new": {
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     3 │ 	"foo": "",
     4 │ 	"foo": "",
@@ -75,7 +75,7 @@ invalid.json:7:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     8 │ 		"ipsum": "",
     9 │ 		"lorem": ""
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
      7 │ 		"lorem": "",
      8 │ 		"ipsum": "",


### PR DESCRIPTION
## What this fixes

Fixed a grammar mistake in an error message. The message was missing the word "is".

**Before (incorrect):**
> This where a duplicated key was declared again.

**After (correct):**
> This is where a duplicated key was declared again.

## What changed

- Fixed the grammar in the error message
- Updated the test to match the corrected message

This makes the error message easier to read and understand for users.

Fixes #7307