### PR TITLE
chore: initialise project layout in test examples

### DIFF
--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -31,24 +31,33 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```js,ignore
+    /// ```json,file=package.json
+    /// {
+    ///   "dependencies": {}
+    /// }
+    /// ```
+    ///
+    /// ```js,expect_diagnostic,file=index.js
     /// import "vite";
     /// ```
     ///
     /// ### Valid
     ///
-    /// ```js,ignore
-    /// import { A } from "./local.js";
+    /// ```json,file=package.json
+    /// {
+    ///   "dependencies": {
+    ///     "vite": "*"
+    ///   }
+    /// }
     /// ```
     ///
-    /// ```js,ignore
-    /// import assert from "node:assert";
-    /// ```
+    /// ```js,file=index.js
+    /// import "vite"; // package is correctly declared
     ///
-    /// If you have declared `type-fest` in the `devDependencies` section:
+    /// import assert from "node:assert"; // Node imports don't need declaration
     ///
-    /// ```js,ignore
-    /// import type { SetRequired } from "type-fest";
+    /// import { A } from "./local.js"; // relative imports don't trigger the rule
+    /// import { B } from "#alias"; // same goes for aliases
     /// ```
     ///
     /// ## Options
@@ -75,15 +84,39 @@ declare_lint_rule! {
     /// if the name of the file being linted (i.e. not the imported file/module) matches a single glob
     /// in the array, and `false` otherwise.
     ///
-    /// In the following example, only test files can use dependencies in `devDependencies` section.
-    /// `dependencies`, `peerDependencies`, and `optionalDependencies` are always available.
+    /// ### Example using the `devDependencies` option
     ///
-    /// ```json
+    /// In this example, only test files can use dependencies in the
+    /// `devDependencies` section. `dependencies`, `peerDependencies`, and
+    /// `optionalDependencies` are always available.
+    ///
+    /// ```json,options
     /// {
     ///   "options": {
-    ///     "devDependencies": ["tests/*.test.js", "tests/*.spec.js"]
+    ///     "devDependencies": ["**/tests/*.test.js", "**/tests/*.spec.js"]
     ///   }
     /// }
+    /// ```
+    ///
+    /// **`package.json`**
+    /// ```json,file=package.json
+    /// {
+    ///   "devDependencies": {
+    ///     "vite": "*"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **`src/index.js`**
+    /// ```js,expect_diagnostic,use_options,file=src/index.js
+    /// // cannot import from a non-test file
+    /// import "vite";
+    /// ```
+    ///
+    /// **`tests/foo.test.js`**
+    /// ```js,use_options,file=tests/foo.test.js
+    /// // this works, because the file matches a glob from the options
+    /// import "vite";
     /// ```
     pub NoUndeclaredDependencies {
         version: "1.6.0",

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -207,7 +207,7 @@ pub fn get_added_paths<'a>(
                 let diagnostics = parsed.diagnostics();
                 assert!(
                     diagnostics.is_empty(),
-                    "Unexpected diagnostics: {diagnostics:?}"
+                    "Unexpected diagnostics: {diagnostics:?}\nWhile parsing:\n{content}"
                 );
                 parsed.try_tree()
             })?;


### PR DESCRIPTION
## Summary

This adds one more improvement on top of #7399 so that the project layout is also initialised with rule documentation examples for multi-file analysis.

cc @ryan-m-walker

## Test Plan

The examples for `noUndeclaredDependencies` have been updated so they are now correctly validated. This shows that multi-file analysis also works with `package.json` manifests.

## Docs

N/A