### PR TITLE
fix(lint/useConsistentCurlyBraces): adjust condition to allow removing the braces

### DIFF
--- a/.changeset/little-seals-taste.md
+++ b/.changeset/little-seals-taste.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7320](https://github.com/biomejs/biome/issues/7320): The [`useConsistentCurlyBraces`](https://biomejs.dev/linter/rules/use-consistent-curly-braces/) rule now correctly detects a string literal including `"` inside a JSX attribute value.

--- a/.changeset/short-cases-think.md
+++ b/.changeset/short-cases-think.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7256](https://github.com/biomejs/biome/issues/7256): The [`useConsistentCurlyBraces`](https://biomejs.dev/linter/rules/use-consistent-curly-braces/) rule now correctly ignores a string literal with braces that contains only whitespaces. Previously, literals that contains single whitespace were only allowed.

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/invalid.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/invalid.jsx
@@ -12,4 +12,18 @@
 <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
 
 <Foo>{x}{'y'}{z}</Foo>
+
+<Foo foo={' '}></Foo>
+
+{/* https://github.com/biomejs/biome/issues/7320 */}
+<ConnectedFieldTemplate
+	description1=
+		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+	description2={
+		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+	}
+	className={
+		"d-block"
+	}
+/>
 </>

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/invalid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/invalid.jsx.snap
@@ -18,6 +18,20 @@ expression: invalid.jsx
 <Foo>{/*comment*/'Hello world'/*comment*/}</Foo>
 
 <Foo>{x}{'y'}{z}</Foo>
+
+<Foo foo={' '}></Foo>
+
+{/* https://github.com/biomejs/biome/issues/7320 */}
+<ConnectedFieldTemplate
+	description1=
+		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+	description2={
+		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+	}
+	className={
+		"d-block"
+	}
+/>
 </>
 
 ```
@@ -151,8 +165,8 @@ invalid.jsx:14:9 lint/style/useConsistentCurlyBraces  FIXABLE  ━━━━━�
     13 │ 
   > 14 │ <Foo>{x}{'y'}{z}</Foo>
        │         ^^^^^
-    15 │ </>
-    16 │ 
+    15 │ 
+    16 │ <Foo foo={' '}></Foo>
   
   i JSX child does not need to be wrapped in curly braces.
   
@@ -160,5 +174,88 @@ invalid.jsx:14:9 lint/style/useConsistentCurlyBraces  FIXABLE  ━━━━━�
   
     14 │ <Foo>{x}{'y'}{z}</Foo>
        │         -- --         
+
+```
+
+```
+invalid.jsx:16:10 lint/style/useConsistentCurlyBraces  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Should not have curly braces around expression.
+  
+    14 │ <Foo>{x}{'y'}{z}</Foo>
+    15 │ 
+  > 16 │ <Foo foo={' '}></Foo>
+       │          ^^^^^
+    17 │ 
+    18 │ {/* https://github.com/biomejs/biome/issues/7320 */}
+  
+  i JSX attribute value does not need to be wrapped in curly braces.
+  
+  i Unsafe fix: Remove curly braces around the expression.
+  
+    16 │ <Foo·foo={'·'}></Foo>
+       │          -   -       
+
+```
+
+```
+invalid.jsx:22:15 lint/style/useConsistentCurlyBraces  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Should not have curly braces around expression.
+  
+    20 │ 	description1=
+    21 │ 		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+  > 22 │ 	description2={
+       │ 	             ^
+  > 23 │ 		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+  > 24 │ 	}
+       │ 	^
+    25 │ 	className={
+    26 │ 		"d-block"
+  
+  i JSX attribute value does not need to be wrapped in curly braces.
+  
+  i Unsafe fix: Remove curly braces around the expression.
+  
+    20 20 │   	description1=
+    21 21 │   		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+    22    │ - → description2={
+       22 │ + → description2=
+    23 23 │   		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+    24    │ - → }
+    25 24 │   	className={
+    26 25 │   		"d-block"
+  
+
+```
+
+```
+invalid.jsx:25:12 lint/style/useConsistentCurlyBraces  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Should not have curly braces around expression.
+  
+    23 │ 		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+    24 │ 	}
+  > 25 │ 	className={
+       │ 	          ^
+  > 26 │ 		"d-block"
+  > 27 │ 	}
+       │ 	^
+    28 │ />
+    29 │ </>
+  
+  i JSX attribute value does not need to be wrapped in curly braces.
+  
+  i Unsafe fix: Remove curly braces around the expression.
+  
+    23 23 │   		'Upload a CSV file containing an "email" column, and optional "first_name" and "last_name" columns'
+    24 24 │   	}
+    25    │ - → className={
+       25 │ + → className=
+    26 26 │   		"d-block"
+    27    │ - → }
+    28 27 │   />
+    29 28 │   </>
+  
 
 ```

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx
@@ -22,6 +22,8 @@ let baz = 4;
 
 <Foo>{' '}</Foo>
 
+<Foo>{'  '}</Foo>
+
 <Foo>Invalid closing tag {'}'}</Foo>
 
 <Foo>{'Invalid closing tag }'}</Foo>

--- a/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/style/useConsistentCurlyBraces/valid.jsx.snap
@@ -28,6 +28,8 @@ let baz = 4;
 
 <Foo>{' '}</Foo>
 
+<Foo>{'  '}</Foo>
+
 <Foo>Invalid closing tag {'}'}</Foo>
 
 <Foo>{'Invalid closing tag }'}</Foo>


### PR DESCRIPTION
## Summary

Fixes #7256
Fixes #7320

### Case 1 (#7256)

The rule used to remove a string literal expression that contains multiple whitespaces. Only one whitespace was allowed in #4154.

```tsx
<>{'  '}</>
```

is now correctly ignored by the rule.

### Case 2 (#7320)

The rule didn't detect a string attribute value with braces that contains `>`, `"`, `'`, or `}`. These special characters should not be allowed when unwrapping a literal within a JSX tag, but they should be allowed in attribute values.

```tsx
<Foo bar={'"'}></Foo>
```

is now turned into:

```tsx
<Foo bar='"'></Foo>
```

, which is a valid JSX syntax.

## Test Plan

Added some snapshot tests.

## Docs

N/A
