### PR TITLE
fix(core): improve inference with conditionals

### DIFF
--- a/crates/biome_analyze/src/options.rs
+++ b/crates/biome_analyze/src/options.rs
@@ -3,7 +3,6 @@ use rustc_hash::FxHashMap;
 
 use crate::{FixKind, Rule, RuleKey};
 use std::any::{Any, TypeId};
-use std::fmt::Debug;
 use std::sync::Arc;
 
 /// A convenient new type data structure to store the options that belong to a rule

--- a/crates/biome_js_type_info/src/helpers.rs
+++ b/crates/biome_js_type_info/src/helpers.rs
@@ -583,6 +583,7 @@ generate_matcher!(is_interface, Interface, _);
 generate_matcher!(is_null, Null);
 generate_matcher!(is_reference, Reference, _);
 generate_matcher!(is_never_keyword, NeverKeyword);
+generate_matcher!(is_undefined, Undefined);
 generate_matcher!(is_union, Union, _);
 generate_matcher!(is_unknown_keyword, UnknownKeyword);
 generate_matcher!(is_void_keyword, VoidKeyword);

--- a/crates/biome_js_type_info/src/lib.rs
+++ b/crates/biome_js_type_info/src/lib.rs
@@ -11,6 +11,7 @@ mod r#type;
 mod type_data;
 mod type_store;
 
+pub use conditionals::*;
 pub use flattening::MAX_FLATTEN_DEPTH;
 pub use globals::{GLOBAL_RESOLVER, GLOBAL_UNKNOWN_ID, GlobalsResolver, NUM_PREDEFINED_TYPES};
 pub use resolver::*;

--- a/crates/biome_js_type_info/src/type.rs
+++ b/crates/biome_js_type_info/src/type.rs
@@ -129,6 +129,17 @@ impl Type {
         }
     }
 
+    /// Returns whether this type is a boolean with the given `value`.
+    pub fn is_boolean_literal(&self, value: bool) -> bool {
+        self.as_raw_data().is_some_and(|ty| match ty {
+            TypeData::Literal(literal) => match literal.as_ref() {
+                Literal::Boolean(literal) => literal.as_bool() == value,
+                _ => false,
+            },
+            _ => false,
+        })
+    }
+
     /// Returns whether `self` is a function with a return type matching the
     /// given `predicate`.
     pub fn is_function_with_return_type(&self, predicate: impl Fn(Self) -> bool) -> bool {
@@ -174,6 +185,19 @@ impl Type {
                 TypeData::Literal(literal) => matches!(literal.as_ref(), Literal::Number(_)),
                 _ => false,
             })
+    }
+
+    /// Returns whether this type is a number with the given `value`.
+    pub fn is_number_literal(&self, value: f64) -> bool {
+        self.as_raw_data().is_some_and(|ty| match ty {
+            TypeData::Literal(literal) => match literal.as_ref() {
+                Literal::Number(literal) => literal
+                    .to_f64()
+                    .is_some_and(|literal_value| literal_value == value),
+                _ => false,
+            },
+            _ => false,
+        })
     }
 
     /// Returns whether this type is the `Promise` class.

--- a/crates/biome_js_type_info/tests/conditionals.rs
+++ b/crates/biome_js_type_info/tests/conditionals.rs
@@ -1,0 +1,42 @@
+mod utils;
+
+use biome_js_type_info::{
+    GlobalsResolver, ScopeId, TypeData, TypeResolver, reference_to_falsy_subset_of,
+};
+
+use utils::{assert_type_data_snapshot, get_variable_declaration, parse_ts};
+
+#[test]
+fn test_reference_to_falsy_subset_of() {
+    const CODE: &str = r#"let foo: undefined | null | number = 1;"#;
+
+    let root = parse_ts(CODE);
+    let decl = get_variable_declaration(&root);
+    let mut resolver = GlobalsResolver::default();
+    let bindings = TypeData::typed_bindings_from_js_variable_declaration(
+        &mut resolver,
+        ScopeId::GLOBAL,
+        &decl,
+    );
+    resolver.run_inference();
+
+    let (var_name, var_ty) = bindings.into_vec().remove(0);
+    assert_eq!(var_name.text(), "foo");
+    let var_ty = resolver
+        .resolve_and_get(&var_ty)
+        .expect("must resolve")
+        .to_data();
+
+    let falsy_subset_of_ty = reference_to_falsy_subset_of(&var_ty, &mut resolver);
+    let falsy_subset_of_ty = resolver
+        .resolve_and_get(&falsy_subset_of_ty.unwrap())
+        .expect("must resolve")
+        .to_data();
+
+    assert_type_data_snapshot(
+        CODE,
+        &falsy_subset_of_ty,
+        &resolver,
+        "test_reference_to_falsy_subset_of",
+    )
+}

