### PR TITLE
ci: ignore @biomejs/plugin-api on publish

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -23,8 +23,9 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@biomejs/benchmark",
     "@biomejs/aria-data",
+    "@biomejs/benchmark",
+    "@biomejs/plugin-api",
     "tailwindcss-config-analyzer"
   ]
 }

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Publish npm packages as beta
         run: |
           for package in packages/@biomejs/*; do
-            if [ $package != "packages/@biomejs/js-api" ]; then
+            if [ $package != "packages/@biomejs/js-api" ] && [ $package != "packages/@biomejs/plugin-api" ]; then
               npm publish $package --tag beta --access public --provenance
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
         run: node packages/@biomejs/biome/scripts/generate-packages.mjs
 
       - name: Publish npm packages as latest
-        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ]; then npm publish $package  --tag latest --access public --provenance; fi; done
+        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ] && [ $package != "packages/@biomejs/plugin-api" ]; then npm publish $package  --tag latest --access public --provenance; fi; done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -247,12 +247,12 @@ jobs:
         run: node packages/@biomejs/biome/scripts/generate-packages.mjs
 
       - name: Publish npm packages as latest
-        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ]; then npm publish $package --tag latest --access public --provenance; fi; done
+        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ] && [ $package != "packages/@biomejs/plugin-api" ]; then npm publish $package --tag latest --access public --provenance; fi; done
         if: needs.build.outputs.prerelease != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish npm packages as nightly
-        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ]; then npm publish $package --tag nightly --access public --provenance; fi; done
+        run: for package in packages/@biomejs/*; do if [ $package != "packages/@biomejs/js-api" ] && [ $package != "packages/@biomejs/plugin-api" ]; then npm publish $package --tag nightly --access public --provenance; fi; done
         if: needs.build.outputs.prerelease == 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

`@biomejs/plugin-api` was introduced for providing type info for JS plugins, but not ready for publish. We have to skip publishing the package for now.

## Test Plan

Wait for the next CI

## Docs

N/A