### PR TITLE
add edition 2024 to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2024"
 newline_style = "Unix"
 style_edition = "2024"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -59,7 +59,7 @@ pub fn reformat_without_preamble(text: impl Display) -> Result<String> {
     let _e = pushenv("RUSTUP_TOOLCHAIN", "stable");
     ensure_rustfmt()?;
     let output = run!(
-        "rustfmt --config newline_style=Unix --config style_edition=2024";
+        "rustfmt";
         <text.to_string().as_bytes()
     )?;
 


### PR DESCRIPTION
fixes #7590 

`rustfmt` now executes during codegen and provides errors that are not edition errors

inline configuration is not necessary in `xtask/src/lib.rs`, because it will use the configuration file at the repo root.