--- a/crates/biome_js_type_info/tests/snapshots/test_reference_to_falsy_subset_of.snap
+++ b/crates/biome_js_type_info/tests/snapshots/test_reference_to_falsy_subset_of.snap
@@ -1,0 +1,30 @@
+---
+source: crates/biome_js_type_info/tests/utils.rs
+expression: content
+---
+## Input
+
+```ts
+let foo: undefined | null | number = 1;
+
+```
+
+## Result
+
+```
+undefined | Global TypeId(0) | Global TypeId(3)
+```
+
+## Registered types
+
+```
+Global TypeId(0) => null
+
+Global TypeId(1) => undefined | Global TypeId(0) | number
+
+Global TypeId(2) => undefined | Global TypeId(0) | number
+
+Global TypeId(3) => value: 0
+
+Global TypeId(4) => undefined | Global TypeId(0) | Global TypeId(3)
+```

--- a/crates/biome_module_graph/tests/spec_tests.rs
+++ b/crates/biome_module_graph/tests/spec_tests.rs
@@ -1625,6 +1625,71 @@ fn test_resolve_single_reexport() {
 }
 
 #[test]
+fn test_resolve_type_of_union_from_imported_module() {
+    let fs = MemoryFileSystem::default();
+    fs.insert(
+        "/node_modules/react.d.ts".into(),
+        r#"
+        type BogusType = false;
+
+        export type ReactPortal = BogusType;
+
+        export type ReactElement = BogusType;
+
+        export type ReactNode =
+            | ReactElement
+            | string
+            | number
+            | Iterable<ReactNode>
+            | ReactPortal
+            | boolean
+            | null
+            | undefined;
+        "#,
+    );
+    fs.insert(
+        "/src/reexport.ts".into(),
+        r#"export { type ReactElement, type ReactNode } from "../node_modules/react.d.ts";"#,
+    );
+    fs.insert(
+        "/src/index.ts".into(),
+        r#"import { type ReactNode } from "./reexport.ts";
+
+        const foo: ReactNode = undefined;
+        const bar = foo && 1;
+        "#,
+    );
+
+    let added_paths = [
+        BiomePath::new("/src/index.ts"),
+        BiomePath::new("/src/reexport.ts"),
+        BiomePath::new("/node_modules/react.d.ts"),
+    ];
+    let added_paths = get_added_paths(&fs, &added_paths);
+
+    let module_graph = Arc::new(ModuleGraph::default());
+    module_graph.update_graph_for_js_paths(&fs, &ProjectLayout::default(), &added_paths, &[]);
+
+    let index_module = module_graph
+        .module_info_for_path(Utf8Path::new("/src/index.ts"))
+        .expect("module must exist");
+    let resolver = Arc::new(ModuleResolver::for_module(
+        index_module,
+        module_graph.clone(),
+    ));
+
+    let result_id = resolver
+        .resolve_type_of(&Text::new_static("bar"), ScopeId::GLOBAL)
+        .expect("bar variable not found");
+    let ty = resolver.resolved_type_for_id(result_id);
+    assert!(ty.has_variant(|ty| ty.is_null()));
+    assert!(ty.has_variant(|ty| ty.is_undefined()));
+    assert!(ty.has_variant(|ty| ty.is_boolean_literal(false)));
+    assert!(ty.has_variant(|ty| ty.is_number_literal(0.)));
+    assert!(ty.has_variant(|ty| ty.is_number_literal(1.)));
+}
+
+#[test]
 fn test_resolve_multiple_reexports() {
     let fs = MemoryFileSystem::default();
     fs.insert(


### PR DESCRIPTION
## Summary

Hopefully fix #7324: Even though we're missing a complete reproduction, I noticed the partial reproductions we had both included a conditionals, so I double-checked the inference code related to those: I noticed an invalid `apply_module_id_to_reference()` happening in `derive_conditional_type()`, because the references coming from `flattened_union_variants()` already have correct module ID applied to them. `flattened_union_variants()` is also a very recent addition, so it could very well explain the regression.

## Test Plan

Tests added. Unfortunately the tests **didn't** reproduce the original problem, so I can only hope it resolves the issue.

## Docs

N/A

Note I didn't even add a changeset as I'm not sure the fix will solve the linked issue.