### PR TITLE
chore: ensure force-ignore syntax works with nested biome.json

### DIFF
--- a/.changeset/forced-files-forget.md
+++ b/.changeset/forced-files-forget.md
@@ -6,7 +6,7 @@ Deprecated the option `files.experimentalScannerIgnores` in favour of **force-ig
 
 `files.includes` supports ignoring files by prefixing globs with an exclamation mark (`!`). With this change, it also supports _force_-ignoring globs by prefixing them with a double exclamation mark (`!!`).
 
-The effect of force-ignoring is that the scanner will not index files matching the glob, even in project mode, and even if those files are imported by other files.
+The effect of force-ignoring is that the scanner will not index files matching the glob, even in project mode, even if those files are imported by other files, and even if they are files that receive special treatment by Biome, such as nested `biome.json` files.
 
 #### Example
 

--- a/crates/biome_cli/tests/snapshots/main_cases_included_files/can_force_ignore_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_included_files/can_force_ignore_biome_json.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "files": { "includes": ["**/*.js", "!!nested/biome.json"] } }
+```
+
+## `nested/biome.json`
+
+```json
+{ "formatter": { "enabled": false } }
+```
+
+## `a.js`
+
+```js
+  statement(  )  
+```
+
+## `nested/a.js`
+
+```js
+  statement(  )  
+```
+
+# Termination Message
+
+```block
+format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Some errors were emitted while running checks.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+a.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - ··statement(··)··
+      1 │ + statement();
+      2 │ + 
+  
+
+```
+
+```block
+biome.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - {·"files":·{·"includes":·["**/*.js",·"!!nested/biome.json"]·}·}
+      1 │ + {·"files":·{·"includes":·["**/*.js",·"!!nested/biome.json"]·}·}
+      2 │ + 
+  
+
+```
+
+```block
+nested/a.js format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Formatter would have printed the following content:
+  
+    1   │ - ··statement(··)··
+      1 │ + statement();
+      2 │ + 
+  
+
+```
+
+```block
+Checked 3 files in <TIME>. No fixes applied.
+Found 3 errors.
+```

--- a/crates/biome_cli/tests/snapshots/main_cases_included_files/errors_on_ignored_nested_biome_json.snap
+++ b/crates/biome_cli/tests/snapshots/main_cases_included_files/errors_on_ignored_nested_biome_json.snap
@@ -1,0 +1,54 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+expression: redactor(content)
+---
+## `biome.json`
+
+```json
+{ "files": { "includes": ["**/*.js", "!nested/biome.json"] } }
+```
+
+## `nested/biome.json`
+
+```json
+{ "formatter": { "enabled": false } }
+```
+
+## `a.js`
+
+```js
+  statement(  )  
+```
+
+## `nested/a.js`
+
+```js
+  statement(  )  
+```
+
+# Termination Message
+
+```block
+configuration ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Biome exited because the configuration resulted in errors. Please fix them.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+<TEMP_DIR>/errors_on_ignored_nested_biome_json/nested/biome.json configuration ━━━━━━━━━━━━━━━━━━━━
+
+  × Found a nested root configuration, but there's already a root configuration.
+  
+  i The other configuration was found in <TEMP_DIR>/errors_on_ignored_nested_biome_json.
+  
+  i Use the migration command from the root of the project to update the configuration.
+  
+  $ biome migrate --write
+  
+
+```


### PR DESCRIPTION
## Summary

Addressed #7414: This is not a functional change, but adds tests and tweaks the wording in the changeset to verify and clarify that force-ignoring can also be used to ignore nested `biome.json` files.

## Test Plan

Tests are added.

## Docs

TODO