### PR TITLE
fix(lsp): project loading

### DIFF
--- a/.changeset/rich-beds-clap.md
+++ b/.changeset/rich-beds-clap.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7411](https://github.com/biomejs/biome/issues/7411). The Biome Language Server had a regression where opening an editor with a file already open wouldn't load the project settings correctly.

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -651,4 +651,13 @@ impl ConfigurationPathHint {
     pub const fn is_from_lsp(&self) -> bool {
         matches!(self, Self::FromLsp(_))
     }
+
+    pub fn to_path_buf(&self) -> Option<Utf8PathBuf> {
+        match self {
+            Self::None => None,
+            Self::FromWorkspace(path) | Self::FromLsp(path) | Self::FromUser(path) => {
+                Some(path.to_path_buf())
+            }
+        }
+    }
 }

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -605,7 +605,7 @@ pub struct ConfigurationPayload {
     pub external_resolution_base_path: Utf8PathBuf,
 }
 
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone, Eq, Hash)]
 pub enum ConfigurationPathHint {
     /// The default mode, not having a configuration file is not an error.
     /// The path will be filled with the working directory if it is not filled at the time of usage.

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -1,15 +1,16 @@
-use std::sync::Arc;
-
 use crate::diagnostics::LspError;
+use crate::session::ConfigurationStatus;
 use crate::utils::apply_document_changes;
 use crate::{documents::Document, session::Session};
+use biome_configuration::ConfigurationPathHint;
 use biome_service::workspace::{
     ChangeFileParams, CloseFileParams, DocumentFileSource, FeaturesBuilder, FileContent,
     GetFileContentParams, IgnoreKind, OpenFileParams, PathIsIgnoredParams,
 };
-use tower_lsp_server::lsp_types;
-use tower_lsp_server::lsp_types::MessageType;
-use tracing::{debug, error, field};
+use camino::Utf8PathBuf;
+use std::sync::Arc;
+use tower_lsp_server::{UriExt, lsp_types};
+use tracing::{debug, error, field, info};
 
 /// Handler for `textDocument/didOpen` LSP notification
 #[tracing::instrument(
@@ -31,22 +32,76 @@ pub(crate) async fn did_open(
 
     let path = session.file_path(&url)?;
 
-    let status = session.configuration_status();
+    eprintln!("Session id {:?}", session.key);
+    let project_key = match session.project_for_path(&path) {
+        Some(project_key) => project_key,
+        None => {
+            info!("No open project for path: {path:?}. Opening new project.");
 
-    let project_key = if status.is_loaded() {
-        match session.project_for_path(&path) {
-            Some(project_key) => project_key,
-            None => {
-                error!("Could not find project for {path}");
+            let project_path = path
+                .parent()
+                .map(|parent| parent.to_path_buf())
+                .unwrap_or_default();
+
+            // We first check if the current file belongs to one of the folders that we registered.
+            // Ifo so, we return the project folder, otherwise we use the folder provided by the function did_open
+            let project_path = if let Some(workspace_folders) = session.get_workspace_folders() {
+                workspace_folders
+                    .iter()
+                    .find_map(|folder| {
+                        folder
+                            .uri
+                            .to_file_path()
+                            .map(|p| {
+                                Utf8PathBuf::from_path_buf(p.to_path_buf())
+                                    .expect("To have a valid UTF-8 path")
+                            })
+                            .map(|folder| {
+                                if project_path.starts_with(&folder) {
+                                    folder
+                                } else {
+                                    project_path.clone()
+                                }
+                            })
+                    })
+                    .unwrap_or(project_path.clone())
+            } else if let Some(base_path) = session.base_path() {
+                if project_path.starts_with(&base_path) {
+                    base_path
+                } else {
+                    project_path.clone()
+                }
+            } else {
+                project_path
+            };
+
+            session.set_configuration_status(ConfigurationStatus::Loading);
+            eprintln!(
+                "Loading configuration from text_document {:?}",
+                &project_path
+            );
+            let status = session
+                .load_biome_configuration_file(ConfigurationPathHint::FromLsp(project_path), false)
+                .await;
+
+            session.set_configuration_status(status);
+
+            if status.is_loaded() {
+                match session.project_for_path(&path) {
+                    Some(project_key) => project_key,
+
+                    None => {
+                        error!("Could not find project for {path}");
+
+                        return Ok(());
+                    }
+                }
+            } else {
+                error!("Configuration could not be loaded for {path}");
+
                 return Ok(());
             }
         }
-    } else {
-        if status.is_plugin_error() {
-            session.client.show_message(MessageType::WARNING, "The plugin loading has failed. Biome will report only parsing errors until the file is fixed or its usage is disabled.").await;
-        }
-        error!("Configuration could not be loaded for {path}");
-        return Ok(());
     };
 
     let is_ignored = session

--- a/crates/biome_lsp/src/handlers/text_document.rs
+++ b/crates/biome_lsp/src/handlers/text_document.rs
@@ -61,7 +61,6 @@ pub(crate) async fn did_open(
                     project_path.clone()
                 }
             } else if let Some(base_path) = session.base_path() {
-            } else if let Some(base_path) = session.base_path() {
                 if project_path.starts_with(&base_path) {
                     base_path
                 } else {

--- a/crates/biome_lsp/src/server.rs
+++ b/crates/biome_lsp/src/server.rs
@@ -6,7 +6,6 @@ use crate::session::{
 };
 use crate::utils::{into_lsp_error, panic_to_lsp_error};
 use crate::{handlers, requests};
-use biome_configuration::ConfigurationPathHint;
 use biome_console::markup;
 use biome_diagnostics::panic::PanicError;
 use biome_fs::{ConfigName, MemoryFileSystem, OsFileSystem};
@@ -310,13 +309,10 @@ impl LanguageServer for LSPServer {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn initialized(&self, params: InitializedParams) {
-        let _ = params;
-
+    async fn initialized(&self, _params: InitializedParams) {
         info!("Attempting to load the configuration from 'biome.json' file");
-
         self.session.load_extension_settings().await;
-        self.session.load_workspace_settings().await;
+        self.session.load_workspace_settings(false).await;
 
         let msg = format!("Server initialized with PID: {}", std::process::id());
         self.session
@@ -360,7 +356,7 @@ impl LanguageServer for LSPServer {
                         || watched_file.ends_with(".editorconfig"))
                 {
                     self.session.load_extension_settings().await;
-                    self.session.load_workspace_settings().await;
+                    self.session.load_workspace_settings(true).await;
                     self.setup_capabilities().await;
                     self.session.update_all_diagnostics().await;
                     // for now we are only interested to the configuration file,
@@ -411,18 +407,8 @@ impl LanguageServer for LSPServer {
             }
         }
 
-        for added in &params.event.added {
-            if let Ok(project_path) = self.session.file_path(&added.uri) {
-                let status = self
-                    .session
-                    .load_biome_configuration_file(ConfigurationPathHint::FromWorkspace(
-                        project_path.to_path_buf(),
-                    ))
-                    .await;
-                debug!("Configuration status: {status:?}");
-                self.session.set_configuration_status(status);
-            }
-        }
+        self.session.update_workspace_folders(params.event.added);
+        self.session.load_workspace_settings(true).await;
     }
 
     async fn code_action(&self, params: CodeActionParams) -> LspResult<Option<CodeActionResponse>> {

--- a/crates/biome_lsp/src/session.rs
+++ b/crates/biome_lsp/src/session.rs
@@ -40,6 +40,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8};
 use tokio::spawn;
 use tokio::sync::Notify;
 use tokio::sync::OnceCell;
+use tokio::sync::RwLock as TokioRwLock;
 use tokio::sync::watch;
 use tokio::task::spawn_blocking;
 use tower_lsp_server::lsp_types::{ClientCapabilities, Diagnostic, Uri};
@@ -71,6 +72,9 @@ pub(crate) struct Session {
     /// The parameters provided by the client in the "initialize" request
     initialize_params: OnceCell<InitializeParams>,
 
+    /// Tracks workspace folders. They can change during the lifecycle of the server
+    workspace_folders: RwLock<Option<Vec<WorkspaceFolder>>>,
+
     /// The settings of the Biome extension (under the `biome` namespace)
     pub(crate) extension_settings: RwLock<ExtensionSettings>,
 
@@ -96,6 +100,10 @@ pub(crate) struct Session {
     /// If we receive a notification here, diagnostics for open documents are
     /// all refreshed.
     service_rx: watch::Receiver<ServiceNotification>,
+
+    /// Lock used to synchronize multiple atomic operations to load the configuration file
+    loading_operations:
+        TokioRwLock<FxHashMap<SessionKey, tokio::sync::broadcast::Sender<ConfigurationStatus>>>,
 }
 
 /// The parameters provided by the client in the "initialize" request
@@ -104,7 +112,6 @@ struct InitializeParams {
     client_capabilities: ClientCapabilities,
     client_information: Option<ClientInformation>,
     root_uri: Option<Uri>,
-    workspace_folders: Option<Vec<WorkspaceFolder>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -207,6 +214,8 @@ impl Session {
             cancellation,
             notified_broken_configuration: AtomicBool::new(false),
             service_rx,
+            loading_operations: Default::default(),
+            workspace_folders: Default::default(),
         }
     }
 
@@ -223,8 +232,12 @@ impl Session {
             client_capabilities,
             client_information,
             root_uri,
-            workspace_folders,
         });
+
+        {
+            let mut this_workspace_folders = self.workspace_folders.write().unwrap();
+            *this_workspace_folders = workspace_folders;
+        }
 
         if let Err(err) = result {
             error!("Failed to initialize session: {err}");
@@ -316,12 +329,13 @@ impl Session {
         project_key: ProjectKey,
         path: BiomePath,
         scan_kind: ScanKind,
+        force: bool,
     ) {
         self.projects.pin().insert(path.clone(), project_key);
 
         // Spawn the scan in the background, to avoid timing out the LSP request.
         let session = self.clone();
-        spawn(async move { session.scan_project(project_key, scan_kind).await })
+        spawn(async move { session.scan_project(project_key, scan_kind, force).await })
             .await
             .expect("Scanning task to complete successfully");
     }
@@ -577,10 +591,13 @@ impl Session {
     }
 
     /// Get the current workspace folders
-    pub(crate) fn get_workspace_folders(&self) -> Option<&Vec<WorkspaceFolder>> {
-        self.initialize_params
-            .get()
-            .and_then(|c| c.workspace_folders.as_ref())
+    pub(crate) fn get_workspace_folders(&self) -> Option<Vec<WorkspaceFolder>> {
+        self.workspace_folders.read().unwrap().clone()
+    }
+
+    pub(crate) fn update_workspace_folders(&self, folders: Vec<WorkspaceFolder>) {
+        let mut workspace_folders = self.workspace_folders.write().unwrap();
+        *workspace_folders = Some(folders);
     }
 
     /// Returns the base path of the workspace on the filesystem if it has one
@@ -609,7 +626,7 @@ impl Session {
     /// This function attempts to read the `biome.json` configuration file from
     /// the root URI and update the workspace settings accordingly
     #[tracing::instrument(level = "debug", skip(self))]
-    pub(crate) async fn load_workspace_settings(self: &Arc<Self>) {
+    pub(crate) async fn load_workspace_settings(self: &Arc<Self>, reload: bool) {
         if let Some(config_path) = self
             .extension_settings
             .read()
@@ -620,7 +637,7 @@ impl Session {
             self.set_configuration_status(ConfigurationStatus::Loading);
 
             let status = self
-                .load_biome_configuration_file(ConfigurationPathHint::FromUser(config_path))
+                .load_biome_configuration_file(ConfigurationPathHint::FromUser(config_path), reload)
                 .await;
             debug!("Configuration status: {:?}", status);
             self.set_configuration_status(status);
@@ -635,9 +652,10 @@ impl Session {
                 match base_path {
                     Some(base_path) => {
                         let status = self
-                            .load_biome_configuration_file(ConfigurationPathHint::FromWorkspace(
-                                base_path,
-                            ))
+                            .load_biome_configuration_file(
+                                ConfigurationPathHint::FromWorkspace(base_path),
+                                reload,
+                            )
                             .await;
                         debug!("Configuration status: {:?}", status);
                         self.set_configuration_status(status);
@@ -655,7 +673,7 @@ impl Session {
                 None => ConfigurationPathHint::default(),
                 Some(path) => ConfigurationPathHint::FromLsp(path),
             };
-            let status = self.load_biome_configuration_file(base_path).await;
+            let status = self.load_biome_configuration_file(base_path, reload).await;
             self.set_configuration_status(status);
         }
     }
@@ -665,6 +683,7 @@ impl Session {
         self: &Arc<Self>,
         project_key: ProjectKey,
         scan_kind: ScanKind,
+        force: bool,
     ) {
         let session = self.clone();
 
@@ -672,7 +691,7 @@ impl Session {
             let result = session.workspace.scan_project(ScanProjectParams {
                 project_key,
                 watch: true,
-                force: false,
+                force,
                 scan_kind,
                 verbose: false,
             });
@@ -708,6 +727,71 @@ impl Session {
     pub(super) async fn load_biome_configuration_file(
         self: &Arc<Self>,
         base_path: ConfigurationPathHint,
+        reload: bool,
+    ) -> ConfigurationStatus {
+        let current_status = self.configuration_status();
+        if current_status.is_loaded() && !reload {
+            return current_status;
+        }
+        // Check if there's already an ongoing operation for this path
+        {
+            let operations = self.loading_operations.read().await;
+
+            if let Some(sender) = operations.get(&self.key).cloned() {
+                drop(operations); // Release read lock
+
+                // Wait for the ongoing operation to complete
+                let mut receiver = sender.subscribe();
+                match receiver.recv().await {
+                    Ok(status) => {
+                        debug!(
+                            "Reused configuration loading result for path: {:?}",
+                            base_path
+                        );
+                        return status;
+                    }
+                    Err(_) => {
+                        // The sender was dropped or no more messages, continue to load
+                        debug!(
+                            "Configuration loading broadcast ended for path: {:?}",
+                            base_path
+                        );
+                    }
+                }
+            }
+        }
+
+        // Create a broadcast channel for this operation
+        let (tx, _rx) = tokio::sync::broadcast::channel(1);
+
+        // Store the receiver for other tasks to subscribe to
+        {
+            let mut operations = self.loading_operations.write().await;
+            operations.insert(self.key, tx.clone());
+        }
+
+        // Perform the actual loading
+        let status = self
+            .load_biome_configuration_file_internal(base_path.clone(), reload)
+            .await;
+
+        // Broadcast the result to any waiting tasks
+        let _ = tx.send(status);
+
+        // Clean up the operation
+        {
+            let mut operations = self.loading_operations.write().await;
+            operations.remove(&self.key);
+        }
+
+        status
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(super) async fn load_biome_configuration_file_internal(
+        self: &Arc<Self>,
+        base_path: ConfigurationPathHint,
+        force: bool,
     ) -> ConfigurationStatus {
         let loaded_configuration = match load_configuration(self.workspace.fs(), base_path.clone())
         {
@@ -816,7 +900,7 @@ impl Session {
             configuration,
         });
 
-        self.insert_and_scan_project(project_key, path.into(), scan_kind)
+        self.insert_and_scan_project(project_key, path.into(), scan_kind, force)
             .await;
 
         if let Err(WorkspaceError::PluginErrors(error)) = result {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

Closes https://github.com/biomejs/biome/issues/7411

This PR makes the loading of configuration files "thread-aware". Unfortunately, the previous fix didn't work out as intended. In this PR, the loading of the configuration files uses a locking mechanism, so when two tasks arrive, the last one waits for the previous one, and uses the same value that was resolved by the first task. The loading operations are locked using the session ID, to avoid conflicts inside the same project.

Second, we enforce the scanning of the project when a `biome.json` file changes (precisely, when a watched file changes). The bug was caused by the fact that when the watcher is enabled, the project isn't re-indexed. This causes the project settings not to be updated. 

We now pass a `force` boolean up until when we call `sca_project`. When a watched file changes, the settings are now correctly reloaded.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Here's a video that shows how diagnostics are correctly updated upon configuration updates





https://github.com/user-attachments/assets/76cbaccf-8d4a-4bd1-ab69-5f0869176086




<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
