### PR TITLE
feat(cli): --skip/--only with domains

### DIFF
--- a/.changeset/wet-results-talk.md
+++ b/.changeset/wet-results-talk.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": minor
+---
+
+Added new capabilities to the CLI arguments `--skip` and `--only`, available to the `biome lint` command.
+
+`--skip` and `--only` can now accept domain names; when provided, Biome will run or skip all the rules that belong to a certain domain.
+
+For example, the following command will only run the rules that belong to the [next](https://biomejs.dev/linter/domains/#next) domain:
+
+```shell
+biome lint --only=next
+```
+
+Another example, the following command will skip the rules that belong to the [project](https://biomejs.dev/linter/domains/#project) domain:
+
+```shell
+biome lint --skip=project
+```

--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -16,6 +16,7 @@ use biome_rowan::{AstNode, BatchMutation, BatchMutationExt, Language, TextRange}
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::str::FromStr;
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -510,6 +511,38 @@ impl RuleDomain {
             Self::Vue => &[],
             Self::Project => &[],
             Self::Tailwind => &[],
+        }
+    }
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::React => "react",
+            Self::Test => "test",
+            Self::Solid => "solid",
+            Self::Next => "next",
+            Self::Qwik => "qwik",
+            Self::Vue => "vue",
+            Self::Project => "project",
+            Self::Tailwind => "tailwind",
+        }
+    }
+}
+
+impl FromStr for RuleDomain {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "react" => Ok(Self::React),
+            "test" => Ok(Self::Test),
+            "solid" => Ok(Self::Solid),
+            "next" => Ok(Self::Next),
+            "qwik" => Ok(Self::Qwik),
+            "vue" => Ok(Self::Vue),
+            "project" => Ok(Self::Project),
+            "tailwind" => Ok(Self::Tailwind),
+
+            _ => Err("Invalid rule domain"),
         }
     }
 }

--- a/crates/biome_cli/src/commands/lint.rs
+++ b/crates/biome_cli/src/commands/lint.rs
@@ -2,7 +2,7 @@ use super::{FixFileModeOptions, determine_fix_file_mode};
 use crate::cli_options::CliOptions;
 use crate::commands::{CommandRunner, get_files_to_process_with_cli_options};
 use crate::{CliDiagnostic, Execution, TraversalMode};
-use biome_configuration::analyzer::RuleSelector;
+use biome_configuration::analyzer::AnalyzerSelector;
 use biome_configuration::css::CssLinterConfiguration;
 use biome_configuration::graphql::GraphqlLinterConfiguration;
 use biome_configuration::javascript::JsLinterConfiguration;
@@ -26,8 +26,8 @@ pub(crate) struct LintCommandPayload {
     pub(crate) vcs_configuration: Option<VcsConfiguration>,
     pub(crate) files_configuration: Option<FilesConfiguration>,
     pub(crate) paths: Vec<OsString>,
-    pub(crate) only: Vec<RuleSelector>,
-    pub(crate) skip: Vec<RuleSelector>,
+    pub(crate) only: Vec<AnalyzerSelector>,
+    pub(crate) skip: Vec<AnalyzerSelector>,
     pub(crate) stdin_file_path: Option<String>,
     pub(crate) staged: bool,
     pub(crate) changed: bool,

--- a/crates/biome_cli/src/commands/mod.rs
+++ b/crates/biome_cli/src/commands/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     setup_cli_subscriber,
 };
 use biome_configuration::analyzer::assist::AssistEnabled;
-use biome_configuration::analyzer::{LinterEnabled, RuleSelector};
+use biome_configuration::analyzer::{AnalyzerSelector, LinterEnabled};
 use biome_configuration::css::{CssFormatterConfiguration, CssLinterConfiguration};
 use biome_configuration::formatter::FormatterEnabled;
 use biome_configuration::graphql::{GraphqlFormatterConfiguration, GraphqlLinterConfiguration};
