### PR TITLE
feat: add 'auto' mode to lineEndings

### DIFF
--- a/.changeset/warm-insects-dress.md
+++ b/.changeset/warm-insects-dress.md
@@ -2,11 +2,13 @@
 "@biomejs/biome": minor
 ---
 
-#### lineEnding has a new option 'auto', that is CRLF on Windows, and LF on non-Windows
+#### lineEnding has a new option `auto`
 
-lineEnding now has an option to match the operating system's expected
-line-ending style, on Windows this will be CRLF and on macOS / Linux this will
-be LF. This allows for cross-platform projects that use Biome to not have to
+The option `lineEnding` now has a variant called `auto` to match the operating system's expected
+line-ending style: on Windows, this will be CRLF (`\r\n`), and on macOS / Linux, this will
+be LF (`\n`). 
+
+This allows for cross-platform projects that use Biome not to have to
 force one option or the other, which aligns better with Git's default behavior
 on these platforms.
 

--- a/.changeset/warm-insects-dress.md
+++ b/.changeset/warm-insects-dress.md
@@ -1,0 +1,24 @@
+---
+"@biomejs/biome": minor
+---
+
+#### lineEnding has a new option 'auto', that is CRLF on Windows, and LF on non-Windows
+
+lineEnding now has an option to match the operating system's expected
+line-ending style, on Windows this will be CRLF and on macOS / Linux this will
+be LF. This allows for cross-platform projects that use Biome to not have to
+force one option or the other, which aligns better with Git's default behavior
+on these platforms.
+
+**Example usage:**
+```json
+{
+  "formatter": {
+    "lineEnding": "auto"
+  }
+}
+```
+
+```bash
+biome format --line-ending auto
+```

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -71,8 +71,9 @@ The configuration that is contained inside the file `biome.json`
                               its super languages) files.
         --javascript-formatter-indent-width=NUMBER  The size of the indentation applied to
                               JavaScript (and its super languages) files. Default to 2.
-        --javascript-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to
-                              JavaScript (and its super languages) files.
+        --javascript-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to
+                              JavaScript (and its super languages) files. `auto` uses CRLF on
+                              Windows and LF on other platforms.
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
@@ -103,8 +104,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --json-formatter-indent-width=NUMBER  The size of the indentation applied to JSON (and its
                               super languages) files. Default to 2.
-        --json-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to JSON (and its
-                              super languages) files.
+        --json-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to JSON (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --json-formatter-line-width=NUMBER  What's the max width of a line applied to JSON (and its
                               super languages) files. Defaults to 80.
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in
@@ -130,8 +132,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --css-formatter-indent-width=NUMBER  The size of the indentation applied to CSS (and its
                               super languages) files. Default to 2.
-        --css-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to CSS (and its
-                              super languages) files.
+        --css-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to CSS (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --css-formatter-line-width=NUMBER  What's the max width of a line applied to CSS (and its
                               super languages) files. Defaults to 80.
         --css-formatter-quote-style=<double|single>  The type of quotes used in CSS code. Defaults
@@ -142,8 +145,8 @@ The configuration that is contained inside the file `biome.json`
         --graphql-formatter-indent-style=<tab|space>  The indent style applied to GraphQL files.
         --graphql-formatter-indent-width=NUMBER  The size of the indentation applied to GraphQL
                               files. Default to 2.
-        --graphql-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to GraphQL
-                              files.
+        --graphql-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to
+                              GraphQL files. `auto` uses CRLF on Windows and LF on other platforms.
         --graphql-formatter-line-width=NUMBER  What's the max width of a line applied to GraphQL
                               files. Defaults to 80.
         --graphql-formatter-quote-style=<double|single>  The type of quotes used in GraphQL code.
@@ -165,8 +168,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --html-formatter-indent-width=NUMBER  The size of the indentation applied to HTML (and its
                               super languages) files. Default to 2.
-        --html-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to HTML (and its
-                              super languages) files.
+        --html-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to HTML (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --html-formatter-line-width=NUMBER  What's the max width of a line applied to HTML (and its
                               super languages) files. Defaults to 80.
         --html-formatter-attribute-position=<multiline|auto>  The attribute position style in HTML

