### PR TITLE
chore: introduce ruledoc utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "biome_ruledoc_utils"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "biome_analyze",
+ "biome_configuration",
+ "biome_fs",
+ "biome_js_analyze",
+ "biome_js_parser",
+ "biome_json_parser",
+ "biome_module_graph",
+ "biome_project_layout",
+ "biome_service",
+ "biome_test_utils",
+ "camino",
+]
+
+[[package]]
 name = "biome_service"
 version = "0.0.0"
 dependencies = [
@@ -4038,8 +4056,8 @@ dependencies = [
  "biome_module_graph",
  "biome_project_layout",
  "biome_rowan",
+ "biome_ruledoc_utils",
  "biome_service",
- "biome_test_utils",
  "camino",
  "pulldown-cmark",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ biome_flags          = { path = "./crates/biome_flags" }
 biome_formatter_test = { path = "./crates/biome_formatter_test" }
 biome_lsp            = { path = "./crates/biome_lsp" }
 biome_migrate        = { path = "./crates/biome_migrate" }
+biome_ruledoc_utils  = { path = "./crates/biome_ruledoc_utils" }
 biome_service        = { path = "./crates/biome_service" }
 biome_test_utils     = { path = "./crates/biome_test_utils" }
 tests_macros         = { path = "./crates/tests_macros" }

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
@@ -44,14 +44,14 @@ declare_source_rule! {
     /// ## Examples
     ///
     /// ```js,expect_diff
-    /// {
+    /// const obj = {
     ///   x: 1,
     ///   a: 2,
     /// };
     /// ```
     ///
     /// ```js,expect_diff
-    /// {
+    /// const obj = {
     ///   x: 1,
     ///   ...f,
     ///   y: 4,
@@ -63,7 +63,7 @@ declare_source_rule! {
     /// ```
     ///
     /// ```js,expect_diff
-    /// {
+    /// const obj = {
     ///   get aab() {
     ///     return this._aab;
     ///   },

--- a/crates/biome_ruledoc_utils/Cargo.toml
+++ b/crates/biome_ruledoc_utils/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+authors.workspace    = true
+categories.workspace = true
+description          = "Utilities for running code blocks in rule docs"
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license.workspace    = true
+name                 = "biome_ruledoc_utils"
+repository.workspace = true
+version              = "0.0.1"
+
+[dependencies]
+anyhow               = { workspace = true }
+biome_analyze        = { workspace = true }
+biome_configuration  = { workspace = true }
+biome_fs             = { workspace = true }
+biome_js_analyze     = { workspace = true }
+biome_js_parser      = { workspace = true }
+biome_json_parser    = { workspace = true }
+biome_module_graph   = { workspace = true }
+biome_project_layout = { workspace = true }
+biome_service        = { workspace = true }
+biome_test_utils     = { workspace = true }
+camino               = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/biome_ruledoc_utils/src/codeblock.rs
+++ b/crates/biome_ruledoc_utils/src/codeblock.rs
@@ -1,0 +1,168 @@
+use std::str::FromStr;
+
+use anyhow::{Result, bail};
+use biome_analyze::AnalyzerOptions;
+use biome_configuration::Configuration;
+use biome_fs::BiomePath;
+use biome_service::{
+    settings::{ServiceLanguage, Settings},
+    workspace::DocumentFileSource,
+};
+
+/// Represents a single code block used for evaluating doc tests.
+///
+/// Code blocks can be either evaluated stand-alone as a self-contained test
+/// snippet, contain configuration to be applied to another code block, or be
+/// part of an in-memory file system used to run examples for rules with
+/// multi-file analysis.
+#[derive(Default)]
+pub struct CodeBlock {
+    /// The language tag of this code block.
+    pub tag: String,
+
+    /// Whether this is an invalid example that should trigger a diagnostic.
+    pub expect_diagnostic: bool,
+
+    /// Whether to expect a code diff.
+    pub expect_diff: bool,
+
+    /// If a file path is provided using the `file=<path>` attribute, it will be
+    /// used as the code block's title in the MDX output. It will also be used
+    /// in generating an in-memory file system for multi-file analysis.
+    file_path: Option<String>,
+
+    /// Whether to ignore this code block.
+    pub ignore: bool,
+
+    /// Whether this is a block of configuration options instead of a
+    /// valid/invalid code example, and if yes, how that block of configuration
+    /// options should be parsed:
+    pub options: OptionsParsingMode,
+
+    /// Whether to use the last code block that was marked with `options` as the
+    /// configuration settings for this code block.
+    pub use_options: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum OptionsParsingMode {
+    /// This code block does not contain configuration options.
+    #[default]
+    NoOptions,
+
+    /// This code block contains the options for a single rule only.
+    RuleOptionsOnly,
+
+    /// This code block contains JSON that adheres to the full `biome.json`
+    /// schema.
+    FullConfiguration,
+}
+
+impl CodeBlock {
+    pub fn create_analyzer_options<L>(
+        &self,
+        config: Option<Configuration>,
+    ) -> Result<AnalyzerOptions>
+    where
+        L: ServiceLanguage,
+    {
+        let mut settings = Settings::default();
+
+        if self.use_options {
+            // Load settings from the preceding `json,options` block if requested
+            let Some(config) = config else {
+                bail!(
+                    "Code blocks tagged with 'use_options' must be preceded by a valid 'json,options' code block."
+                );
+            };
+
+            settings.merge_with_configuration(config, None)?;
+        }
+
+        let language_settings = &L::lookup_settings(&settings.languages).linter;
+        let environment = L::resolve_environment(&settings);
+        let suppression_reason = None;
+
+        Ok(L::resolve_analyzer_options(
+            &settings,
+            language_settings,
+            environment,
+            &BiomePath::new(self.file_path()),
+            &self.document_file_source(),
+            suppression_reason,
+        ))
+    }
+
+    pub fn document_file_source(&self) -> DocumentFileSource {
+        DocumentFileSource::from_extension(&self.tag)
+    }
+
+    /// Returns the block's file path, but only if one was set explicitly using
+    /// the `file=<path>` attribute.
+    pub fn explicit_file_path(&self) -> Option<&str> {
+        self.file_path.as_deref()
+    }
+
+    /// Returns the block's file path, with a fallback in case one was not set
+    /// explicitly.
+    pub fn file_path(&self) -> String {
+        self.explicit_file_path()
+            .map_or_else(|| format!("code-block.{}", self.tag), ToString::to_string)
+    }
+}
+
+impl FromStr for CodeBlock {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self> {
+        let tokens = input
+            .split([',', ' ', '\t'])
+            .map(str::trim)
+            .filter(|token| !token.is_empty());
+
+        let mut code_block = Self::default();
+
+        for token in tokens {
+            match token {
+                "expect_diagnostic" => code_block.expect_diagnostic = true,
+                "expect_diff" => code_block.expect_diff = true,
+                "full_options" => code_block.options = OptionsParsingMode::FullConfiguration,
+                "ignore" => code_block.ignore = true,
+                "options" => code_block.options = OptionsParsingMode::RuleOptionsOnly,
+                "use_options" => code_block.use_options = true,
+                _ => {
+                    if let Some(path) = token.strip_prefix("file=") {
+                        if path.is_empty() {
+                            bail!("The 'file' attribute must be followed by a file path");
+                        }
+
+                        code_block.file_path = Some(normalize_file_path(path));
+                    } else {
+                        if code_block.document_file_source() != DocumentFileSource::Unknown {
+                            bail!(
+                                "Only one language tag is accepted per code block. Found '{}' and '{}'",
+                                code_block.tag,
+                                token
+                            );
+                        }
+
+                        code_block.tag = token.to_string();
+
+                        if code_block.document_file_source() == DocumentFileSource::Unknown {
+                            bail!("Unrecognised attribute in code block: {token}");
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(code_block)
+    }
+}
+
+/// Normalizes a file path to an absolute path for easier module graph path
+/// resolution.
+fn normalize_file_path(path: &str) -> String {
+    let path = path.trim_start_matches("./").trim_start_matches("../");
+    format!("/{path}")
+}

--- a/crates/biome_ruledoc_utils/src/lib.rs
+++ b/crates/biome_ruledoc_utils/src/lib.rs
@@ -1,0 +1,99 @@
+mod codeblock;
+
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::sync::Arc;
+
+use biome_fs::{BiomePath, MemoryFileSystem};
+use biome_js_analyze::JsAnalyzerServices;
+use biome_js_parser::JsFileSource;
+use biome_json_parser::{JsonParserOptions, parse_json};
+use biome_module_graph::ModuleGraph;
+use biome_project_layout::ProjectLayout;
+use biome_test_utils::get_added_paths;
+use camino::Utf8PathBuf;
+
+pub use codeblock::*;
+
+/// Builder that can be used for constructing analyzer services.
+///
+/// The builder can be reused to create cheap instances of analyzer services
+/// for multiple code blocks.
+pub struct AnalyzerServicesBuilder {
+    module_graph: Arc<ModuleGraph>,
+    project_layout: Arc<ProjectLayout>,
+}
+
+impl AnalyzerServicesBuilder {
+    /// Creates a service builder from a map of `files`.
+    ///
+    /// Constructs an in-memory file system from the given files and uses it
+    /// to initialise a module graph and project layout.
+    ///
+    /// # Arguments
+    ///
+    /// * `files` - A map of file paths to their contents.
+    pub fn from_files<S: BuildHasher>(files: HashMap<String, String, S>) -> Self {
+        if files.is_empty() {
+            return Self {
+                module_graph: Default::default(),
+                project_layout: Default::default(),
+            };
+        }
+
+        let fs = MemoryFileSystem::default();
+        let layout = ProjectLayout::default();
+
+        let mut added_paths = Vec::with_capacity(files.len());
+
+        for (path, src) in files {
+            let path_buf = Utf8PathBuf::from(path);
+            let biome_path = BiomePath::new(&path_buf);
+            if biome_path.is_manifest() {
+                match biome_path.file_name() {
+                    Some("package.json") => {
+                        let parsed = parse_json(&src, JsonParserOptions::default());
+                        layout.insert_serialized_node_manifest(
+                            path_buf.parent().unwrap().into(),
+                            &parsed.syntax().as_send().unwrap(),
+                        );
+                    }
+                    Some("tsconfig.json") => {
+                        let parsed = parse_json(
+                            &src,
+                            JsonParserOptions::default()
+                                .with_allow_comments()
+                                .with_allow_trailing_commas(),
+                        );
+                        layout.insert_serialized_tsconfig(
+                            path_buf.parent().unwrap().into(),
+                            &parsed.syntax().as_send().unwrap(),
+                        );
+                    }
+                    _ => unimplemented!("Unhandled manifest: {biome_path}"),
+                }
+            } else {
+                added_paths.push(biome_path);
+            }
+
+            fs.insert(path_buf, src);
+        }
+
+        let module_graph = ModuleGraph::default();
+        let added_paths = get_added_paths(&fs, &added_paths);
+        module_graph.update_graph_for_js_paths(&fs, &layout, &added_paths, &[]);
+
+        Self {
+            module_graph: Arc::new(module_graph),
+            project_layout: Arc::new(layout),
+        }
+    }
+
+    pub fn build_for_js_file_source(&self, file_source: JsFileSource) -> JsAnalyzerServices {
+        JsAnalyzerServices::from((
+            self.module_graph.clone(),
+            self.project_layout.clone(),
+            file_source,
+        ))
+    }
+}

--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -1,5 +1,9 @@
 #![deny(clippy::use_self)]
 
+use std::ffi::c_int;
+use std::fmt::Write;
+use std::sync::{Arc, Once};
+
 use biome_analyze::options::{JsxRuntime, PreferredQuote};
 use biome_analyze::{AnalyzerAction, AnalyzerConfiguration, AnalyzerOptions};
 use biome_configuration::Configuration;
@@ -7,11 +11,10 @@ use biome_console::fmt::{Formatter, Termcolor};
 use biome_console::markup;
 use biome_diagnostics::termcolor::Buffer;
 use biome_diagnostics::{DiagnosticExt, Error, PrintDiagnostic};
-use biome_fs::{BiomePath, FileSystem, MemoryFileSystem, OsFileSystem};
-use biome_js_analyze::JsAnalyzerServices;
+use biome_fs::{BiomePath, FileSystem, OsFileSystem};
 use biome_js_parser::{AnyJsRoot, JsFileSource, JsParserOptions};
 use biome_js_type_info::{TypeData, TypeResolver};
-use biome_json_parser::{JsonParserOptions, ParseDiagnostic, parse_json};
+use biome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use biome_module_graph::ModuleGraph;
 use biome_package::PackageJson;
 use biome_project_layout::ProjectLayout;
@@ -24,11 +27,6 @@ use biome_string_case::StrLikeExtension;
 use camino::{Utf8Path, Utf8PathBuf};
 use json_comments::StripComments;
 use similar::{DiffableStr, TextDiff};
-use std::collections::HashMap;
-use std::ffi::c_int;
-use std::fmt::Write;
-use std::hash::BuildHasher;
-use std::sync::{Arc, Once};
 
 mod bench_case;
 
@@ -609,65 +607,4 @@ pub fn assert_diagnostics_expectation_comment<L: Language>(
             }
         }
     }
-}
-
-/// Creates an in-memory module graph for the given files.
-/// Returns the services for analyzing a single code snippet, including module graph and project layout.
-/// The module graph will be empty if no `files` are provided.
-///
-/// # Arguments
-///
-/// * `file_source` - The file source to use for the returned analyzer services.
-/// * `files` - A map of file paths to their contents.
-pub fn get_test_services<S: BuildHasher>(
-    file_source: JsFileSource,
-    files: &HashMap<String, String, S>,
-) -> JsAnalyzerServices {
-    if files.is_empty() {
-        return JsAnalyzerServices::from((Default::default(), Default::default(), file_source));
-    }
-
-    let fs = MemoryFileSystem::default();
-    let layout = ProjectLayout::default();
-
-    let mut added_paths = Vec::with_capacity(files.len());
-
-    for (path, src) in files.iter() {
-        let path_buf = Utf8PathBuf::from(path);
-        let biome_path = BiomePath::new(&path_buf);
-        if biome_path.is_manifest() {
-            match biome_path.file_name() {
-                Some("package.json") => {
-                    let parsed = parse_json(src, JsonParserOptions::default());
-                    layout.insert_serialized_node_manifest(
-                        path_buf.parent().unwrap().into(),
-                        &parsed.syntax().as_send().unwrap(),
-                    );
-                }
-                Some("tsconfig.json") => {
-                    let parsed = parse_json(
-                        src,
-                        JsonParserOptions::default()
-                            .with_allow_comments()
-                            .with_allow_trailing_commas(),
-                    );
-                    layout.insert_serialized_tsconfig(
-                        path_buf.parent().unwrap().into(),
-                        &parsed.syntax().as_send().unwrap(),
-                    );
-                }
-                _ => unimplemented!("Unhandled manifest: {biome_path}"),
-            }
-        } else {
-            added_paths.push(biome_path);
-        }
-
-        fs.insert(path_buf, src.as_bytes().to_vec());
-    }
-
-    let module_graph = ModuleGraph::default();
-    let added_paths = get_added_paths(&fs, &added_paths);
-    module_graph.update_graph_for_js_paths(&fs, &layout, &added_paths, &[]);
-
-    JsAnalyzerServices::from((Arc::new(module_graph), Arc::new(layout), file_source))
 }

--- a/xtask/rules_check/Cargo.toml
+++ b/xtask/rules_check/Cargo.toml
@@ -29,8 +29,8 @@ biome_json_syntax     = { workspace = true }
 biome_module_graph    = { workspace = true }
 biome_project_layout  = { workspace = true }
 biome_rowan           = { workspace = true }
+biome_ruledoc_utils   = { workspace = true }
 biome_service         = { workspace = true }
-biome_test_utils      = { workspace = true }
 camino                = { workspace = true }
 pulldown-cmark        = "0.13.0"
 


### PR DESCRIPTION
## Summary

Creates a new crate `biome_ruledoc_utils`, and moved some of the code for parsing ruledoc code blocks there, as well as the logic for creating analyzer services evaluating the code blocks. This avoids a bunch of code duplication between codegen in the main repository and the website repository.

## Test Plan

`just lint-rules` still works.

## Docs

N/A