### PR TITLE
fix(noDuplicateProperties): false positives in `@container` and `@starting-style` at-rules

### DIFF
--- a/.changeset/thin-cases-dig.md
+++ b/.changeset/thin-cases-dig.md
@@ -4,7 +4,7 @@
 
 Fixed [#7470](https://github.com/biomejs/biome/issues/7470): solved a false positive for [`noDuplicateProperties`](https://biomejs.dev/linter/rules/no-duplicate-properties/). Previously, declarations in `@container` and `@starting-style` at-rules were incorrectly flagged as duplicates of identical declarations at the root selector.
 
-For example, the linter no longer flags the `display` declaration in `@container` or the `opacity` declaration in `@starting-style`:
+For example, the linter no longer flags the `display` declaration in `@container` or the `opacity` declaration in `@starting-style`.
 
 ```css
 a {

--- a/.changeset/thin-cases-dig.md
+++ b/.changeset/thin-cases-dig.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7470](https://github.com/biomejs/biome/issues/7470): Fixed false positives for [`noDuplicateProperties`](https://biomejs.dev/linter/rules/no-duplicate-properties/) in `@container` and `@starting-style` at-rules.

--- a/.changeset/thin-cases-dig.md
+++ b/.changeset/thin-cases-dig.md
@@ -2,4 +2,22 @@
 "@biomejs/biome": patch
 ---
 
-Fixed [#7470](https://github.com/biomejs/biome/issues/7470): Fixed false positives for [`noDuplicateProperties`](https://biomejs.dev/linter/rules/no-duplicate-properties/) in `@container` and `@starting-style` at-rules.
+Fixed [#7470](https://github.com/biomejs/biome/issues/7470): solved a false positive for [`noDuplicateProperties`](https://biomejs.dev/linter/rules/no-duplicate-properties/). Previously, declarations in `@container` and `@starting-style` at-rules were incorrectly flagged as duplicates of identical declarations at the root selector.
+
+For example, the linter no longer flags the `display` declaration in `@container` or the `opacity` declaration in `@starting-style`:
+
+```css
+a {
+    display: block;
+    @container (min-width: 600px) {
+        display: none;
+    }
+}
+
+[popover]:popover-open {
+    opacity: 1;
+    @starting-style {
+        opacity: 0;
+    }
+}
+```

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/invalid.css
@@ -59,3 +59,19 @@ a {
         }
     }
 }
+
+a {
+    opacity: 1;
+    @starting-style {
+        opacity: 0;
+        opacity: 1;
+    }
+}
+
+a {
+    display: block;
+    @container (min-width: 600px) {
+        display: none;
+        display: block;
+    }
+}

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/invalid.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: invalid.css
+snapshot_kind: text
 ---
 # Input
 ```css
@@ -63,6 +64,22 @@ a {
             color: orange;
             color: black;
         }
+    }
+}
+
+a {
+    opacity: 1;
+    @starting-style {
+        opacity: 0;
+        opacity: 1;
+    }
+}
+
+a {
+    display: block;
+    @container (min-width: 600px) {
+        display: none;
+        display: block;
     }
 }
 
@@ -449,6 +466,58 @@ invalid.css:58:13 lint/suspicious/noDuplicateProperties ━━━━━━━━
        │             ^^^^^
     58 │             color: black;
     59 │         }
+  
+  i Remove or rename the duplicate property to ensure consistent styling.
+  
+
+```
+
+```
+invalid.css:67:9 lint/suspicious/noDuplicateProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate properties can lead to unexpected behavior and may override previous declarations unintentionally.
+  
+    65 │     @starting-style {
+    66 │         opacity: 0;
+  > 67 │         opacity: 1;
+       │         ^^^^^^^
+    68 │     }
+    69 │ }
+  
+  i opacity is already defined here.
+  
+    64 │     opacity: 1;
+    65 │     @starting-style {
+  > 66 │         opacity: 0;
+       │         ^^^^^^^
+    67 │         opacity: 1;
+    68 │     }
+  
+  i Remove or rename the duplicate property to ensure consistent styling.
+  
+
+```
+
+```
+invalid.css:75:9 lint/suspicious/noDuplicateProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Duplicate properties can lead to unexpected behavior and may override previous declarations unintentionally.
+  
+    73 │     @container (min-width: 600px) {
+    74 │         display: none;
+  > 75 │         display: block;
+       │         ^^^^^^^
+    76 │     }
+    77 │ }
+  
+  i display is already defined here.
+  
+    72 │     display: block;
+    73 │     @container (min-width: 600px) {
+  > 74 │         display: none;
+       │         ^^^^^^^
+    75 │         display: block;
+    76 │     }
   
   i Remove or rename the duplicate property to ensure consistent styling.
   

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/valid.css
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/valid.css
@@ -31,6 +31,20 @@ a {
     }
 }
 
