### PR TITLE
feat(biome-js-analyze): adjusts members update assignments to be marked as valid in noUnusedPrivateClassMembers

### DIFF
--- a/.changeset/no_unused_private_class_members_bug.md
+++ b/.changeset/no_unused_private_class_members_bug.md
@@ -1,0 +1,18 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7192](https://github.com/biomejs/biome/issues/7192):
+`noUnusedPrivateClassMembers` now treats private members in compound assignments (+=, -=, ??=, etc.) as used,
+while plain assignments (=) do not count as usage.
+
+Example that is now correctly flagged:
+
+```typescript
+class App {
+  #persistenceRequest: Promise<boolean> | undefined;
+  saveData() {
+    this.#persistenceRequest +=  2;
+  }
+}
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.js
@@ -14,14 +14,6 @@ class OnlyWrite {
 	}
 }
 
-class SelfUpdate {
-	#usedOnlyToUpdateItself = 5;
-
-	method() {
-			this.#usedOnlyToUpdateItself++;
-	}
-}
-
 class Accessor {
 	get #unusedAccessor() {}
 	set #unusedAccessor(value) {}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
 expression: invalid.js
 ---
 # Input
@@ -17,14 +18,6 @@ class OnlyWrite {
 
 	method() {
 			this.#usedOnlyInWrite = 212;
-	}
-}
-
-class SelfUpdate {
-	#usedOnlyToUpdateItself = 5;
-
-	method() {
-			this.#usedOnlyToUpdateItself++;
 	}
 }
 
@@ -133,156 +126,90 @@ invalid.js:10:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━
 ```
 
 ```
-invalid.js:18:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:18:6 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    17 │ class SelfUpdate {
-  > 18 │ 	#usedOnlyToUpdateItself = 5;
-       │ 	^^^^^^^^^^^^^^^^^^^^^^^
-    19 │ 
-    20 │ 	method() {
+    17 │ class Accessor {
+  > 18 │ 	get #unusedAccessor() {}
+       │ 	    ^^^^^^^^^^^^^^^
+    19 │ 	set #unusedAccessor(value) {}
+    20 │ }
   
   i Unsafe fix: Remove unused declaration.
   
     16 16 │   
-    17 17 │   class SelfUpdate {
-    18    │ - → #usedOnlyToUpdateItself·=·5;
-    19 18 │   
-    20 19 │   	method() {
+    17 17 │   class Accessor {
+    18    │ - → get·#unusedAccessor()·{}
+    19 18 │   	set #unusedAccessor(value) {}
+    20 19 │   }
   
 
 ```
 
 ```
-invalid.js:26:6 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:19:6 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    25 │ class Accessor {
-  > 26 │ 	get #unusedAccessor() {}
+    17 │ class Accessor {
+    18 │ 	get #unusedAccessor() {}
+  > 19 │ 	set #unusedAccessor(value) {}
        │ 	    ^^^^^^^^^^^^^^^
-    27 │ 	set #unusedAccessor(value) {}
-    28 │ }
+    20 │ }
+    21 │ 
   
   i Unsafe fix: Remove unused declaration.
   
-    24 24 │   
-    25 25 │   class Accessor {
-    26    │ - → get·#unusedAccessor()·{}
-    27 26 │   	set #unusedAccessor(value) {}
-    28 27 │   }
+    17 17 │   class Accessor {
+    18 18 │   	get #unusedAccessor() {}
+    19    │ - → set·#unusedAccessor(value)·{}
+    20 19 │   }
+    21 20 │   
   
 
 ```
 
 ```
-invalid.js:27:6 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:23:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    25 │ class Accessor {
-    26 │ 	get #unusedAccessor() {}
-  > 27 │ 	set #unusedAccessor(value) {}
-       │ 	    ^^^^^^^^^^^^^^^
-    28 │ }
-    29 │ 
-  
-  i Unsafe fix: Remove unused declaration.
-  
-    25 25 │   class Accessor {
-    26 26 │   	get #unusedAccessor() {}
-    27    │ - → set·#unusedAccessor(value)·{}
-    28 27 │   }
-    29 28 │   
-  
-
-```
-
-```
-invalid.js:31:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This private class member is defined but never used.
-  
-    30 │ class First {
-  > 31 │ 	#unusedMemberInFirstClass = 5;
+    22 │ class First {
+  > 23 │ 	#unusedMemberInFirstClass = 5;
        │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
-    32 │ }
-    33 │ 
+    24 │ }
+    25 │ 
   
   i Unsafe fix: Remove unused declaration.
   
-    29 29 │   
-    30 30 │   class First {
-    31    │ - → #unusedMemberInFirstClass·=·5;
-    32 31 │   }
-    33 32 │   
+    21 21 │   
+    22 22 │   class First {
+    23    │ - → #unusedMemberInFirstClass·=·5;
+    24 23 │   }
+    25 24 │   
   
 
 ```
 
 ```
-invalid.js:35:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.js:27:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    34 │ class Foo {
-  > 35 │ 	#usedOnlyInWrite = 5;
+    26 │ class Foo {
+  > 27 │ 	#usedOnlyInWrite = 5;
        │ 	^^^^^^^^^^^^^^^^
-    36 │ 	method() {
-    37 │ 			this.#usedOnlyInWrite = 42;
+    28 │ 	method() {
+    29 │ 			this.#usedOnlyInWrite = 42;
   
   i Unsafe fix: Remove unused declaration.
   
-    33 33 │   
-    34 34 │   class Foo {
-    35    │ - → #usedOnlyInWrite·=·5;
-    36 35 │   	method() {
-    37 36 │   			this.#usedOnlyInWrite = 42;
-  
-
-```
-
-```
-invalid.js:42:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This private class member is defined but never used.
-  
-    41 │ class Foo {
-  > 42 │ 	#usedOnlyInWriteStatement = 5;
-       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^
-    43 │ 	method() {
-    44 │ 			this.#usedOnlyInWriteStatement += 42;
-  
-  i Unsafe fix: Remove unused declaration.
-  
-    40 40 │   
-    41 41 │   class Foo {
-    42    │ - → #usedOnlyInWriteStatement·=·5;
-    43 42 │   	method() {
-    44 43 │   			this.#usedOnlyInWriteStatement += 42;
-  
-
-```
-
-```
-invalid.js:49:2 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This private class member is defined but never used.
-  
-    48 │ class C {
-  > 49 │ 	#usedOnlyInIncrement;
-       │ 	^^^^^^^^^^^^^^^^^^^^
-    50 │ 
-    51 │ 	foo() {
-  
-  i Unsafe fix: Remove unused declaration.
-  
-    47 47 │   
-    48 48 │   class C {
-    49    │ - → #usedOnlyInIncrement;
-    50 49 │   
-    51 50 │   	foo() {
+    25 25 │   
+    26 26 │   class Foo {
+    27    │ - → #usedOnlyInWrite·=·5;
+    28 27 │   	method() {
+    29 28 │   			this.#usedOnlyInWrite = 42;
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts
@@ -21,14 +21,6 @@ class TsOnlyWrite {
 	}
 }
 
-class TsSelfUpdate {
-	private usedOnlyToUpdateItself = 5;
-
-	method() {
-		this.usedOnlyToUpdateItself++;
-	}
-}
-
 class TsAccessor {
 	private get unusedAccessor() { }
 	private set unusedAccessor(value) { }

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/invalid.ts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
-assertion_line: 146
+assertion_line: 152
 expression: invalid.ts
 ---
 # Input
@@ -25,14 +25,6 @@ class TsOnlyWrite {
 
 	method() {
 		this.usedOnlyInWrite = 21;
-	}
-}
-
-class TsSelfUpdate {
-	private usedOnlyToUpdateItself = 5;
-
-	method() {
-		this.usedOnlyToUpdateItself++;
 	}
 }
 
@@ -149,114 +141,92 @@ invalid.ts:17:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━�
 ```
 
 ```
-invalid.ts:25:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:25:14 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    24 │ class TsSelfUpdate {
-  > 25 │ 	private usedOnlyToUpdateItself = 5;
-       │ 	        ^^^^^^^^^^^^^^^^^^^^^^
-    26 │ 
-    27 │ 	method() {
+    24 │ class TsAccessor {
+  > 25 │ 	private get unusedAccessor() { }
+       │ 	            ^^^^^^^^^^^^^^
+    26 │ 	private set unusedAccessor(value) { }
+    27 │ }
   
   i Unsafe fix: Remove unused declaration.
   
     23 23 │   
-    24 24 │   class TsSelfUpdate {
-    25    │ - → private·usedOnlyToUpdateItself·=·5;
-    26 25 │   
-    27 26 │   	method() {
+    24 24 │   class TsAccessor {
+    25    │ - → private·get·unusedAccessor()·{·}
+    26 25 │   	private set unusedAccessor(value) { }
+    27 26 │   }
   
 
 ```
 
 ```
-invalid.ts:33:14 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:26:14 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    32 │ class TsAccessor {
-  > 33 │ 	private get unusedAccessor() { }
+    24 │ class TsAccessor {
+    25 │ 	private get unusedAccessor() { }
+  > 26 │ 	private set unusedAccessor(value) { }
        │ 	            ^^^^^^^^^^^^^^
-    34 │ 	private set unusedAccessor(value) { }
-    35 │ }
+    27 │ }
+    28 │ 
   
   i Unsafe fix: Remove unused declaration.
   
-    31 31 │   
-    32 32 │   class TsAccessor {
-    33    │ - → private·get·unusedAccessor()·{·}
-    34 33 │   	private set unusedAccessor(value) { }
-    35 34 │   }
+    24 24 │   class TsAccessor {
+    25 25 │   	private get unusedAccessor() { }
+    26    │ - → private·set·unusedAccessor(value)·{·}
+    27 26 │   }
+    28 27 │   
   
 
 ```
 
 ```
-invalid.ts:34:14 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:31:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    32 │ class TsAccessor {
-    33 │ 	private get unusedAccessor() { }
-  > 34 │ 	private set unusedAccessor(value) { }
-       │ 	            ^^^^^^^^^^^^^^
-    35 │ }
-    36 │ 
-  
-  i Unsafe fix: Remove unused declaration.
-  
-    32 32 │   class TsAccessor {
-    33 33 │   	private get unusedAccessor() { }
-    34    │ - → private·set·unusedAccessor(value)·{·}
-    35 34 │   }
-    36 35 │   
-  
-
-```
-
-```
-invalid.ts:39:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ! This private class member is defined but never used.
-  
-    37 │ // github.com/biomejs/biome/issues/6165
-    38 │ class TsBioo2 {
-  > 39 │ 	private unusedProperty = 5;
+    29 │ // github.com/biomejs/biome/issues/6165
+    30 │ class TsBioo2 {
+  > 31 │ 	private unusedProperty = 5;
        │ 	        ^^^^^^^^^^^^^^
-    40 │ 	private unusedMethod() {}
-    41 │ 
+    32 │ 	private unusedMethod() {}
+    33 │ 
   
   i Unsafe fix: Remove unused declaration.
   
-    37 37 │   // github.com/biomejs/biome/issues/6165
-    38 38 │   class TsBioo2 {
-    39    │ - → private·unusedProperty·=·5;
-    40 39 │   	private unusedMethod() {}
-    41 40 │   
+    29 29 │   // github.com/biomejs/biome/issues/6165
+    30 30 │   class TsBioo2 {
+    31    │ - → private·unusedProperty·=·5;
+    32 31 │   	private unusedMethod() {}
+    33 32 │   
   
 
 ```
 
 ```
-invalid.ts:40:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.ts:32:10 lint/correctness/noUnusedPrivateClassMembers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! This private class member is defined but never used.
   
-    38 │ class TsBioo2 {
-    39 │ 	private unusedProperty = 5;
-  > 40 │ 	private unusedMethod() {}
+    30 │ class TsBioo2 {
+    31 │ 	private unusedProperty = 5;
+  > 32 │ 	private unusedMethod() {}
        │ 	        ^^^^^^^^^^^^
-    41 │ 
-    42 │ 	private usedProperty = 4;
+    33 │ 
+    34 │ 	private usedProperty = 4;
   
   i Unsafe fix: Remove unused declaration.
   
-    38 38 │   class TsBioo2 {
-    39 39 │   	private unusedProperty = 5;
-    40    │ - → private·unusedMethod()·{}
-    41 40 │   
-    42 41 │   	private usedProperty = 4;
+    30 30 │   class TsBioo2 {
+    31 31 │   	private unusedProperty = 5;
+    32    │ - → private·unusedMethod()·{}
+    33 32 │   
+    34 33 │   	private usedProperty = 4;
   
 
 ```

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js
@@ -203,3 +203,164 @@ class UsedPostUpdateExpr {
     return this.#val++;
   }
 }