--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -29,7 +29,7 @@ The configuration that is contained inside the file `biome.json`
                               that doesn't know
         --indent-style=<tab|space>  The indent style.
         --indent-width=NUMBER  The size of the indentation, 2 by default
-        --line-ending=<lf|crlf|cr>  The type of line ending.
+        --line-ending=<lf|crlf|cr|auto>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTML-ish languages.
                               Defaults to auto.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -30,7 +30,7 @@ The configuration that is contained inside the file `biome.json`
                               that doesn't know
         --indent-style=<tab|space>  The indent style.
         --indent-width=NUMBER  The size of the indentation, 2 by default
-        --line-ending=<lf|crlf|cr>  The type of line ending.
+        --line-ending=<lf|crlf|cr|auto>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTML-ish languages.
                               Defaults to auto.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -72,8 +72,9 @@ The configuration that is contained inside the file `biome.json`
                               its super languages) files.
         --javascript-formatter-indent-width=NUMBER  The size of the indentation applied to
                               JavaScript (and its super languages) files. Default to 2.
-        --javascript-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to
-                              JavaScript (and its super languages) files.
+        --javascript-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to
+                              JavaScript (and its super languages) files. `auto` uses CRLF on
+                              Windows and LF on other platforms.
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
@@ -104,8 +105,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --json-formatter-indent-width=NUMBER  The size of the indentation applied to JSON (and its
                               super languages) files. Default to 2.
-        --json-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to JSON (and its
-                              super languages) files.
+        --json-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to JSON (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --json-formatter-line-width=NUMBER  What's the max width of a line applied to JSON (and its
                               super languages) files. Defaults to 80.
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in
@@ -131,8 +133,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --css-formatter-indent-width=NUMBER  The size of the indentation applied to CSS (and its
                               super languages) files. Default to 2.
-        --css-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to CSS (and its
-                              super languages) files.
+        --css-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to CSS (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --css-formatter-line-width=NUMBER  What's the max width of a line applied to CSS (and its
                               super languages) files. Defaults to 80.
         --css-formatter-quote-style=<double|single>  The type of quotes used in CSS code. Defaults
@@ -143,8 +146,8 @@ The configuration that is contained inside the file `biome.json`
         --graphql-formatter-indent-style=<tab|space>  The indent style applied to GraphQL files.
         --graphql-formatter-indent-width=NUMBER  The size of the indentation applied to GraphQL
                               files. Default to 2.
-        --graphql-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to GraphQL
-                              files.
+        --graphql-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to
+                              GraphQL files. `auto` uses CRLF on Windows and LF on other platforms.
         --graphql-formatter-line-width=NUMBER  What's the max width of a line applied to GraphQL
                               files. Defaults to 80.
         --graphql-formatter-quote-style=<double|single>  The type of quotes used in GraphQL code.
@@ -166,8 +169,9 @@ The configuration that is contained inside the file `biome.json`
                               languages) files.
         --html-formatter-indent-width=NUMBER  The size of the indentation applied to HTML (and its
                               super languages) files. Default to 2.
-        --html-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to HTML (and its
-                              super languages) files.
+        --html-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to HTML (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --html-formatter-line-width=NUMBER  What's the max width of a line applied to HTML (and its
                               super languages) files. Defaults to 80.
         --html-formatter-attribute-position=<multiline|auto>  The attribute position style in HTML

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -53,8 +53,9 @@ Formatting options specific to the JavaScript files
                               its super languages) files.
         --javascript-formatter-indent-width=NUMBER  The size of the indentation applied to
                               JavaScript (and its super languages) files. Default to 2.
-        --javascript-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to
-                              JavaScript (and its super languages) files.
+        --javascript-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to
+                              JavaScript (and its super languages) files. `auto` uses CRLF on
+                              Windows and LF on other platforms.
         --javascript-formatter-line-width=NUMBER  What's the max width of a line applied to
                               JavaScript (and its super languages) files. Defaults to 80.
         --javascript-formatter-quote-style=<double|single>  The type of quotes used in JavaScript
@@ -143,8 +144,9 @@ Available options:
                               languages) files.
         --json-formatter-indent-width=NUMBER  The size of the indentation applied to JSON (and its
                               super languages) files. Default to 2.
