### PR TITLE
fix(useSortedClasses): recognize negative placement utilities

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/tailwind_preset.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/tailwind_preset.rs
@@ -5,7 +5,7 @@ use super::sort_config::UtilityLayer;
 
 const COMPONENTS_LAYER_CLASSES: [&str; 1] = ["container$"];
 
-const UTILITIES_LAYER_CLASSES: [&str; 578] = [
+const UTILITIES_LAYER_CLASSES: [&str; 587] = [
     "sr-only$",
     "not-sr-only$",
     "pointer-events-none$",
@@ -19,14 +19,23 @@ const UTILITIES_LAYER_CLASSES: [&str; 578] = [
     "relative$",
     "sticky$",
     "inset-",
+    "-inset-",
     "inset-x-",
+    "-inset-x-",
     "inset-y-",
+    "-inset-y-",
     "start-",
+    "-start-",
     "end-",
+    "-end-",
     "top-",
+    "-top-",
     "right-",
+    "-right-",
     "bottom-",
+    "-bottom-",
     "left-",
+    "-left-",
     "isolate$",
     "isolation-auto$",
     "z-",


### PR DESCRIPTION
## Summary

Fixes #7407 by adding negative versions of placement utilities (e.g. `-end`) to the list of Tailwind utilities.

_Changeset_: Biome now recognizes [negative placement](https://tailwindcss.com/docs/top-right-bottom-left) utilities such as `-inset-px` or `-end-full`.  This means that it'll no longer put them at the start of the class list.

## Test Plan

?
