### PR TITLE
fix: resolve parse errors in ruledoc code blocks

### DIFF
--- a/crates/biome_css_analyze/src/lint/suspicious/no_irregular_whitespace.rs
+++ b/crates/biome_css_analyze/src/lint/suspicious/no_irregular_whitespace.rs
@@ -28,11 +28,6 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```css,expect_diagnostic
-    /// .firstClass .secondClass {
-    ///   color:red;
-    /// }
-    /// ```
     /// ### Valid
     ///
     /// ```css

--- a/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
+++ b/crates/biome_js_analyze/src/assist/source/use_sorted_keys.rs
@@ -62,7 +62,7 @@ declare_source_rule! {
     /// };
     /// ```
     ///
-    /// ```js,expect_diff
+    /// ```js
     /// const obj = {
     ///   get aab() {
     ///     return this._aab;
@@ -100,7 +100,7 @@ declare_source_rule! {
     ///     }
     /// }
     /// ```
-    /// ```js,use_options,expect_diagnostic
+    /// ```js,use_options,expect_diff
     /// const obj = {
     ///     val13: 1,
     ///     val1: 1,
@@ -119,7 +119,7 @@ declare_source_rule! {
     ///     }
     /// }
     /// ```
-    /// ```js,use_options,expect_diagnostic
+    /// ```js,use_options,expect_diff
     /// const obj = {
     ///     val13: 1,
     ///     val1: 1,

--- a/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_static_only_class.rs
@@ -34,7 +34,7 @@ declare_lint_rule! {
     ///   static bar() {};
     /// }
     /// ```
-    /// ```js,expect_diagnostic
+    /// ```ts,expect_diagnostic
     /// class StaticConstants {
     ///   static readonly version = 42;
     ///

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_constructor.rs
@@ -56,7 +56,7 @@ declare_lint_rule! {
     /// }
     /// ```
     ///
-    /// ```js,expect_diagnostic
+    /// ```ts,expect_diagnostic
     /// class A {
     ///     protected constructor() {
     ///         this.prop = 1;

--- a/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
+++ b/crates/biome_js_analyze/src/lint/complexity/no_useless_type_constraint.rs
@@ -58,6 +58,7 @@ declare_lint_rule! {
     /// ```ts,expect_diagnostic
     /// class BazUnknown<T extends unknown> {
     /// }
+    /// ```
     /// ```ts,expect_diagnostic
     /// class BazUnknown {
     ///   quxUnknown<U extends unknown>() {}

--- a/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_invalid_use_before_declaration.rs
@@ -24,7 +24,7 @@ declare_lint_rule! {
     /// ```js,expect_diagnostic
     /// function f() {
     ///     console.log(x);
-    ///     const x;
+    ///     let x;
     /// }
     /// ```
     ///

--- a/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_unused_imports.rs
@@ -66,10 +66,12 @@ declare_lint_rule! {
     /// export { B }
     /// ```
     ///
-    /// ```js,expect_diagnostic
+    /// ```ts,expect_diagnostic
     /// // Header comment
     /// import /*inner comment */ A from 'mod'; // Associated comment
+    /// ```
     ///
+    /// ```ts,expect_diagnostic
     /// // Another header comment
     /// import {
     ///     // A's header comment

--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes.rs
@@ -60,7 +60,7 @@ declare_lint_rule! {
     /// ```
     ///
     /// ```jsx,expect_diagnostic
-    /// <div class="hover:focus:m-2 foo hover:px-2 p-4">
+    /// <div class="hover:focus:m-2 foo hover:px-2 p-4" />
     /// ```
     ///
     /// ## Options

--- a/crates/biome_js_analyze/src/lint/style/no_restricted_imports.rs
+++ b/crates/biome_js_analyze/src/lint/style/no_restricted_imports.rs
@@ -261,7 +261,7 @@ declare_lint_rule! {
     /// ```
     ///
     /// ```js,expect_diagnostic,use_options
-    /// import { export1 } 'import-foo';
+    /// import { export1 } from 'import-foo';
     /// ```
     ///
     /// ### `paths.<import>.importNames`

--- a/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_block_statements.rs
@@ -60,10 +60,6 @@ declare_lint_rule! {
     /// ```js,expect_diagnostic
     ///    while (x);
     /// ```
-    ///
-    /// ```js,expect_diagnostic
-    ///   with (x);
-    /// ```
     pub UseBlockStatements {
         version: "1.0.0",
         name: "useBlockStatements",

--- a/crates/biome_json_analyze/src/assist/source/use_sorted_keys.rs
+++ b/crates/biome_json_analyze/src/assist/source/use_sorted_keys.rs
@@ -46,13 +46,13 @@ declare_source_rule! {
     ///     }
     /// }
     /// ```
-    /// ```json,use_options,expect_diagnostic
+    /// ```json,use_options,expect_diff
     /// {
     ///     "val13": 1,
     ///     "val1": 1,
     ///     "val2": 1,
     ///     "val21": 1,
-    ///     "val11": 1,
+    ///     "val11": 1
     /// }
     /// ```
     ///
@@ -65,13 +65,13 @@ declare_source_rule! {
     ///     }
     /// }
     /// ```
-    /// ```json,use_options,expect_diagnostic
+    /// ```json,use_options,expect_diff
     /// {
     ///     "val13": 1,
     ///     "val1": 1,
     ///     "val2": 1,
     ///     "val21": 1,
-    ///     "val11": 1,
+    ///     "val11": 1
     /// }
     /// ```
     ///

--- a/crates/biome_ruledoc_utils/src/codeblock.rs
+++ b/crates/biome_ruledoc_utils/src/codeblock.rs
@@ -138,6 +138,11 @@ impl FromStr for CodeBlock {
 
                         code_block.file_path = Some(normalize_file_path(path));
                     } else {
+                        if DocumentFileSource::from_extension(token) == DocumentFileSource::Unknown
+                        {
+                            bail!("Unrecognised attribute in code block: {token}");
+                        }
+
                         if code_block.document_file_source() != DocumentFileSource::Unknown {
                             bail!(
                                 "Only one language tag is accepted per code block. Found '{}' and '{}'",
@@ -147,10 +152,6 @@ impl FromStr for CodeBlock {
                         }
 
                         code_block.tag = token.to_string();
-
-                        if code_block.document_file_source() == DocumentFileSource::Unknown {
-                            bail!("Unrecognised attribute in code block: {token}");
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Several ruledoc code blocks still contained parse errors, which were silently ignored by `just lint-rules`. This tightens the validation and resolves parse errors in various rule documentation examples.

## Test Plan

`just lint-rules` should still be green.

## Docs

N/A