### PR TITLE
docs: fix correct graphql references

### DIFF
--- a/crates/biome_analyze/src/rule.rs
+++ b/crates/biome_analyze/src/rule.rs
@@ -97,10 +97,10 @@ pub enum RuleSource {
     Clippy(&'static str),
     /// Rules from [Eslint](https://eslint.org/)
     Eslint(&'static str),
-    /// Rules from [GraphQL-ESLint](https://github.com/dimaMachina/graphql-eslint)
+    /// Rules from [GraphQL-ESLint](https://github.com/graphql-hive/graphql-eslint)
     EslintGraphql(&'static str),
     /// Rules from [graphql-schema-linter](https://github.com/cjoudrey/graphql-schema-linter)
-    EslintGraphqlSchemaLinter(&'static str),
+    GraphqlSchemaLinter(&'static str),
     /// Rules from [Eslint Plugin Import](https://github.com/import-js/eslint-plugin-import)
     EslintImport(&'static str),
     /// Rules from [Eslint Plugin Import Access](https://github.com/uhyo/eslint-plugin-import-access)
@@ -177,7 +177,7 @@ impl std::fmt::Display for RuleSource {
             Self::Clippy(_) => write!(f, "Clippy"),
             Self::Eslint(_) => write!(f, "ESLint"),
             Self::EslintGraphql(_) => write!(f, "GraphQL-ESLint"),
-            Self::EslintGraphqlSchemaLinter(_) => write!(f, "graphql-schema-linter"),
+            Self::GraphqlSchemaLinter(_) => write!(f, "graphql-schema-linter"),
             Self::EslintImport(_) => write!(f, "eslint-plugin-import"),
             Self::EslintImportAccess(_) => write!(f, "eslint-plugin-import-access"),
             Self::EslintJest(_) => write!(f, "eslint-plugin-jest"),
@@ -261,7 +261,7 @@ impl RuleSource {
             Self::Clippy(rule_name)
             | Self::Eslint(rule_name)
             | Self::EslintGraphql(rule_name)
-            | Self::EslintGraphqlSchemaLinter(rule_name)
+            | Self::GraphqlSchemaLinter(rule_name)
             | Self::EslintImport(rule_name)
             | Self::EslintImportAccess(rule_name)
             | Self::EslintJest(rule_name)
@@ -298,9 +298,10 @@ impl RuleSource {
 
     pub fn to_namespaced_rule_name(&self) -> String {
         match self {
-            Self::Clippy(rule_name) | Self::Eslint(rule_name) => (*rule_name).to_string(),
-            Self::EslintGraphql(rule_name) => format!("graphql/{rule_name}"),
-            Self::EslintGraphqlSchemaLinter(rule_name) => format!("graphql/{rule_name}"),
+            Self::Clippy(rule_name)
+            | Self::Eslint(rule_name)
+            | Self::GraphqlSchemaLinter(rule_name) => (*rule_name).to_string(),
+            Self::EslintGraphql(rule_name) => format!("@graphql-eslint/{rule_name}"),
             Self::EslintImport(rule_name) => format!("import/{rule_name}"),
             Self::EslintImportAccess(rule_name) => format!("import-access/{rule_name}"),
             Self::EslintJest(rule_name) => format!("jest/{rule_name}"),
@@ -344,7 +345,7 @@ impl RuleSource {
             Self::Clippy(rule_name) => format!("https://rust-lang.github.io/rust-clippy/master/#{rule_name}"),
             Self::Eslint(rule_name) => format!("https://eslint.org/docs/latest/rules/{rule_name}"),
             Self::EslintGraphql(rule_name) => format!("https://the-guild.dev/graphql/eslint/rules/{rule_name}"),
-            Self::EslintGraphqlSchemaLinter(rule_name) => format!("https://github.com/cjoudrey/graphql-schema-linter?tab=readme-ov-file#{rule_name}"),
+            Self::GraphqlSchemaLinter(rule_name) => format!("https://github.com/cjoudrey/graphql-schema-linter?tab=readme-ov-file#{rule_name}"),
             Self::EslintImport(rule_name) => format!("https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/{rule_name}.md"),
             Self::EslintImportAccess(_) => "https://github.com/uhyo/eslint-plugin-import-access".to_string(),
             Self::EslintJest(rule_name) => format!("https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/{rule_name}.md"),

--- a/crates/biome_graphql_analyze/src/lint/style/use_graphql_naming_convention.rs
+++ b/crates/biome_graphql_analyze/src/lint/style/use_graphql_naming_convention.rs
@@ -33,7 +33,7 @@ declare_lint_rule! {
         name: "useGraphqlNamingConvention",
         language: "graphql",
         recommended: false,
-        sources: &[RuleSource::EslintGraphqlSchemaLinter("enum-values-all-caps").inspired()],
+        sources: &[RuleSource::GraphqlSchemaLinter("enum-values-all-caps").inspired()],
     }
 }
 


### PR DESCRIPTION
## Summary

- `graphql-schema-linter` is it's own linter, not part of Eslint, so no `Eslint` prefix
- Correct `GraphQL-ESLint` documentation url
- Correct `GraphQL-ESLint` rule prefix is `@graphql-eslint/` not `graphql/`