-        --json-formatter-line-ending=<lf|crlf|cr>  The type of line ending applied to JSON (and its
-                              super languages) files.
+        --json-formatter-line-ending=<lf|crlf|cr|auto>  The type of line ending applied to JSON (and
+                              its super languages) files. `auto` uses CRLF on Windows and LF on
+                              other platforms.
         --json-formatter-line-width=NUMBER  What's the max width of a line applied to JSON (and its
                               super languages) files. Defaults to 80.
         --json-formatter-trailing-commas=<none|all>  Print trailing commas wherever possible in

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -12,7 +12,7 @@ Usage: format [--write] [--staged] [--changed] [--since=REF] [PATH]...
 Generic options applied to all files
         --indent-style=<tab|space>  The indent style.
         --indent-width=NUMBER  The size of the indentation, 2 by default
-        --line-ending=<lf|crlf|cr>  The type of line ending.
+        --line-ending=<lf|crlf|cr|auto>  The type of line ending.
         --line-width=NUMBER   What's the max width of a line. Defaults to 80.
         --attribute-position=<multiline|auto>  The attribute position style in HTML-ish languages.
                               Defaults to auto.

--- a/crates/biome_configuration/src/css.rs
+++ b/crates/biome_configuration/src/css.rs
@@ -81,8 +81,8 @@ pub struct CssFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
-    /// The type of line ending applied to CSS (and its super languages) files.
-    #[bpaf(long("css-formatter-line-ending"), argument("lf|crlf|cr"))]
+    /// The type of line ending applied to CSS (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
+    #[bpaf(long("css-formatter-line-ending"), argument("lf|crlf|cr|auto"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 

