### PR TITLE
feat(core): add force-ignore syntax to `files.includes`

### DIFF
--- a/.changeset/forced-files-forget.md
+++ b/.changeset/forced-files-forget.md
@@ -1,0 +1,40 @@
+---
+"@biomejs/biome": minor
+---
+
+Removed the option `files.experimentalScannerIgnores` in favour of **force-ignore** syntax in `files.includes`.
+
+`files.includes` supports ignoring files by prefixing globs with an exclamation mark (`!`). With this change, it also supports _force_-ignoring globs by prefixing them with a double exclamation mark (`!!`).
+
+The effect of force-ignoring is that the scanner will not index files matching the glob, even in project mode and those files are imported by other files.
+
+#### Example
+
+Let's take the following configuration:
+
+```json
+{
+    "files": {
+        "includes": [
+            "**",
+            "!**/generated",
+            "!!**/dist",
+            "fixtures/example/dist/*.js"
+        ]
+    },
+    "linter": {
+        "domains": {
+            "project": "all"
+        }
+    }
+}
+```
+
+This configuration achieves the following:
+
+- Because the [project domain](https://biomejs.dev/linter/domains/#project) is enabled, all supported files in the project are indexed _and_ processed by the linter, _except_:
+- Files inside a `generated` folder are not processed by the linter, but they will get indexed _if_ a file outside of a `generated` folder imports them.
+- Files inside a `dist` folder are never indexed nor processed, not even if they are imported for any purpose, _except_:
+- When the `dist` folder is inside `fixtures/example/`, its `.js` files _do_ get both indexed and processed.
+
+In general, we now recommend using the force-ignore syntax for any folders that contain _output_ files, such as `build/` and `dist/`. For such folders, it is highly unlikely that indexing has any useful benefits. For folders containing generated files, you may wish to use the regular ignore syntax so that type information can still be extracted from the files.

--- a/.changeset/forced-files-forget.md
+++ b/.changeset/forced-files-forget.md
@@ -2,11 +2,11 @@
 "@biomejs/biome": minor
 ---
 
-Removed the option `files.experimentalScannerIgnores` in favour of **force-ignore** syntax in `files.includes`.
+Deprecated the option `files.experimentalScannerIgnores` in favour of **force-ignore** syntax in `files.includes`.
 
 `files.includes` supports ignoring files by prefixing globs with an exclamation mark (`!`). With this change, it also supports _force_-ignoring globs by prefixing them with a double exclamation mark (`!!`).
 
-The effect of force-ignoring is that the scanner will not index files matching the glob, even in project mode and those files are imported by other files.
+The effect of force-ignoring is that the scanner will not index files matching the glob, even in project mode, and even if those files are imported by other files.
 
 #### Example
 
@@ -33,8 +33,10 @@ Let's take the following configuration:
 This configuration achieves the following:
 
 - Because the [project domain](https://biomejs.dev/linter/domains/#project) is enabled, all supported files in the project are indexed _and_ processed by the linter, _except_:
-- Files inside a `generated` folder are not processed by the linter, but they will get indexed _if_ a file outside of a `generated` folder imports them.
+- Files inside a `generated` folder are not processed by the linter, but they will get indexed _if_ a file outside a `generated` folder imports them.
 - Files inside a `dist` folder are never indexed nor processed, not even if they are imported for any purpose, _except_:
 - When the `dist` folder is inside `fixtures/example/`, its `.js` files _do_ get both indexed and processed.
 
 In general, we now recommend using the force-ignore syntax for any folders that contain _output_ files, such as `build/` and `dist/`. For such folders, it is highly unlikely that indexing has any useful benefits. For folders containing generated files, you may wish to use the regular ignore syntax so that type information can still be extracted from the files.
+
+`experimentalScannerIgnores` will continue to work for now, but you'll see a deprecation warning if you still use it.

--- a/biome.json
+++ b/biome.json
@@ -32,12 +32,9 @@
       "!**/__snapshots__",
       "!**/undefined",
       "!**/benchmark/target",
-      "!**/benches"
-    ],
-    "experimentalScannerIgnores": [
-      ".cargo",
-      ".git",
-      "target"
+      "!**/benches",
+      "!!**/target",
+      "!!.cargo"
     ]
   },
   "formatter": {

--- a/crates/biome_cli/tests/snapshots/main_cases_included_files/does_not_handle_files_inside_force_ignored_folders.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_included_files/does_not_handle_files_inside_force_ignored_folders.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "files": { "includes": ["*.js", "!!test"] } }
+```
+
+## `a.js`
+
+```js
+statement();
+
+```
+
+## `test/a.js`
+
+```js
+  statement(  )  
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_included_files/does_not_handle_included_files_if_overridden_by_forced_ignore.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_included_files/does_not_handle_included_files_if_overridden_by_forced_ignore.snap
@@ -1,0 +1,28 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "files": { "includes": ["*.js", "!!test.js"] } }
+```
+
+## `test.js`
+
+```js
+  statement(  )  
+```
+
+## `test2.js`
+
+```js
+statement();
+
+```
+
+# Emitted Messages
+
+```block
+Formatted 1 file in <TIME>. Fixed 1 file.
+```

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -548,51 +548,6 @@ pub struct FilesConfiguration {
     #[bpaf(hide, pure(Default::default()))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub includes: Option<Vec<biome_glob::NormalizedGlob>>,
-
-    /// Set of file and folder names that should be unconditionally ignored by
-    /// Biome's scanner.
-    ///
-    /// Biome maintains an internal list of default ignore entries, which is
-    /// based on user feedback and which may change in any release. This setting
-    /// allows overriding this internal list completely.
-    ///
-    /// This is considered an advanced feature that users _should_ not need to
-    /// tweak themselves, but they can as a last resort. This setting can only
-    /// be configured in root configurations, and is ignored in nested configs.
-    ///
-    /// Entries must be file or folder *names*. Specific paths and globs are not
-    /// supported.
-    ///
-    /// Examples where this may be useful:
-    ///
-    /// ```jsonc
-    /// {
-    ///     "files": {
-    ///         "experimentalScannerIgnores": [
-    ///             // You almost certainly don't want to scan your `.git`
-    ///             // folder, which is why it's already ignored by default:
-    ///             ".git",
-    ///
-    ///             // But the scanner does scan `node_modules` by default. If
-    ///             // you *really* don't want this, you can ignore it like
-    ///             // this:
-    ///             "node_modules",
-    ///
-    ///             // But it's probably better to ignore a specific dependency.
-    ///             // For instance, one that happens to be particularly slow to
-    ///             // scan:
-    ///             "RedisCommander.d.ts",
-    ///         ],
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// Please be aware that rules relying on the module graph or type inference
-    /// information may be negatively affected if dependencies of your project
-    /// aren't (fully) scanned.
-    #[bpaf(hide, pure(Default::default()))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub experimental_scanner_ignores: Option<Vec<String>>,
 }
 
 #[derive(Debug)]

