### PR TITLE
fix(linter): `useImportExtensions` handles queries and hashes

### DIFF
--- a/.changeset/extended-extensions-excel.md
+++ b/.changeset/extended-extensions-excel.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7638](https://github.com/biomejs/biome/issues/7638): [`useImportExtensions`](https://biomejs.dev/linter/rules/use-import-extensions/) no longer emits diagnostics on valid import paths that end with a query or hash.
+
+#### Example
+
+```js
+// This no longer warns if `index.css` exists:
+import style from '../theme/index.css?inline';
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/theme.css
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/sub/theme.css
@@ -1,0 +1,1 @@
+/* should not generate diagnostics */

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js
@@ -19,6 +19,7 @@ require('./sub/foo.ts');
 import "./sub/styles.css.ts"
 import "./sub/component.svg.svelte.ts";
 import "./sub/component.svg.svelte.ts?query=string&query2#hash";
+import style from './sub/theme.css?inline'
 
 // If the import doesn't resolve at all, we don't report a diagnostic:
 // It means the import is broken beyond missing an extension.

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/valid.js.snap
@@ -25,6 +25,7 @@ require('./sub/foo.ts');
 import "./sub/styles.css.ts"
 import "./sub/component.svg.svelte.ts";
 import "./sub/component.svg.svelte.ts?query=string&query2#hash";
+import style from './sub/theme.css?inline'
 
 // If the import doesn't resolve at all, we don't report a diagnostic:
 // It means the import is broken beyond missing an extension.


### PR DESCRIPTION
## Summary

Fixed #7638: [`useImportExtensions`](https://biomejs.dev/linter/rules/use-import-extensions/) no longer emits diagnostics on valid import paths that end with a query or hash.

#### Example

```js
// This no longer warns if `index.css` exists:
import style from '../theme/index.css?inline';
```

## Test Plan

Test case added. Existing test cases still pass.

## Docs

N/A