### PR TITLE
perf: only query settings once

### DIFF
--- a/.changeset/max-managers-mandate.md
+++ b/.changeset/max-managers-mandate.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed an issue with the `files.maxSize` setting. Previously the setting would always be looked up in the root settings, even in monorepos where a closer `biome.json` is available. It now correctly uses the nearest configuration.

--- a/crates/biome_service/src/projects.rs
+++ b/crates/biome_service/src/projects.rs
@@ -327,31 +327,6 @@ impl Projects {
 
         belongs_to_project && !belongs_to_other
     }
-
-    /// Returns the maximum file size setting for the given project.
-    pub fn get_max_file_size(&self, project_key: ProjectKey, file_path: &Utf8Path) -> usize {
-        let limit = self
-            .0
-            .pin()
-            .get(&project_key)
-            .and_then(|data| {
-                data.root_settings
-                    .override_settings
-                    .patterns
-                    .iter()
-                    .find_map(|pattern| {
-                        if pattern.is_file_included(file_path) {
-                            pattern.files.max_size
-                        } else {
-                            None
-                        }
-                    })
-                    .or(data.root_settings.files.max_size)
-            })
-            .unwrap_or_default();
-
-        usize::from(limit)
-    }
 }
 
 #[inline]

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1162,6 +1162,25 @@ impl Settings {
             .unwrap_or_default()
             .into()
     }
+
+    /// Returns the maximum file size setting for the given `file_path`.
+    pub fn get_max_file_size(&self, file_path: &Utf8Path) -> usize {
+        let limit = self
+            .override_settings
+            .patterns
+            .iter()
+            .find_map(|pattern| {
+                if pattern.is_file_included(file_path) {
+                    pattern.files.max_size
+                } else {
+                    None
+                }
+            })
+            .or(self.files.max_size)
+            .unwrap_or_default();
+
+        usize::from(limit)
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/biome_service/src/settings.rs
+++ b/crates/biome_service/src/settings.rs
@@ -1169,6 +1169,7 @@ impl Settings {
             .override_settings
             .patterns
             .iter()
+            .rev()
             .find_map(|pattern| {
                 if pattern.is_file_included(file_path) {
                     pattern.files.max_size


### PR DESCRIPTION
## Summary

Tiny optimisation to only query settings once when opening/indexing files. Previously, settings were queried in the `parse()` method, and separately for determining the max file size. For HTML files there was even a third query to pass settings to the embedded parsers, and similarly plain JavaScript files also had a third query to determine the `jsx_everywhere` setting. Now there's always only a single settings query.

This even fixes a tiny issue with max file size setting, which was previously always looked up in the root settings.

## Test Plan

Everything should stay green.

## Docs

N/A