+
+class AppSelfAdd {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest += this.#persistenceRequest;
+	}
+}
+
+class AppSelfSubtract {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest -= this.#persistenceRequest;
+	}
+}
+
+class AppSelfMultiply {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest *= this.#persistenceRequest;
+	}
+}
+
+class AppSelfDivide {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest /= this.#persistenceRequest;
+	}
+}
+
+class AppSelfExponent {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest **= this.#persistenceRequest;
+	}
+}
+
+class AppSelfAnd {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &&= this.#persistenceRequest;
+	}
+}
+
+class AppSelfOr {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ||= this.#persistenceRequest;
+	}
+}
+
+class AppSelfNullish {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ??= this.#persistenceRequest;
+	}
+}
+
+class AppAddAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest += 1;
+	}
+}
+
+class AppSubtractAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest -= 1;
+	}
+}
+
+class AppMultiplyAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest *= 2;
+	}
+}
+
+class AppDivideAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest /= 2;
+	}
+}
+
+class AppExponentAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest **= 2;
+	}
+}
+
+class AppModuloAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest %= 2;
+	}
+}
+
+class AppAndAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &= 1;
+	}
+}
+
+class AppOrAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest |= 1;
+	}
+}
+
+class AppXorAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ^= 1;
+	}
+}
+
+class AppLeftShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest <<= 1;
+	}
+}
+
+class AppRightShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest >>= 1;
+	}
+}
+
+class AppUnsignedRightShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest >>>= 1;
+	}
+}
+
+class AppAndLogicalAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &&= 1;
+	}
+}
+
+class AppOrLogicalAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ||= 1;
+	}
+}
+
+class AppNullishAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ??= 1;
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUnusedPrivateClassMembers/valid.js.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
 expression: valid.js
 ---
 # Input