--- a/crates/biome_configuration/src/formatter.rs
+++ b/crates/biome_configuration/src/formatter.rs
@@ -40,7 +40,7 @@ pub struct FormatterConfiguration {
     pub indent_width: Option<IndentWidth>,
 
     /// The type of line ending.
-    #[bpaf(long("line-ending"), argument("lf|crlf|cr"))]
+    #[bpaf(long("line-ending"), argument("lf|crlf|cr|auto"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 

--- a/crates/biome_configuration/src/generated/domain_selector.rs
+++ b/crates/biome_configuration/src/generated/domain_selector.rs
@@ -22,6 +22,7 @@ static PROJECT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
         RuleFilter::Rule("correctness", "noUndeclaredDependencies"),
         RuleFilter::Rule("correctness", "useImportExtensions"),
         RuleFilter::Rule("correctness", "useJsonImportAttributes"),
+        RuleFilter::Rule("nursery", "noDeprecatedImports"),
         RuleFilter::Rule("nursery", "noFloatingPromises"),
         RuleFilter::Rule("nursery", "noImportCycles"),
         RuleFilter::Rule("nursery", "noMisusedPromises"),
@@ -50,6 +51,7 @@ static REACT_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
         RuleFilter::Rule("correctness", "useHookAtTopLevel"),
         RuleFilter::Rule("correctness", "useJsxKeyInIterable"),
         RuleFilter::Rule("correctness", "useUniqueElementIds"),
+        RuleFilter::Rule("nursery", "noReactForwardRef"),
         RuleFilter::Rule("nursery", "useReactFunctionComponents"),
         RuleFilter::Rule("security", "noDangerouslySetInnerHtml"),
         RuleFilter::Rule("security", "noDangerouslySetInnerHtmlWithChildren"),
@@ -75,6 +77,7 @@ static TEST_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
 static VUE_FILTERS: LazyLock<Vec<RuleFilter<'static>>> = LazyLock::new(|| {
     vec![
         RuleFilter::Rule("nursery", "noVueDataObjectDeclaration"),
+        RuleFilter::Rule("nursery", "noVueDuplicateKeys"),
         RuleFilter::Rule("nursery", "noVueReservedKeys"),
         RuleFilter::Rule("nursery", "noVueReservedProps"),
         RuleFilter::Rule("nursery", "useVueMultiWordComponentNames"),

--- a/crates/biome_configuration/src/graphql.rs
+++ b/crates/biome_configuration/src/graphql.rs
@@ -50,8 +50,8 @@ pub struct GraphqlFormatterConfiguration {
     #[bpaf(long("graphql-formatter-indent-width"), argument("NUMBER"))]
     pub indent_width: Option<IndentWidth>,
 
-    /// The type of line ending applied to GraphQL files.
-    #[bpaf(long("graphql-formatter-line-ending"), argument("lf|crlf|cr"))]
+    /// The type of line ending applied to GraphQL files. `auto` uses CRLF on Windows and LF on other platforms.
+    #[bpaf(long("graphql-formatter-line-ending"), argument("lf|crlf|cr|auto"))]
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line applied to GraphQL files. Defaults to 80.

--- a/crates/biome_configuration/src/html.rs
+++ b/crates/biome_configuration/src/html.rs
@@ -65,8 +65,12 @@ pub struct HtmlFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
-    /// The type of line ending applied to HTML (and its super languages) files.
-    #[bpaf(long("html-formatter-line-ending"), argument("lf|crlf|cr"), optional)]
+    /// The type of line ending applied to HTML (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
+    #[bpaf(
+        long("html-formatter-line-ending"),
+        argument("lf|crlf|cr|auto"),
+        optional
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 

--- a/crates/biome_configuration/src/javascript/formatter.rs
+++ b/crates/biome_configuration/src/javascript/formatter.rs
@@ -74,10 +74,10 @@ pub struct JsFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
-    /// The type of line ending applied to JavaScript (and its super languages) files.
+    /// The type of line ending applied to JavaScript (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
     #[bpaf(
         long("javascript-formatter-line-ending"),
-        argument("lf|crlf|cr"),
+        argument("lf|crlf|cr|auto"),
         optional
     )]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/biome_configuration/src/json.rs
+++ b/crates/biome_configuration/src/json.rs
@@ -77,8 +77,8 @@ pub struct JsonFormatterConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indent_width: Option<IndentWidth>,
 
-    /// The type of line ending applied to JSON (and its super languages) files.
-    #[bpaf(long("json-formatter-line-ending"), argument("lf|crlf|cr"))]
+    /// The type of line ending applied to JSON (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
+    #[bpaf(long("json-formatter-line-ending"), argument("lf|crlf|cr|auto"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<LineEnding>,
 

--- a/crates/biome_configuration/src/overrides.rs
+++ b/crates/biome_configuration/src/overrides.rs
@@ -142,7 +142,7 @@ pub struct OverrideFormatterConfiguration {
 
     /// The type of line ending.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[bpaf(long("line-ending"), argument("lf|crlf|cr"))]
+    #[bpaf(long("line-ending"), argument("lf|crlf|cr|auto"))]
     pub line_ending: Option<LineEnding>,
 
     /// What's the max width of a line. Defaults to 80.

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -162,9 +162,13 @@ impl LineEnding {
             Self::Cr => "\r",
             Self::Auto => {
                 #[cfg(windows)]
-                { "\r\n" }
+                {
+                    "\r\n"
+                }
                 #[cfg(not(windows))]
-                { "\n" }
+                {
+                    "\n"
+                }
             }
         }
     }

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -154,6 +154,17 @@ pub enum LineEnding {
 }
 
 impl LineEnding {
+    /// Get the string representation of this line ending variant.
+    ///
+    /// For `LineEnding::Auto`, this returns `"\r\n"` on Windows and `"\n"` on other platforms.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::LineEnding;
+    ///
+    /// assert_eq!(LineEnding::Lf.as_str(), "\n");
+    /// ```
     #[inline]
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -183,12 +194,37 @@ impl LineEnding {
         matches!(self, Self::Crlf)
     }
 
-    /// Returns `true` if this is a [LineEnding::Cr].
+    /// Checks whether the line ending is a carriage return (CR).
+    ///
+    /// Returns `true` if the variant is `LineEnding::Cr`, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::LineEnding;
+    ///
+    /// let cr = LineEnding::Cr;
+    /// assert!(cr.is_carriage_return());
+    ///
+    /// let lf = LineEnding::Lf;
+    /// assert!(!lf.is_carriage_return());
+    /// ```
     pub const fn is_carriage_return(&self) -> bool {
         matches!(self, Self::Cr)
     }
 
-    /// Returns `true` if this is a [LineEnding::Auto].
+    /// Checks whether the line ending is set to automatic selection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::LineEnding;
+    ///
+    /// assert!(LineEnding::Auto.is_auto());
+    /// assert!(!LineEnding::Lf.is_auto());
+    /// ```
+    ///
+    /// @returns `true` if the variant is `LineEnding::Auto`, `false` otherwise.
     pub const fn is_auto(&self) -> bool {
         matches!(self, Self::Auto)
     }
@@ -197,6 +233,21 @@ impl LineEnding {
 impl FromStr for LineEnding {
     type Err = &'static str;
 
+    /// Parses a textual representation of a line ending into a `LineEnding`.
+    ///
+    /// Accepts the exact, lowercase strings: `"lf"`, `"crlf"`, `"cr"`, and `"auto"`.
+    /// The input is case-sensitive; other values produce an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err("Value not supported for LineEnding")` when the input does not match any supported value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let e: LineEnding = "auto".parse().unwrap();
+    /// assert_eq!(e, LineEnding::Auto);
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "lf" => Ok(Self::Lf),
@@ -210,6 +261,17 @@ impl FromStr for LineEnding {
 }
 
 impl std::fmt::Display for LineEnding {
+    /// Formats the `LineEnding` as its uppercase identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::LineEnding;
+    /// assert_eq!(format!("{}", LineEnding::Lf), "LF");
+    /// assert_eq!(format!("{}", LineEnding::Crlf), "CRLF");
+    /// assert_eq!(format!("{}", LineEnding::Cr), "CR");
+    /// assert_eq!(format!("{}", LineEnding::Auto), "AUTO");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Lf => std::write!(f, "LF"),

--- a/crates/biome_formatter/src/lib.rs
+++ b/crates/biome_formatter/src/lib.rs
@@ -148,15 +148,24 @@ pub enum LineEnding {
 
     /// Carriage Return character only (\r), used very rarely
     Cr,
+
+    /// Automatically use CRLF on Windows and LF on other platforms
+    Auto,
 }
 
 impl LineEnding {
     #[inline]
-    pub const fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Lf => "\n",
             Self::Crlf => "\r\n",
             Self::Cr => "\r",
+            Self::Auto => {
+                #[cfg(windows)]
+                { "\r\n" }
+                #[cfg(not(windows))]
+                { "\n" }
+            }
         }
     }
 
@@ -174,6 +183,11 @@ impl LineEnding {
     pub const fn is_carriage_return(&self) -> bool {
         matches!(self, Self::Cr)
     }
+
+    /// Returns `true` if this is a [LineEnding::Auto].
+    pub const fn is_auto(&self) -> bool {
+        matches!(self, Self::Auto)
+    }
 }
 
 impl FromStr for LineEnding {
@@ -184,6 +198,7 @@ impl FromStr for LineEnding {
             "lf" => Ok(Self::Lf),
             "crlf" => Ok(Self::Crlf),
             "cr" => Ok(Self::Cr),
+            "auto" => Ok(Self::Auto),
             // TODO: replace this error with a diagnostic
             _ => Err("Value not supported for LineEnding"),
         }
@@ -196,6 +211,7 @@ impl std::fmt::Display for LineEnding {
             Self::Lf => std::write!(f, "LF"),
             Self::Crlf => std::write!(f, "CRLF"),
             Self::Cr => std::write!(f, "CR"),
+            Self::Auto => std::write!(f, "AUTO"),
         }
     }
 }

--- a/crates/biome_formatter/src/printer/mod.rs
+++ b/crates/biome_formatter/src/printer/mod.rs
@@ -1524,6 +1524,39 @@ a"#,
     }
 
     #[test]
+    fn it_converts_line_endings_to_auto() {
+        let options = PrinterOptions {
+            line_ending: LineEnding::Auto,
+            ..PrinterOptions::default()
+        };
+
+        let result = format_with_options(
+            &format_args![
+                text("function main() {"),
+                block_indent(&text("let x = `This is a multiline\nstring`;")),
+                text("}"),
+                hard_line_break()
+            ],
+            options,
+        );
+
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                "function main() {\r\n\tlet x = `This is a multiline\r\nstring`;\r\n}\r\n",
+                result.as_code()
+            );
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(
+                "function main() {\n\tlet x = `This is a multiline\nstring`;\n}\n",
+                result.as_code()
+            );
+        }
+    }
+
+    #[test]
     fn it_breaks_a_group_if_a_string_contains_a_newline() {
         let result = format(&FormatArrayElements {
             items: vec![

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -270,15 +270,15 @@ where
 
             let max_width = format_language.options().line_width().value() as usize;
 
-            // There are some logs that print different line endings, and we can't snapshot those
-            // otherwise we risk automatically having them replaced with LF by git.
-            //
-            // This is a workaround, and it might not work for all cases.
-            const CRLF_PATTERN: &str = "\r\n";
-            const CR_PATTERN: &str = "\r";
-            output_code = output_code
-                .replace(CRLF_PATTERN, "<CRLF>\n")
-                .replace(CR_PATTERN, "<CR>\n");
+            // Apply line ending normalization for options path, but not for AUTO line ending
+            // to preserve platform-specific behavior in snapshots
+            if !format_language.options().line_ending().is_auto() {
+                const CRLF_PATTERN: &str = "\r\n";
+                const CR_PATTERN: &str = "\r";
+                output_code = output_code
+                    .replace(CRLF_PATTERN, "<CRLF>\n")
+                    .replace(CR_PATTERN, "<CR>\n");
+            }
 
             snapshot_builder = snapshot_builder
                 .with_output_and_options(

--- a/crates/biome_formatter_test/src/spec.rs
+++ b/crates/biome_formatter_test/src/spec.rs
@@ -219,6 +219,24 @@ where
         (output_code, formatted)
     }
 
+    /// Generates and records snapshot outputs for the test file using the configured format language.
+    ///
+    /// This runs the formatter on the test file's input and adds one or two outputs to the snapshot:
+    /// - the default formatted output using the snapshot's `format_language` and associated checks (unimplemented markers and line-width violations),
+    /// - optionally, if an `options.json` exists next to the test file, a second formatted output produced with settings merged from that configuration (with the same checks).
+    ///
+    /// When an `options.json` is present and its `line_ending` option is not `Auto`, this method normalizes CRLF and CR occurrences in the generated output to `<CRLF>\n` and `<CR>\n` respectively to preserve platform-independent snapshot behavior; if `line_ending` is `Auto`, normalization is skipped to preserve platform-specific line endings.
+    ///
+    /// The final snapshot is written using the test file's relative path.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use crate::SpecSnapshot;
+    /// # fn run_example<L: crate::TestFormatLanguage>(snapshot: SpecSnapshot<'_, L>) {
+    /// snapshot.test();
+    /// # }
+    /// ```
     pub fn test(self) {
         let input_file = self.test_file().input_file().as_path();
 

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language/generated_mappings.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language/generated_mappings.rs
@@ -199,6 +199,18 @@ pub fn kind_by_name(node_name: &str) -> Option<CssSyntaxKind> {
             .iter()
             .next(),
         "CssViewTransitionAtRule" => lang::CssViewTransitionAtRule::KIND_SET.iter().next(),
+        "TwApplyAtRule" => lang::TwApplyAtRule::KIND_SET.iter().next(),
+        "TwConfigAtRule" => lang::TwConfigAtRule::KIND_SET.iter().next(),
+        "TwCustomVariantAtRule" => lang::TwCustomVariantAtRule::KIND_SET.iter().next(),
+        "TwCustomVariantShorthand" => lang::TwCustomVariantShorthand::KIND_SET.iter().next(),
+        "TwFunctionalUtilityName" => lang::TwFunctionalUtilityName::KIND_SET.iter().next(),
+        "TwPluginAtRule" => lang::TwPluginAtRule::KIND_SET.iter().next(),
+        "TwReferenceAtRule" => lang::TwReferenceAtRule::KIND_SET.iter().next(),
+        "TwSourceAtRule" => lang::TwSourceAtRule::KIND_SET.iter().next(),
+        "TwThemeAtRule" => lang::TwThemeAtRule::KIND_SET.iter().next(),
+        "TwUtilityAtRule" => lang::TwUtilityAtRule::KIND_SET.iter().next(),
+        "TwValueThemeReference" => lang::TwValueThemeReference::KIND_SET.iter().next(),
+        "TwVariantAtRule" => lang::TwVariantAtRule::KIND_SET.iter().next(),
         _ => None,
     }
 }

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/line_ending.js
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/line_ending.js
@@ -1,0 +1,17 @@
+// Original file in LF
+// just some random code
+export const env = createEnv({
+  DISCORD_TOKEN: { type: 'string' },
+  TOPGG_TOKEN: { type: 'string' },
+
+  GUILD_LOGS: { type: 'string' },
+  GLOBAL_DETECTOR_LOGS: { type: 'string' },
+  TEST_GUILD: { type: 'string' },
+
+  SUPPORT_INVITE: { type: 'string' },
+  GAS_INVITE: { type: 'string' },
+
+  DOCS_LINK: { type: 'string' },
+
+  NODE_ENV: { type: 'string' },
+});

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/line_ending.js.snap
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/line_ending.js.snap
@@ -1,0 +1,112 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+assertion_line: 211
+info: js/module/line-ending/auto/line_ending.js
+---
+# Input
+
+```js
+// Original file in LF
+// just some random code
+export const env = createEnv({
+  DISCORD_TOKEN: { type: 'string' },
+  TOPGG_TOKEN: { type: 'string' },
+
+  GUILD_LOGS: { type: 'string' },
+  GLOBAL_DETECTOR_LOGS: { type: 'string' },
+  TEST_GUILD: { type: 'string' },
+
+  SUPPORT_INVITE: { type: 'string' },
+  GAS_INVITE: { type: 'string' },
+
+  DOCS_LINK: { type: 'string' },
+
+  NODE_ENV: { type: 'string' },
+});
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Expand lists: Auto
+Operator linebreak: After
+-----
+
+```js
+// Original file in LF
+// just some random code
+export const env = createEnv({
+	DISCORD_TOKEN: { type: "string" },
+	TOPGG_TOKEN: { type: "string" },
+
+	GUILD_LOGS: { type: "string" },
+	GLOBAL_DETECTOR_LOGS: { type: "string" },
+	TEST_GUILD: { type: "string" },
+
+	SUPPORT_INVITE: { type: "string" },
+	GAS_INVITE: { type: "string" },
+
+	DOCS_LINK: { type: "string" },
+
+	NODE_ENV: { type: "string" },
+});
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: AUTO
+Line width: 80
+Quote style: Double Quotes
+JSX quote style: Double Quotes
+Quote properties: As needed
+Trailing commas: All
+Semicolons: Always
+Arrow parentheses: Always
+Bracket spacing: true
+Bracket same line: false
+Attribute Position: Auto
+Expand lists: Auto
+Operator linebreak: After
+-----
+
+```js
+// Original file in LF
+// just some random code
+export const env = createEnv({
+	DISCORD_TOKEN: { type: "string" },
+	TOPGG_TOKEN: { type: "string" },
+
+	GUILD_LOGS: { type: "string" },
+	GLOBAL_DETECTOR_LOGS: { type: "string" },
+	TEST_GUILD: { type: "string" },
+
+	SUPPORT_INVITE: { type: "string" },
+	GAS_INVITE: { type: "string" },
+
+	DOCS_LINK: { type: "string" },
+
+	NODE_ENV: { type: "string" },
+});
+```

--- a/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/options.json
+++ b/crates/biome_js_formatter/tests/specs/js/module/line-ending/auto/options.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "lineEnding": "auto"
+  }
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -390,7 +390,7 @@ export interface CssFormatterConfiguration {
 	 */
 	indentWidth?: IndentWidth;
 	/**
-	 * The type of line ending applied to CSS (and its super languages) files.
+	 * The type of line ending applied to CSS (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
 	 */
 	lineEnding?: LineEnding;
 	/**
@@ -475,7 +475,7 @@ export interface GraphqlFormatterConfiguration {
 	 */
 	indentWidth?: IndentWidth;
 	/**
-	 * The type of line ending applied to GraphQL files.
+	 * The type of line ending applied to GraphQL files. `auto` uses CRLF on Windows and LF on other platforms.
 	 */
 	lineEnding?: LineEnding;
 	/**
@@ -559,7 +559,7 @@ export interface HtmlFormatterConfiguration {
 	 */
 	indentWidth?: IndentWidth;
 	/**
-	 * The type of line ending applied to HTML (and its super languages) files.
+	 * The type of line ending applied to HTML (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
 	 */
 	lineEnding?: LineEnding;
 	/**
@@ -634,7 +634,7 @@ export interface JsFormatterConfiguration {
 	 */
 	jsxQuoteStyle?: QuoteStyle;
 	/**
-	 * The type of line ending applied to JavaScript (and its super languages) files.
+	 * The type of line ending applied to JavaScript (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
 	 */
 	lineEnding?: LineEnding;
 	/**
@@ -727,7 +727,7 @@ export interface JsonFormatterConfiguration {
 	 */
 	indentWidth?: IndentWidth;
 	/**
-	 * The type of line ending applied to JSON (and its super languages) files.
+	 * The type of line ending applied to JSON (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.
 	 */
 	lineEnding?: LineEnding;
 	/**

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -438,7 +438,7 @@ export type BracketSpacing = boolean;
 export type Expand = "auto" | "always" | "never";
 export type IndentStyle = "tab" | "space";
 export type IndentWidth = number;
-export type LineEnding = "lf" | "crlf" | "cr";
+export type LineEnding = "lf" | "crlf" | "cr" | "auto";
 /**
 	* Validated value for the `line_width` formatter options
 

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1350,7 +1350,7 @@
 					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
-					"description": "The type of line ending applied to CSS (and its super languages) files.",
+					"description": "The type of line ending applied to CSS (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.",
 					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
 				},
 				"lineWidth": {
@@ -1673,7 +1673,7 @@
 					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
-					"description": "The type of line ending applied to GraphQL files.",
+					"description": "The type of line ending applied to GraphQL files. `auto` uses CRLF on Windows and LF on other platforms.",
 					"default": null,
 					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
 				},
@@ -1903,7 +1903,7 @@
 					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
-					"description": "The type of line ending applied to HTML (and its super languages) files.",
+					"description": "The type of line ending applied to HTML (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.",
 					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
 				},
 				"lineWidth": {
@@ -2085,7 +2085,7 @@
 					"anyOf": [{ "$ref": "#/definitions/QuoteStyle" }, { "type": "null" }]
 				},
 				"lineEnding": {
-					"description": "The type of line ending applied to JavaScript (and its super languages) files.",
+					"description": "The type of line ending applied to JavaScript (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.",
 					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
 				},
 				"lineWidth": {
@@ -2227,7 +2227,7 @@
 					"anyOf": [{ "$ref": "#/definitions/IndentWidth" }, { "type": "null" }]
 				},
 				"lineEnding": {
-					"description": "The type of line ending applied to JSON (and its super languages) files.",
+					"description": "The type of line ending applied to JSON (and its super languages) files. `auto` uses CRLF on Windows and LF on other platforms.",
 					"anyOf": [{ "$ref": "#/definitions/LineEnding" }, { "type": "null" }]
 				},
 				"lineWidth": {
@@ -2404,6 +2404,11 @@
 					"description": "Carriage Return character only (\\r), used very rarely",
 					"type": "string",
 					"enum": ["cr"]
+				},
+				{
+					"description": "Automatically use CRLF on Windows and LF on other platforms",
+					"type": "string",
+					"enum": ["auto"]
 				}
 			]
 		},


### PR DESCRIPTION
## Summary

Related to https://github.com/biomejs/biome/discussions/7598, this implements suggestion 3, "auto" as a lineEnding format, without making it the default. Without this feature, it is very difficult to run Biome against cross-platform environments such as Electron apps, because `biome check` in CI will inevitably fail either macOS or Windows, there is no correct option other than completely disabling the formatter in CI, or using `.gitattributes` to force the repo to be checked out in LF

## Test Plan

Unit tests
