### PR TITLE
perf(linter): improve `noImportCycles` performance

### DIFF
--- a/.changeset/cynical-cyclops-cycles.md
+++ b/.changeset/cynical-cyclops-cycles.md
@@ -1,0 +1,7 @@
+---
+"@biomejs/biome": patch
+---
+
+Greatly improved performance of `noImportCycles` by eliminating allocations.
+
+In one repository, the total runtime of Biome with only `noImportCycles` enabled went from ~23s down to ~4s.


### PR DESCRIPTION
## Summary

Greatly improved performance of `noImportCycles` by eliminating allocations.

In one repository, the total runtime of Biome with only `noImportCycles` enabled went from ~23s down to ~4s.

## Test Plan

Manually tested on the `unleash` repository.

## Docs

N/A