### PR TITLE
fix(lint/useExhaustiveDependencies): correctly fix the dependency list from a shorthand object member

### DIFF
--- a/.changeset/brave-camels-sin.md
+++ b/.changeset/brave-camels-sin.md
@@ -1,0 +1,19 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#6893](https://github.com/biomejs/biome/issues/6893): The [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) rule now correctly adds a dependency that is captured in a shorthand object member. For example:
+
+```jsx
+useEffect(() => {
+  console.log({firstId, secondId});
+}, []);
+```
+
+is now correctly fixed to:
+
+```jsx
+useEffect(() => {
+  console.log({firstId, secondId});
+}, [firstId, secondId]);
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6893.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6893.js
@@ -1,0 +1,8 @@
+function App() {
+	const firstId = `${Math.random()}`
+	const secondId = `${Math.random()}`
+
+	React.useEffect(() => {
+		console.log({firstId, secondId})
+	}, [])
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6893.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue6893.js.snap
@@ -1,0 +1,75 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue6893.js
+---
+# Input
+```js
+function App() {
+	const firstId = `${Math.random()}`
+	const secondId = `${Math.random()}`
+
+	React.useEffect(() => {
+		console.log({firstId, secondId})
+	}, [])
+}
+
+```
+
+# Diagnostics
+```
+issue6893.js:5:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook does not specify its dependency on firstId.
+  
+    3 │ 	const secondId = `${Math.random()}`
+    4 │ 
+  > 5 │ 	React.useEffect(() => {
+      │ 	      ^^^^^^^^^
+    6 │ 		console.log({firstId, secondId})
+    7 │ 	}, [])
+  
+  i This dependency is being used here, but is not specified in the hook dependency list.
+  
+    5 │ 	React.useEffect(() => {
+  > 6 │ 		console.log({firstId, secondId})
+      │ 		             ^^^^^^^
+    7 │ 	}, [])
+    8 │ }
+  
+  i Either include it or remove the dependency array.
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    7 │ → },·[firstId])
+      │       +++++++  
+
+```
+
+```
+issue6893.js:5:8 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook does not specify its dependency on secondId.
+  
+    3 │ 	const secondId = `${Math.random()}`
+    4 │ 
+  > 5 │ 	React.useEffect(() => {
+      │ 	      ^^^^^^^^^
+    6 │ 		console.log({firstId, secondId})
+    7 │ 	}, [])
+  
+  i This dependency is being used here, but is not specified in the hook dependency list.
+  
+    5 │ 	React.useEffect(() => {
+  > 6 │ 		console.log({firstId, secondId})
+      │ 		                      ^^^^^^^^
+    7 │ 	}, [])
+    8 │ }
+  
+  i Either include it or remove the dependency array.
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    7 │ → },·[secondId])
+      │       ++++++++  
+
+```


### PR DESCRIPTION
## Summary

Fixes #6893

The rule is used to find a first ancestor node that is a valid expression. However, some nodes including a shorthand object member doesn't have an expression inside. To catch these cases, I changed the logic to also find a reference identifier while searching the ancestors.

## Test Plan

Added a snapshot test.

## Docs

N/A
