### PR TITLE
chore: validate diagnostics in examples of `Promise`-related rules

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -1211,6 +1211,8 @@ The documentation needs to adhere to the following rules:
 
   For rules that analyze relationships between multiple files (e.g., import cycles, cross-file dependencies), you can use the `file=<path>` property to create an in-memory file system for testing.
 
+  This is also useful to trigger type inference even for examples that only consist of individual files.
+
   Files are organized by documentation section (Markdown headings), where all files in a section are collected before any tests run. This ensures each test has access to the complete file system regardless of definition order.
 
   ````rust

--- a/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_floating_promises.rs
@@ -31,14 +31,14 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-fn.ts
     /// async function returnsPromise(): Promise<string> {
     ///   return 'value';
     /// }
     /// returnsPromise().then(() => {});
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-fn2.ts
     /// const returnsPromise = async (): Promise<string> => {
     ///   return 'value';
     /// }
@@ -47,16 +47,16 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts
+    /// ```js,expect_diagnostic,file=new-promise.js
     /// const promise = new Promise((resolve) => resolve('value'));
     /// promise.then(() => { }).finally(() => { });
     /// ```
     ///
-    /// ```ts
+    /// ```js,expect_diagnostic,file=promise-all.js
     /// Promise.all([p1, p2, p3])
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-method.ts
     /// class Api {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -67,7 +67,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-super-method.ts
     /// class Parent {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -81,7 +81,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-method2.ts
     /// class Api {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -91,7 +91,7 @@ declare_lint_rule! {
     /// api.returnsPromise().then(() => {}).finally(() => {});
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-object-method.ts
     /// const obj = {
     ///   async returnsPromise(): Promise<string> {
     ///     return 'value';
@@ -101,7 +101,7 @@ declare_lint_rule! {
     /// obj.returnsPromise();
     /// ```
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=async-prop.ts
     /// type Props = {
     ///   returnsPromise: () => Promise<void>;
     /// };
@@ -113,7 +113,7 @@ declare_lint_rule! {
     ///
     /// ### Valid
     ///
-    /// ```ts
+    /// ```ts,file=valid-examples.ts
     /// async function returnsPromise(): Promise<string> {
     ///   return 'value';
     /// }
@@ -141,9 +141,7 @@ declare_lint_rule! {
     ///     await this.returnsPromise();
     ///   }
     /// }
-    /// ```
     ///
-    /// ```ts
     /// type Props = {
     ///   returnsPromise: () => Promise<void>;
     /// };

--- a/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_misused_promises.rs
@@ -28,34 +28,34 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=promise-in-condition.js
     /// const promise = Promise.resolve('value');
     /// if (promise) { /* This branch will always execute */ }
     /// ```
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=promise-in-ternary-condition.js
     /// const promise = Promise.resolve('value');
     /// const val = promise ? 123 : 456; // Always evaluates to `123`.
     /// ```
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=promise-in-filter.js
     /// // The following filter has no effect:
     /// const promise = Promise.resolve('value');
     /// [1, 2, 3].filter(() => promise);
     /// ```
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=promise-while-condition.js
     /// const promise = Promise.resolve('value');
     /// while (promise) { /* This is an endless loop */ }
     /// ```
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=spread-promise.js
     /// // Using a `Promise` as an iterable expands to nothing:
     /// const getData = () => fetch('/');
     /// console.log({ foo: 42, ...getData() });
     /// ```
     ///
-    /// ```js
+    /// ```js,expect_diagnostic,file=promise-in-forEach.js
     /// // These `fetch`-es are not `await`-ed in order:
     /// [1, 2, 3].forEach(async value => {
     ///     await fetch(`/${value}`);
@@ -64,7 +64,7 @@ declare_lint_rule! {
     ///
     /// ### Valid
     ///
-    /// ```js
+    /// ```js,file=valid-promises.js
     /// const promise = Promise.resolve('value');
     /// if (await promise) { /* Do something */ }
     ///


### PR DESCRIPTION
## Summary

This adds annotations to the `noFloatingPromises` and `noMisusedPromises` rules so that we validate the diagnostics from their examples.

## Test Plan

CI should remain green.

## Docs

Added a little explanation that the `file=<path>` annotation can be useful beyond multi-file snippets, for instance to initialise type inference.