### PR TITLE
fix(biome_js_semantic): fix incorrect semantic resolution of `arguments` object

### DIFF
--- a/.changeset/every-baths-dream.md
+++ b/.changeset/every-baths-dream.md
@@ -1,0 +1,12 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7628](https://github.com/biomejs/biome/issues/7628): the `noArguments` rule now correctly recognizes the scope of the `arguments` object, as Biome now properly resolves the implicit `arguments` object.
+
+```js
+let arguments = 0;
+function func() {
+    return arguments[0];  // <- now invalid
+}
+```

--- a/crates/biome_js_analyze/tests/specs/complexity/noArguments/invalid.cjs
+++ b/crates/biome_js_analyze/tests/specs/complexity/noArguments/invalid.cjs
@@ -1,3 +1,4 @@
+let arguments = 0;
 function f() {
     console.log(arguments);
 
@@ -6,7 +7,9 @@ function f() {
     }
 }
 
-function f() {
+function g() {
+    function h() {
+        console.log(arguments);
+    }
     let arguments = 1;
-    console.log(arguments);
 }

--- a/crates/biome_js_analyze/tests/specs/complexity/noArguments/invalid.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noArguments/invalid.cjs.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
 expression: invalid.cjs
 ---
 # Input
 ```cjs
+let arguments = 0;
 function f() {
     console.log(arguments);
 
@@ -12,23 +14,27 @@ function f() {
     }
 }
 
-function f() {
+function g() {
+    function h() {
+        console.log(arguments);
+    }
     let arguments = 1;
-    console.log(arguments);
 }
+
 ```
 
 # Diagnostics
 ```
-invalid.cjs:2:17 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.cjs:3:17 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the rest parameters instead of arguments.
   
-    1 │ function f() {
-  > 2 │     console.log(arguments);
+    1 │ let arguments = 0;
+    2 │ function f() {
+  > 3 │     console.log(arguments);
       │                 ^^^^^^^^^
-    3 │ 
-    4 │     for(let i = 0;i < arguments.length; ++i) {
+    4 │ 
+    5 │     for(let i = 0;i < arguments.length; ++i) {
   
   i arguments does not have Array.prototype methods and can be inconvenient to use.
   
@@ -36,16 +42,16 @@ invalid.cjs:2:17 lint/complexity/noArguments ━━━━━━━━━━━�
 ```
 
 ```
-invalid.cjs:4:23 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.cjs:5:23 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the rest parameters instead of arguments.
   
-    2 │     console.log(arguments);
-    3 │ 
-  > 4 │     for(let i = 0;i < arguments.length; ++i) {
+    3 │     console.log(arguments);
+    4 │ 
+  > 5 │     for(let i = 0;i < arguments.length; ++i) {
       │                       ^^^^^^^^^
-    5 │         console.log(arguments[i]);
-    6 │     }
+    6 │         console.log(arguments[i]);
+    7 │     }
   
   i arguments does not have Array.prototype methods and can be inconvenient to use.
   
@@ -53,15 +59,32 @@ invalid.cjs:4:23 lint/complexity/noArguments ━━━━━━━━━━━�
 ```
 
 ```
-invalid.cjs:5:21 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+invalid.cjs:6:21 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ! Use the rest parameters instead of arguments.
   
-    4 │     for(let i = 0;i < arguments.length; ++i) {
-  > 5 │         console.log(arguments[i]);
+    5 │     for(let i = 0;i < arguments.length; ++i) {
+  > 6 │         console.log(arguments[i]);
       │                     ^^^^^^^^^
-    6 │     }
-    7 │ }
+    7 │     }
+    8 │ }
+  
+  i arguments does not have Array.prototype methods and can be inconvenient to use.
+  
+
+```
+
+```
+invalid.cjs:12:21 lint/complexity/noArguments ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ! Use the rest parameters instead of arguments.
+  
+    10 │ function g() {
+    11 │     function h() {
+  > 12 │         console.log(arguments);
+       │                     ^^^^^^^^^
+    13 │     }
+    14 │     let arguments = 1;
   
   i arguments does not have Array.prototype methods and can be inconvenient to use.
   

--- a/crates/biome_js_analyze/tests/specs/complexity/noArguments/valid.cjs
+++ b/crates/biome_js_analyze/tests/specs/complexity/noArguments/valid.cjs
@@ -1,0 +1,5 @@
+/* should not generate diagnostics */
+function f() {
+    let arguments = 1;
+    console.log(arguments);
+}

--- a/crates/biome_js_analyze/tests/specs/complexity/noArguments/valid.cjs.snap
+++ b/crates/biome_js_analyze/tests/specs/complexity/noArguments/valid.cjs.snap
@@ -1,0 +1,14 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 152
+expression: valid.cjs
+---
+# Input
+```cjs
+/* should not generate diagnostics */
+function f() {
+    let arguments = 1;
+    console.log(arguments);
+}
+
+```

--- a/crates/biome_js_semantic/src/tests/assertions.rs
+++ b/crates/biome_js_semantic/src/tests/assertions.rs
@@ -15,6 +15,15 @@ use std::collections::BTreeMap;
 /// the tree looking at tokens with trailing comments following a specifically patterns
 /// specifying if a scope has started or ended.
 ///
+/// ### Source Type Configuration
+///
+/// By default, tests are parsed as TSX. To parse as a script file, add a comment at the beginning:
+///
+/// ```js
+/// // @script
+/// var x = 1;
+/// ```
+///
 /// ### Available Patterns
 ///
 /// #### Declaration Assertion
@@ -106,7 +115,12 @@ use std::collections::BTreeMap;
 /// if(true) ;/*NOEVENT*/;
 /// ```
 pub fn assert(code: &str, test_name: &str) {
-    let r = biome_js_parser::parse(code, JsFileSource::tsx(), JsParserOptions::default());
+    let file_source = if code.trim_start().starts_with("// @script") {
+        JsFileSource::js_script()
+    } else {
+        JsFileSource::tsx()
+    };
+    let r = biome_js_parser::parse(code, file_source, JsParserOptions::default());
 
     if r.has_errors() {
         let mut console = EnvConsole::default();

--- a/crates/biome_js_semantic/src/tests/references.rs
+++ b/crates/biome_js_semantic/src/tests/references.rs
@@ -202,6 +202,45 @@ assert_semantics! {
                 console.log(arguments/*?*/[i]);
             }
         }"#,
+    ok_unresolved_reference_arguments_function_declaration,
+        r#"// @script
+        const arguments/*#A*/ = 1;
+        const foo/*#B*/ = 2;
+        function f() {
+            console.log(arguments/*?*/);
+            console.log(foo/*READ B*/);
+        }"#,
+    ok_unresolved_reference_arguments_function_expression,
+        r#"// @script
+        const arguments/*#A*/ = 1;
+        const foo/*#B*/ = 2;
+        const f = function() {
+            console.log(arguments/*?*/);
+            console.log(foo/*READ B*/);
+        }"#,
+    ok_resolved_reference_arguments_arrow_function_expression,
+        r#"// @script
+        const arguments/*#A*/ = 1;
+        const f = () => {
+            console.log(arguments/*READ A*/);
+        }"#,
+    ok_unresolved_reference_arguments_in_nested_function,
+        r#"// @script
+        function f() {
+            function g() {
+                console.log(arguments/*?*/);
+            }
+            const arguments/*#A*/ = 1;
+            g(arguments/*READ A*/);
+        }
+        const h = function() {
+            const i = function() {
+                console.log(arguments/*?*/);
+            }
+            const arguments/*#B*/ = 1;
+            i(arguments/*READ B*/);
+        }
+        "#,
 }
 
 // Exports


### PR DESCRIPTION
## Summary
Closes #7628

The `arguments` object was incorrectly resolved to outer scope declarations, even though it implicitly exists within functions.
This PR ensures that the `arguments` object is resolved only within the function.
As a result, #7628 will be resolved.

**Before:**
```js
let arguments = 0;
function func() {
    return arguments[0];  // Incorrectly resolved to outer `arguments` variable
}
```
**After:**
```js
let arguments = 0;
function func() {
    return arguments[0];  // Correctly unresolved
}
```

Please feel free to give feedback if tests are lacking or hard to read.

## Test Plan
- existing tests (js_analyze, js_semantic)
- new tests (js_analyze, js_semantic)
  - Update semantic test logic to support script mode parsing

## Docs
- changeset
- rustdoc