### PR TITLE
fix(parser): detect missing elements in TypeScript generics as parse errors

### DIFF
--- a/.changeset/tasty-dingos-flow.md
+++ b/.changeset/tasty-dingos-flow.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7494](https://github.com/biomejs/biome/issues/7494): the parser now reports errors for missing elements in TypeScript generics.
+
+```ts
+// Before
+type Foo<A, , B> = A & B;
+type Foo = Bar<1, , 2>;
+
+// After
+type Foo<A, , B> = A & B;
+//          ^ Expected a type parameter but instead found ','.
+type Foo = Bar<1, , 2>;
+//                ^ Expected a type parameter but instead found ','.
+```

--- a/crates/biome_js_parser/src/syntax/typescript/types.rs
+++ b/crates/biome_js_parser/src/syntax/typescript/types.rs
@@ -280,6 +280,10 @@ impl ParseSeparatedList for TsTypeParameterList {
     fn allow_trailing_separating_element(&self) -> bool {
         true
     }
+
+    fn allow_missing_elements(&self) -> bool {
+        false
+    }
 }
 
 // test_err ts type_parameter_modifier
@@ -2274,6 +2278,10 @@ impl ParseSeparatedList for TypeArgumentsList {
     }
 
     fn allow_trailing_separating_element(&self) -> bool {
+        false
+    }
+
+    fn allow_missing_elements(&self) -> bool {
         false
     }
 }

--- a/crates/biome_js_parser/tests/js_test_suite/error/type_arguments_missing_elements.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/error/type_arguments_missing_elements.ts
@@ -1,0 +1,3 @@
+type Foo = Bar<, A>;
+
+type Foo = Bar<A, , B>;