@@ -233,20 +233,28 @@ pub enum BiomeCommand {
         #[bpaf(external, hide_usage)]
         cli_options: CliOptions,
 
-        /// Run only the given rule or group of rules.
+        /// Run only the given rule, group of rules or domain.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
         ///
-        /// Example: `biome lint --only=correctness/noUnusedVariables --only=suspicious`
-        #[bpaf(long("only"), argument("GROUP|RULE"))]
-        only: Vec<RuleSelector>,
+        /// Example:
+        ///
+        /// ```shell
+        /// biome lint --only=correctness/noUnusedVariables --only=suspicious --only=test
+        /// ```
+        #[bpaf(long("only"), argument("GROUP|RULE|DOMAIN"))]
+        only: Vec<AnalyzerSelector>,
 
-        /// Skip the given rule or group of rules by setting the severity level of the rules to `off`.
+        /// Skip the given rule, group of rules or domain by setting the severity level of the rules to `off`.
         /// This option takes precedence over `--only`.
         ///
-        /// Example: `biome lint --skip=correctness/noUnusedVariables --skip=suspicious`
-        #[bpaf(long("skip"), argument("GROUP|RULE"))]
-        skip: Vec<RuleSelector>,
+        /// Example:
+        ///
+        /// ```shell
+        /// biome lint --skip=correctness/noUnusedVariables --skip=suspicious --skip=project
+        /// ```
+        #[bpaf(long("skip"), argument("GROUP|RULE|DOMAIN"))]
+        skip: Vec<AnalyzerSelector>,
 
         /// Use this option when you want to format code piped from `stdin`, and print the output to `stdout`.
         ///

--- a/crates/biome_cli/src/commands/scan_kind.rs
+++ b/crates/biome_cli/src/commands/scan_kind.rs
@@ -80,7 +80,8 @@ pub(crate) fn derive_best_scan_kind(
 mod tests {
     use super::*;
     use crate::{TraversalMode, VcsTargeted};
-    use biome_configuration::{LinterConfiguration, analyzer::RuleSelector};
+    use biome_configuration::LinterConfiguration;
+    use biome_configuration::analyzer::RuleSelector;
 
     #[test]
     fn should_return_none_for_lint_command() {
@@ -88,7 +89,7 @@ mod tests {
             fix_file_mode: None,
             stdin: None,
             only: vec![],
-            skip: vec![RuleSelector::Rule("correctness", "noPrivateImports")],
+            skip: vec![RuleSelector::Rule("correctness", "noPrivateImports").into()],
 
             vcs_targeted: VcsTargeted::default(),
             suppress: false,

--- a/crates/biome_cli/src/execute/mod.rs
+++ b/crates/biome_cli/src/execute/mod.rs
@@ -18,7 +18,7 @@ use crate::reporter::terminal::{ConsoleReporter, ConsoleReporterVisitor};
 use crate::{
     CliDiagnostic, CliSession, DiagnosticsPayload, Reporter, TEMPORARY_INTERNAL_REPORTER_FILE,
 };
-use biome_configuration::analyzer::RuleSelector;
+use biome_configuration::analyzer::AnalyzerSelector;
 use biome_console::{ConsoleExt, markup};
 use biome_diagnostics::{Category, category};
 use biome_diagnostics::{Resource, SerdeJsonError};
@@ -126,10 +126,10 @@ pub enum TraversalMode {
         /// Run only the given rule or group of rules.
         /// If the severity level of a rule is `off`,
         /// then the severity level of the rule is set to `error` if it is a recommended rule or `warn` otherwise.
-        only: Vec<RuleSelector>,
+        only: Vec<AnalyzerSelector>,
         /// Skip the given rule or group of rules by setting the severity level of the rules to `off`.
         /// This option takes precedence over `--only`.
-        skip: Vec<RuleSelector>,
+        skip: Vec<AnalyzerSelector>,
         /// A flag to know vcs integrated options such as `--staged` or `--changed` are enabled
         vcs_targeted: VcsTargeted,
         /// Suppress existing diagnostics with a `// biome-ignore` comment

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_domains/should_disable_domain_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_domains/should_disable_domain_via_cli.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `test1.js`
+
+```js
+describe.only("bar", () => {});
+
+```
+
+## `test2.js`
+
+```js
+
+describe("foo", () => {
+	beforeEach(() => {});
+    beforeEach(() => {});
+    test("bar", () => {
+        someFn();
+    });
+});
+    
+```
+
+# Emitted Messages
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_linter_domains/should_enable_domain_via_cli.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_linter_domains/should_enable_domain_via_cli.snap
@@ -1,0 +1,95 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{
+  "linter": {
+    "rules": {
+      "recommended": false
+    },
+    "domains": {
+      "test": "all"
+    }
+  }
+}
+```
+
+## `test1.js`
+
+```js
+describe.only("bar", () => {});
+
+```
+
+## `test2.js`
+
+```js
+
+describe("foo", () => {
+	beforeEach(() => {});
+    beforeEach(() => {});
+    test("bar", () => {
+        someFn();
+    });
+});
+    
+```
+
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+test1.js:1:10 lint/suspicious/noFocusedTests  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Don't focus the test.
+  
+  > 1 │ describe.only("bar", () => {});
+      │          ^^^^
+    2 │ 
+  
+  i The 'only' method is often used for debugging or during implementation.
+  
+  i Consider removing 'only' to ensure all tests are executed.
+  
+  i Unsafe fix: Remove focus from test.
+  
+    1 │ describe.only("bar",·()·=>·{});
+      │         -----                  
+
+```
+
+```block
+test2.js:4:5 lint/suspicious/noDuplicateTestHooks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Disallow duplicate setup and teardown hooks.
+  
+    2 │ describe("foo", () => {
+    3 │ 	beforeEach(() => {});
+  > 4 │     beforeEach(() => {});
+      │     ^^^^^^^^^^^^^^^^^^^^
+    5 │     test("bar", () => {
+    6 │         someFn();
+  
+  i Disallow beforeEach duplicacy inside the describe function.
+  
+
+```
+
+```block
+Checked 2 files in <TIME>. No fixes applied.
+Found 1 error.
+Found 1 warning.
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -7,8 +7,8 @@ expression: redactor(content)
 ```block
 Run various checks on a set of files.
 
-Usage: lint [--write] [--unsafe] [--suppress] [--reason=STRING] [--only=<GROUP|RULE>]... [--skip=
-<GROUP|RULE>]... [--staged] [--changed] [--since=REF] [PATH]...
+Usage: lint [--write] [--unsafe] [--suppress] [--reason=STRING] [--only=<GROUP|RULE|DOMAIN>]... [
+--skip=<GROUP|RULE|DOMAIN>]... [--staged] [--changed] [--since=REF] [PATH]...
 
 Set of properties to integrate Biome with a VCS software.
         --vcs-enabled=<true|false>  Whether Biome should integrate itself with the VCS client
@@ -85,15 +85,18 @@ Available options:
         --suppress            Fixes lint rule violations with comment suppressions instead of using
                               a rule code action (fix)
         --reason=STRING       Explanation for suppressing diagnostics with `--suppress`
-        --only=<GROUP|RULE>   Run only the given rule or group of rules. If the severity level of a
-                              rule is `off`, then the severity level of the rule is set to `error`
-                              if it is a recommended rule or `warn` otherwise.
-                              Example: `biome lint --only=correctness/noUnusedVariables
-                              --only=suspicious`
-        --skip=<GROUP|RULE>   Skip the given rule or group of rules by setting the severity level of
-                              the rules to `off`. This option takes precedence over `--only`.
-                              Example: `biome lint --skip=correctness/noUnusedVariables
-                              --skip=suspicious`
+        --only=<GROUP|RULE|DOMAIN>  Run only the given rule, group of rules or domain. If the
+                              severity level of a rule is `off`, then the severity level of the rule
+                              is set to `error` if it is a recommended rule or `warn` otherwise.
+                              Example:
+                              ```shell biome lint --only=correctness/noUnusedVariables
+                              --only=suspicious --only=test ```
+        --skip=<GROUP|RULE|DOMAIN>  Skip the given rule, group of rules or domain by setting the
+                              severity level of the rules to `off`. This option takes precedence
+                              over `--only`.
+                              Example:
+                              ```shell biome lint --skip=correctness/noUnusedVariables
+                              --skip=suspicious --skip=project ```
         --stdin-file-path=PATH  Use this option when you want to format code piped from `stdin`, and
                               print the output to `stdout`.
                               The file doesn't need to exist on disk, what matters is the extension

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_doesnt_exist.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_only_rule_doesnt_exist.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_cli/tests/snap_test.rs
-expression: content
+expression: redactor(content)
 ---
 ## `check.js`
 
@@ -17,7 +17,7 @@ flags/invalid ━━━━━━━━━━━━━━━━━━━━━━
   × Failed to parse CLI arguments.
     
     Caused by:
-      couldn't parse `suspicious/inexistant`: This rule doesn't exist.
+      couldn't parse `suspicious/inexistant`: The rule, group or domain doesn't exist.
   
 
 

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -527,17 +527,17 @@ impl RuleSelector {
     /// - `quickfix.biome.a11y.useAltText`
     ///
     /// ```
-    /// use biome_configuration::analyzer::AnalyzerSelector;
+    /// use biome_configuration::analyzer::{AnalyzerSelector, RuleSelector};
     ///
     /// let filter = "source.biome.useSortedKeys";
     /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, AnalyzerSelector::Rule("source", "useSortedKeys"));
+    /// assert_eq!(selector, RuleSelector::Rule("source", "useSortedKeys").into());
     /// let filter = "quickfix.biome.style.useConst";
     /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, AnalyzerSelector::Rule("style", "useConst"));
+    /// assert_eq!(selector, RuleSelector::Rule("style", "useConst").into());
     /// let filter = "quickfix.biome.a11y.useAltText";
     /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, AnalyzerSelector::Rule("a11y", "useAltText"));
+    /// assert_eq!(selector, RuleSelector::Rule("a11y", "useAltText").into());
     /// ```
     pub fn from_lsp_filter(filter: &str) -> Option<Self> {
         if let Some(filter) = filter.strip_prefix("source.biome.") {

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -543,14 +543,14 @@ impl RuleSelector {
     /// use biome_configuration::analyzer::{AnalyzerSelector, RuleSelector};
     ///
     /// let filter = "source.biome.useSortedKeys";
-    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("source", "useSortedKeys").into());
+    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, RuleSelector::Rule("source", "useSortedKeys"));
     /// let filter = "quickfix.biome.style.useConst";
-    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("style", "useConst").into());
+    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, RuleSelector::Rule("style", "useConst"));
     /// let filter = "quickfix.biome.a11y.useAltText";
-    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("a11y", "useAltText").into());
+    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, RuleSelector::Rule("a11y", "useAltText"));
     /// ```
     pub fn from_lsp_filter(filter: &str) -> Option<Self> {
         if let Some(filter) = filter.strip_prefix("source.biome.") {

--- a/crates/biome_configuration/src/analyzer/mod.rs
+++ b/crates/biome_configuration/src/analyzer/mod.rs
@@ -4,7 +4,7 @@ pub mod linter;
 use crate::analyzer::assist::Actions;
 pub use crate::analyzer::linter::*;
 use biome_analyze::options::RuleOptions;
-use biome_analyze::{FixKind, RuleCategory, RuleFilter};
+use biome_analyze::{FixKind, RuleCategory, RuleDomain, RuleFilter};
 use biome_deserialize::{
     Deserializable, DeserializableType, DeserializableValue, DeserializationContext, Merge,
 };
@@ -414,6 +414,88 @@ impl<T: Default> Merge for RuleWithFixOptions<T> {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub enum AnalyzerSelector {
+    Rule(RuleSelector),
+    Domain(DomainSelector),
+}
+
+impl From<RuleSelector> for AnalyzerSelector {
+    fn from(value: RuleSelector) -> Self {
+        Self::Rule(value)
+    }
+}
+
+impl From<DomainSelector> for AnalyzerSelector {
+    fn from(value: DomainSelector) -> Self {
+        Self::Domain(value)
+    }
+}
+
+impl Debug for AnalyzerSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for AnalyzerSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rule(group) => Display::fmt(group, f),
+            Self::Domain(domain) => Display::fmt(domain, f),
+        }
+    }
+}
+
+impl FromStr for AnalyzerSelector {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        RuleSelector::from_str(s)
+            .map(Self::Rule)
+            .or(DomainSelector::from_str(s).map(Self::Domain))
+            .or(Err("The rule, group or domain doesn't exist."))
+    }
+}
+
+impl serde::Serialize for AnalyzerSelector {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Rule(rule) => rule.serialize(serializer),
+            Self::Domain(domain) => domain.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for AnalyzerSelector {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = AnalyzerSelector;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("<group>/<rule_name> or <domain>")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match AnalyzerSelector::from_str(v) {
+                    Ok(result) => Ok(result),
+                    Err(error) => Err(serde::de::Error::custom(error)),
+                }
+            }
+        }
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for AnalyzerSelector {
+    fn schema_name() -> String {
+        "Selector".to_string()
+    }
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(generator)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub enum RuleSelector {
     Group(&'static str),
     Rule(&'static str, &'static str),
@@ -445,17 +527,17 @@ impl RuleSelector {
     /// - `quickfix.biome.a11y.useAltText`
     ///
     /// ```
-    /// use biome_configuration::analyzer::RuleSelector;
+    /// use biome_configuration::analyzer::AnalyzerSelector;
     ///
     /// let filter = "source.biome.useSortedKeys";
-    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("source", "useSortedKeys"));
+    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, AnalyzerSelector::Rule("source", "useSortedKeys"));
     /// let filter = "quickfix.biome.style.useConst";
-    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("style", "useConst"));
+    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, AnalyzerSelector::Rule("style", "useConst"));
     /// let filter = "quickfix.biome.a11y.useAltText";
