### PR TITLE
fix: set correct string for diagnostic

### DIFF
--- a/.changeset/gold-moments-move.md
+++ b/.changeset/gold-moments-move.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [7574](https://github.com/biomejs/biome/pull/7574). The diagnostic message for the rule `useSolidForComponent` now correctly emphasizes `<For />` and provides a working hyperlink to the Solid documentation.

--- a/crates/biome_js_analyze/src/lint/performance/use_solid_for_component.rs
+++ b/crates/biome_js_analyze/src/lint/performance/use_solid_for_component.rs
@@ -107,7 +107,7 @@ impl Rule for UseSolidForComponent {
             "Array.prototype.map will cause DOM elements to be recreated, it is not recommended to use it in Solid here."
             },
         ).note(markup! {
-            "Use Solid's <Emphasis>"<For />"</Emphasis> component for efficiently rendering lists. See \
+            "Use Solid's "<Emphasis>"<For />"</Emphasis>" component for efficiently rendering lists. See \
             "<Hyperlink href="https://docs.solidjs.com/reference/components/for">"Solid docs"</Hyperlink>" for more details."
         }))
     }

--- a/crates/biome_js_analyze/tests/specs/performance/useSolidForComponent/invalid.tsx.snap
+++ b/crates/biome_js_analyze/tests/specs/performance/useSolidForComponent/invalid.tsx.snap
@@ -34,7 +34,7 @@ invalid.tsx:1:33 lint/performance/useSolidForComponent ━━━━━━━━�
     2 │ 
     3 │ let Component = (props) => <>{props.data.map(d => <li>{d.text}</li>)}</>;
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -51,7 +51,7 @@ invalid.tsx:3:31 lint/performance/useSolidForComponent ━━━━━━━━�
     4 │ 
     5 │ let Component = (props) => <ol>{props.data.map(d => <li key={d.id}>{d.text}</li>)}</ol>;
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -68,7 +68,7 @@ invalid.tsx:5:33 lint/performance/useSolidForComponent ━━━━━━━━�
     6 │ 
     7 │ function Component(props) {
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -84,7 +84,7 @@ invalid.tsx:8:15 lint/performance/useSolidForComponent ━━━━━━━━�
      9 │ }
     10 │ 
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -100,7 +100,7 @@ invalid.tsx:12:15 lint/performance/useSolidForComponent ━━━━━━━━
     13 │ }
     14 │ 
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -117,7 +117,7 @@ invalid.tsx:15:33 lint/performance/useSolidForComponent ━━━━━━━━
     16 │ 
     17 │ let Component = (props) => <ol>{props.data.map((...args) => <li>{args[0].text}</li>)}</ol>;
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```
@@ -132,7 +132,7 @@ invalid.tsx:17:33 lint/performance/useSolidForComponent ━━━━━━━━
   > 17 │ let Component = (props) => <ol>{props.data.map((...args) => <li>{args[0].text}</li>)}</ol>;
        │                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  i Use Solid's <Emphasis></Emphasis> component for efficiently rendering lists. See Solid docs for more details.
+  i Use Solid's <For /> component for efficiently rendering lists. See Solid docs for more details.
   
 
 ```


### PR DESCRIPTION
Fixes #7570

This PR corrects the diagnostic message for the `useSolidForComponent`  rule. The previous message was incorrect and did not properly highlight `<For />`  or include a working hyperlink to the documentation.