+a {
+    opacity: 1;
+    @starting-style {
+        opacity: 0;
+    }
+}
+
+a {
+    display: block;
+    @container (min-width: 600px) {
+        display: none;
+    }
+}
+
 /* TODO */
 /* @fontface {
     src: url(font.eof);

--- a/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/suspicious/noDuplicateProperties/valid.css.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/biome_css_analyze/tests/spec_tests.rs
 expression: valid.css
+snapshot_kind: text
 ---
 # Input
 ```css
@@ -34,6 +35,20 @@ a {
         &:hover {
             color: orange;
         }
+    }
+}
+
+a {
+    opacity: 1;
+    @starting-style {
+        opacity: 0;
+    }
+}
+
+a {
+    display: block;
+    @container (min-width: 600px) {
+        display: none;
     }
 }
 

--- a/crates/biome_css_semantic/src/events.rs
+++ b/crates/biome_css_semantic/src/events.rs
@@ -63,7 +63,9 @@ impl SemanticEventExtractor {
             // allowing for proper scoping and inheritance of styles.
             kind if kind == CSS_QUALIFIED_RULE
                 || kind == CSS_NESTED_QUALIFIED_RULE
+                || kind == CSS_CONTAINER_AT_RULE
                 || kind == CSS_MEDIA_AT_RULE
+                || kind == CSS_STARTING_STYLE_AT_RULE
                 || kind == CSS_SUPPORTS_AT_RULE =>
             {
                 if let Some(start) = AnyRuleStart::cast(node.clone()) {

--- a/crates/biome_css_semantic/src/semantic_model/model.rs
+++ b/crates/biome_css_semantic/src/semantic_model/model.rs
@@ -1,7 +1,8 @@
 use biome_css_syntax::{
-    CssComplexSelector, CssComposesPropertyValue, CssCompoundSelector, CssDashedIdentifier,
-    CssDeclaration, CssGenericComponentValueList, CssIdentifier, CssMediaAtRule,
-    CssNestedQualifiedRule, CssQualifiedRule, CssRoot, CssSupportsAtRule,
+    CssComplexSelector, CssComposesPropertyValue, CssCompoundSelector, CssContainerAtRule,
+    CssDashedIdentifier, CssDeclaration, CssGenericComponentValueList, CssIdentifier,
+    CssMediaAtRule, CssNestedQualifiedRule, CssQualifiedRule, CssRoot, CssStartingStyleAtRule,
+    CssSupportsAtRule,
 };
 use biome_rowan::{
     AstNode, AstNodeList, SyntaxNodeText, SyntaxResult, TextRange, TextSize, TokenText,
@@ -167,7 +168,7 @@ impl Rule {
 }
 
 declare_node_union! {
-    pub AnyRuleStart = CssQualifiedRule | CssNestedQualifiedRule | CssMediaAtRule | CssSupportsAtRule
+    pub AnyRuleStart = CssQualifiedRule | CssNestedQualifiedRule | CssContainerAtRule | CssMediaAtRule | CssStartingStyleAtRule | CssSupportsAtRule
 }
 
 impl AnyRuleStart {
@@ -175,7 +176,9 @@ impl AnyRuleStart {
         match self {
             Self::CssQualifiedRule(node) => node.syntax().text_trimmed_range(),
             Self::CssNestedQualifiedRule(node) => node.syntax().text_trimmed_range(),
+            Self::CssContainerAtRule(node) => node.syntax().text_trimmed_range(),
             Self::CssMediaAtRule(node) => node.syntax().text_trimmed_range(),
+            Self::CssStartingStyleAtRule(node) => node.syntax().text_trimmed_range(),
             Self::CssSupportsAtRule(node) => node.syntax().text_trimmed_range(),
         }
     }


### PR DESCRIPTION


## Summary

Fixed https://github.com/biomejs/biome/issues/7470 and a false positive in `@starting-style` ([playground link](https://biomejs.dev/playground/?lineWidth=120&attributePosition=multiline&lintRules=noDuplicateProperties&analyzerFixMode=safeAndUnsafeFixes&code=WwBwAG8AcABvAHYAZQByAF0AOgBwAG8AcABvAHYAZQByAC0AbwBwAGUAbgAgAHsACgAgACAAbwBwAGEAYwBpAHQAeQA6ACAAMQA7AAoACgAgACAAQABzAHQAYQByAHQAaQBuAGcALQBzAHQAeQBsAGUAIAB7AAoAIAAgACAAIABvAHAAYQBjAGkAdAB5ADoAIAAwADsACgAgACAAfQAKAH0A&language=css)).

## Test Plan

- Added more tests for `@container` and `@starting-style`.
- Existing tests pass.