--- a/crates/biome_js_parser/tests/js_test_suite/error/type_arguments_missing_elements.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/type_arguments_missing_elements.ts.snap
@@ -1,0 +1,191 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+assertion_line: 177
+expression: snapshot
+---
+## Input
+
+```ts
+type Foo = Bar<, A>;
+
+type Foo = Bar<A, , B>;
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@5..9 "Foo" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@9..11 "=" [] [Whitespace(" ")],
+            ty: TsReferenceType {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@11..14 "Bar" [] [],
+                },
+                type_arguments: TsTypeArguments {
+                    l_angle_token: L_ANGLE@14..15 "<" [] [],
+                    ts_type_argument_list: TsTypeArgumentList [],
+                    r_angle_token: missing (required),
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsBogusStatement {
+            items: [
+                COMMA@15..17 "," [] [Whitespace(" ")],
+                IDENT@17..18 "A" [] [],
+                R_ANGLE@18..19 ">" [] [],
+            ],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@19..20 ";" [] [],
+        },
+        TsTypeAliasDeclaration {
+            type_token: TYPE_KW@20..27 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+            binding_identifier: TsIdentifierBinding {
+                name_token: IDENT@27..31 "Foo" [] [Whitespace(" ")],
+            },
+            type_parameters: missing (optional),
+            eq_token: EQ@31..33 "=" [] [Whitespace(" ")],
+            ty: TsReferenceType {
+                name: JsReferenceIdentifier {
+                    value_token: IDENT@33..36 "Bar" [] [],
+                },
+                type_arguments: TsTypeArguments {
+                    l_angle_token: L_ANGLE@36..37 "<" [] [],
+                    ts_type_argument_list: TsTypeArgumentList [
+                        TsReferenceType {
+                            name: JsReferenceIdentifier {
+                                value_token: IDENT@37..38 "A" [] [],
+                            },
+                            type_arguments: missing (optional),
+                        },
+                        COMMA@38..40 "," [] [Whitespace(" ")],
+                        missing element,
+                    ],
+                    r_angle_token: missing (required),
+                },
+            },
+            semicolon_token: missing (optional),
+        },
+        JsBogusStatement {
+            items: [
+                COMMA@40..42 "," [] [Whitespace(" ")],
+                IDENT@42..43 "B" [] [],
+                R_ANGLE@43..44 ">" [] [],
+            ],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@44..45 ";" [] [],
+        },
+    ],
+    eof_token: EOF@45..46 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..46
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..45
+    0: TS_TYPE_ALIAS_DECLARATION@0..15
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..9
+        0: IDENT@5..9 "Foo" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@9..11 "=" [] [Whitespace(" ")]
+      4: TS_REFERENCE_TYPE@11..15
+        0: JS_REFERENCE_IDENTIFIER@11..14
+          0: IDENT@11..14 "Bar" [] []
+        1: TS_TYPE_ARGUMENTS@14..15
+          0: L_ANGLE@14..15 "<" [] []
+          1: TS_TYPE_ARGUMENT_LIST@15..15
+          2: (empty)
+      5: (empty)
+    1: JS_BOGUS_STATEMENT@15..19
+      0: COMMA@15..17 "," [] [Whitespace(" ")]
+      1: IDENT@17..18 "A" [] []
+      2: R_ANGLE@18..19 ">" [] []
+    2: JS_EMPTY_STATEMENT@19..20
+      0: SEMICOLON@19..20 ";" [] []
+    3: TS_TYPE_ALIAS_DECLARATION@20..40
+      0: TYPE_KW@20..27 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@27..31
+        0: IDENT@27..31 "Foo" [] [Whitespace(" ")]
+      2: (empty)
+      3: EQ@31..33 "=" [] [Whitespace(" ")]
+      4: TS_REFERENCE_TYPE@33..40
+        0: JS_REFERENCE_IDENTIFIER@33..36
+          0: IDENT@33..36 "Bar" [] []
+        1: TS_TYPE_ARGUMENTS@36..40
+          0: L_ANGLE@36..37 "<" [] []
+          1: TS_TYPE_ARGUMENT_LIST@37..40
+            0: TS_REFERENCE_TYPE@37..38
+              0: JS_REFERENCE_IDENTIFIER@37..38
+                0: IDENT@37..38 "A" [] []
+              1: (empty)
+            1: COMMA@38..40 "," [] [Whitespace(" ")]
+            2: (empty)
+          2: (empty)
+      5: (empty)
+    4: JS_BOGUS_STATEMENT@40..44
+      0: COMMA@40..42 "," [] [Whitespace(" ")]
+      1: IDENT@42..43 "B" [] []
+      2: R_ANGLE@43..44 ">" [] []
+    5: JS_EMPTY_STATEMENT@44..45
+      0: SEMICOLON@44..45 ";" [] []
+  4: EOF@45..46 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+type_arguments_missing_elements.ts:1:16 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type parameter but instead found ','.
+  
+  > 1 │ type Foo = Bar<, A>;
+      │                ^
+    2 │ 
+    3 │ type Foo = Bar<A, , B>;
+  
+  i Expected a type parameter here.
+  
+  > 1 │ type Foo = Bar<, A>;
+      │                ^
+    2 │ 
+    3 │ type Foo = Bar<A, , B>;
+  
+type_arguments_missing_elements.ts:3:19 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type parameter but instead found ','.
+  
+    1 │ type Foo = Bar<, A>;
+    2 │ 
+  > 3 │ type Foo = Bar<A, , B>;
+      │                   ^
+    4 │ 
+  
+  i Expected a type parameter here.
+  
+    1 │ type Foo = Bar<, A>;
+    2 │ 
+  > 3 │ type Foo = Bar<A, , B>;
+      │                   ^
+    4 │ 
+  
+```

--- a/crates/biome_js_parser/tests/js_test_suite/error/type_parameter_missing_elements.ts
+++ b/crates/biome_js_parser/tests/js_test_suite/error/type_parameter_missing_elements.ts
@@ -1,0 +1,3 @@
+type Foo<, A> = A;
+
+type Foo<A, , B> = A & B;

