### PR TITLE
feat: implemented embedded JSON parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,8 +813,6 @@ dependencies = [
 name = "biome_html_syntax"
 version = "0.5.7"
 dependencies = [
- "biome_html_factory",
- "biome_html_parser",
  "biome_rowan",
  "biome_string_case",
  "camino",

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -1450,7 +1450,7 @@ pub fn format_node<L: FormatLanguage>(
     language: L,
     delegate_fmt_embedded_nodes: bool,
 ) -> FormatResult<Formatted<L::Context>> {
-    let (root, source_map) = match language.transform(&root.clone()) {
+    let (root, source_map) = match language.transform(root) {
         Some((transformed, source_map)) => {
             // we don't need to insert the node back if it has the same offset
             if &transformed == root {
@@ -1524,7 +1524,7 @@ pub fn format_node_with_offset<L: FormatLanguage>(
     language: L,
     delegate_fmt_embedded_nodes: bool,
 ) -> FormatResult<Formatted<L::Context>> {
-    let (root, source_map) = match language.transform(&root.node.clone()) {
+    let (root, source_map) = match language.transform(&root.node) {
         Some((transformed, source_map)) => {
             // we don't need to insert the node back if it has the same offset
             if transformed == root.node {

--- a/crates/biome_html_formatter/src/html/auxiliary/element.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/element.rs
@@ -46,8 +46,8 @@ impl FormatNodeRule<HtmlElement> for FormatHtmlElement {
         });
 
         let should_format_embedded_nodes = if f.context().should_delegate_fmt_embedded_nodes() {
-            // Only delegate for JS <script> or <style> content
-            node.is_javascript_tag()? || node.is_style_tag()?
+            // Only delegate for supported <script> or <style> content
+            node.is_supported_script_tag() || node.is_style_tag()
         } else {
             false
         };

--- a/crates/biome_html_formatter/src/html/auxiliary/embedded_content.rs
+++ b/crates/biome_html_formatter/src/html/auxiliary/embedded_content.rs
@@ -21,9 +21,7 @@ impl FormatNodeRule<HtmlEmbeddedContent> for FormatHtmlEmbeddedContent {
             .ancestors()
             .skip(1)
             .find_map(HtmlElement::cast)?;
-        if element.is_javascript_tag().unwrap_or_default()
-            || element.is_style_tag().unwrap_or_default()
-        {
+        if element.is_supported_script_tag() || element.is_style_tag() {
             Some(node.range())
         } else {
             None

--- a/crates/biome_html_parser/tests/spec_tests.rs
+++ b/crates/biome_html_parser/tests/spec_tests.rs
@@ -1,9 +1,104 @@
 mod spec_test;
 
+use biome_html_factory::syntax::HtmlElement;
+use biome_html_parser::{HtmlParseOptions, parse_html};
+use biome_html_syntax::ScriptType;
+use biome_rowan::AstNode;
+
 mod ok {
     tests_macros::gen_tests! {"tests/html_specs/ok/**/*.{html,astro,vue,svelte}", crate::spec_test::run, "ok"}
 }
 
 mod error {
     tests_macros::gen_tests! {"tests/html_specs/error/**/*.{html,astro,vue,svelte}", crate::spec_test::run, "error"}
+}
+
+#[test]
+fn test_is_javascript_tag() {
+    let html = r#"
+        <script type="text/javascript">
+        </script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(element.is_javascript_tag());
+
+    let html = r#"
+        <script type="application/javascript">
+        </script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(element.is_javascript_tag());
+    assert_eq!(element.get_script_type(), Some(ScriptType::Classic));
+
+    let html = r#"
+        <script type="application/ecmascript">
+        </script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(element.is_javascript_tag());
+    assert_eq!(element.get_script_type(), Some(ScriptType::Classic));
+
+    let html = r#"
+        <script type="module">
+        </script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(element.is_javascript_tag());
+    assert_eq!(element.get_script_type(), Some(ScriptType::Module));
+
+    let html = r#"
+        <script></script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(element.is_javascript_tag());
+    assert_eq!(element.get_script_type(), Some(ScriptType::Classic));
+
+    let html = r#"
+        <script type="importmap"></script>
+        "#;
+    let syntax = parse_html(html, HtmlParseOptions::default());
+    let element = syntax
+        .tree()
+        .syntax()
+        .descendants()
+        .find_map(HtmlElement::cast)
+        .unwrap();
+
+    assert!(!element.is_javascript_tag());
+    assert_eq!(element.get_script_type(), Some(ScriptType::ImportMap));
 }

--- a/crates/biome_html_parser/tests/spec_tests.rs
+++ b/crates/biome_html_parser/tests/spec_tests.rs
@@ -74,6 +74,21 @@ fn test_is_javascript_tag() {
     assert!(element.is_javascript_tag());
     assert_eq!(element.get_script_type(), Some(ScriptType::Module));
 
+    // FIXME: Uncomment when the parser supports unquoted attribute values.
+    //let html = r#"
+    //    <script type=module></script>
+    //    "#;
+    //let syntax = parse_html(html, HtmlParseOptions::default());
+    //let element = syntax
+    //    .tree()
+    //    .syntax()
+    //    .descendants()
+    //    .find_map(HtmlElement::cast)
+    //    .unwrap();
+    //
+    //assert!(element.is_javascript_tag());
+    //assert_eq!(element.get_script_type(), Some(ScriptType::Module));
+
     let html = r#"
         <script></script>
         "#;

--- a/crates/biome_html_syntax/Cargo.toml
+++ b/crates/biome_html_syntax/Cargo.toml
@@ -19,10 +19,6 @@ camino            = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true, features = ["derive"] }
 
-[dev-dependencies]
-biome_html_factory = { path = "../biome_html_factory" }
-biome_html_parser  = { path = "../biome_html_parser" }
-
 [features]
 schema = ["schemars", "biome_rowan/serde"]
 

--- a/crates/biome_html_syntax/src/attr_ext.rs
+++ b/crates/biome_html_syntax/src/attr_ext.rs
@@ -1,0 +1,17 @@
+use crate::{AnyHtmlAttributeInitializer, inner_string_text};
+use biome_rowan::Text;
+
+impl AnyHtmlAttributeInitializer {
+    /// Returns the string value of the attribute, if available, without quotes.
+    pub fn string_value(&self) -> Option<Text> {
+        match self {
+            Self::HtmlSingleTextExpression(_) => None,
+            Self::HtmlString(string) => Some(
+                string
+                    .value_token()
+                    .map(|token| inner_string_text(&token).into())
+                    .unwrap_or_default(),
+            ),
+        }
+    }
+}

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -1,7 +1,4 @@
-use crate::{
-    AnyHtmlElement, HtmlAttribute, HtmlElement, HtmlSelfClosingElement, ScriptType,
-    inner_string_text,
-};
+use crate::{AnyHtmlElement, HtmlAttribute, HtmlElement, HtmlSelfClosingElement, ScriptType};
 use biome_rowan::{AstNodeList, SyntaxResult};
 
 /// https://html.spec.whatwg.org/#void-elements
@@ -116,14 +113,9 @@ impl HtmlElement {
         let script_type = self
             .find_attribute_by_name("type")
             .and_then(|attribute| {
-                attribute
-                    .initializer()
-                    .and_then(|initializer| initializer.value().ok())
-                    .and_then(|value| {
-                        let value = value.as_html_string()?;
-                        let token = value.value_token().ok()?;
-                        Some(ScriptType::from_type_value(&inner_string_text(&token)))
-                    })
+                let initializer = attribute.initializer()?;
+                let value = initializer.value().ok()?.string_value()?;
+                Some(ScriptType::from_type_value(&value))
             })
             .unwrap_or_default();
         Some(script_type)

--- a/crates/biome_html_syntax/src/element_ext.rs
+++ b/crates/biome_html_syntax/src/element_ext.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AnyHtmlElement, HtmlAttribute, HtmlElement, HtmlSelfClosingElement, inner_string_text,
+    AnyHtmlElement, HtmlAttribute, HtmlElement, HtmlSelfClosingElement, ScriptType,
+    inner_string_text,
 };
 use biome_rowan::{AstNodeList, SyntaxResult};
 
@@ -22,22 +23,22 @@ impl HtmlSelfClosingElement {
 }
 
 impl AnyHtmlElement {
-    pub fn is_javascript_tag(&self) -> SyntaxResult<bool> {
+    pub fn is_javascript_tag(&self) -> bool {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
             | Self::HtmlSelfClosingElement(_)
-            | Self::HtmlCdataSection(_) => Ok(false),
+            | Self::HtmlCdataSection(_) => false,
             Self::HtmlElement(element) => element.is_javascript_tag(),
         }
     }
 
-    pub fn is_style_tag(&self) -> SyntaxResult<bool> {
+    pub fn is_style_tag(&self) -> bool {
         match self {
             Self::AnyHtmlContent(_)
             | Self::HtmlBogusElement(_)
             | Self::HtmlSelfClosingElement(_)
-            | Self::HtmlCdataSection(_) => Ok(false),
+            | Self::HtmlCdataSection(_) => false,
             Self::HtmlElement(element) => element.is_style_tag(),
         }
     }
@@ -91,123 +92,64 @@ impl HtmlElement {
             })
     }
 
-    pub fn is_javascript_tag(&self) -> SyntaxResult<bool> {
-        let is_script = self.is_script_tag()?;
-        let type_attribute = self.find_attribute_by_name("type");
-
-        let is_type_javascript = type_attribute.is_none_or(|attribute| {
-            attribute
-                .initializer()
-                .and_then(|initializer| initializer.value().ok())
-                .and_then(|value| value.as_html_string().cloned())
-                .and_then(|value| value.value_token().ok())
-                .is_some_and(|token| {
-                    let text = inner_string_text(&token);
-                    text.eq_ignore_ascii_case("text/javascript")
-                        || text.eq_ignore_ascii_case("application/javascript")
-                        || text.eq_ignore_ascii_case("application/ecmascript")
-                        || text.eq_ignore_ascii_case("module")
-                })
-        });
-
-        Ok(is_script && is_type_javascript)
+    pub fn is_javascript_tag(&self) -> bool {
+        self.get_script_type()
+            .is_some_and(ScriptType::is_javascript)
     }
 
-    pub fn is_javascript_module(&self) -> SyntaxResult<bool> {
-        let is_script = self.is_script_tag()?;
-        let type_attribute = self.find_attribute_by_name("type");
-        let is_type_module = type_attribute.is_some_and(|attribute| {
-            attribute
-                .initializer()
-                .and_then(|initializer| initializer.value().ok())
-                .and_then(|value| value.as_html_string().cloned())
-                .and_then(|value| value.value_token().ok())
-                .is_some_and(|token| {
-                    let text = inner_string_text(&token);
-                    text.eq_ignore_ascii_case("module")
-                })
-        });
-
-        Ok(is_script && is_type_module)
+    pub fn is_supported_script_tag(&self) -> bool {
+        self.get_script_type().is_some_and(ScriptType::is_supported)
     }
 
-    pub fn is_style_tag(&self) -> SyntaxResult<bool> {
-        let opening_element = self.opening_element()?;
-        let name = opening_element.name()?;
-        let name_text = name.value_token()?;
-        Ok(name_text.text_trimmed().eq_ignore_ascii_case("style"))
+    /// Returns the type of script for a `<script>` tag.
+    ///
+    /// Returns `Some` [`ScriptType`] if this is a `<script>` tag, even if it
+    /// has no `type` attribute, because the omission of the `type` attribute
+    /// implies [`ScriptType::Classic`].
+    ///
+    /// Returns `None` for non-`<script>` tags.
+    pub fn get_script_type(&self) -> Option<ScriptType> {
+        if !self.is_script_tag() {
+            return None;
+        }
+
+        let script_type = self
+            .find_attribute_by_name("type")
+            .and_then(|attribute| {
+                attribute
+                    .initializer()
+                    .and_then(|initializer| initializer.value().ok())
+                    .and_then(|value| {
+                        let value = value.as_html_string()?;
+                        let token = value.value_token().ok()?;
+                        Some(ScriptType::from_type_value(&inner_string_text(&token)))
+                    })
+            })
+            .unwrap_or_default();
+        Some(script_type)
     }
 
-    pub fn is_script_tag(&self) -> SyntaxResult<bool> {
-        let opening_element = self.opening_element()?;
-        let name = opening_element.name()?;
-        let name_text = name.value_token()?;
-        Ok(name_text.text_trimmed().eq_ignore_ascii_case("script"))
+    pub fn is_style_tag(&self) -> bool {
+        let Ok(name_token) = self
+            .opening_element()
+            .and_then(|el| el.name())
+            .and_then(|name| name.value_token())
+        else {
+            return false;
+        };
+
+        name_token.text_trimmed().eq_ignore_ascii_case("style")
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use biome_html_factory::syntax::HtmlElement;
-    use biome_html_parser::{HtmlParseOptions, parse_html};
-    use biome_rowan::AstNode;
+    pub fn is_script_tag(&self) -> bool {
+        let Ok(name_token) = self
+            .opening_element()
+            .and_then(|el| el.name())
+            .and_then(|name| name.value_token())
+        else {
+            return false;
+        };
 
-    #[test]
-    fn test_is_javascript_tag() {
-        let html = r#"
-        <script type="text/javascript">
-        </script>
-        "#;
-        let syntax = parse_html(html, HtmlParseOptions::default());
-        let element = syntax
-            .tree()
-            .syntax()
-            .descendants()
-            .find_map(HtmlElement::cast)
-            .unwrap();
-
-        assert!(element.is_javascript_tag().unwrap());
-
-        let html = r#"
-        <script type="application/javascript">
-        </script>
-        "#;
-        let syntax = parse_html(html, HtmlParseOptions::default());
-        let element = syntax
-            .tree()
-            .syntax()
-            .descendants()
-            .find_map(HtmlElement::cast)
-            .unwrap();
-
-        assert!(element.is_javascript_tag().unwrap());
-
-        let html = r#"
-        <script type="application/ecmascript">
-        </script>
-        "#;
-        let syntax = parse_html(html, HtmlParseOptions::default());
-        let element = syntax
-            .tree()
-            .syntax()
-            .descendants()
-            .find_map(HtmlElement::cast)
-            .unwrap();
-
-        assert!(element.is_javascript_tag().unwrap());
-
-        let html = r#"
-        <script type="module">
-        </script>
-        "#;
-        let syntax = parse_html(html, HtmlParseOptions::default());
-        let element = syntax
-            .tree()
-            .syntax()
-            .descendants()
-            .find_map(HtmlElement::cast)
-            .unwrap();
-
-        assert!(element.is_javascript_tag().unwrap());
+        name_token.text_trimmed().eq_ignore_ascii_case("script")
     }
 }

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -4,11 +4,13 @@
 mod generated;
 pub mod element_ext;
 mod file_source;
+mod script_type;
 mod syntax_node;
 
-pub use self::generated::*;
 pub use biome_rowan::{TextLen, TextRange, TextSize, TokenAtOffset, TriviaPieceKind, WalkEvent};
 pub use file_source::{HtmlFileSource, HtmlTextExpressions, HtmlVariant};
+pub use generated::*;
+pub use script_type::*;
 pub use syntax_node::*;
 
 use crate::HtmlSyntaxKind::{

--- a/crates/biome_html_syntax/src/lib.rs
+++ b/crates/biome_html_syntax/src/lib.rs
@@ -1,9 +1,10 @@
 #![deny(clippy::use_self)]
 
 #[macro_use]
-mod generated;
+mod attr_ext;
 pub mod element_ext;
 mod file_source;
+mod generated;
 mod script_type;
 mod syntax_node;
 

--- a/crates/biome_html_syntax/src/script_type.rs
+++ b/crates/biome_html_syntax/src/script_type.rs
@@ -1,0 +1,70 @@
+/// Determines the kind of script that is contained in a `<script>` tag.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ScriptType {
+    /// Used for any `<script>` tag that either has no `type` attribute, or that
+    /// has a `type` attribute with a supported JavaScript MIME type.
+    #[default]
+    Classic,
+
+    /// `<script type="module">`
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#applying_the_module_to_your_html
+    Module,
+
+    /// `<script type="importmap">`
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
+    ImportMap,
+
+    /// `<script type="application/json">`
+    JSON,
+
+    /// The `<script>` tag has a `type` attribute, but the value is not
+    /// supported by Biome.
+    Unsupported,
+}
+
+impl ScriptType {
+    /// Returns the script type based on the value of a `<script type="...">`
+    /// attribute.
+    pub fn from_type_value(type_value: &str) -> Self {
+        if type_value.eq_ignore_ascii_case("module") {
+            Self::Module
+        } else if type_value.eq_ignore_ascii_case("text/javascript")
+            || type_value.eq_ignore_ascii_case("application/javascript")
+            || type_value.eq_ignore_ascii_case("application/ecmascript")
+        {
+            Self::Classic
+        } else if type_value.eq_ignore_ascii_case("importmap") {
+            Self::ImportMap
+        } else if type_value.eq_ignore_ascii_case("application/json") {
+            Self::JSON
+        } else {
+            Self::Unsupported
+        }
+    }
+
+    /// Returns whether the script type indicates JavaScript content.
+    ///
+    /// Returns `true` for both classic scripts as well as ECMAScript modules.
+    pub fn is_javascript(self) -> bool {
+        matches!(self, Self::Classic | Self::Module)
+    }
+
+    /// Returns whether the script type indicates a JavaScript module.
+    pub fn is_javascript_module(self) -> bool {
+        matches!(self, Self::Module)
+    }
+
+    /// Returns whether the script type indicates JSON content.
+    ///
+    /// Returns `true` for JSON content, including import maps.
+    pub fn is_json(self) -> bool {
+        matches!(self, Self::JSON | Self::ImportMap)
+    }
+
+    /// Returns `true` for any script type that can be handled by Biome.
+    pub fn is_supported(self) -> bool {
+        !matches!(self, Self::Unsupported)
+    }
+}

--- a/crates/biome_json_formatter/src/lib.rs
+++ b/crates/biome_json_formatter/src/lib.rs
@@ -24,7 +24,9 @@ use biome_formatter::{
     TransformSourceMap, write,
 };
 use biome_formatter::{Formatted, Printed};
-use biome_json_syntax::{AnyJsonValue, JsonLanguage, JsonSyntaxNode, JsonSyntaxToken};
+use biome_json_syntax::{
+    AnyJsonValue, JsonLanguage, JsonSyntaxNode, JsonSyntaxNodeWithOffset, JsonSyntaxToken,
+};
 use biome_rowan::{AstNode, SyntaxNode, TextRange};
 
 /// Used to get an object that knows how to format this object.
@@ -347,6 +349,16 @@ pub fn format_node(
     root: &JsonSyntaxNode,
 ) -> FormatResult<Formatted<JsonFormatContext>> {
     biome_formatter::format_node(root, JsonFormatLanguage::new(options), false)
+}
+
+/// Formats a JSON syntax tree.
+///
+/// It returns the [Formatted] document that can be printed to a string.
+pub fn format_node_with_offset(
+    options: JsonFormatOptions,
+    root: &JsonSyntaxNodeWithOffset,
+) -> FormatResult<Formatted<JsonFormatContext>> {
+    biome_formatter::format_node_with_offset(root, JsonFormatLanguage::new(options), false)
 }
 
 /// Formats a single node within a file, supported by Biome.

--- a/crates/biome_json_parser/src/lib.rs
+++ b/crates/biome_json_parser/src/lib.rs
@@ -8,7 +8,7 @@ use biome_json_factory::JsonSyntaxFactory;
 use biome_json_syntax::{JsonLanguage, JsonRoot, JsonSyntaxNode};
 use biome_parser::AnyParse;
 pub use biome_parser::prelude::*;
-use biome_rowan::{AstNode, NodeCache};
+use biome_rowan::{AstNode, NodeCache, SyntaxNodeWithOffset, TextSize};
 pub use parser::JsonParserOptions;
 
 mod lexer;
@@ -19,6 +19,9 @@ mod token_source;
 
 pub(crate) type JsonLosslessTreeSink<'source> =
     LosslessTreeSink<'source, JsonLanguage, JsonSyntaxFactory>;
+
+pub(crate) type JsonOffsetLosslessTreeSink<'source> =
+    OffsetLosslessTreeSink<'source, JsonLanguage, JsonSyntaxFactory>;
 
 pub fn parse_json(source: &str, options: JsonParserOptions) -> JsonParse {
     let mut cache = NodeCache::default();
@@ -42,6 +45,94 @@ pub fn parse_json_with_cache(
     let (green, diagnostics) = tree_sink.finish();
 
     JsonParse::new(green, diagnostics)
+}
+
+/// A utility struct for managing the result of an offset-aware JSON parser job.
+#[derive(Clone, Debug)]
+pub struct JsonOffsetParse {
+    root: SyntaxNodeWithOffset<JsonLanguage>,
+    diagnostics: Vec<ParseDiagnostic>,
+}
+
+impl JsonOffsetParse {
+    pub fn new(
+        root: SyntaxNodeWithOffset<JsonLanguage>,
+        diagnostics: Vec<ParseDiagnostic>,
+    ) -> Self {
+        Self { root, diagnostics }
+    }
+
+    /// The offset-aware syntax node represented by this parse result.
+    pub fn syntax(&self) -> &SyntaxNodeWithOffset<JsonLanguage> {
+        &self.root
+    }
+
+    /// Gets the diagnostics which occurred when parsing.
+    pub fn diagnostics(&self) -> &[ParseDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Retrieves the diagnostics which occurred when parsing.
+    pub fn into_diagnostics(self) -> Vec<ParseDiagnostic> {
+        self.diagnostics
+    }
+
+    /// Returns `true` if the parser encountered some errors during the parsing.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.is_error())
+    }
+
+    /// Convert this parse into a typed AST node.
+    ///
+    /// # Panics
+    /// Panics if the node represented by this parse result mismatches.
+    pub fn tree(&self) -> JsonRoot {
+        JsonRoot::unwrap_cast(self.root.inner().clone())
+    }
+
+    /// Get the base offset applied to this parse result.
+    pub fn base_offset(&self) -> TextSize {
+        self.root.base_offset()
+    }
+
+    /// Convert back to the underlying parse result, discarding offset information.
+    pub fn into_inner(self) -> JsonParse {
+        JsonParse::new(self.root.into_inner(), self.diagnostics)
+    }
+}
+
+/// Parses JSON `source` with a `base_offset` for embedded content.
+pub fn parse_json_with_offset(
+    source: &str,
+    base_offset: TextSize,
+    config: JsonParserOptions,
+) -> JsonOffsetParse {
+    parse_json_with_offset_and_cache(source, base_offset, &mut NodeCache::default(), config)
+}
+
+/// Parses JSON `source` with a `base_offset` and `cache` for embedded content.
+///
+/// This is the cache-enabled version of [`parse_json_with_offset`] for improved
+/// performance when parsing multiple embedded JSON blocks.
+pub fn parse_json_with_offset_and_cache(
+    source: &str,
+    base_offset: TextSize,
+    cache: &mut NodeCache,
+    config: JsonParserOptions,
+) -> JsonOffsetParse {
+    let mut parser = JsonParser::new(source, config);
+
+    parse_root(&mut parser);
+
+    let (events, diagnostics, trivia) = parser.finish();
+
+    let mut tree_sink = JsonOffsetLosslessTreeSink::with_cache(source, &trivia, cache, base_offset);
+    biome_parser::event::process(&mut tree_sink, events, diagnostics);
+    let (green, diagnostics) = tree_sink.finish();
+
+    JsonOffsetParse::new(green, diagnostics)
 }
 
 /// A utility struct for managing the result of a parser job

--- a/crates/biome_json_syntax/src/syntax_node.rs
+++ b/crates/biome_json_syntax/src/syntax_node.rs
@@ -22,3 +22,4 @@ pub type JsonSyntaxElement = biome_rowan::SyntaxElement<JsonLanguage>;
 pub type JsonSyntaxNodeChildren = biome_rowan::SyntaxNodeChildren<JsonLanguage>;
 pub type JsonSyntaxElementChildren = biome_rowan::SyntaxElementChildren<JsonLanguage>;
 pub type JsonSyntaxList = biome_rowan::SyntaxList<JsonLanguage>;
+pub type JsonSyntaxNodeWithOffset = biome_rowan::SyntaxNodeWithOffset<JsonLanguage>;

--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -470,88 +470,48 @@ fn format_embedded(
         let mut iter = embedded_nodes.iter();
         let node = iter.find(|node| node.range == range)?;
 
+        let wrap_document = |document: Document| {
+            if indent_script_and_style {
+                let elements = vec![
+                    FormatElement::Line(LineMode::Hard),
+                    FormatElement::Tag(Tag::StartIndent),
+                    FormatElement::Line(LineMode::Hard),
+                    FormatElement::Interned(Interned::new(document.into_elements())),
+                    FormatElement::Tag(Tag::EndIndent),
+                ];
+
+                Document::new(elements)
+            } else {
+                let elements = vec![
+                    FormatElement::Line(LineMode::Hard),
+                    FormatElement::Interned(Interned::new(document.into_elements())),
+                ];
+                Document::new(elements)
+            }
+        };
+
         match node.source {
             DocumentFileSource::Js(_) => {
                 let js_options = settings.format_options::<JsLanguage>(biome_path, &node.source);
-                let node = node.node.clone().root.into_node::<JsLanguage>();
+                let node = node.node.root.clone().into_node::<JsLanguage>();
                 let formatted =
                     biome_js_formatter::format_node_with_offset(js_options, &node).ok()?;
-                if indent_script_and_style {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Tag(Tag::StartIndent),
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                        FormatElement::Tag(Tag::EndIndent),
-                    ];
-
-                    Some(Document::new(elements))
-                } else {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                    ];
-                    Some(Document::new(elements))
-                }
+                Some(wrap_document(formatted.into_document()))
             }
             DocumentFileSource::Json(_) => {
                 let json_options =
                     settings.format_options::<JsonLanguage>(biome_path, &node.source);
-                let node = node.node.clone().root.into_node::<JsonLanguage>();
+                let node = node.node.root.clone().into_node::<JsonLanguage>();
                 let formatted =
                     biome_json_formatter::format_node_with_offset(json_options, &node).ok()?;
-                if indent_script_and_style {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Tag(Tag::StartIndent),
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                        FormatElement::Tag(Tag::EndIndent),
-                    ];
-
-                    Some(Document::new(elements))
-                } else {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                    ];
-                    Some(Document::new(elements))
-                }
+                Some(wrap_document(formatted.into_document()))
             }
             DocumentFileSource::Css(_) => {
                 let css_options = settings.format_options::<CssLanguage>(biome_path, &node.source);
-                let node = node.node.clone().root.into_node::<CssLanguage>();
+                let node = node.node.root.clone().into_node::<CssLanguage>();
                 let formatted =
                     biome_css_formatter::format_node_with_offset(css_options, &node).ok()?;
-                if indent_script_and_style {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Tag(Tag::StartIndent),
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                        FormatElement::Tag(Tag::EndIndent),
-                    ];
-                    let document = Document::new(elements);
-                    Some(document)
-                } else {
-                    let elements = vec![
-                        FormatElement::Line(LineMode::Hard),
-                        FormatElement::Interned(Interned::new(
-                            formatted.into_document().into_elements(),
-                        )),
-                    ];
-                    Some(Document::new(elements))
-                }
+                Some(wrap_document(formatted.into_document()))
             }
             _ => None,
         }

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -55,7 +55,7 @@ mod client;
 mod document;
 mod server;
 
-pub use document::{EmbeddedCssContent, EmbeddedJsContent, SendEmbeddedParse};
+pub use document::{EmbeddedContent, SendEmbeddedParse};
 use std::{
     borrow::Cow,
     fmt::{Debug, Display, Formatter},

--- a/crates/biome_service/src/workspace/document.rs
+++ b/crates/biome_service/src/workspace/document.rs
@@ -1,12 +1,19 @@
+use std::marker::PhantomData;
+
 use biome_css_parser::CssOffsetParse;
 use biome_css_syntax::CssLanguage;
 use biome_js_parser::JsOffsetParse;
 use biome_js_syntax::JsLanguage;
+use biome_json_parser::JsonOffsetParse;
+use biome_json_syntax::JsonLanguage;
 use biome_parser::AnyParse;
 use biome_parser::diagnostic::ParseDiagnostic;
 use biome_rowan::{EmbeddedSendNode, SyntaxNodeWithOffset, TextRange, TextSize};
 
-use crate::diagnostics::FileTooLarge;
+use crate::{
+    diagnostics::FileTooLarge, file_handlers::FormatEmbedNode, settings::ServiceLanguage,
+    workspace::DocumentFileSource,
+};
 
 #[derive(Clone, Debug)]
 pub struct SendEmbeddedParse {
@@ -24,6 +31,15 @@ impl From<JsOffsetParse> for SendEmbeddedParse {
     }
 }
 
+impl From<JsonOffsetParse> for SendEmbeddedParse {
+    fn from(value: JsonOffsetParse) -> Self {
+        Self {
+            root: value.syntax().clone().as_embedded_send(),
+            diagnostics: value.into_diagnostics(),
+        }
+    }
+}
+
 impl From<CssOffsetParse> for SendEmbeddedParse {
     fn from(value: CssOffsetParse) -> Self {
         Self {
@@ -33,12 +49,59 @@ impl From<CssOffsetParse> for SendEmbeddedParse {
     }
 }
 
-/// Represents embedded JavaScript content extracted from HTML documents.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct EmbeddedLanguageSnippets {
+    /// Embedded JavaScript content found in HTML documents (script tags).
+    ///
+    /// Each entry contains the parsed JavaScript with offset-aware positioning
+    /// relative to the parent HTML document.
+    pub scripts: Vec<EmbeddedContent<JsLanguage>>,
+
+    /// Embedded JSON blocks found in HTML documents inside script tags.
+    ///
+    /// Each entry contains the parsed JSON with offset-aware positioning
+    /// relative to the parent HTML document.
+    pub json: Vec<EmbeddedContent<JsonLanguage>>,
+
+    /// Embedded CSS content found in HTML documents (style tags).
+    ///
+    /// Each entry contains the parsed CSS with offset-aware positioning
+    /// relative to the parent HTML document
+    pub styles: Vec<EmbeddedContent<CssLanguage>>,
+}
+
+impl EmbeddedLanguageSnippets {
+    pub fn get_format_nodes(
+        &self,
+        get_file_source: impl Fn(usize) -> DocumentFileSource,
+    ) -> Vec<FormatEmbedNode> {
+        self.scripts
+            .iter()
+            .map(|node| FormatEmbedNode {
+                range: node.content_range,
+                source: get_file_source(node.file_source_index),
+                node: node.parse.clone(),
+            })
+            .chain(self.json.iter().map(|node| FormatEmbedNode {
+                range: node.content_range,
+                source: get_file_source(node.file_source_index),
+                node: node.parse.clone(),
+            }))
+            .chain(self.styles.iter().map(|node| FormatEmbedNode {
+                range: node.content_range,
+                source: get_file_source(node.file_source_index),
+                node: node.parse.clone(),
+            }))
+            .collect()
+    }
+}
+
+/// Represents embedded content extracted from HTML documents.
 ///
-/// This struct stores parsing metadata and provides access to the parsed content
-/// with offset-aware positioning to maintain correct source locations.
+/// This struct stores parsing metadata and provides access to the parsed
+/// content with offset-aware positioning to maintain correct source locations.
 #[derive(Clone, Debug)]
-pub struct EmbeddedJsContent {
+pub struct EmbeddedContent<L: ServiceLanguage + 'static> {
     /// The JavaScript source code extracted from the script element.
     pub parse: SendEmbeddedParse,
 
@@ -54,47 +117,35 @@ pub struct EmbeddedJsContent {
     /// This is used for offset-aware parsing.
     pub content_offset: TextSize,
 
-    /// The file source of the document
+    /// The file source of the document.
     pub file_source_index: usize,
+
+    _phantom: PhantomData<L>,
 }
 
-impl EmbeddedJsContent {
-    /// Returns a syntax node
-    pub fn node(&self) -> SyntaxNodeWithOffset<JsLanguage> {
-        self.parse.root.clone().into_node::<JsLanguage>()
+impl<L: ServiceLanguage + 'static> EmbeddedContent<L> {
+    /// Constructs new embedded content for a specific language.
+    pub fn new(
+        parse: SendEmbeddedParse,
+        element_range: TextRange,
+        content_range: TextRange,
+        content_offset: TextSize,
+        file_source_index: usize,
+    ) -> Self {
+        Self {
+            parse,
+            element_range,
+            content_range,
+            content_offset,
+            file_source_index,
+            _phantom: PhantomData,
+        }
     }
-}
 
-impl EmbeddedCssContent {
-    /// Returns a syntax node
-    pub fn node(&self) -> SyntaxNodeWithOffset<CssLanguage> {
-        self.parse.root.clone().into_node::<CssLanguage>()
+    /// Returns a syntax node.
+    pub fn node(&self) -> SyntaxNodeWithOffset<L> {
+        self.parse.root.clone().into_node::<L>()
     }
-}
-
-/// Represents embedded CSS content extracted from HTML documents.
-///
-/// This struct stores parsing metadata and provides access to the parsed content
-/// with offset-aware positioning to maintain correct source locations.
-#[derive(Clone, Debug)]
-pub struct EmbeddedCssContent {
-    /// The CSS source code extracted from the style element.
-    pub parse: SendEmbeddedParse,
-
-    /// The range of the entire style element in the HTML document,
-    /// including the opening and closing tags.
-    pub element_range: TextRange,
-
-    /// The range of just the CSS content within the style element,
-    /// excluding the style tags themselves.
-    pub content_range: TextRange,
-
-    /// The offset where the CSS content starts in the parent document.
-    /// This is used for offset-aware parsing.
-    pub content_offset: TextSize,
-
-    /// The file source of the embedded document
-    pub file_source_index: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -123,13 +174,6 @@ pub(crate) struct Document {
     /// - `AnyParse`: the result of the parsed file
     pub(crate) syntax: Option<Result<AnyParse, FileTooLarge>>,
 
-    /// Embedded JavaScript content found in HTML documents (script tags).
-    /// Each entry contains the parsed JavaScript with offset-aware positioning
-    /// relative to the parent HTML document.
-    pub(crate) embedded_scripts: Vec<EmbeddedJsContent>,
-
-    /// Embedded CSS content found in HTML documents (style tags).
-    /// Each entry contains the parsed CSS with offset-aware positioning
-    /// relative to the parent HTML document
-    pub(crate) embedded_styles: Vec<EmbeddedCssContent>,
+    /// Embedded content for foreign language snippets.
+    pub(crate) embedded_snippets: EmbeddedLanguageSnippets,
 }

--- a/crates/biome_service/src/workspace/server.tests.rs
+++ b/crates/biome_service/src/workspace/server.tests.rs
@@ -99,11 +99,11 @@ fn store_embedded_nodes_with_current_ranges() {
     assert!(document.is_some());
 
     let document = document.unwrap();
-    assert_eq!(document.embedded_scripts.len(), 1);
-    assert_eq!(document.embedded_styles.len(), 1);
+    assert_eq!(document.embedded_snippets.scripts.len(), 1);
+    assert_eq!(document.embedded_snippets.styles.len(), 1);
 
-    let script = document.embedded_scripts.first().unwrap();
-    let style = document.embedded_styles.first().unwrap();
+    let script = document.embedded_snippets.scripts.first().unwrap();
+    let style = document.embedded_snippets.styles.first().unwrap();
 
     let script_node = script.node();
     assert!(script_node.text_range_with_trivia().start() > TextSize::from(0));
@@ -119,6 +119,9 @@ fn format_html_with_scripts_and_css() {
         <style>
             #id { background-color: red; }
         </style>
+        <script type="importmap">         
+            { "imports":{"circle": "https://example.com/shapes/circle.js","square":"./modules/shapes/square.js"} }
+        </script>
         <script>
             const foo = "bar";
             function bar() { const object = { ["literal"]: "SOME OTHER STRING" }; return 1; }
@@ -130,16 +133,6 @@ fn format_html_with_scripts_and_css() {
     fs.insert(Utf8PathBuf::from("/project/file.html"), FILE_CONTENT);
 
     let (workspace, project_key) = setup_workspace_and_open_project(fs, "/");
-
-    workspace
-        .scan_project(ScanProjectParams {
-            project_key,
-            watch: false,
-            force: false,
-            scan_kind: ScanKind::Project,
-            verbose: false,
-        })
-        .unwrap();
 
     workspace
         .open_file(OpenFileParams {
@@ -166,6 +159,14 @@ fn format_html_with_scripts_and_css() {
     			background-color: red;
     		}
     		</style>
+    		<script type="importmap">
+    		{
+    			"imports": {
+    				"circle": "https://example.com/shapes/circle.js",
+    				"square": "./modules/shapes/square.js"
+    			}
+    		}
+    		</script>
     		<script>
     		const foo = "bar";
     		function bar() {


### PR DESCRIPTION
## Summary

This adds the ability to format `<script type="importmap">` and `<script type="application/json>` tags in HTML files.

Contains minor refactoring to make it a little easier to add additional languages. Embedded nodes are now also collected in a single pass over the source tree, instead of one per embedded language.

## Test Plan

Added a test. The rest should stay green.

## Docs

@ematipico Does this require a changeset? I'm not sure to which extend the HTML formatting is stable yet...