--- a/crates/biome_configuration/tests/invalid/experimental_scanner_ignores.json
+++ b/crates/biome_configuration/tests/invalid/experimental_scanner_ignores.json
@@ -1,0 +1,5 @@
+{
+	"files": {
+		"experimentalScannerIgnores": ["node_modules", "problematic-file.js", ".git"]
+	}
+}

--- a/crates/biome_configuration/tests/invalid/experimental_scanner_ignores.json.snap
+++ b/crates/biome_configuration/tests/invalid/experimental_scanner_ignores.json.snap
@@ -1,0 +1,21 @@
+---
+source: crates/biome_configuration/tests/spec_tests.rs
+expression: experimental_scanner_ignores.json
+---
+experimental_scanner_ignores.json:3:3 deserialize  DEPRECATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! The property experimentalScannerIgnores is deprecated.
+  
+    1 │ {
+    2 │ 	"files": {
+  > 3 │ 		"experimentalScannerIgnores": ["node_modules", "problematic-file.js", ".git"]
+      │ 		^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    4 │ 	}
+    5 │ }
+  
+  i You may want to add the following entries to files.includes instead:
+  
+  - "!!**/node_modules"
+  - "!!**/problematic-file.js"
+  
+  i See the files.includes documentation for more information.

--- a/crates/biome_configuration/tests/invalid/files_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/files_extraneous_field.json.snap
@@ -18,4 +18,3 @@ files_extraneous_field.json:3:3 deserialize ━━━━━━━━━━━━
   - maxSize
   - ignoreUnknown
   - includes
