### PR TITLE
ci: don't run the autofix workflow on an autofix commit

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   autofix:
     runs-on: depot-ubuntu-24.04-arm-16
+    if: ${{ github.actor != 'autofix-ci[bot]' }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
## Summary

The autofix workflow should not be run on an autofix commit. It prevents infinite loop and will reduce unnecessary workflow runs.

## Test Plan

N/A

## Docs

N/A