### PR TITLE
fix(formatter): patch ID_Continue to omit U+30FB and U+FF65 added in Unicode 15.1

### DIFF
--- a/.changeset/clever-worlds-heal.md
+++ b/.changeset/clever-worlds-heal.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7261](https://github.com/biomejs/biome/issues/7261): two characters `・` (KATAKANA MIDDLE DOT, U+30FB) and `･` (HALFWIDTH KATAKANA MIDDLE DOT, U+FF65) are no longer considered as valid characters in identifiers. Property keys containing these character(s) are now preserved as string literals.

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js
@@ -5,4 +5,7 @@ const foo = {
       "lorem-ipsum": true
     },
   },
+	// https://github.com/biomejs/biome/issues/7261
+	"実用文・会話文": "長文読解",
+	"実用文･会話文": "長文読解",
 };

--- a/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/object/property_key.js.snap
@@ -12,6 +12,9 @@ const foo = {
       "lorem-ipsum": true
     },
   },
+	// https://github.com/biomejs/biome/issues/7261
+	"実用文・会話文": "長文読解",
+	"実用文･会話文": "長文読解",
 };
 
 ```
@@ -49,5 +52,8 @@ const foo = {
 			"lorem-ipsum": true,
 		},
 	},
+	// https://github.com/biomejs/biome/issues/7261
+	"実用文・会話文": "長文読解",
+	"実用文･会話文": "長文読解",
 };
 ```

--- a/crates/biome_unicode_table/src/lib.rs
+++ b/crates/biome_unicode_table/src/lib.rs
@@ -61,6 +61,14 @@ pub fn is_js_id_start(c: char) -> bool {
 /// Tests if `c` is a valid continuation of a js identifier.
 #[inline]
 pub fn is_js_id_continue(c: char) -> bool {
+    // KATAKANA MIDDLE DOT (U+30FB) and HALFWIDTH KATAKANA MIDDLE DOT (U+FF65) have been added to
+    // the ID_Continue property in Unicode 15.1, but they're still invalid in ECMAScript.
+    // ref: https://github.com/evanw/esbuild/pull/3424
+    // ref: https://github.com/oxc-project/oxc/pull/12829
+    if c == '・' || c == '･' {
+        return false;
+    }
+
     c == '$' || c == '\u{200d}' || c == '\u{200c}' || ID_Continue(c)
 }
 


### PR DESCRIPTION
## Summary

These two characters have been added to the `ID_Continue` property in Unicode 15.1, but they're not supported in ECMAScript. To avoid an syntax error, Biome will omit these on checking if a character is in `ID_Continue`.

- U+30FB KATAKANA MIDDLE DOT `・`
- U+FF65 HALFWIDTH KATAKANA MIDDLE DOT `･`

## Test Plan

Added a snapshot test.

## Docs

N/A
