### PR TITLE
fix(lint/useExhaustiveSwitchCases): improve type narrowing for default parameters

### DIFF
--- a/.changeset/fix-exhaustive-switch-default-params.md
+++ b/.changeset/fix-exhaustive-switch-default-params.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7525](https://github.com/biomejs/biome/issues/7525): The [`useExhaustiveSwitchCases`](https://biomejs.dev/linter/rules/use-exhaustive-switch-cases/) rule now correctly handles destructured parameters with default values and excludes `undefined` from exhaustiveness checking when a default value is present.

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue7525.ts
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue7525.ts
@@ -1,0 +1,18 @@
+interface test {
+	a?: number;
+	b?: "thing" | "other" | "more";
+}
+
+function fn(param: number, { a = 1, b = "thing" }: test = {}) {
+	// incorrectly flagged as not exhaustive
+	// even though `b` is never `undefined`
+	// due to having a default value
+	switch (b) {
+		case "thing":
+			return 1;
+		case "other":
+			return 2;
+		case "more":
+			return 3;
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue7525.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useExhaustiveSwitchCases/invalidIssue7525.ts.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
+expression: invalidIssue7525.ts
+---
+# Input
+```ts
+interface test {
+	a?: number;
+	b?: "thing" | "other" | "more";
+}
+
+function fn(param: number, { a = 1, b = "thing" }: test = {}) {
+	// incorrectly flagged as not exhaustive
+	// even though `b` is never `undefined`
+	// due to having a default value
+	switch (b) {
+		case "thing":
+			return 1;
+		case "other":
+			return 2;
+		case "more":
+			return 3;
+	}
+}
+
+```


### PR DESCRIPTION
Fix incorrect type inference where destructured parameters with default values were still considered to include undefined in their type union.

Fixes #7525

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

The `useExhaustiveSwitchCases` rule was incorrectly flagging switch statements as non-exhaustive when using destructured parameters with default values.

  **Problem**: When a parameter has a default value like `{ b = "thing" }: { b?: "thing" | "other" | "more" }`, the
  variable `b` can never be `undefined` because it has a default value. However, the rule was still requiring an
  `undefined` case in switch statements.

  **Solution**: Added logic to detect when a discriminant variable comes from a destructured parameter with a default
  value, and exclude `undefined` from exhaustiveness checking in those cases.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
- Added new test case `invalidIssue7525.ts` with scenario of destructured parameters with defaults
  - All existing tests continue to pass
  - The new test verifies that switch statements with destructured params + defaults no longer incorrectly require
  `undefined` cases

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->

  No documentation changes needed - this is a bug fix that improves existing rule behavior.