--- a/crates/biome_js_parser/tests/js_test_suite/error/type_parameter_missing_elements.ts.snap
+++ b/crates/biome_js_parser/tests/js_test_suite/error/type_parameter_missing_elements.ts.snap
@@ -1,0 +1,190 @@
+---
+source: crates/biome_js_parser/tests/spec_test.rs
+assertion_line: 177
+expression: snapshot
+---
+## Input
+
+```ts
+type Foo<, A> = A;
+
+type Foo<A, , B> = A & B;
+
+```
+
+
+## AST
+
+```
+JsModule {
+    bom_token: missing (optional),
+    interpreter_token: missing (optional),
+    directives: JsDirectiveList [],
+    items: JsModuleItemList [
+        JsBogusStatement {
+            items: [
+                TYPE_KW@0..5 "type" [] [Whitespace(" ")],
+                TsIdentifierBinding {
+                    name_token: IDENT@5..8 "Foo" [] [],
+                },
+                JsBogus {
+                    items: [
+                        L_ANGLE@8..9 "<" [] [],
+                        JsBogus {
+                            items: [
+                                TsTypeParameterModifierList [],
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        JsBogusStatement {
+            items: [
+                COMMA@9..11 "," [] [Whitespace(" ")],
+                IDENT@11..12 "A" [] [],
+                R_ANGLE@12..14 ">" [] [Whitespace(" ")],
+                EQ@14..16 "=" [] [Whitespace(" ")],
+                IDENT@16..17 "A" [] [],
+            ],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@17..18 ";" [] [],
+        },
+        JsBogusStatement {
+            items: [
+                TYPE_KW@18..25 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")],
+                TsIdentifierBinding {
+                    name_token: IDENT@25..28 "Foo" [] [],
+                },
+                JsBogus {
+                    items: [
+                        L_ANGLE@28..29 "<" [] [],
+                        JsBogus {
+                            items: [
+                                TsTypeParameter {
+                                    modifiers: TsTypeParameterModifierList [],
+                                    name: TsTypeParameterName {
+                                        ident_token: IDENT@29..30 "A" [] [],
+                                    },
+                                    constraint: missing (optional),
+                                    default: missing (optional),
+                                },
+                                COMMA@30..32 "," [] [Whitespace(" ")],
+                                TsTypeParameterModifierList [],
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        JsBogusStatement {
+            items: [
+                COMMA@32..34 "," [] [Whitespace(" ")],
+                IDENT@34..35 "B" [] [],
+                R_ANGLE@35..37 ">" [] [Whitespace(" ")],
+                EQ@37..39 "=" [] [Whitespace(" ")],
+                IDENT@39..41 "A" [] [Whitespace(" ")],
+                AMP@41..43 "&" [] [Whitespace(" ")],
+                IDENT@43..44 "B" [] [],
+            ],
+        },
+        JsEmptyStatement {
+            semicolon_token: SEMICOLON@44..45 ";" [] [],
+        },
+    ],
+    eof_token: EOF@45..46 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: JS_MODULE@0..46
+  0: (empty)
+  1: (empty)
+  2: JS_DIRECTIVE_LIST@0..0
+  3: JS_MODULE_ITEM_LIST@0..45
+    0: JS_BOGUS_STATEMENT@0..9
+      0: TYPE_KW@0..5 "type" [] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@5..8
+        0: IDENT@5..8 "Foo" [] []
+      2: JS_BOGUS@8..9
+        0: L_ANGLE@8..9 "<" [] []
+        1: JS_BOGUS@9..9
+          0: TS_TYPE_PARAMETER_MODIFIER_LIST@9..9
+    1: JS_BOGUS_STATEMENT@9..17
+      0: COMMA@9..11 "," [] [Whitespace(" ")]
+      1: IDENT@11..12 "A" [] []
+      2: R_ANGLE@12..14 ">" [] [Whitespace(" ")]
+      3: EQ@14..16 "=" [] [Whitespace(" ")]
+      4: IDENT@16..17 "A" [] []
+    2: JS_EMPTY_STATEMENT@17..18
+      0: SEMICOLON@17..18 ";" [] []
+    3: JS_BOGUS_STATEMENT@18..32
+      0: TYPE_KW@18..25 "type" [Newline("\n"), Newline("\n")] [Whitespace(" ")]
+      1: TS_IDENTIFIER_BINDING@25..28
+        0: IDENT@25..28 "Foo" [] []
+      2: JS_BOGUS@28..32
+        0: L_ANGLE@28..29 "<" [] []
+        1: JS_BOGUS@29..32
+          0: TS_TYPE_PARAMETER@29..30
+            0: TS_TYPE_PARAMETER_MODIFIER_LIST@29..29
+            1: TS_TYPE_PARAMETER_NAME@29..30
+              0: IDENT@29..30 "A" [] []
+            2: (empty)
+            3: (empty)
+          1: COMMA@30..32 "," [] [Whitespace(" ")]
+          2: TS_TYPE_PARAMETER_MODIFIER_LIST@32..32
+    4: JS_BOGUS_STATEMENT@32..44
+      0: COMMA@32..34 "," [] [Whitespace(" ")]
+      1: IDENT@34..35 "B" [] []
+      2: R_ANGLE@35..37 ">" [] [Whitespace(" ")]
+      3: EQ@37..39 "=" [] [Whitespace(" ")]
+      4: IDENT@39..41 "A" [] [Whitespace(" ")]
+      5: AMP@41..43 "&" [] [Whitespace(" ")]
+      6: IDENT@43..44 "B" [] []
+    5: JS_EMPTY_STATEMENT@44..45
+      0: SEMICOLON@44..45 ";" [] []
+  4: EOF@45..46 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+type_parameter_missing_elements.ts:1:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type parameter but instead found ','.
+  
+  > 1 │ type Foo<, A> = A;
+      │          ^
+    2 │ 
+    3 │ type Foo<A, , B> = A & B;
+  
+  i Expected a type parameter here.
+  
+  > 1 │ type Foo<, A> = A;
+      │          ^
+    2 │ 
+    3 │ type Foo<A, , B> = A & B;
+  
+type_parameter_missing_elements.ts:3:13 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a type parameter but instead found ','.
+  
+    1 │ type Foo<, A> = A;
+    2 │ 
+  > 3 │ type Foo<A, , B> = A & B;
+      │             ^
+    4 │ 
+  
+  i Expected a type parameter here.
+  
+    1 │ type Foo<, A> = A;
+    2 │ 
+  > 3 │ type Foo<A, , B> = A & B;
+      │             ^
+    4 │ 
+  
+```

