### PR TITLE
chore: cleanup file annotations

### DIFF
--- a/crates/biome_analyze/CONTRIBUTING.md
+++ b/crates/biome_analyze/CONTRIBUTING.md
@@ -1218,7 +1218,6 @@ The documentation needs to adhere to the following rules:
   ````rust
   /// ### Invalid
   ///
-  /// **`foo.js`**
   /// ```js,expect_diagnostic,file=foo.js
   /// import { bar } from "./bar.js";
   /// export function foo() {
@@ -1226,7 +1225,6 @@ The documentation needs to adhere to the following rules:
   /// }
   /// ```
   ///
-  /// **`bar.js`**
   /// ```js,expect_diagnostic,file=bar.js
   /// import { foo } from "./foo.js";
   /// export function bar() {

--- a/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_private_imports.rs
@@ -89,16 +89,14 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// **`sub/foo.js`**
-    /// ```js
+    /// ```js,file=sub/foo.js
     /// /**
     ///  * @package
     ///  */
     /// export const fooPackageVariable = 1;
     /// ```
     ///
-    /// **`bar.js`**
-    /// ```js
+    /// ```js,expect_diagnostic,file=bar.js
     /// // Attempt to import package private variable from `sub/foo.js` from
     /// // outside its `sub` module:
     /// import { fooPackageVariable } from "./sub/foo.js";
@@ -109,18 +107,16 @@ declare_lint_rule! {
     /// export function getTestStuff() {}
     /// ```
     ///
-    /// **`bar.test.js`** // Attempt to import a private export. To allow this,
-    /// you probably want // to configure an `override` to disable this rule in
-    /// test files. // See:
-    /// https://biomejs.dev/reference/configuration/#overrides
-    /// ```js
+    /// ```js,expect_diagnostic,file=bar.test.js
+    /// // Attempt to import a private export. To allow this, you probably want
+    /// // to configure an `override` to disable this rule in test files.
+    /// // See: https://biomejs.dev/reference/configuration/#overrides
     /// import { getTestStuff } from "./bar.js";
     /// ```
     ///
     /// ### Valid
     ///
-    /// **`sub/index.js`**
-    /// ```js
+    /// ```js,file=sub/index.js
     /// // Package-private exports can be imported from inside the same module.
     /// import { fooPackageVariable } from "./foo.js";
     ///
@@ -131,8 +127,7 @@ declare_lint_rule! {
     /// export const subPrivateVariable = 2;
     /// ```
     ///
-    /// **`sub/deep/index.js`**
-    /// ```js
+    /// ```js,file=sub/deep/index.js
     /// // Private exports are accessible within the same module only, but
     /// // modules can be nested. So the following works because you can always
     /// // import from the index file of a parent module:

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -98,7 +98,6 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// **`package.json`**
     /// ```json,file=package.json
     /// {
     ///   "devDependencies": {
@@ -107,13 +106,11 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// **`src/index.js`**
     /// ```js,expect_diagnostic,use_options,file=src/index.js
     /// // cannot import from a non-test file
     /// import "vite";
     /// ```
     ///
-    /// **`tests/foo.test.js`**
     /// ```js,use_options,file=tests/foo.test.js
     /// // this works, because the file matches a glob from the options
     /// import "vite";

--- a/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_import_cycles.rs
@@ -36,7 +36,7 @@ declare_lint_rule! {
     /// ### Invalid
     ///
     /// ```js,expect_diagnostic,file=foobar.js
-    ///  import { baz } from "./baz.js";
+    /// import { baz } from "./baz.js";
     ///
     /// export function foo() {
     ///     baz();

--- a/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/no_unresolved_imports.rs
@@ -31,21 +31,22 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// **`foo.js`**
-    /// ```js
+    /// ```js,file=foo.js
     /// export function foo() {};
     /// ```
     ///
-    /// **`bar.js`**
-    /// ```js
+    /// ```js,expect_diagnostic,file=bar.js
     /// // Attempt to import symbol with a typo:
     /// import { fooo } from "./foo.js";
     /// ```
     ///
     /// ### Valid
     ///
-    /// **`bar.js`**
-    /// ```js
+    /// ```js,file=foo.js
+    /// export function foo() {};
+    /// ```
+    ///
+    /// ```js,file=bar.js
     /// // Fixed typo:
     /// import { foo } from "./foo.js";
     /// ```

--- a/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_exhaustive_switch_cases.rs
@@ -30,7 +30,7 @@ declare_lint_rule! {
     ///
     /// ### Invalid
     ///
-    /// ```ts
+    /// ```ts,expect_diagnostic,file=invalid.ts
     /// type Day =
     ///   | 'Monday'
     ///   | 'Tuesday'
@@ -52,7 +52,7 @@ declare_lint_rule! {
     ///
     /// ### Valid
     ///
-    /// ```ts
+    /// ```ts,file=valid.ts
     /// type Day =
     ///   | 'Monday'
     ///   | 'Tuesday'

--- a/crates/biome_resolver/tests/spec_tests.rs
+++ b/crates/biome_resolver/tests/spec_tests.rs
@@ -371,6 +371,42 @@ fn test_resolve_shared_biome_config() {
 
 #[test]
 fn test_resolve_typescript_path_aliases() {
+    let base_dir = get_fixtures_path("resolver_cases_3");
+    let fs = OsFileSystem::new(base_dir.clone());
+
+    assert_eq!(
+        resolve(
+            "@/components/Foo",
+            &base_dir.join("src"),
+            &fs,
+            &ResolveOptions {
+                default_files: &["index"],
+                extensions: &["ts", "js"],
+                ..Default::default()
+            }
+        ),
+        Ok(Utf8PathBuf::from(format!(
+            "{base_dir}/src/components/Foo.ts"
+        )))
+    );
+
+    assert_eq!(
+        resolve(
+            "@/components",
+            &base_dir,
+            &fs,
+            &ResolveOptions {
+                default_files: &["index"],
+                extensions: &["ts", "js"],
+                ..Default::default()
+            }
+        ),
+        Err(ResolveError::NotFound)
+    );
+}
+
+#[test]
+fn test_resolve_typescript_path_aliases2() {
     let base_dir = get_fixtures_path("resolver_cases_4");
     let fs = OsFileSystem::new(base_dir.clone());
 


### PR DESCRIPTION
## Summary

Cleaned up file name annotations in the docs for multi-file rules besides `noImportCycles`.

## Test Plan

We need to check the docs on the website.

## Docs

N/A