@@ -208,6 +209,167 @@ class UsedPostUpdateExpr {
   method() {
     return this.#val++;
   }
+}
+
+class AppSelfAdd {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest += this.#persistenceRequest;
+	}
+}
+
+class AppSelfSubtract {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest -= this.#persistenceRequest;
+	}
+}
+
+class AppSelfMultiply {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest *= this.#persistenceRequest;
+	}
+}
+
+class AppSelfDivide {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest /= this.#persistenceRequest;
+	}
+}
+
+class AppSelfExponent {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest **= this.#persistenceRequest;
+	}
+}
+
+class AppSelfAnd {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &&= this.#persistenceRequest;
+	}
+}
+
+class AppSelfOr {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ||= this.#persistenceRequest;
+	}
+}
+
+class AppSelfNullish {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ??= this.#persistenceRequest;
+	}
+}
+
+class AppAddAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest += 1;
+	}
+}
+
+class AppSubtractAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest -= 1;
+	}
+}
+
+class AppMultiplyAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest *= 2;
+	}
+}
+
+class AppDivideAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest /= 2;
+	}
+}
+
+class AppExponentAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest **= 2;
+	}
+}
+
+class AppModuloAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest %= 2;
+	}
+}
+
+class AppAndAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &= 1;
+	}
+}
+
+class AppOrAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest |= 1;
+	}
+}
+
+class AppXorAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ^= 1;
+	}
+}
+
+class AppLeftShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest <<= 1;
+	}
+}
+
+class AppRightShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest >>= 1;
+	}
+}
+
+class AppUnsignedRightShiftAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest >>>= 1;
+	}
+}
+
+class AppAndLogicalAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest &&= 1;
+	}
+}
+
+class AppOrLogicalAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ||= 1;
+	}
+}
+
+class AppNullishAssignment {
+	#persistenceRequest = 0;
+	saveData() {
+		this.#persistenceRequest ??= 1;
+	}
 }
 
 ```


### PR DESCRIPTION
## Summary

`noUnusedPrivateClassMembers` now treats private members in compound assignments (+=, -=, ??=, etc.) as used,
while plain assignments (=) do not count as usage.


Example that is now correctly flagged:

```typescript
class App {
  #persistenceRequest: Promise<boolean> | undefined;
  saveData() {
    this.#persistenceRequest +=  2;
  }
}
```

closes #7192