### PR TITLE
fix(noUnusedPrivateClassMembers): ignore all TS `private` members if a `this[computed]` is found

### DIFF
--- a/.changeset/little-heads-divide.md
+++ b/.changeset/little-heads-divide.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7323](https://github.com/biomejs/biome/issues/7323). [`noUnusedPrivateClassMembers`](https://biomejs.dev/linter/rules/no-unused-private-class-members/) no longer reports as unused TypeScript `private` members if the rule encounters a computed access on `this`.
+
+In the following example, `member` as previously reported as unused.
+It is no longer reported.
+
+```ts
+class TsBioo {
+  private member: number;
+
+  set_with_name(name: string, value: number) {
+    this[name] = value;
+  }
+}
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_dynamic_access.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_dynamic_access.ts
@@ -1,0 +1,13 @@
+export class Sample {
+  private member;
+  #prop;
+
+  constructor() {
+    this.#prop = 0;
+    this.member = 0;
+  }
+
+  method(name) {
+    return this[name];
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_dynamic_access.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid_dynamic_access.ts.snap
@@ -1,0 +1,45 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid_dynamic_access.ts
+---
+# Input
+```ts
+export class Sample {
+  private member;
+  #prop;
+
+  constructor() {
+    this.#prop = 0;
+    this.member = 0;
+  }
+
+  method(name) {
+    return this[name];
+  }
+}
+
+```
+
+# Diagnostics
+```
+invalid_dynamic_access.ts:3:3 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━
+
+  ! This private class member is defined but never used.
+  
+    1 │ export class Sample {
+    2 │   private member;
+  > 3 │   #prop;
+      │   ^^^^^
+    4 │ 
+    5 │   constructor() {
+  
+  i Unsafe fix: Remove unused declaration.
+  
+     1  1 │   export class Sample {
+     2  2 │     private member;
+     3    │ - ··#prop;
+     4  3 │   
+     5  4 │     constructor() {
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid_dynamic_access.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid_dynamic_access.ts
@@ -1,0 +1,14 @@
+/* should not generate diagnostics */
+
+export class Sample {
+  private add: () => void;
+
+  constructor(private remove: () => void) {
+    this.add = () => {};
+    this.remove = () => {};
+  }
+
+  on(action: "add" | "remove"): void {
+    this[action]();
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid_dynamic_access.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid_dynamic_access.ts.snap
@@ -1,0 +1,22 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid_dynamic_access.ts
+---
+# Input
+```ts
+/* should not generate diagnostics */
+
+export class Sample {
+  private add: () => void;
+
+  constructor(private remove: () => void) {
+    this.add = () => {};
+    this.remove = () => {};
+  }
+
+  on(action: "add" | "remove"): void {
+    this[action]();
+  }
+}
+
+```


### PR DESCRIPTION
## Summary

Fixes https://github.com/biomejs/biome/issues/7323

The rule now considers as used all TS `private` members if a computed access on `this` is found.

## Test Plan

I added two tests:
- A test that demonstrates that TS private members are no longer reported when a computed access on `this` is found.
- A test that demonstrates that unused `#member` are still reported even if a computed access on `this` is found.

## Docs

I added a Caveat section describing the new behavior.
