### PR TITLE
feat: add react library aliases

### DIFF
--- a/.changeset/new-signs-tie.md
+++ b/.changeset/new-signs-tie.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+Added "@rbxts/react" as an alias for "react" for handling the reactClassic jsxRuntime.

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -132,6 +132,13 @@ impl ReactLibrary {
             Self::ReactDOM => "ReactDOM",
         }
     }
+
+    pub const fn get_import_aliases(self) -> &'static [&'static str] {
+        match self {
+            Self::React => &["@rbxts/react"],
+            Self::ReactDOM => &[],
+        }
+    }
 }
 
 /// List of valid [`React` API]
@@ -324,5 +331,9 @@ pub(crate) fn is_global_react_import(binding: &JsIdentifierBinding, lib: ReactLi
         .skip(1)
         .find_map(JsImport::cast)
         .and_then(|import| import.source_text().ok())
-        .is_some_and(|source| lib.import_names().contains(&source.text()))
+        .is_some_and(|source| {
+            let source_text = source.text();
+            lib.import_names().contains(&source_text)
+                || lib.get_import_aliases().contains(&source_text)
+        })
 }

--- a/crates/biome_js_analyze/src/react.rs
+++ b/crates/biome_js_analyze/src/react.rs
@@ -121,7 +121,13 @@ pub enum ReactLibrary {
 impl ReactLibrary {
     pub const fn import_names(self) -> &'static [&'static str] {
         match self {
-            Self::React => &["react", "preact/compat", "preact/hooks"],
+            Self::React => &[
+                "react",
+                "preact/compat",
+                "preact/hooks",
+                "@rbxts/react",
+                "@rbxts-js/react",
+            ],
             Self::ReactDOM => &["react-dom"],
         }
     }
@@ -130,13 +136,6 @@ impl ReactLibrary {
         match self {
             Self::React => "React",
             Self::ReactDOM => "ReactDOM",
-        }
-    }
-
-    pub const fn get_import_aliases(self) -> &'static [&'static str] {
-        match self {
-            Self::React => &["@rbxts/react"],
-            Self::ReactDOM => &[],
         }
     }
 }
@@ -331,9 +330,5 @@ pub(crate) fn is_global_react_import(binding: &JsIdentifierBinding, lib: ReactLi
         .skip(1)
         .find_map(JsImport::cast)
         .and_then(|import| import.source_text().ok())
-        .is_some_and(|source| {
-            let source_text = source.text();
-            lib.import_names().contains(&source_text)
-                || lib.get_import_aliases().contains(&source_text)
-        })
+        .is_some_and(|source| lib.import_names().contains(&source.text()))
 }


### PR DESCRIPTION
## Summary

This updates the `is_global_react_import` function to include aliases for React. This is useful in cases where you are using the `reactClassic` jsxRuntime, but won't actually be importing from React, but a React-like library. The most prevalent (and only example I personally know of) would be the "@rbxts/react" package, which is used by hundreds of developers in the roblox-ts community.

See https://github.com/biomejs/biome/discussions/7487.

## Test Plan

My pull request merely adds a hardcoded reference to "@rbxts/react". I do not foresee a significant amount of users otherwise ever having to modify this behavior to point to a separate package, so I believe what we have now will suffice.
