### PR TITLE
fix(css): allow navigation property for view-transition (fixes #7340)

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_json_files.snap
@@ -43,7 +43,7 @@ test.json:1:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━━�
   > 1 │ { "foo": true, "foo": true }
       │   ^^^^^
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
   > 1 │ { "foo": true, "foo": true }
       │                ^^^^^

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/check_json_files.snap
@@ -43,7 +43,7 @@ test.json:1:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━━�
   > 1 │ { "foo": true, "foo": true }
       │   ^^^^^
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
   > 1 │ { "foo": true, "foo": true }
       │                ^^^^^

--- a/crates/biome_css_analyze/src/keywords.rs
+++ b/crates/biome_css_analyze/src/keywords.rs
@@ -983,6 +983,7 @@ pub const OTHER_PSEUDO_CLASSES: [&str; 51] = [
 // https://github.com/known-css/known-css-properties/blob/master/source/w3c.json
 pub const KNOWN_PROPERTIES: &[&str] = &[
     "-webkit-line-clamp",
+    "navigation", // https://www.w3.org/TR/css-view-transitions-2/#view-transition-navigation-descriptor
     "accent-color",
     "align-content",
     "align-items",

--- a/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css
+++ b/crates/biome_css_analyze/tests/specs/correctness/noUnknownProperty/valid.css
@@ -67,3 +67,8 @@ a {
   composes: classA;
   color: yellow;
 }
+
+/* View Transition navigation property (should not be flagged) */
+view-transition {
+  navigation: auto;
+}

--- a/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
+++ b/crates/biome_json_analyze/src/lint/suspicious/no_duplicate_object_keys.rs
@@ -83,7 +83,7 @@ impl Rule for NoDuplicateObjectKeys {
             diagnostic = diagnostic.detail(
                 range,
                 markup! {
-                    "This where a duplicated key was declared again."
+                    "This is where a duplicated key was declared again."
                 },
             );
         }

--- a/crates/biome_json_analyze/tests/specs/suspicious/noDuplicateObjectKeys/invalid.json.snap
+++ b/crates/biome_json_analyze/tests/specs/suspicious/noDuplicateObjectKeys/invalid.json.snap
@@ -31,7 +31,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     3 │ 	"foo": "",
     4 │ 	"foo": "",
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     1 │ {
     2 │ 	"foo": "",
@@ -40,7 +40,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     4 │ 	"foo": "",
     5 │ 	"foo": "",
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     2 │ 	"foo": "",
     3 │ 	"foo": "",
@@ -49,7 +49,7 @@ invalid.json:2:2 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     5 │ 	"foo": "",
     6 │ 	"new": {
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
     3 │ 	"foo": "",
     4 │ 	"foo": "",
@@ -75,7 +75,7 @@ invalid.json:7:3 lint/suspicious/noDuplicateObjectKeys ━━━━━━━━�
     8 │ 		"ipsum": "",
     9 │ 		"lorem": ""
   
-  i This where a duplicated key was declared again.
+  i This is where a duplicated key was declared again.
   
      7 │ 		"lorem": "",
      8 │ 		"ipsum": "",


### PR DESCRIPTION
This PR fixes a false positive in the lint/correctness/noUnknownProperty rule for CSS.

->Adds "navigation" to the list of known CSS properties, following the [CSS View Transitions spec](vscode-file://vscode-app/c:/Users/Jeetu%20Suthar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
->Adds a test to ensure navigation: auto is not flagged as unknown.
Why:
The navigation property is valid for view transitions, but was previously not recognized by the linter, causing a false positive.

Test:
A test case is added to [valid.css](vscode-file://vscode-app/c:/Users/Jeetu%20Suthar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to confirm that navigation: auto is accepted.

Fixes #7340