### PR TITLE
chore(rules_check): remove file name titles from noImportCycles lint …

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -35,7 +35,6 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// **`foobar.js`**
     /// ```js,expect_diagnostic,file=foobar.js
     ///  import { baz } from "./baz.js";
     ///
@@ -48,7 +47,6 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// **`baz.js`**
     /// ```js,expect_diagnostic,file=baz.js
     /// import { bar } from "./foobar.js";
     ///
@@ -59,7 +57,6 @@ declare_lint_rule! {
     ///
     /// ### Valid
     ///
-    /// **`foo.js`**
     /// ```js,file=foo.js
     /// import { baz } from "./baz.js";
     ///
@@ -68,14 +65,12 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// **`bar.js`**
     /// ```js,file=bar.js
     /// export function bar() {
     ///     console.log("foobar");
     /// }
     /// ```
     ///
-    /// **`baz.js`**
     /// ```js,file=baz.js
     /// import { bar } from "./bar.js";
     ///
@@ -84,7 +79,6 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// **`types.ts`**
     /// ```ts,file=types.ts
     /// import type { bar } from "./qux.ts";
     ///
@@ -93,7 +87,6 @@ declare_lint_rule! {
     /// };
     /// ```
     ///
-    /// **`qux.ts`**
     /// ```ts,file=qux.ts
     /// import type { Foo } from "./types.ts";
     ///
@@ -123,8 +116,7 @@ declare_lint_rule! {
     ///
     /// #### Invalid
     ///
-    /// **`types.ts`**
-    /// ```ts
+    /// ```ts,file=types.ts
     /// import type { bar } from "./qux.ts";
     ///
     /// export type Foo = {
@@ -132,8 +124,7 @@ declare_lint_rule! {
     /// };
     /// ```
     ///
-    /// **`qux.ts`**
-    /// ```ts,use_options
+    /// ```ts,use_options,expect_diagnostic,file=qux.ts
     /// import type { Foo } from "./types.ts";
     ///
     /// export function bar(foo: Foo) {


### PR DESCRIPTION
## Summary

Once [this PR](https://github.com/biomejs/website/pull/3052) merges in the website repo the bold file name Markdown blocks will no longer be needed since the `file=<path>` attribute will automatically render the filename in the example. This PR also adds a missing `expect_diagnostic` and file attributes to some missing example code blocks

## Test Plan

Manually running `just lint-rules`

## Docs

n/a