-  - experimentalScannerIgnores

--- a/crates/biome_configuration/tests/invalid/files_extraneous_field.json.snap
+++ b/crates/biome_configuration/tests/invalid/files_extraneous_field.json.snap
@@ -18,3 +18,4 @@ files_extraneous_field.json:3:3 deserialize ━━━━━━━━━━━━
   - maxSize
   - ignoreUnknown
   - includes
+  - experimentalScannerIgnores

--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -394,10 +394,10 @@ enum GlobKind {
     #[default]
     Normal,
 
-    /// A negated glob, preceeded by a single exclamation mark (`!`).
+    /// A negated glob, preceded by a single exclamation mark (`!`).
     Negated,
 
-    /// A force-negated glob, preceeded by a double exclamation mark (`!!`).
+    /// A force-negated glob, preceded by a double exclamation mark (`!!`).
     ForceNegated,
 }
 

--- a/crates/biome_glob/src/lib.rs
+++ b/crates/biome_glob/src/lib.rs
@@ -204,9 +204,10 @@ impl AsRef<Glob> for NormalizedGlob {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(try_from = "String", into = "String"))]
 pub struct Glob {
-    is_negated: bool,
+    kind: GlobKind,
     glob: globset::GlobMatcher,
 }
+
 impl Glob {
     /// Returns `true` if this glob is negated.
     ///
@@ -214,11 +215,30 @@ impl Glob {
     /// let glob = "!*.js".parse::<biome_glob::Glob>().unwrap();
     /// assert!(glob.is_negated());
     ///
+    /// let glob = "!!*.js".parse::<biome_glob::Glob>().unwrap();
+    /// assert!(glob.is_negated());
+    ///
     /// let glob = "*.js".parse::<biome_glob::Glob>().unwrap();
     /// assert!(!glob.is_negated());
     /// ```
     pub fn is_negated(&self) -> bool {
-        self.is_negated
+        matches!(self.kind, GlobKind::Negated | GlobKind::ForceNegated)
+    }
+
+    /// Returns `true` if this glob is force-negated.
+    ///
+    /// ```
+    /// let glob = "!!*.js".parse::<biome_glob::Glob>().unwrap();
+    /// assert!(glob.is_force_negated());
+    ///
+    /// let glob = "!*.js".parse::<biome_glob::Glob>().unwrap();
+    /// assert!(!glob.is_force_negated());
+    ///
+    /// let glob = "*.js".parse::<biome_glob::Glob>().unwrap();
+    /// assert!(!glob.is_force_negated());
+    /// ```
+    pub fn is_force_negated(&self) -> bool {
+        matches!(self.kind, GlobKind::ForceNegated)
     }
 
     /// Returns the negated version of this glob.
@@ -232,14 +252,18 @@ impl Glob {
     /// ```
     pub fn negated(self) -> Self {
         Self {
-            is_negated: !self.is_negated,
+            kind: if matches!(self.kind, GlobKind::Normal) {
+                GlobKind::Negated
+            } else {
+                GlobKind::Normal
+            },
             glob: self.glob,
         }
     }
 
     /// Tests whether the given path matches this pattern.
     pub fn is_match(&self, path: impl AsRef<std::path::Path>) -> bool {
-        self.is_raw_match(path) != self.is_negated
+        self.is_raw_match(path) != self.is_negated()
     }
 
     /// Tests whether the given path matches this pattern, ignoring the negation.
@@ -249,7 +273,7 @@ impl Glob {
 
     /// Tests whether the given path matches this pattern.
     fn is_match_candidate(&self, path: &CandidatePath<'_>) -> bool {
-        self.is_raw_match_candidate(path) != self.is_negated
+        self.is_raw_match_candidate(path) != self.is_negated()
     }
 
     /// Tests whether the given path matches this pattern, ignoring the negation.
@@ -264,21 +288,20 @@ impl AsRef<Self> for Glob {
 }
 impl PartialEq for Glob {
     fn eq(&self, other: &Self) -> bool {
-        self.is_negated == other.is_negated && self.glob.glob() == other.glob.glob()
+        self.kind == other.kind && self.glob.glob() == other.glob.glob()
     }
 }
 impl Eq for Glob {}
 impl std::hash::Hash for Glob {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.is_negated.hash(state);
+        self.kind.hash(state);
         self.glob.glob().hash(state);
     }
 }
 impl std::fmt::Display for Glob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let repr = self.glob.glob();
-        let negation = if self.is_negated { "!" } else { "" };
-        write!(f, "{negation}{repr}")
+        write!(f, "{}{repr}", self.kind)
     }
 }
 impl std::fmt::Debug for Glob {
@@ -294,10 +317,14 @@ impl From<Glob> for String {
 impl std::str::FromStr for Glob {
     type Err = GlobError;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let (is_negated, value) = if let Some(stripped) = value.strip_prefix('!') {
-            (true, stripped)
+        let (kind, value) = if let Some(stripped) = value.strip_prefix('!') {
+            if let Some(stripped) = stripped.strip_prefix('!') {
+                (GlobKind::ForceNegated, stripped)
+            } else {
+                (GlobKind::Negated, stripped)
+            }
         } else {
-            (false, value)
+            (GlobKind::Normal, value)
         };
         validate_glob(value)?;
         let mut glob_builder = globset::GlobBuilder::new(value);
@@ -307,7 +334,7 @@ impl std::str::FromStr for Glob {
         glob_builder.literal_separator(true);
         match glob_builder.build() {
             Ok(glob) => Ok(Self {
-                is_negated,
+                kind,
                 glob: glob.compile_matcher(),
             }),
             Err(error) => Err(GlobError::Generic(
@@ -358,6 +385,29 @@ impl schemars::JsonSchema for Glob {
 
     fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         String::json_schema(generator)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+enum GlobKind {
+    /// A regular glob without modifiers.
+    #[default]
+    Normal,
+
+    /// A negated glob, preceeded by a single exclamation mark (`!`).
+    Negated,
+
+    /// A force-negated glob, preceeded by a double exclamation mark (`!!`).
+    ForceNegated,
+}
+
+impl std::fmt::Display for GlobKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Normal => "",
+            Self::Negated => "!",
+            Self::ForceNegated => "!!",
+        })
     }
 }
 
@@ -469,6 +519,48 @@ impl<'a> CandidatePath<'a> {
             }
         }
         default
+    }
+
+    /// Matches against a list of globs and returns whether the path is
+    /// force-ignored by one of the globs.
+    ///
+    /// A forced negation can be undone by a later glob that includes the path.
+    ///
+    /// Let's take an example:
+    ///
+    /// ```
+    /// use biome_glob::{CandidatePath, Glob};
+    ///
+    /// let globs: &[Glob] = &[
+    ///     "*".parse().unwrap(),
+    ///     "!!a*".parse().unwrap(),
+    ///     "a".parse().unwrap(),
+    /// ];
+    ///
+    /// assert!(CandidatePath::new(&"abc").matches_forced_negation(globs));
+    /// assert!(!CandidatePath::new(&"a").matches_forced_negation(globs));
+    /// assert!(!CandidatePath::new(&"b").matches_forced_negation(globs));
+    /// ```
+    ///
+    /// - `abc` matches the forced negation `!!a*`. The later glob `a` doesn't
+    ///   match `abc`, so `abc` is force-negated.
+    /// - `a` also matches the forced negation `!!a*`, but gets included again
+    ///   due to the later glob `a`, so it isn't force-negated.
+    /// - `b` only matches `*` and is therefore not negated.
+    ///
+    pub fn matches_forced_negation<I>(&self, globs: I) -> bool
+    where
+        I: IntoIterator,
+        I::IntoIter: DoubleEndedIterator,
+        I::Item: AsRef<Glob>,
+    {
+        // Iterate in reverse order to avoid unnecessary glob matching.
+        for glob in globs.into_iter().rev() {
+            if glob.as_ref().is_raw_match_candidate(self) {
+                return glob.as_ref().is_force_negated();
+            }
+        }
+        false
     }
 }
 

--- a/crates/biome_module_graph/src/js_module_info/diagnostics.rs
+++ b/crates/biome_module_graph/src/js_module_info/diagnostics.rs
@@ -67,10 +67,10 @@ impl Diagnostic for ExceededTypesLimitDiagnostic {
 
     fn advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
         visitor.record_log(LogCategory::Info, &markup!{
-            "In the meantime, you can ignore this file by adding its name or folder in the "<Emphasis>"files.experimentalScannerIgnores"</Emphasis>" option in your configuration file."
+            "In the meantime, you can ignore this file by force-ignoring it using a `!!` pattern in the "<Emphasis>"files.includes"</Emphasis>" option in your configuration file."
         })?;
         visitor.record_log(LogCategory::Info, &markup!{
-            "Refer to the "<Hyperlink href={"https://biomejs.dev/reference/configuration/#filesexperimentalscannerignores"}>"documentation"</Hyperlink>" for more information."
+            "Refer to the "<Hyperlink href={"https://biomejs.dev/reference/configuration/#filesincludes"}>"documentation"</Hyperlink>" for more information."
         })?;
 
         visitor.record_log(

--- a/crates/biome_module_graph/src/js_module_info/diagnostics.rs
+++ b/crates/biome_module_graph/src/js_module_info/diagnostics.rs
@@ -67,7 +67,7 @@ impl Diagnostic for ExceededTypesLimitDiagnostic {
 
     fn advices(&self, visitor: &mut dyn Visit) -> std::io::Result<()> {
         visitor.record_log(LogCategory::Info, &markup!{
-            "In the meantime, you can ignore this file by force-ignoring it using a `!!` pattern in the "<Emphasis>"files.includes"</Emphasis>" option in your configuration file."
+            "In the meantime, you can force this file to be ignored using a `!!` pattern in the "<Emphasis>"files.includes"</Emphasis>" option in your configuration file."
         })?;
         visitor.record_log(LogCategory::Info, &markup!{
             "Refer to the "<Hyperlink href={"https://biomejs.dev/reference/configuration/#filesincludes"}>"documentation"</Hyperlink>" for more information."

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -5,7 +5,7 @@ use crate::workspace::{
     DocumentFileSource, FeatureName, FeaturesSupported, FileFeaturesResult, IgnoreKind,
 };
 use biome_fs::ConfigName;
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use papaya::HashMap;
 use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,22 @@ use std::fmt::Display;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tracing::{debug, instrument};
+
+// List of entries that will be ignored by the scanner regardless of
+// `files.includes`.
+const FORCED_SCANNER_IGNORE_ENTRIES: &[&[u8]] = &[
+    b".cache",
+    b".git",
+    b".hg",
+    b".netlify",
+    b".output",
+    b".svn",
+    b".yarn",
+    b".timestamp",
+    b".turbo",
+    b".vercel",
+    b".DS_Store",
+];
 
 /// The information tracked for each project.
 #[derive(Debug, Default)]
@@ -125,17 +141,30 @@ impl Projects {
             .map(|data| data.root_settings.clone())
     }
 
-    /// Returns whether a path is ignored based on the
-    /// `files.experimentalScannerIgnores` setting only.
-    pub fn is_ignored_by_scanner(&self, project_key: ProjectKey, path: &Utf8Path) -> bool {
-        self.0.pin().get(&project_key).is_none_or(|data| {
-            let ignore_entries = &data.root_settings.files.scanner_ignore_entries;
-            path.components().any(|component| {
-                ignore_entries
-                    .iter()
-                    .any(|entry| entry == component.as_os_str().as_encoded_bytes())
-            })
-        })
+    /// Returns whether a path is force-ignored using a forced negation (`!!`)
+    /// as part of `files.includes`.
+    pub fn is_force_ignored(&self, project_key: ProjectKey, path: &Utf8Path) -> bool {
+        if path.components().any(|component| match component {
+            Utf8Component::Normal(c) => FORCED_SCANNER_IGNORE_ENTRIES.contains(&c.as_bytes()),
+            _ => false,
+        }) {
+            return true;
+        }
+
+        let data = self.0.pin();
+        let Some(project_data) = data.get(&project_key) else {
+            return false;
+        };
+
+        let includes = project_data
+            .nested_settings
+            .iter()
+            .find(|(project_path, _)| path.starts_with(project_path))
+            .map_or(
+                &project_data.root_settings.files.includes,
+                |(_, settings)| &settings.files.includes,
+            );
+        includes.is_force_ignored(path)
     }
 
     pub fn is_ignored_by_top_level_config(

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -12,11 +12,11 @@ use biome_configuration::max_size::MaxSize;
 use biome_configuration::plugins::Plugins;
 use biome_configuration::vcs::{VcsClientKind, VcsConfiguration, VcsEnabled, VcsUseIgnoreFile};
 use biome_configuration::{
-    BiomeDiagnostic, Configuration, CssConfiguration, FilesConfiguration,
-    FilesIgnoreUnknownEnabled, FormatterConfiguration, GraphqlConfiguration, GritConfiguration,
-    JsConfiguration, JsonConfiguration, LinterConfiguration, OverrideAssistConfiguration,
-    OverrideFormatterConfiguration, OverrideGlobs, OverrideLinterConfiguration, Overrides, Rules,
-    push_to_analyzer_assist, push_to_analyzer_rules,
+    BiomeDiagnostic, Configuration, CssConfiguration, DEFAULT_SCANNER_IGNORE_ENTRIES,
+    FilesConfiguration, FilesIgnoreUnknownEnabled, FormatterConfiguration, GraphqlConfiguration,
+    GritConfiguration, JsConfiguration, JsonConfiguration, LinterConfiguration,
+    OverrideAssistConfiguration, OverrideFormatterConfiguration, OverrideGlobs,
+    OverrideLinterConfiguration, Overrides, Rules, push_to_analyzer_assist, push_to_analyzer_rules,
 };
 use biome_css_formatter::context::CssFormatOptions;
 use biome_css_parser::CssParserOptions;
@@ -689,6 +689,10 @@ pub struct FilesSettings {
 
     /// Files not recognized by Biome should not emit a diagnostic
     pub ignore_unknown: Option<FilesIgnoreUnknownEnabled>,
+
+    /// List of file and folder names that should be unconditionally ignored by
+    /// the scanner.
+    pub scanner_ignore_entries: Vec<Vec<u8>>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -1018,6 +1022,15 @@ fn to_file_settings(
         max_size: config.max_size,
         includes: Includes::new(working_directory, config.includes),
         ignore_unknown: config.ignore_unknown,
+        scanner_ignore_entries: config.experimental_scanner_ignores.map_or_else(
+            || {
+                DEFAULT_SCANNER_IGNORE_ENTRIES
+                    .iter()
+                    .map(|entry| entry.to_vec())
+                    .collect()
+            },
+            |entries| entries.into_iter().map(String::into_bytes).collect(),
+        ),
     })
 }
 

--- a/crates/biome_service/src/snapshots/module_diagnostic.snap
+++ b/crates/biome_service/src/snapshots/module_diagnostic.snap
@@ -10,7 +10,7 @@ example.js project  INTERNAL  ━━━━━━━━━━━━━━━━�
     
     Please follow these instructions to discover if you are accidentally analyzing large files and what to do about them in the relative guide.
   
-  i In the meantime, you can ignore this file by adding its name or folder in the files.experimentalScannerIgnores option in your configuration file.
+  i In the meantime, you can ignore this file by force-ignoring it using a `!!` pattern in the files.includes option in your configuration file.
   
   i Refer to the documentation for more information.
   

--- a/crates/biome_service/src/snapshots/module_diagnostic.snap
+++ b/crates/biome_service/src/snapshots/module_diagnostic.snap
@@ -10,7 +10,7 @@ example.js project  INTERNAL  ━━━━━━━━━━━━━━━━�
     
     Please follow these instructions to discover if you are accidentally analyzing large files and what to do about them in the relative guide.
   
-  i In the meantime, you can ignore this file by force-ignoring it using a `!!` pattern in the files.includes option in your configuration file.
+  i In the meantime, you can force this file to be ignored using a `!!` pattern in the files.includes option in your configuration file.
   
   i Refer to the documentation for more information.
   

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -542,7 +542,7 @@ impl WorkspaceServer {
         path: &Utf8Path,
         request_kind: IndexRequestKind,
     ) -> Result<bool, WorkspaceError> {
-        if self.projects.is_ignored_by_scanner(project_key, path) {
+        if self.projects.is_force_ignored(project_key, path) {
             return Ok(true);
         }
 

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -139,26 +139,6 @@ export type Extends = string[] | string;
  */
 export interface FilesConfiguration {
 	/**
-	* Set of file and folder names that should be unconditionally ignored by Biome's scanner.
-
-Biome maintains an internal list of default ignore entries, which is based on user feedback and which may change in any release. This setting allows overriding this internal list completely.
-
-This is considered an advanced feature that users _should_ not need to tweak themselves, but they can as a last resort. This setting can only be configured in root configurations, and is ignored in nested configs.
-
-Entries must be file or folder *names*. Specific paths and globs are not supported.
-
-Examples where this may be useful:
-
-```jsonc { "files": { "experimentalScannerIgnores": [ // You almost certainly don't want to scan your `.git` // folder, which is why it's already ignored by default: ".git",
-
-// But the scanner does scan `node_modules` by default. If // you *really* don't want this, you can ignore it like // this: "node_modules",
-
-// But it's probably better to ignore a specific dependency. // For instance, one that happens to be particularly slow to // scan: "RedisCommander.d.ts", ], } } ```
-
-Please be aware that rules relying on the module graph or type inference information may be negatively affected if dependencies of your project aren't (fully) scanned. 
-	 */
-	experimentalScannerIgnores?: string[];
-	/**
 	 * Tells Biome to not emit diagnostics when handling files that doesn't know
 	 */
 	ignoreUnknown?: Bool;

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -139,6 +139,12 @@ export type Extends = string[] | string;
  */
 export interface FilesConfiguration {
 	/**
+	* **Deprecated:** Please use _force-ignore syntax_ in `files.includes` instead: https://biomejs.dev/reference/configuration/#filesincludes
+
+Set of file and folder names that should be unconditionally ignored by Biome's scanner. 
+	 */
+	experimentalScannerIgnores?: string[];
+	/**
 	 * Tells Biome to not emit diagnostics when handling files that doesn't know
 	 */
 	ignoreUnknown?: Bool;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1490,6 +1490,11 @@
 			"description": "The configuration of the filesystem",
 			"type": "object",
 			"properties": {
+				"experimentalScannerIgnores": {
+					"description": "**Deprecated:** Please use _force-ignore syntax_ in `files.includes` instead: https://biomejs.dev/reference/configuration/#filesincludes\n\nSet of file and folder names that should be unconditionally ignored by Biome's scanner.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				},
 				"ignoreUnknown": {
 					"description": "Tells Biome to not emit diagnostics when handling files that doesn't know",
 					"anyOf": [{ "$ref": "#/definitions/Bool" }, { "type": "null" }]

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1490,11 +1490,6 @@
 			"description": "The configuration of the filesystem",
 			"type": "object",
 			"properties": {
-				"experimentalScannerIgnores": {
-					"description": "Set of file and folder names that should be unconditionally ignored by Biome's scanner.\n\nBiome maintains an internal list of default ignore entries, which is based on user feedback and which may change in any release. This setting allows overriding this internal list completely.\n\nThis is considered an advanced feature that users _should_ not need to tweak themselves, but they can as a last resort. This setting can only be configured in root configurations, and is ignored in nested configs.\n\nEntries must be file or folder *names*. Specific paths and globs are not supported.\n\nExamples where this may be useful:\n\n```jsonc { \"files\": { \"experimentalScannerIgnores\": [ // You almost certainly don't want to scan your `.git` // folder, which is why it's already ignored by default: \".git\",\n\n// But the scanner does scan `node_modules` by default. If // you *really* don't want this, you can ignore it like // this: \"node_modules\",\n\n// But it's probably better to ignore a specific dependency. // For instance, one that happens to be particularly slow to // scan: \"RedisCommander.d.ts\", ], } } ```\n\nPlease be aware that rules relying on the module graph or type inference information may be negatively affected if dependencies of your project aren't (fully) scanned.",
-					"type": ["array", "null"],
-					"items": { "type": "string" }
-				},
 				"ignoreUnknown": {
 					"description": "Tells Biome to not emit diagnostics when handling files that doesn't know",
 					"anyOf": [{ "$ref": "#/definitions/Bool" }, { "type": "null" }]


### PR DESCRIPTION
## Summary

Deprecated the option `files.experimentalScannerIgnores` in favour of **force-ignore** syntax in `files.includes`.

`files.includes` supports ignoring files by prefixing globs with an exclamation mark (`!`). With this change, it also supports _force_-ignoring globs by prefixing them with a double exclamation mark (`!!`).

The effect of force-ignoring is that the scanner will not index files matching
the glob, even in project mode and those files are imported by other files.

#### Example

Let's take the following configuration:

```json
{
    "files": {
        "includes": [
            "**",
            "!**/generated",
            "!!**/dist",
            "fixtures/example/dist/*.js"
        ]
    },
    "linter": {
        "domains": {
            "project": "all"
        }
    }
}
```

This configuration achieves the following:

- Because the [project domain](https://biomejs.dev/linter/domains/#project) is enabled, all supported files in the project are indexed _and_ processed by the linter, _except_:
- Files inside a `generated` folder are not processed by the linter, but they will get indexed _if_ a file outside of a `generated` folder imports them.
- Files inside a `dist` folder are never indexed nor processed, not even if they are imported for any purpose, _except_:
- When the `dist` folder is inside `fixtures/example/`, its `.js` files _do_ get both indexed and processed.

In general, we now recommend using the force-ignore syntax for any folders that contain _output_ files, such as `build/` and `dist/`. For such folders, it is highly unlikely that indexing has any useful benefits. For folders containing generated files, you may wish to use the regular ignore syntax so that type information can still be extracted from the files.

## Test Plan

Multiple tests added.

## Docs

* Website PR: https://github.com/biomejs/website/pull/3022