-    /// let selector = RuleSelector::from_lsp_filter(filter).unwrap();
-    /// assert_eq!(selector, RuleSelector::Rule("a11y", "useAltText"));
+    /// let selector = AnalyzerSelector::from_lsp_filter(filter).unwrap();
+    /// assert_eq!(selector, AnalyzerSelector::Rule("a11y", "useAltText"));
     /// ```
     pub fn from_lsp_filter(filter: &str) -> Option<Self> {
         if let Some(filter) = filter.strip_prefix("source.biome.") {
@@ -518,20 +600,8 @@ impl FromStr for RuleSelector {
             // once we have promoted the GraphQL `useNamingConvention` rule.
             //
             // See https://github.com/biomejs/biome/issues/6018
-            if optional_group_name.is_none_or(|name| name == static_group_name)
-                || (rule_or_group_name == "useNamingConvention"
-                    && optional_group_name == Some("style"))
-            {
+            if optional_group_name.is_none_or(|name| name == static_group_name) {
                 if matches!(selector_kind, None | Some(RuleCategory::Lint)) {
-                    // TODO: remove the `style/useNamingConvention` exception,
-                    // once we have promoted the GraphQL `useNamingConvention` rule.
-                    let static_group_name = if rule_or_group_name == "useNamingConvention"
-                        && optional_group_name == Some("style")
-                    {
-                        "style"
-                    } else {
-                        static_group_name
-                    };
                     Ok(Self::Rule(static_group_name, rule_name.as_str()))
                 } else {
                     Err(
@@ -623,6 +693,57 @@ impl schemars::JsonSchema for RuleSelector {
     }
     fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         String::json_schema(generator)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct DomainSelector(pub &'static str);
+
+impl Debug for DomainSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for DomainSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for DomainSelector {
+    type Err = &'static str;
+    fn from_str(domain: &str) -> Result<Self, Self::Err> {
+        if let Ok(domain) = RuleDomain::from_str(domain) {
+            Ok(Self(domain.as_str()))
+        } else {
+            Err("This domain doesn't exist.")
+        }
+    }
+}
+
+impl serde::Serialize for DomainSelector {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&format!("{self}"))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DomainSelector {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = DomainSelector;
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("<domain>")
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match DomainSelector::from_str(v) {
+                    Ok(result) => Ok(result),
+                    Err(error) => Err(serde::de::Error::custom(error)),
+                }
+            }
+        }
+        deserializer.deserialize_str(Visitor)
     }
 }
 

--- a/crates/biome_configuration/src/generated.rs
+++ b/crates/biome_configuration/src/generated.rs
@@ -1,4 +1,5 @@
 mod assist;
+mod domain_selector;
 mod linter;
 
 pub use assist::push_to_analyzer_assist;

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -1,0 +1,106 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use crate::analyzer::DomainSelector;
+use biome_analyze::{Rule, RuleFilter};
+use std::sync::LazyLock;
+static NEXT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("correctness", "useExhaustiveDependencies"),
+        RuleFilter::Rule("correctness", "useHookAtTopLevel"),
+        RuleFilter::Rule("nursery", "noNextAsyncClientComponent"),
+        RuleFilter::Rule("performance", "noImgElement"),
+        RuleFilter::Rule("performance", "noUnwantedPolyfillio"),
+        RuleFilter::Rule("performance", "useGoogleFontPreconnect"),
+        RuleFilter::Rule("style", "noHeadElement"),
+        RuleFilter::Rule("suspicious", "noDocumentImportInPage"),
+        RuleFilter::Rule("suspicious", "noHeadImportInDocument"),
+    ]
+});
+static PROJECT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("correctness", "noPrivateImports"),
+        RuleFilter::Rule("correctness", "noUndeclaredDependencies"),
+        RuleFilter::Rule("correctness", "useImportExtensions"),
+        RuleFilter::Rule("correctness", "useJsonImportAttributes"),
+        RuleFilter::Rule("nursery", "noFloatingPromises"),
+        RuleFilter::Rule("nursery", "noImportCycles"),
+        RuleFilter::Rule("nursery", "noMisusedPromises"),
+        RuleFilter::Rule("nursery", "noUnnecessaryConditions"),
+        RuleFilter::Rule("nursery", "noUnresolvedImports"),
+        RuleFilter::Rule("nursery", "useExhaustiveSwitchCases"),
+    ]
+});
+static QWIK_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("correctness", "useJsxKeyInIterable"),
+        RuleFilter::Rule("nursery", "noQwikUseVisibleTask"),
+        RuleFilter::Rule("nursery", "useAnchorHref"),
+        RuleFilter::Rule("nursery", "useImageSize"),
+        RuleFilter::Rule("nursery", "useQwikClasslist"),
+        RuleFilter::Rule("suspicious", "noReactSpecificProps"),
+    ]
+});
+static REACT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("correctness", "noNestedComponentDefinitions"),
+        RuleFilter::Rule("correctness", "noRenderReturnValue"),
+        RuleFilter::Rule("correctness", "useExhaustiveDependencies"),
+        RuleFilter::Rule("correctness", "useHookAtTopLevel"),
+        RuleFilter::Rule("correctness", "useJsxKeyInIterable"),
+        RuleFilter::Rule("correctness", "useUniqueElementIds"),
+        RuleFilter::Rule("nursery", "useReactFunctionComponents"),
+    ]
+});
+static SOLID_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("correctness", "noSolidDestructuredProps"),
+        RuleFilter::Rule("performance", "useSolidForComponent"),
+        RuleFilter::Rule("suspicious", "noReactSpecificProps"),
+    ]
+});
+static TEST_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("complexity", "noExcessiveNestedTestSuites"),
+        RuleFilter::Rule("suspicious", "noDuplicateTestHooks"),
+        RuleFilter::Rule("suspicious", "noExportsInTest"),
+        RuleFilter::Rule("suspicious", "noFocusedTests"),
+    ]
+});
+static VUE_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
+    vec![
+        RuleFilter::Rule("nursery", "noVueDataObjectDeclaration"),
+        RuleFilter::Rule("nursery", "noVueReservedKeys"),
+        RuleFilter::Rule("nursery", "noVueReservedProps"),
+    ]
+});
+impl DomainSelector {
+    pub fn as_rule_filters(&self) -> Vec<RuleFilter<'static>> {
+        match self.0 {
+            "next" => NEXT_FILTERS.clone(),
+            "project" => PROJECT_FILTERS.clone(),
+            "qwik" => QWIK_FILTERS.clone(),
+            "react" => REACT_FILTERS.clone(),
+            "solid" => SOLID_FILTERS.clone(),
+            "test" => TEST_FILTERS.clone(),
+            "vue" => VUE_FILTERS.clone(),
+            _ => unreachable!("DomainFilter::as_rule_filters: domain {} not found", self.0),
+        }
+    }
+    pub fn match_rule<R>(&self) -> bool
+    where
+        R: Rule,
+    {
+        match self.0 {
+            "next" => NEXT_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "project" => PROJECT_FILTERS
+                .iter()
+                .any(|filter| filter.match_rule::<R>()),
+            "qwik" => QWIK_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "react" => REACT_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "solid" => SOLID_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "test" => TEST_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            "vue" => VUE_FILTERS.iter().any(|filter| filter.match_rule::<R>()),
+            _ => false,
+        }
+    }
+}

