### PR TITLE
chore: `AnyEmbeddedSnippet` terminology

### DIFF
--- a/crates/biome_service/src/file_handlers/html.rs
+++ b/crates/biome_service/src/file_handlers/html.rs
@@ -4,7 +4,7 @@ use super::{
     LintParams, LintResults, ParseEmbedResult, ParseResult, ParserCapabilities, SearchCapabilities,
 };
 use crate::settings::{OverrideSettings, check_feature_activity, check_override_feature_activity};
-use crate::workspace::EmbeddedLanguageContent;
+use crate::workspace::EmbeddedSnippet;
 use crate::workspace::{FixFileResult, PullActionsResult};
 use crate::{
     WorkspaceError,
@@ -419,7 +419,7 @@ pub(crate) fn parse_embedded_script(
     element: HtmlElement,
     cache: &mut NodeCache,
     options: JsParserOptions,
-) -> Option<(EmbeddedLanguageContent<JsLanguage>, DocumentFileSource)> {
+) -> Option<(EmbeddedSnippet<JsLanguage>, DocumentFileSource)> {
     if element.is_javascript_tag() {
         let is_modules = element.is_javascript_module().unwrap_or_default();
         let file_source = if is_modules {
@@ -449,7 +449,7 @@ pub(crate) fn parse_embedded_script(
                     cache,
                 );
 
-                Some(EmbeddedLanguageContent::new(
+                Some(EmbeddedSnippet::new(
                     parse.into(),
                     child.range(),
                     content.text_range(),
@@ -466,7 +466,7 @@ pub(crate) fn parse_embedded_style(
     element: HtmlElement,
     cache: &mut NodeCache,
     options: CssParserOptions,
-) -> Option<(EmbeddedLanguageContent<CssLanguage>, DocumentFileSource)> {
+) -> Option<(EmbeddedSnippet<CssLanguage>, DocumentFileSource)> {
     if element.is_style_tag() {
         // This is probably an error
         if element.children().len() > 1 {
@@ -488,7 +488,7 @@ pub(crate) fn parse_embedded_style(
                     options,
                 );
 
-                Some(EmbeddedLanguageContent::new(
+                Some(EmbeddedSnippet::new(
                     parse.into(),
                     child.range(),
                     content.text_range(),
@@ -505,7 +505,7 @@ pub(crate) fn parse_embedded_json(
     element: HtmlElement,
     cache: &mut NodeCache,
     options: JsonParserOptions,
-) -> Option<(EmbeddedLanguageContent<JsonLanguage>, DocumentFileSource)> {
+) -> Option<(EmbeddedSnippet<JsonLanguage>, DocumentFileSource)> {
     // This is probably an error
     if element.children().len() > 1 {
         return None;
@@ -523,7 +523,7 @@ pub(crate) fn parse_embedded_json(
             options,
         );
 
-        Some(EmbeddedLanguageContent::new(
+        Some(EmbeddedSnippet::new(
             parse.into(),
             child.range(),
             content.text_range(),

--- a/crates/biome_service/src/file_handlers/mod.rs
+++ b/crates/biome_service/src/file_handlers/mod.rs
@@ -11,7 +11,7 @@ pub use crate::file_handlers::svelte::{SVELTE_FENCE, SvelteFileHandler};
 pub use crate::file_handlers::vue::{VUE_FENCE, VueFileHandler};
 use crate::settings::Settings;
 use crate::workspace::{
-    EmbeddedSnippets, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
+    AnyEmbeddedSnippet, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
     RenameResult,
 };
 use biome_analyze::{
@@ -462,7 +462,7 @@ pub struct ParseResult {
 }
 
 pub struct ParseEmbedResult {
-    pub(crate) nodes: Vec<(EmbeddedSnippets, DocumentFileSource)>,
+    pub(crate) nodes: Vec<(AnyEmbeddedSnippet, DocumentFileSource)>,
 }
 
 type Parse = fn(&BiomePath, DocumentFileSource, &str, &Settings, &mut NodeCache) -> ParseResult;

--- a/crates/biome_service/src/workspace.rs
+++ b/crates/biome_service/src/workspace.rs
@@ -55,7 +55,7 @@ mod client;
 mod document;
 mod server;
 
-pub use document::{EmbeddedLanguageContent, EmbeddedSnippets};
+pub use document::{AnyEmbeddedSnippet, EmbeddedSnippet};
 use std::{
     borrow::Cow,
     fmt::{Debug, Display, Formatter},

--- a/crates/biome_service/src/workspace/document.rs
+++ b/crates/biome_service/src/workspace/document.rs
@@ -12,31 +12,31 @@ use biome_rowan::{SyntaxNodeWithOffset, TextRange, TextSize};
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub enum EmbeddedSnippets {
-    Js(EmbeddedLanguageContent<JsLanguage>),
-    Css(EmbeddedLanguageContent<CssLanguage>),
-    Json(EmbeddedLanguageContent<JsonLanguage>),
+pub enum AnyEmbeddedSnippet {
+    Js(EmbeddedSnippet<JsLanguage>),
+    Css(EmbeddedSnippet<CssLanguage>),
+    Json(EmbeddedSnippet<JsonLanguage>),
 }
 
-impl From<EmbeddedLanguageContent<JsLanguage>> for EmbeddedSnippets {
-    fn from(content: EmbeddedLanguageContent<JsLanguage>) -> Self {
+impl From<EmbeddedSnippet<JsLanguage>> for AnyEmbeddedSnippet {
+    fn from(content: EmbeddedSnippet<JsLanguage>) -> Self {
         Self::Js(content)
     }
 }
 
-impl From<EmbeddedLanguageContent<CssLanguage>> for EmbeddedSnippets {
-    fn from(content: EmbeddedLanguageContent<CssLanguage>) -> Self {
+impl From<EmbeddedSnippet<CssLanguage>> for AnyEmbeddedSnippet {
+    fn from(content: EmbeddedSnippet<CssLanguage>) -> Self {
         Self::Css(content)
     }
 }
 
-impl From<EmbeddedLanguageContent<JsonLanguage>> for EmbeddedSnippets {
-    fn from(content: EmbeddedLanguageContent<JsonLanguage>) -> Self {
+impl From<EmbeddedSnippet<JsonLanguage>> for AnyEmbeddedSnippet {
+    fn from(content: EmbeddedSnippet<JsonLanguage>) -> Self {
         Self::Json(content)
     }
 }
 
-impl EmbeddedSnippets {
+impl AnyEmbeddedSnippet {
     pub const fn is_js(&self) -> bool {
         matches!(self, Self::Js(..))
     }
@@ -45,25 +45,25 @@ impl EmbeddedSnippets {
         matches!(self, Self::Css(..))
     }
 
-    pub fn as_js_embedded_snippet(&self) -> Option<EmbeddedLanguageContent<JsLanguage>> {
+    pub fn as_js_embedded_snippet(&self) -> Option<&EmbeddedSnippet<JsLanguage>> {
         if let Self::Js(content) = self {
-            Some(content.clone())
+            Some(content)
         } else {
             None
         }
     }
 
-    pub fn as_css_embedded_snippet(&self) -> Option<EmbeddedLanguageContent<CssLanguage>> {
+    pub fn as_css_embedded_snippet(&self) -> Option<&EmbeddedSnippet<CssLanguage>> {
         if let Self::Css(content) = self {
-            Some(content.clone())
+            Some(content)
         } else {
             None
         }
     }
 
-    pub fn as_json_embedded_snippet(&self) -> Option<EmbeddedLanguageContent<JsonLanguage>> {
+    pub fn as_json_embedded_snippet(&self) -> Option<&EmbeddedSnippet<JsonLanguage>> {
         if let Self::Json(content) = self {
-            Some(content.clone())
+            Some(content)
         } else {
             None
         }
@@ -123,7 +123,7 @@ impl EmbeddedSnippets {
 /// This struct stores parsing metadata and provides access to the parsed
 /// content with offset-aware positioning to maintain correct source locations.
 #[derive(Clone, Debug)]
-pub struct EmbeddedLanguageContent<L: ServiceLanguage + 'static> {
+pub struct EmbeddedSnippet<L: ServiceLanguage + 'static> {
     /// The JavaScript source code extracted from the script element.
     pub parse: AnyParse,
 
@@ -145,7 +145,7 @@ pub struct EmbeddedLanguageContent<L: ServiceLanguage + 'static> {
     _phantom: PhantomData<L>,
 }
 
-impl<L: ServiceLanguage + 'static> EmbeddedLanguageContent<L> {
+impl<L: ServiceLanguage + 'static> EmbeddedSnippet<L> {
     /// Constructs new embedded content for a specific language.
     pub fn new(
         parse: AnyParse,
@@ -212,7 +212,7 @@ pub(crate) struct Document {
     pub(crate) syntax: Option<Result<AnyParse, FileTooLarge>>,
 
     /// Embedded content for foreign language snippets.
-    pub(crate) embedded_snippets: Vec<EmbeddedSnippets>,
+    pub(crate) embedded_snippets: Vec<AnyEmbeddedSnippet>,
 }
 
 impl Document {

--- a/crates/biome_service/src/workspace/server.rs
+++ b/crates/biome_service/src/workspace/server.rs
@@ -15,7 +15,7 @@ use crate::scanner::{
     IndexRequestKind, IndexTrigger, ScanOptions, Scanner, ScannerWatcherBridge, WatcherInstruction,
     WorkspaceScannerBridge,
 };
-use crate::workspace::document::EmbeddedSnippets;
+use crate::workspace::document::AnyEmbeddedSnippet;
 use append_only_vec::AppendOnlyVec;
 use biome_analyze::{AnalyzerPluginVec, RuleCategory};
 use biome_configuration::bool::Bool;
@@ -497,7 +497,7 @@ impl WorkspaceServer {
             })
     }
 
-    fn get_language_snippets(&self, path: &Utf8Path) -> Vec<EmbeddedSnippets> {
+    fn get_language_snippets(&self, path: &Utf8Path) -> Vec<AnyEmbeddedSnippet> {
         let documents = self.documents.pin();
         documents
             .get(path)
@@ -513,7 +513,7 @@ impl WorkspaceServer {
         source: &DocumentFileSource,
         root: &AnyParse,
         cache: &mut NodeCache,
-    ) -> Result<Vec<EmbeddedSnippets>, WorkspaceError> {
+    ) -> Result<Vec<AnyEmbeddedSnippet>, WorkspaceError> {
         let mut embedded_nodes = Vec::new();
         let capabilities = self.get_file_capabilities(path);
         let Some(parse_embedded) = capabilities.parser.parse_embedded_nodes else {


### PR DESCRIPTION
## Summary

Renames `EmbeddedSnippets` to `AnyEmbeddedSnippet` and `EmbeddedLanguageContent` to `EmbeddedSnippet`.

Also applied my own suggestion to return references from the `as_*_embedded_snippet()` methods, since I touched those methods anyway, so this shouldn't cause additional merge conflicts.

## Test Plan

Greenness.

## Docs

N/A