--- a/crates/biome_parser/src/parse_lists.rs
+++ b/crates/biome_parser/src/parse_lists.rs
@@ -127,6 +127,11 @@ pub trait ParseSeparatedList {
         false
     }
 
+    /// `true` if the list allows for missing elements
+    fn allow_missing_elements(&self) -> bool {
+        true
+    }
+
     /// Method called at each iteration of the loop and checks if the expected
     /// separator is present.
     ///
@@ -166,7 +171,10 @@ pub trait ParseSeparatedList {
 
             let parsed_element = self.parse_element(p);
 
-            if parsed_element.is_absent() && p.at(self.separating_element_kind()) {
+            if parsed_element.is_absent()
+                && p.at(self.separating_element_kind())
+                && self.allow_missing_elements()
+            {
                 // a missing element
                 continue;
             }


### PR DESCRIPTION
## Summary
Closes #7494

Following the TypeScript spec, the parser treats missing elements in generics as parse errors.
```diff
// type parameters
- type Foo<A, , B> = A & B;
+ type Foo<A, , B> = A & B;
+ //          ^ Expected a type parameter but instead found ','.

// type arguments
- type Foo = Bar<1, , 2>;
+ type Foo = Bar<1, , 2>;
+ //                ^ Expected a type parameter but instead found ','.
```
This PR also makes it easier to fix similar cases that use the ParseSeparatedList trait, of which there are likely several.

## Test Plan
snap tests

## Docs
changeset only