--- a/crates/biome_lsp/src/handlers/analysis.rs
+++ b/crates/biome_lsp/src/handlers/analysis.rs
@@ -7,7 +7,7 @@ use biome_analyze::{
     ActionCategory, RuleCategoriesBuilder, SUPPRESSION_INLINE_ACTION_CATEGORY,
     SUPPRESSION_TOP_LEVEL_ACTION_CATEGORY, SourceActionKind,
 };
-use biome_configuration::analyzer::RuleSelector;
+use biome_configuration::analyzer::{AnalyzerSelector, RuleSelector};
 use biome_diagnostics::Error;
 use biome_fs::BiomePath;
 use biome_line_index::LineIndex;
@@ -158,6 +158,7 @@ pub(crate) fn code_actions(
         enabled_rules: filters
             .iter()
             .filter_map(|filter| RuleSelector::from_lsp_filter(filter))
+            .map(AnalyzerSelector::from)
             .collect(),
         categories: categories.build(),
     }) {

--- a/crates/biome_lsp/src/server.tests.rs
+++ b/crates/biome_lsp/src/server.tests.rs
@@ -3466,7 +3466,7 @@ export function bar() {
                 categories: RuleCategories::all(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3496,7 +3496,7 @@ export function bar() {
                 categories: RuleCategories::empty(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3522,7 +3522,7 @@ export function bar() {
                 categories: RuleCategories::all(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3552,7 +3552,7 @@ export function bar() {
                 categories: RuleCategories::all(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3676,7 +3676,7 @@ export function bar() {
                 categories: RuleCategories::all(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3710,7 +3710,7 @@ export function bar() {
                 categories: RuleCategories::empty(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )
@@ -3741,7 +3741,7 @@ export function bar() {
                 categories: RuleCategories::all(),
                 only: Vec::new(),
                 skip: Vec::new(),
-                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles")],
+                enabled_rules: vec![RuleSelector::Rule("nursery", "noImportCycles").into()],
                 pull_code_actions: false,
             },
         )

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -4,7 +4,7 @@ use crate::workspace::ScanKind;
 use biome_analyze::{
     AnalyzerRules, Queryable, RegistryVisitor, Rule, RuleDomain, RuleFilter, RuleGroup,
 };
-use biome_configuration::analyzer::{RuleDomainValue, RuleSelector};
+use biome_configuration::analyzer::{AnalyzerSelector, RuleDomainValue, RuleSelector};
 use biome_configuration::diagnostics::{
     CantLoadExtendFile, CantResolve, EditorConfigDiagnostic, ParseFailedDiagnostic,
 };
@@ -699,8 +699,8 @@ pub struct ProjectScanComputer<'a> {
     requires_project_scan: bool,
     enabled_rules: FxHashSet<RuleFilter<'a>>,
     configuration: &'a Configuration,
-    skip: &'a [RuleSelector],
-    only: &'a [RuleSelector],
+    skip: &'a [AnalyzerSelector],
+    only: &'a [AnalyzerSelector],
 }
 
 impl<'a> ProjectScanComputer<'a> {
@@ -717,8 +717,8 @@ impl<'a> ProjectScanComputer<'a> {
 
     pub fn with_rule_selectors(
         mut self,
-        skip: &'a [RuleSelector],
-        only: &'a [RuleSelector],
+        skip: &'a [AnalyzerSelector],
+        only: &'a [AnalyzerSelector],
     ) -> Self {
         self.skip = skip;
         self.only = only;
@@ -761,7 +761,7 @@ impl<'a> ProjectScanComputer<'a> {
         R: Rule<Options: Default, Query: Queryable<Language = L, Output: Clone>> + 'static,
     {
         let filter = RuleFilter::Rule(<R::Group as RuleGroup>::NAME, R::METADATA.name);
-        let selector = RuleSelector::Rule(<R::Group as RuleGroup>::NAME, R::METADATA.name);
+        let selector = RuleSelector::Rule(<R::Group as RuleGroup>::NAME, R::METADATA.name).into();
         if !self.only.is_empty() {
             if self.only.contains(&selector) {
                 let domains = R::METADATA.domains;
@@ -904,7 +904,7 @@ mod tests {
         assert_eq!(
             ProjectScanComputer::new(&configuration)
                 .with_rule_selectors(
-                    &[RuleSelector::Rule("correctness", "noPrivateImports")],
+                    &[RuleSelector::Rule("correctness", "noPrivateImports").into()],
                     &[]
                 )
                 .compute(),
@@ -934,7 +934,7 @@ mod tests {
             ProjectScanComputer::new(&configuration)
                 .with_rule_selectors(
                     &[],
-                    &[RuleSelector::Rule("correctness", "noPrivateImports")]
+                    &[RuleSelector::Rule("correctness", "noPrivateImports").into()]
                 )
                 .compute(),
             ScanKind::Project

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -4,7 +4,7 @@ use crate::workspace::ScanKind;
 use biome_analyze::{
     AnalyzerRules, Queryable, RegistryVisitor, Rule, RuleDomain, RuleFilter, RuleGroup,
 };
-use biome_configuration::analyzer::{AnalyzerSelector, RuleDomainValue, RuleSelector};
+use biome_configuration::analyzer::{AnalyzerSelector, RuleDomainValue};
 use biome_configuration::diagnostics::{
     CantLoadExtendFile, CantResolve, EditorConfigDiagnostic, ParseFailedDiagnostic,
 };

--- a/crates/biome_service/src/configuration.rs
+++ b/crates/biome_service/src/configuration.rs
@@ -822,7 +822,7 @@ impl RegistryVisitor<GraphqlLanguage> for ProjectScanComputer<'_> {
 mod tests {
     use super::*;
     use biome_configuration::analyzer::{
-        Correctness, DomainSelector, RuleDomainValue, RuleDomains, SeverityOrGroup,
+        Correctness, DomainSelector, RuleDomainValue, RuleDomains, RuleSelector, SeverityOrGroup,
     };
     use biome_configuration::{
         LinterConfiguration, RuleConfiguration, RulePlainConfiguration, Rules,

--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -521,7 +521,7 @@ fn lint(params: LintParams) -> LintResults {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_selectors)
             .with_project_layout(params.project_layout.clone())
             .finish();
 
@@ -580,7 +580,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
-            .with_enabled_rules(&rules)
+            .with_enabled_selectors(&rules)
             .with_project_layout(project_layout)
             .finish();
 
@@ -626,7 +626,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_rules)
             .with_project_layout(params.project_layout)
             .finish();
 

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -426,7 +426,7 @@ fn lint(params: LintParams) -> LintResults {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_selectors)
             .with_project_layout(params.project_layout.clone())
             .finish();
 
@@ -484,7 +484,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
-            .with_enabled_rules(&rules)
+            .with_enabled_selectors(&rules)
             .with_project_layout(project_layout)
             .finish();
 
@@ -530,7 +530,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_rules)
             .with_project_layout(params.project_layout)
             .finish();
 

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -723,7 +723,7 @@ pub(crate) fn lint(params: LintParams) -> LintResults {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_selectors)
             .with_project_layout(params.project_layout.clone())
             .finish();
 
@@ -777,7 +777,7 @@ pub(crate) fn code_actions(params: CodeActionsParams) -> PullActionsResult {
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
-            .with_enabled_rules(&rules)
+            .with_enabled_selectors(&rules)
             .with_project_layout(project_layout.clone())
             .finish();
     let filter = AnalysisFilter {
@@ -838,7 +838,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_rules)
             .with_project_layout(params.project_layout.clone())
             .finish();
 

--- a/crates/biome_service/src/file_handlers/json.rs
+++ b/crates/biome_service/src/file_handlers/json.rs
@@ -506,7 +506,7 @@ fn lint(params: LintParams) -> LintResults {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_selectors)
             .with_project_layout(params.project_layout.clone())
             .finish();
 
@@ -573,7 +573,7 @@ fn code_actions(params: CodeActionsParams) -> PullActionsResult {
             .with_only(&only)
             .with_skip(&skip)
             .with_path(path.as_path())
-            .with_enabled_rules(&rules)
+            .with_enabled_selectors(&rules)
             .with_project_layout(project_layout)
             .finish();
 
@@ -622,7 +622,7 @@ fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceError> {
             .with_only(&params.only)
             .with_skip(&params.skip)
             .with_path(params.biome_path.as_path())
-            .with_enabled_rules(&params.enabled_rules)
+            .with_enabled_selectors(&params.enabled_rules)
             .with_project_layout(params.project_layout)
             .finish();
 

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -65,7 +65,7 @@ use std::{
 };
 
 use biome_analyze::{ActionCategory, RuleCategories};
-use biome_configuration::{Configuration, analyzer::RuleSelector};
+use biome_configuration::{Configuration, analyzer::AnalyzerSelector};
 use biome_console::{Markup, MarkupBuf, markup};
 use biome_diagnostics::{CodeSuggestion, serde::Diagnostic};
 use biome_formatter::Printed;
@@ -918,12 +918,12 @@ pub struct PullDiagnosticsParams {
     pub path: BiomePath,
     pub categories: RuleCategories,
     #[serde(default)]
-    pub only: Vec<RuleSelector>,
+    pub only: Vec<AnalyzerSelector>,
     #[serde(default)]
-    pub skip: Vec<RuleSelector>,
+    pub skip: Vec<AnalyzerSelector>,
     /// Rules to apply on top of the configuration
     #[serde(default)]
-    pub enabled_rules: Vec<RuleSelector>,
+    pub enabled_rules: Vec<AnalyzerSelector>,
     /// When `false` the diagnostics, don't have code frames of the code actions (fixes, suppressions, etc.)
     pub pull_code_actions: bool,
 }
@@ -946,11 +946,11 @@ pub struct PullActionsParams {
     pub range: Option<TextRange>,
     pub suppression_reason: Option<String>,
     #[serde(default)]
-    pub only: Vec<RuleSelector>,
+    pub only: Vec<AnalyzerSelector>,
     #[serde(default)]
-    pub skip: Vec<RuleSelector>,
+    pub skip: Vec<AnalyzerSelector>,
     #[serde(default)]
-    pub enabled_rules: Vec<RuleSelector>,
+    pub enabled_rules: Vec<AnalyzerSelector>,
     #[serde(default)]
     pub categories: RuleCategories,
 }
@@ -1019,12 +1019,12 @@ pub struct FixFileParams {
     pub fix_file_mode: FixFileMode,
     pub should_format: bool,
     #[serde(default)]
-    pub only: Vec<RuleSelector>,
+    pub only: Vec<AnalyzerSelector>,
     #[serde(default)]
-    pub skip: Vec<RuleSelector>,
+    pub skip: Vec<AnalyzerSelector>,
     /// Rules to apply to the file
     #[serde(default)]
-    pub enabled_rules: Vec<RuleSelector>,
+    pub enabled_rules: Vec<AnalyzerSelector>,
     pub rule_categories: RuleCategories,
     #[serde(default)]
     pub suppression_reason: Option<String>,
@@ -1636,8 +1636,8 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn pull_diagnostics(
         &self,
         categories: RuleCategories,
-        only: Vec<RuleSelector>,
-        skip: Vec<RuleSelector>,
+        only: Vec<AnalyzerSelector>,
+        skip: Vec<AnalyzerSelector>,
         pull_code_actions: bool,
     ) -> Result<PullDiagnosticsResult, WorkspaceError> {
         self.workspace.pull_diagnostics(PullDiagnosticsParams {
@@ -1654,10 +1654,10 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
     pub fn pull_actions(
         &self,
         range: Option<TextRange>,
-        only: Vec<RuleSelector>,
-        skip: Vec<RuleSelector>,
+        only: Vec<AnalyzerSelector>,
+        skip: Vec<AnalyzerSelector>,
         suppression_reason: Option<String>,
-        enabled_rules: Vec<RuleSelector>,
+        enabled_rules: Vec<AnalyzerSelector>,
         categories: RuleCategories,
     ) -> Result<PullActionsResult, WorkspaceError> {
         self.workspace.pull_actions(PullActionsParams {
@@ -1707,8 +1707,8 @@ impl<'app, W: Workspace + ?Sized> FileGuard<'app, W> {
         fix_file_mode: FixFileMode,
         should_format: bool,
         rule_categories: RuleCategories,
-        only: Vec<RuleSelector>,
-        skip: Vec<RuleSelector>,
+        only: Vec<AnalyzerSelector>,
+        skip: Vec<AnalyzerSelector>,
         suppression_reason: Option<String>,
     ) -> Result<FixFileResult, WorkspaceError> {
         self.workspace.fix_file(FixFileParams {

--- a/crates/biome_service/src/workspace.tests.rs
+++ b/crates/biome_service/src/workspace.tests.rs
@@ -273,10 +273,7 @@ fn correctly_pulls_lint_diagnostics() {
     .unwrap();
     let result = graphql_file.pull_diagnostics(
         RuleCategories::all(),
-        vec![RuleSelector::Rule(
-            RuleGroup::Style.as_str(),
-            "useDeprecatedReason",
-        )],
+        vec![RuleSelector::Rule(RuleGroup::Style.as_str(), "useDeprecatedReason").into()],
         vec![],
         true,
     );

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -1308,7 +1308,7 @@ impl Workspace for WorkspaceServer {
                 module_graph: self.module_graph.clone(),
                 project_layout: self.project_layout.clone(),
                 suppression_reason: None,
-                enabled_rules,
+                enabled_selectors: enabled_rules,
                 pull_code_actions,
                 plugins: if categories.is_lint() {
                     plugins

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -9313,18 +9313,17 @@ export interface PullDiagnosticsParams {
 	/**
 	 * Rules to apply on top of the configuration
 	 */
-	enabledRules?: RuleCode[];
-	only?: RuleCode[];
+	enabledRules?: Selector[];
+	only?: Selector[];
 	path: BiomePath;
 	projectKey: ProjectKey;
 	/**
 	 * When `false` the diagnostics, don't have code frames of the code actions (fixes, suppressions, etc.)
 	 */
 	pullCodeActions: boolean;
-	skip?: RuleCode[];
+	skip?: Selector[];
 }
 export type RuleCategories = RuleCategory[];
-export type RuleCode = string;
 export type RuleCategory = "syntax" | "lint" | "action" | "transformation";
 export interface PullDiagnosticsResult {
 	diagnostics: Diagnostic[];
@@ -9333,12 +9332,12 @@ export interface PullDiagnosticsResult {
 }
 export interface PullActionsParams {
 	categories?: RuleCategories;
-	enabledRules?: RuleCode[];
-	only?: RuleCode[];
+	enabledRules?: Selector[];
+	only?: Selector[];
 	path: BiomePath;
 	projectKey: ProjectKey;
 	range?: TextRange;
-	skip?: RuleCode[];
+	skip?: Selector[];
 	suppressionReason?: string;
 }
 export interface PullActionsResult {
@@ -9433,14 +9432,14 @@ export interface FixFileParams {
 	/**
 	 * Rules to apply to the file
 	 */
-	enabledRules?: RuleCode[];
+	enabledRules?: Selector[];
 	fixFileMode: FixFileMode;
-	only?: RuleCode[];
+	only?: Selector[];
 	path: BiomePath;
 	projectKey: ProjectKey;
 	ruleCategories: RuleCategories;
 	shouldFormat: boolean;
-	skip?: RuleCode[];
+	skip?: Selector[];
 	suppressionReason?: string;
 }
 /**


### PR DESCRIPTION
## Summary

Closes https://github.com/biomejs/biome/issues/6880

Now `--skip` and `--only` support domains too! They work the same as when you pass a group. However, we need to rely to some codegen because domains work across groups, so we need to codegen the filters generated by those domains.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added new tests

<!-- What demonstrates that your implementation is correct? -->

## Docs

Updated the relative CLI commands. Docs will be updated automatically upon release.

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
