### PR TITLE
feat: indentation for vue and svelte files

### DIFF
--- a/.changeset/dull-drinks-switch.md
+++ b/.changeset/dull-drinks-switch.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": minor
+---
+
+Updated the formatting of `.svelte` and `.vue` files. Now the indentation of the JavaScript blocks matches Prettier's:
+
+```diff
+<script>
+- import Component from "./Component"
++   import Component from "./Component"
+</script>
+```

--- a/crates/biome_cli/tests/cases/handle_svelte_files.rs
+++ b/crates/biome_cli/tests/cases/handle_svelte_files.rs
@@ -23,12 +23,6 @@ const hello  :      string      = "world";
 </script>
 <div></div>"#;
 
-const SVELTE_TS_CONTEXT_MODULE_FILE_FORMATTED: &str = r#"<script context="module" lang="ts">
-import Button from "./components/Button.svelte";
-const hello: string = "world";
-</script>
-<div></div>"#;
-
 const SVELTE_CARRIAGE_RETURN_LINE_FEED_FILE_UNFORMATTED: &str =
     "<script>\r\n  const a    = \"b\";\r\n</script>\r\n<div></div>";
 
@@ -175,12 +169,6 @@ fn format_svelte_ts_context_module_files_write() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(
-        &fs,
-        svelte_file_path,
-        SVELTE_TS_CONTEXT_MODULE_FILE_FORMATTED,
-    );
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/cases/handle_vue_files.rs
+++ b/crates/biome_cli/tests/cases/handle_vue_files.rs
@@ -11,33 +11,15 @@ statement ( ) ;
 </script>
 <template></template>"#;
 
-const VUE_IMPLICIT_JS_FILE_FORMATTED: &str = r#"<script>
-import { something } from "file.vue";
-statement();
-</script>
-<template></template>"#;
-
 const VUE_EXPLICIT_JS_FILE_UNFORMATTED: &str = r#"<script lang="js">
 import {    something } from "file.vue";
 statement ( ) ;
 </script>
 <template></template>"#;
 
-const VUE_EXPLICIT_JS_FILE_FORMATTED: &str = r#"<script lang="js">
-import { something } from "file.vue";
-statement();
-</script>
-<template></template>"#;
-
 const VUE_TS_FILE_UNFORMATTED: &str = r#"<script setup lang="ts">
 import     { type     something } from "file.vue";
 const hello  :      string      = "world";
-</script>
-<template></template>"#;
-
-const VUE_TS_FILE_FORMATTED: &str = r#"<script setup lang="ts">
-import { type something } from "file.vue";
-const hello: string = "world";
 </script>
 <template></template>"#;
 
@@ -155,8 +137,6 @@ fn format_vue_implicit_js_files_write() {
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
-    assert_file_contents(&fs, vue_file_path, VUE_IMPLICIT_JS_FILE_FORMATTED);
-
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_vue_implicit_js_files_write",
@@ -214,8 +194,6 @@ fn format_vue_explicit_js_files_write() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, vue_file_path, VUE_EXPLICIT_JS_FILE_FORMATTED);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -295,8 +273,6 @@ fn format_vue_ts_files_write() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, vue_file_path, VUE_TS_FILE_FORMATTED);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/commands/format.rs
+++ b/crates/biome_cli/tests/commands/format.rs
@@ -47,33 +47,15 @@ statement ( ) ;
 </script>
 <div></div>"#;
 
-const SVELTE_IMPLICIT_JS_FILE_FORMATTED: &str = r#"<script>
-import { something } from "file.svelte";
-statement();
-</script>
-<div></div>"#;
-
 const SVELTE_EXPLICIT_JS_FILE_UNFORMATTED: &str = r#"<script lang="js">
 import {    something } from "file.svelte";
 statement ( ) ;
 </script>
 <div></div>"#;
 
-const SVELTE_EXPLICIT_JS_FILE_FORMATTED: &str = r#"<script lang="js">
-import { something } from "file.svelte";
-statement();
-</script>
-<div></div>"#;
-
 const SVELTE_TS_FILE_UNFORMATTED: &str = r#"<script setup lang="ts">
 import     { type     something } from "file.svelte";
 const hello  :      string      = "world";
