### PR TITLE
fix(noPositiveTabindex): suppression action

### DIFF
--- a/.changeset/two-cobras-dance.md
+++ b/.changeset/two-cobras-dance.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed a bug where the suppression action for `noPositiveTabindex` didn't place the suppression comment in the correct position.

--- a/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
+++ b/crates/biome_js_analyze/src/lint/a11y/no_positive_tabindex.rs
@@ -196,6 +196,14 @@ impl Rule for NoPositiveTabindex {
             mutation,
         ))
     }
+
+    fn text_range(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<TextRange> {
+        if let NoPositiveTabindexQuery::AnyJsxElement(element) = ctx.query() {
+            Some(element.range())
+        } else {
+            None
+        }
+    }
 }
 
 /// Verify that a JSX attribute value has a valid tab index, meaning it is not positive.

--- a/crates/biome_js_analyze/tests/suppression/a11y/noPositiveTabindex/invalid.jsx
+++ b/crates/biome_js_analyze/tests/suppression/a11y/noPositiveTabindex/invalid.jsx
@@ -1,0 +1,4 @@
+<>
+	<div tabIndex={1} />
+	<div tabIndex={"1"} />
+</>

--- a/crates/biome_js_analyze/tests/suppression/a11y/noPositiveTabindex/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/suppression/a11y/noPositiveTabindex/invalid.jsx.snap
@@ -1,0 +1,81 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalid.jsx
+---
+# Input
+```jsx
+<>
+	<div tabIndex={1} />
+	<div tabIndex={"1"} />
+</>
+
+```
+
+# Diagnostics
+```
+invalid.jsx:2:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid positive values for the tabIndex prop.
+  
+    1 │ <>
+  > 2 │ 	<div tabIndex={1} />
+      │ 	              ^^^
+    3 │ 	<div tabIndex={"1"} />
+    4 │ </>
+  
+  i Elements with a positive tabIndex override natural page content order. This causes elements without a positive tab index to come last when navigating using a keyboard.
+  
+  i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for this line.
+  
+    1 1 │   <>
+    2   │ - → <div·tabIndex={1}·/>
+      2 │ + → {/**·biome-ignore·lint/a11y/noPositiveTabindex:·<explanation>·*/}
+      3 │ + <div·tabIndex={1}·/>
+    3 4 │   	<div tabIndex={"1"} />
+    4 5 │   </>
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for the whole file.
+  
+      1 │ + /**·biome-ignore-all·lint/a11y/noPositiveTabindex:·<explanation>·*/
+    1 2 │   <>
+    2 3 │   	<div tabIndex={1} />
+  
+
+```
+
+```
+invalid.jsx:3:16 lint/a11y/noPositiveTabindex  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Avoid positive values for the tabIndex prop.
+  
+    1 │ <>
+    2 │ 	<div tabIndex={1} />
+  > 3 │ 	<div tabIndex={"1"} />
+      │ 	              ^^^^^
+    4 │ </>
+    5 │ 
+  
+  i Elements with a positive tabIndex override natural page content order. This causes elements without a positive tab index to come last when navigating using a keyboard.
+  
+  i Use only 0 and -1 as tabIndex values. Avoid using tabIndex values greater than 0 and CSS properties that can change the order of focusable HTML elements.
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for this line.
+  
+    1 1 │   <>
+    2 2 │   	<div tabIndex={1} />
+    3   │ - → <div·tabIndex={"1"}·/>
+      3 │ + → {/**·biome-ignore·lint/a11y/noPositiveTabindex:·<explanation>·*/}
+      4 │ + <div·tabIndex={"1"}·/>
+    4 5 │   </>
+    5 6 │   
+  
+  i Safe fix: Suppress rule lint/a11y/noPositiveTabindex for the whole file.
+  
+      1 │ + /**·biome-ignore-all·lint/a11y/noPositiveTabindex:·<explanation>·*/
+    1 2 │   <>
+    2 3 │   	<div tabIndex={1} />
+  
+
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

While checking https://github.com/biomejs/biome/issues/7473, I found a bug in `noPositiveTabindex`. This PR its suppression action by pointing it to the correct text range, so the analyzer emits the suppression action in the correct place

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

Added a new test

<!-- What demonstrates that your implementation is correct? -->

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
