### PR TITLE
feat(lint): move some rules to the `react` domain

### DIFF
--- a/.changeset/crazy-steaks-mix.md
+++ b/.changeset/crazy-steaks-mix.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": minor
+---
+
+The rules in a domain are no longer enabled automatically by the installed dependencies unless the rule is recommended.

--- a/.changeset/seven-beans-cough.md
+++ b/.changeset/seven-beans-cough.md
@@ -2,11 +2,11 @@
 "@biomejs/biome": minor
 ---
 
-The following rules are now a part of the `react` domain, and they won't be enabled automatically unless you enabled the domain:
+The following rules are now a part of the `react` domain, and they won't be enabled automatically unless you enabled the domain, or Biome detects `react` as a dependency of your closest `package.json`:
 
-- `lint/correctness/noChildrenProp` (recommended)
-- `lint/correctness/noReactPropAssignments`
-- `lint/security/noDangerouslySetInnerHtml` (recommended)
-- `lint/security/noDangerouslySetInnerHtmlWithChildren` (recommended)
-- `lint/style/useComponentExportOnlyModules`
-- `lint/suspicious/noArrayIndexKey` (recommended)
+- [`lint/correctness/noChildrenProp`](https://biomejs.dev/linter/rules/no-children-prop/) (recommended)
+- [`lint/correctness/noReactPropAssignments`](https://biomejs.dev/linter/rules/no-react-prop-assignments/)
+- [`lint/security/noDangerouslySetInnerHtml`](https://biomejs.dev/linter/rules/no-dangerously-set-inner-html/) (recommended)
+- [`lint/security/noDangerouslySetInnerHtmlWithChildren`](https://biomejs.dev/linter/rules/no-dangerously-set-inner-html-with-children/) (recommended)
+- [`lint/style/useComponentExportOnlyModules`](https://biomejs.dev/linter/rules/use-component-export-only-modules/)
+- [`lint/suspicious/noArrayIndexKey`](https://biomejs.dev/linter/rules/no-array-index-key/) (recommended)

--- a/.changeset/seven-beans-cough.md
+++ b/.changeset/seven-beans-cough.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": minor
+---
+
+The following rules are now a part of the `react` domain, and they won't be enabled automatically unless you enabled the domain:
+
+- `lint/correctness/noChildrenProp` (recommended)
+- `lint/correctness/noReactPropAssignments`
+- `lint/security/noDangerouslySetInnerHtml` (recommended)
+- `lint/security/noDangerouslySetInnerHtmlWithChildren` (recommended)
+- `lint/style/useComponentExportOnlyModules`
+- `lint/suspicious/noArrayIndexKey` (recommended)

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -3465,7 +3465,6 @@ impl Correctness {
         "useYield",
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
@@ -5443,8 +5442,6 @@ impl Security {
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
     ];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
@@ -6960,7 +6957,6 @@ impl Suspicious {
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
-        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]),

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -42,13 +42,19 @@ static QWIK_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
 });
 static REACT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
     vec![
+        RuleFilter::Rule("correctness", "noChildrenProp"),
         RuleFilter::Rule("correctness", "noNestedComponentDefinitions"),
+        RuleFilter::Rule("correctness", "noReactPropAssignments"),
         RuleFilter::Rule("correctness", "noRenderReturnValue"),
         RuleFilter::Rule("correctness", "useExhaustiveDependencies"),
         RuleFilter::Rule("correctness", "useHookAtTopLevel"),
         RuleFilter::Rule("correctness", "useJsxKeyInIterable"),
         RuleFilter::Rule("correctness", "useUniqueElementIds"),
         RuleFilter::Rule("nursery", "useReactFunctionComponents"),
+        RuleFilter::Rule("security", "noDangerouslySetInnerHtml"),
+        RuleFilter::Rule("security", "noDangerouslySetInnerHtmlWithChildren"),
+        RuleFilter::Rule("style", "useComponentExportOnlyModules"),
+        RuleFilter::Rule("suspicious", "noArrayIndexKey"),
     ]
 });
 static SOLID_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {

--- a/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_children_prop.rs
@@ -1,12 +1,13 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleDomain, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{JsCallExpression, JsxAttribute};
 use biome_rowan::{AstNode, TextRange, declare_node_union};
 use biome_rule_options::no_children_prop::NoChildrenPropOptions;
+
 declare_lint_rule! {
     /// Prevent passing of **children** as props.
     ///
@@ -29,6 +30,7 @@ declare_lint_rule! {
         name: "noChildrenProp",
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-children-prop").same()],
+        domains: &[RuleDomain::React],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/correctness/no_react_prop_assignments.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_react_prop_assignments.rs
@@ -2,7 +2,9 @@ use crate::react::components::{
     AnyPotentialReactComponentDeclaration, ReactComponentInfo, ReactComponentKind,
 };
 use crate::services::semantic::Semantic;
-use biome_analyze::{Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule};
+use biome_analyze::{
+    Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
+};
 use biome_console::markup;
 use biome_js_semantic::SemanticModel;
 use biome_js_syntax::{AnyJsExpression, AnyJsStatement, JsParameterList};
@@ -42,6 +44,7 @@ declare_lint_rule! {
         name: "noReactPropAssignments",
         language: "jsx",
         sources: &[RuleSource::EslintReactHooks("react-compiler").same()],
+        domains: &[RuleDomain::React],
         recommended: false,
     }
 }

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html.rs
@@ -1,7 +1,7 @@
 use crate::react::ReactCreateElementCall;
 use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleDomain, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{AnyJsxAttributeName, JsCallExpression, JsxAttribute};
@@ -32,6 +32,7 @@ declare_lint_rule! {
         name: "noDangerouslySetInnerHtml",
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-danger").same()],
+        domains: &[RuleDomain::React],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
+++ b/crates/biome_js_analyze/src/lint/security/no_dangerously_set_inner_html_with_children.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactApiCall, ReactCreateElementCall};
 use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleDomain, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_semantic::SemanticModel;
@@ -41,6 +41,7 @@ declare_lint_rule! {
         name: "noDangerouslySetInnerHtmlWithChildren",
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-danger-with-children").same()],
+        domains: &[RuleDomain::React],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_js_analyze/src/lint/style/use_component_export_only_modules.rs
+++ b/crates/biome_js_analyze/src/lint/style/use_component_export_only_modules.rs
@@ -1,6 +1,6 @@
 use crate::react::components::ReactComponentInfo;
 use biome_analyze::{
-    Ast, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+    Ast, Rule, RuleDiagnostic, RuleDomain, RuleSource, context::RuleContext, declare_lint_rule,
 };
 use biome_console::markup;
 use biome_diagnostics::Severity;
@@ -101,6 +101,7 @@ declare_lint_rule! {
         name: "useComponentExportOnlyModules",
         language: "jsx",
         sources: &[RuleSource::EslintReactRefresh("only-export-components").inspired()],
+        domains: &[RuleDomain::React],
         recommended: false,
         severity: Severity::Warning,
     }

--- a/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
+++ b/crates/biome_js_analyze/src/lint/suspicious/no_array_index_key.rs
@@ -1,7 +1,7 @@
 use crate::react::{ReactLibrary, is_react_call_api};
 use crate::services::semantic::Semantic;
 use biome_analyze::context::RuleContext;
-use biome_analyze::{Rule, RuleDiagnostic, RuleSource, declare_lint_rule};
+use biome_analyze::{Rule, RuleDiagnostic, RuleDomain, RuleSource, declare_lint_rule};
 use biome_console::markup;
 use biome_diagnostics::Severity;
 use biome_js_syntax::{
@@ -70,6 +70,7 @@ declare_lint_rule! {
         name: "noArrayIndexKey",
         language: "jsx",
         sources: &[RuleSource::EslintReact("no-array-index-key").same()],
+        domains: &[RuleDomain::React],
         recommended: true,
         severity: Severity::Error,
     }

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -1036,8 +1036,9 @@ impl<'a, 'b> LintVisitor<'a, 'b> {
 
         let path = self.path.expect("File path");
 
+        let is_recommended = R::METADATA.recommended;
         let recommended_enabled = self.settings.linter_recommended_enabled();
-        if !recommended_enabled {
+        if !is_recommended || !recommended_enabled {
             return;
         }
 


### PR DESCRIPTION
## Summary

The following rules are now a part of the `react` domain. It will prevent the rules to be applied where it's not a React world.

- `lint/correctness/noChildrenProp`
- `lint/correctness/noReactPropAssignments`
- `lint/security/noDangerouslySetInnerHtml`
- `lint/security/noDangerouslySetInnerHtmlWithChildren`
- `lint/style/useComponentExportOnlyModules`
- `lint/suspicious/noArrayIndexKey`

Migration is unlikely needed as Biome will enable the `react` domain automatically when it detects React in the dependencies.

## Test Plan

N/A

## Docs

N/A