-</script>
-<div></div>"#;
-
-const SVELTE_TS_FILE_FORMATTED: &str = r#"<script setup lang="ts">
-import { type something } from "file.svelte";
-const hello: string = "world";
 </script>
 <div></div>"#;
 
@@ -2996,8 +2978,6 @@ fn format_svelte_implicit_js_files_write() {
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
 
-    assert_file_contents(&fs, svelte_file_path, SVELTE_IMPLICIT_JS_FILE_FORMATTED);
-
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
         "format_svelte_implicit_js_files_write",
@@ -3055,8 +3035,6 @@ fn format_svelte_explicit_js_files_write() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, svelte_file_path, SVELTE_EXPLICIT_JS_FILE_FORMATTED);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),
@@ -3142,8 +3120,6 @@ fn format_svelte_ts_files_write() {
     );
 
     assert!(result.is_ok(), "run_cli returned {result:?}");
-
-    assert_file_contents(&fs, svelte_file_path, SVELTE_TS_FILE_FORMATTED);
 
     assert_cli_snapshot(SnapshotPayload::new(
         module_path!(),

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.astro`
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_astro_files_write.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.astro`
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_stdin_write_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_astro_files/format_stdin_write_successfully.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/check_stdin_write_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/check_stdin_write_successfully.snap
@@ -19,12 +19,12 @@ var foo: string = "";
 
 ```block
 <script context="module" lang="ts">
-import Button from "./components/Button.svelte";
-import { Form } from "./components/Form.svelte";
+	import Button from "./components/Button.svelte";
+	import { Form } from "./components/Form.svelte";
 
-debugger;
-statement();
-var foo: string = "";
+	debugger;
+	statement();
+	var foo: string = "";
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/check_stdin_write_unsafe_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/check_stdin_write_unsafe_successfully.snap
@@ -19,8 +19,8 @@ var foo: string = "";
 
 ```block
 <script context="module" lang="ts">
-statement();
-var _foo: string = "";
+	statement();
+	var _foo: string = "";
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_stdin_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_stdin_successfully.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -16,8 +16,8 @@ const hello  :      string      = "world";
 
 ```block
 <script context="module" lang="ts">
-import Button from "./components/Button.svelte";
-const hello: string = "world";
+	import Button from "./components/Button.svelte";
+	const hello: string = "world";
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_stdin_write_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_stdin_write_successfully.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -16,8 +16,8 @@ const hello  :      string      = "world";
 
 ```block
 <script context="module" lang="ts">
-import Button from "./components/Button.svelte";
-const hello: string = "world";
+	import Button from "./components/Button.svelte";
+	const hello: string = "world";
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_carriage_return_line_feed_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
@@ -31,7 +31,7 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
   
     1 1 │   <script>␍
     2   │ - ··const·a····=·"b";␍
-      2 │ + const·a·=·"b";
+      2 │ + → const·a·=·"b";
     3 3 │   </script>␍
     4 4 │   <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
@@ -33,8 +33,8 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script context="module" lang="ts">
     2   │ - import·····Button·····from·"./components/Button.svelte";
     3   │ - const·hello··:······string······=·"world";
-      2 │ + import·Button·from·"./components/Button.svelte";
-      3 │ + const·hello:·string·=·"world";
+      2 │ + → import·Button·from·"./components/Button.svelte";
+      3 │ + → const·hello:·string·=·"world";
     4 4 │   </script>
     5 5 │   <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_svelte_files/format_svelte_ts_context_module_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
 ```svelte
 <script context="module" lang="ts">
-import Button from "./components/Button.svelte";
-const hello: string = "world";
+	import Button from "./components/Button.svelte";
+	const hello: string = "world";
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/check_stdin_write_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/check_stdin_write_successfully.snap
@@ -18,10 +18,10 @@ delete a.c;
 
 ```block
 <script setup lang="ts">
-import * as vueUse from "vue-use";
-import { Button } from "./components/Button.vue";
+	import * as vueUse from "vue-use";
+	import { Button } from "./components/Button.vue";
 
-delete a.c;
+	delete a.c;
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/check_stdin_write_unsafe_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/check_stdin_write_unsafe_successfully.snap
@@ -18,7 +18,7 @@ delete a.c;
 
 ```block
 <script setup lang="ts">
-delete a.c;
+	delete a.c;
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_stdin_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_stdin_successfully.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -16,8 +16,8 @@ const hello  :      string      = "world";
 
 ```block
 <script setup lang="ts">
-import { type something } from "file.vue";
-const hello: string = "world";
+	import { type something } from "file.vue";
+	const hello: string = "world";
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_stdin_write_successfully.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_stdin_write_successfully.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 # Input messages
 
@@ -16,8 +16,8 @@ const hello  :      string      = "world";
 
 ```block
 <script setup lang="ts">
-import { type something } from "file.vue";
-const hello: string = "world";
+	import { type something } from "file.vue";
+	const hello: string = "world";
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_carriage_return_line_feed_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
@@ -31,7 +31,7 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
   
     1 1 │   <script>␍
     2   │ - ··const·a····=·"b";␍
-      2 │ + const·a·=·"b";
+      2 │ + → const·a·=·"b";
     3 3 │   </script>␍
     4 4 │   <template></template>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
@@ -33,8 +33,8 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script lang="js">
     2   │ - import·{····something·}·from·"file.vue";
     3   │ - statement·(·)·;
-      2 │ + import·{·something·}·from·"file.vue";
-      3 │ + statement();
+      2 │ + → import·{·something·}·from·"file.vue";
+      3 │ + → statement();
     4 4 │   </script>
     5 5 │   <template></template>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_explicit_js_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
 ```vue
 <script lang="js">
-import { something } from "file.vue";
-statement();
+	import { something } from "file.vue";
+	statement();
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_generic_component_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
@@ -30,7 +30,7 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
   
     1 1 │   <script generic="T extends Record<string, any>" lang="ts" setup>
     2   │ - const·a·····=·····"a";
-      2 │ + const·a·=·"a";
+      2 │ + → const·a·=·"a";
     3 3 │   </script>
   
 

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
@@ -33,8 +33,8 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script>
     2   │ - import·{····something·}·from·"file.vue";
     3   │ - statement·(·)·;
-      2 │ + import·{·something·}·from·"file.vue";
-      3 │ + statement();
+      2 │ + → import·{·something·}·from·"file.vue";
+      3 │ + → statement();
     4 4 │   </script>
     5 5 │   <template></template>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_implicit_js_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
 ```vue
 <script>
-import { something } from "file.vue";
-statement();
+	import { something } from "file.vue";
+	statement();
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
@@ -33,8 +33,8 @@ file.vue format ━━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script setup lang="ts">
     2   │ - import·····{·type·····something·}·from·"file.vue";
     3   │ - const·hello··:······string······=·"world";
-      2 │ + import·{·type·something·}·from·"file.vue";
-      3 │ + const·hello:·string·=·"world";
+      2 │ + → import·{·type·something·}·from·"file.vue";
+      3 │ + → const·hello:·string·=·"world";
     4 4 │   </script>
     5 5 │   <template></template>
   

--- a/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_handle_vue_files/format_vue_ts_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.vue`
 
 ```vue
 <script setup lang="ts">
-import { type something } from "file.vue";
-const hello: string = "world";
+	import { type something } from "file.vue";
+	const hello: string = "world";
 </script>
 <template></template>
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
@@ -33,8 +33,8 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script lang="js">
     2   │ - import·{····something·}·from·"file.svelte";
     3   │ - statement·(·)·;
-      2 │ + import·{·something·}·from·"file.svelte";
-      3 │ + statement();
+      2 │ + → import·{·something·}·from·"file.svelte";
+      3 │ + → statement();
     4 4 │   </script>
     5 5 │   <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_explicit_js_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
 ```svelte
 <script lang="js">
-import { something } from "file.svelte";
-statement();
+	import { something } from "file.svelte";
+	statement();
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
@@ -33,8 +33,8 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script>
     2   │ - import·{····something·}·from·"file.svelte";
     3   │ - statement·(·)·;
-      2 │ + import·{·something·}·from·"file.svelte";
-      3 │ + statement();
+      2 │ + → import·{·something·}·from·"file.svelte";
+      3 │ + → statement();
     4 4 │   </script>
     5 5 │   <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_implicit_js_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
 ```svelte
 <script>
-import { something } from "file.svelte";
-statement();
+	import { something } from "file.svelte";
+	statement();
 </script>
 <div></div>
 ```

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
@@ -33,8 +33,8 @@ file.svelte format ━━━━━━━━━━━━━━━━━━━━�
     1 1 │   <script setup lang="ts">
     2   │ - import·····{·type·····something·}·from·"file.svelte";
     3   │ - const·hello··:······string······=·"world";
-      2 │ + import·{·type·something·}·from·"file.svelte";
-      3 │ + const·hello:·string·=·"world";
+      2 │ + → import·{·type·something·}·from·"file.svelte";
+      3 │ + → const·hello:·string·=·"world";
     4 4 │   </script>
     5 5 │   <div></div>
   

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files_write.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_svelte_ts_files_write.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `file.svelte`
 
 ```svelte
 <script setup lang="ts">
-import { type something } from "file.svelte";
-const hello: string = "world";
+	import { type something } from "file.svelte";
+	const hello: string = "world";
 </script>
 <div></div>
 ```

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -58,26 +58,24 @@ impl<'a> Printer<'a> {
         document: &'a Document,
         indent: u16,
     ) -> PrintResult<Printed> {
-        tracing::debug_span!("Printer::print").in_scope(move || {
-            let mut stack = PrintCallStack::new(PrintElementArgs::new());
-            let mut queue: PrintQueue<'a> = PrintQueue::new(document.as_ref());
-            let mut indent_stack = PrintIndentStack::new(Indention::Level(indent));
+        let mut stack = PrintCallStack::new(PrintElementArgs::new());
+        let mut queue: PrintQueue<'a> = PrintQueue::new(document.as_ref());
+        let mut indent_stack = PrintIndentStack::new(Indention::Level(indent));
+        self.state.pending_indent = indent_stack.indention();
+        while let Some(element) = queue.pop() {
+            self.print_element(&mut stack, &mut indent_stack, &mut queue, element)?;
 
-            while let Some(element) = queue.pop() {
-                self.print_element(&mut stack, &mut indent_stack, &mut queue, element)?;
-
-                if queue.is_empty() {
-                    self.flush_line_suffixes(&mut queue, &mut stack, &mut indent_stack, None);
-                }
+            if queue.is_empty() {
+                self.flush_line_suffixes(&mut queue, &mut stack, &mut indent_stack, None);
             }
+        }
 
-            Ok(Printed::new(
-                self.state.buffer,
-                None,
-                self.state.source_markers,
-                self.state.verbatim_markers,
-            ))
-        })
+        Ok(Printed::new(
+            self.state.buffer,
+            None,
+            self.state.source_markers,
+            self.state.verbatim_markers,
+        ))
     }
 
     /// Prints a single element and push the following elements to queue
@@ -1421,6 +1419,18 @@ mod tests {
             .expect("Document to be valid")
     }
 
+    fn format_with_options_and_indentation(
+        root: &dyn Format<SimpleFormatContext>,
+        options: PrinterOptions,
+        indent: u16,
+    ) -> Printed {
+        let formatted = crate::format!(SimpleFormatContext::default(), [root]).unwrap();
+
+        Printer::new(options)
+            .print_with_indent(formatted.document(), indent)
+            .expect("Document to be valid")
+    }
+
     #[test]
     fn it_prints_a_group_on_a_single_line_if_it_fits() {
         let result = format(&FormatArrayElements {
@@ -1809,6 +1819,85 @@ Group 1 breaks"#
             "(\nThis is a string\n containing a newline\n)",
             result.as_code()
         );
+    }
+
+    #[test]
+    fn break_group_if_partial_string_exceeds_print_width_with_indent() {
+        let options = PrinterOptions {
+            print_width: PrintWidth::new(10),
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options_and_indentation(
+            &format_args![group(&format_args!(
+                text("Hello world"),
+                soft_line_break(),
+                text("Hello world")
+            ))],
+            options,
+            1,
+        );
+
+        assert_eq!(result.as_code(), "\tHello world\n\tHello world");
+    }
+
+    #[test]
+    fn test_fill_breaks_with_indent() {
+        let mut state = FormatState::new(());
+        let mut buffer = VecBuffer::new(&mut state);
+        let mut formatter = Formatter::new(&mut buffer);
+
+        formatter
+            .fill()
+            // These all fit on the same line together
+            .entry(
+                &soft_line_break_or_space(),
+                &format_args!(text("1"), text(",")),
+            )
+            .entry(
+                &soft_line_break_or_space(),
+                &format_args!(text("2"), text(",")),
+            )
+            .entry(
+                &soft_line_break_or_space(),
+                &format_args!(text("3"), text(",")),
+            )
+            // This one fits on a line by itself,
+            .entry(
+                &soft_line_break_or_space(),
+                &format_args!(text("723493294"), text(",")),
+            )
+            // fits without breaking
+            .entry(
+                &soft_line_break_or_space(),
+                &group(&format_args!(
+                    text("["),
+                    soft_block_indent(&text("5")),
+                    text("],")
+                )),
+            )
+            // this one must be printed in expanded mode to fit
+            .entry(
+                &soft_line_break_or_space(),
+                &group(&format_args!(
+                    text("["),
+                    soft_block_indent(&text("123456789")),
+                    text("]"),
+                )),
+            )
+            .finish()
+            .unwrap();
+
+        let document = Document::from(buffer.into_vec());
+
+        let printed = Printer::new(PrinterOptions::default().with_print_width(PrintWidth::new(10)))
+            .print_with_indent(&document, 1)
+            .unwrap();
+
+        assert_eq!(
+            printed.as_code(),
+            "\t1, 2, 3,\n\t723493294,\n\t[5],\n\t[\n\t\t123456789\n\t]"
+        )
     }
 
     struct FormatArrayElements<'a> {

--- a/crates/biome_service/src/file_handlers/vue.rs
+++ b/crates/biome_service/src/file_handlers/vue.rs
@@ -1,3 +1,4 @@
+use super::{SearchCapabilities, parse_lang_from_script_opening_tag};
 use crate::WorkspaceError;
 use crate::file_handlers::{
     AnalyzerCapabilities, Capabilities, CodeActionsParams, DebugCapabilities, EnabledForPath,
@@ -8,15 +9,14 @@ use crate::settings::Settings;
 use crate::workspace::{DocumentFileSource, FixFileResult, PullActionsResult};
 use biome_formatter::Printed;
 use biome_fs::BiomePath;
+use biome_js_formatter::format_node;
 use biome_js_parser::{JsParserOptions, parse_js_with_cache};
-use biome_js_syntax::{EmbeddingKind, JsFileSource, TextRange, TextSize};
+use biome_js_syntax::{EmbeddingKind, JsFileSource, JsLanguage, TextRange, TextSize};
 use biome_parser::AnyParse;
 use biome_rowan::NodeCache;
 use regex::{Match, Regex};
 use std::sync::LazyLock;
-use tracing::debug;
-
-use super::{SearchCapabilities, parse_lang_from_script_opening_tag};
+use tracing::{debug, error};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct VueFileHandler;
@@ -141,7 +141,16 @@ fn format(
     parse: AnyParse,
     settings: &Settings,
 ) -> Result<Printed, WorkspaceError> {
-    javascript::format(biome_path, document_file_source, parse, settings)
+    let options = settings.format_options::<JsLanguage>(biome_path, document_file_source);
+    let tree = parse.syntax();
+    let formatted = format_node(options, &tree)?;
+    match formatted.print_with_indent(1) {
+        Ok(printed) => Ok(printed),
+        Err(error) => {
+            error!("The file {} couldn't be formatted", biome_path.as_str());
+            Err(WorkspaceError::FormatError(error.into()))
+        }
+    }
 }
 
 pub(crate) fn format_range(


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The function `print_with_indent` was already available in our printer, but it was broken. While I was working at the embedded languages, I found out the issue and fixed it.

We can ship this as a minor in the meantime, I bet the users will like this improvement :)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests, updated existing snapshots.

<!-- What demonstrates that your implementation is correct? -->

## Docs

Will need to open a PR to update the language support

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
