### PR TITLE
feat(lint): port `property-no-deprecated` rule from stylelint

### DIFF
--- a/.changeset/afraid-planes-dig.md
+++ b/.changeset/afraid-planes-dig.md
@@ -1,0 +1,21 @@
+---
+"@biomejs/biome": patch
+---
+
+Added a nursery rule [`noDeprecatedProperties`](https://biomejs.dev/linter/rules/no-deprecated-properties/) that detects usages of deprecated CSS properties. The rule was ported from the [`property-no-deprecated`](https://stylelint.io/user-guide/rules/property-no-deprecated) rule in Stylelint.
+
+For example, the following patterns are considered as invalid:
+
+```css
+a {
+  word-wrap: break-word;
+}
+```
+
+If applicable, Biome will suggest to replace it with another valid property:
+
+```css
+a {
+  overflow-wrap: break-word;
+}
+```

--- a/crates/biome_configuration/src/analyzer/linter/rules.rs
+++ b/crates/biome_configuration/src/analyzer/linter/rules.rs
@@ -130,6 +130,7 @@ pub enum RuleName {
     NoDefaultExport,
     NoDelete,
     NoDeprecatedImports,
+    NoDeprecatedProperties,
     NoDescendingSpecificity,
     NoDistractingElements,
     NoDocumentCookie,
@@ -494,6 +495,7 @@ impl RuleName {
             Self::NoDefaultExport => "noDefaultExport",
             Self::NoDelete => "noDelete",
             Self::NoDeprecatedImports => "noDeprecatedImports",
+            Self::NoDeprecatedProperties => "noDeprecatedProperties",
             Self::NoDescendingSpecificity => "noDescendingSpecificity",
             Self::NoDistractingElements => "noDistractingElements",
             Self::NoDocumentCookie => "noDocumentCookie",
@@ -862,6 +864,7 @@ impl RuleName {
             Self::NoDefaultExport => RuleGroup::Style,
             Self::NoDelete => RuleGroup::Performance,
             Self::NoDeprecatedImports => RuleGroup::Nursery,
+            Self::NoDeprecatedProperties => RuleGroup::Nursery,
             Self::NoDescendingSpecificity => RuleGroup::Style,
             Self::NoDistractingElements => RuleGroup::A11y,
             Self::NoDocumentCookie => RuleGroup::Suspicious,
@@ -1231,6 +1234,7 @@ impl std::str::FromStr for RuleName {
             "noDefaultExport" => Ok(Self::NoDefaultExport),
             "noDelete" => Ok(Self::NoDelete),
             "noDeprecatedImports" => Ok(Self::NoDeprecatedImports),
+            "noDeprecatedProperties" => Ok(Self::NoDeprecatedProperties),
             "noDescendingSpecificity" => Ok(Self::NoDescendingSpecificity),
             "noDistractingElements" => Ok(Self::NoDistractingElements),
             "noDocumentCookie" => Ok(Self::NoDocumentCookie),
@@ -4638,11 +4642,12 @@ impl From<GroupPlainConfiguration> for Correctness {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 #[doc = r" A list of rules that belong to this group"]
-pub struct Nursery { # [doc = r" Enables the recommended rules for this group"] # [serde (skip_serializing_if = "Option::is_none")] pub recommended : Option < bool > , # [doc = "Restrict imports of deprecated exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_deprecated_imports : Option < RuleConfiguration < biome_rule_options :: no_deprecated_imports :: NoDeprecatedImportsOptions >> , # [doc = "Prevent the listing of duplicate dependencies. The rule supports the following dependency groups: \"bundledDependencies\", \"bundleDependencies\", \"dependencies\", \"devDependencies\", \"overrides\", \"optionalDependencies\", and \"peerDependencies\"."] # [serde (skip_serializing_if = "Option::is_none")] pub no_duplicate_dependencies : Option < RuleConfiguration < biome_rule_options :: no_duplicate_dependencies :: NoDuplicateDependenciesOptions >> , # [doc = "Require Promise-like statements to be handled appropriately."] # [serde (skip_serializing_if = "Option::is_none")] pub no_floating_promises : Option < RuleFixConfiguration < biome_rule_options :: no_floating_promises :: NoFloatingPromisesOptions >> , # [doc = "Prevent import cycles."] # [serde (skip_serializing_if = "Option::is_none")] pub no_import_cycles : Option < RuleConfiguration < biome_rule_options :: no_import_cycles :: NoImportCyclesOptions >> , # [doc = "Disallow string literals inside JSX elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_jsx_literals : Option < RuleConfiguration < biome_rule_options :: no_jsx_literals :: NoJsxLiteralsOptions >> , # [doc = "Disallow Promises to be used in places where they are almost certainly a mistake."] # [serde (skip_serializing_if = "Option::is_none")] pub no_misused_promises : Option < RuleFixConfiguration < biome_rule_options :: no_misused_promises :: NoMisusedPromisesOptions >> , # [doc = "Prevent client components from being async functions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_next_async_client_component : Option < RuleConfiguration < biome_rule_options :: no_next_async_client_component :: NoNextAsyncClientComponentOptions >> , # [doc = "Disallow non-null assertions after optional chaining expressions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_non_null_asserted_optional_chain : Option < RuleConfiguration < biome_rule_options :: no_non_null_asserted_optional_chain :: NoNonNullAssertedOptionalChainOptions >> , # [doc = "Disallow useVisibleTask$() functions in Qwik components."] # [serde (skip_serializing_if = "Option::is_none")] pub no_qwik_use_visible_task : Option < RuleConfiguration < biome_rule_options :: no_qwik_use_visible_task :: NoQwikUseVisibleTaskOptions >> , # [doc = "Replaces usages of forwardRef with passing ref as a prop."] # [serde (skip_serializing_if = "Option::is_none")] pub no_react_forward_ref : Option < RuleFixConfiguration < biome_rule_options :: no_react_forward_ref :: NoReactForwardRefOptions >> , # [doc = "Disallow usage of sensitive data such as API keys and tokens."] # [serde (skip_serializing_if = "Option::is_none")] pub no_secrets : Option < RuleConfiguration < biome_rule_options :: no_secrets :: NoSecretsOptions >> , # [doc = "Disallow variable declarations from shadowing variables declared in the outer scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_shadow : Option < RuleConfiguration < biome_rule_options :: no_shadow :: NoShadowOptions >> , # [doc = "Disallow unnecessary type-based conditions that can be statically determined as redundant."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unnecessary_conditions : Option < RuleConfiguration < biome_rule_options :: no_unnecessary_conditions :: NoUnnecessaryConditionsOptions >> , # [doc = "Warn when importing non-existing exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unresolved_imports : Option < RuleConfiguration < biome_rule_options :: no_unresolved_imports :: NoUnresolvedImportsOptions >> , # [doc = "Disallow expression statements that are neither a function call nor an assignment."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unused_expressions : Option < RuleConfiguration < biome_rule_options :: no_unused_expressions :: NoUnusedExpressionsOptions >> , # [doc = "Disallow unused catch bindings."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_catch_binding : Option < RuleFixConfiguration < biome_rule_options :: no_useless_catch_binding :: NoUselessCatchBindingOptions >> , # [doc = "Disallow the use of useless undefined."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_undefined : Option < RuleFixConfiguration < biome_rule_options :: no_useless_undefined :: NoUselessUndefinedOptions >> , # [doc = "Enforce that Vue component data options are declared as functions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_data_object_declaration : Option < RuleFixConfiguration < biome_rule_options :: no_vue_data_object_declaration :: NoVueDataObjectDeclarationOptions >> , # [doc = "Disallow duplicate keys in Vue component data, methods, computed properties, and other options."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_duplicate_keys : Option < RuleConfiguration < biome_rule_options :: no_vue_duplicate_keys :: NoVueDuplicateKeysOptions >> , # [doc = "Disallow reserved keys in Vue component data and computed properties."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_keys : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_keys :: NoVueReservedKeysOptions >> , # [doc = "Disallow reserved names to be used as props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_props : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_props :: NoVueReservedPropsOptions >> , # [doc = "Enforces href attribute for \\<a> elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_anchor_href : Option < RuleConfiguration < biome_rule_options :: use_anchor_href :: UseAnchorHrefOptions >> , # [doc = "Enforce consistent arrow function bodies."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_arrow_return : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_arrow_return :: UseConsistentArrowReturnOptions >> , # [doc = "Enforce type definitions to consistently use either interface or type."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_type_definitions : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_type_definitions :: UseConsistentTypeDefinitionsOptions >> , # [doc = "Require switch-case statements to be exhaustive."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exhaustive_switch_cases : Option < RuleFixConfiguration < biome_rule_options :: use_exhaustive_switch_cases :: UseExhaustiveSwitchCasesOptions >> , # [doc = "Enforce types in functions, methods, variables, and parameters."] # [serde (skip_serializing_if = "Option::is_none")] pub use_explicit_type : Option < RuleConfiguration < biome_rule_options :: use_explicit_type :: UseExplicitTypeOptions >> , # [doc = "Enforces that \\<img> elements have both width and height attributes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_image_size : Option < RuleConfiguration < biome_rule_options :: use_image_size :: UseImageSizeOptions >> , # [doc = "Enforce a maximum number of parameters in function definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_max_params : Option < RuleConfiguration < biome_rule_options :: use_max_params :: UseMaxParamsOptions >> , # [doc = "Prefer using the class prop as a classlist over the classnames helper."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_classlist : Option < RuleConfiguration < biome_rule_options :: use_qwik_classlist :: UseQwikClasslistOptions >> , # [doc = "Disallow use* hooks outside of component$ or other use* hooks in Qwik applications."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_method_usage : Option < RuleConfiguration < biome_rule_options :: use_qwik_method_usage :: UseQwikMethodUsageOptions >> , # [doc = "Disallow unserializable expressions in Qwik dollar ($) scopes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_valid_lexical_scope : Option < RuleConfiguration < biome_rule_options :: use_qwik_valid_lexical_scope :: UseQwikValidLexicalScopeOptions >> , # [doc = "Enforce that components are defined as functions and never as classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_react_function_components : Option < RuleConfiguration < biome_rule_options :: use_react_function_components :: UseReactFunctionComponentsOptions >> , # [doc = "Enforce the sorting of CSS utility classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_sorted_classes : Option < RuleFixConfiguration < biome_rule_options :: use_sorted_classes :: UseSortedClassesOptions >> , # [doc = "Enforce multi-word component names in Vue components."] # [serde (skip_serializing_if = "Option::is_none")] pub use_vue_multi_word_component_names : Option < RuleConfiguration < biome_rule_options :: use_vue_multi_word_component_names :: UseVueMultiWordComponentNamesOptions >> }
+pub struct Nursery { # [doc = r" Enables the recommended rules for this group"] # [serde (skip_serializing_if = "Option::is_none")] pub recommended : Option < bool > , # [doc = "Restrict imports of deprecated exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_deprecated_imports : Option < RuleConfiguration < biome_rule_options :: no_deprecated_imports :: NoDeprecatedImportsOptions >> , # [doc = "Disallow deprecated properties."] # [serde (skip_serializing_if = "Option::is_none")] pub no_deprecated_properties : Option < RuleFixConfiguration < biome_rule_options :: no_deprecated_properties :: NoDeprecatedPropertiesOptions >> , # [doc = "Prevent the listing of duplicate dependencies. The rule supports the following dependency groups: \"bundledDependencies\", \"bundleDependencies\", \"dependencies\", \"devDependencies\", \"overrides\", \"optionalDependencies\", and \"peerDependencies\"."] # [serde (skip_serializing_if = "Option::is_none")] pub no_duplicate_dependencies : Option < RuleConfiguration < biome_rule_options :: no_duplicate_dependencies :: NoDuplicateDependenciesOptions >> , # [doc = "Require Promise-like statements to be handled appropriately."] # [serde (skip_serializing_if = "Option::is_none")] pub no_floating_promises : Option < RuleFixConfiguration < biome_rule_options :: no_floating_promises :: NoFloatingPromisesOptions >> , # [doc = "Prevent import cycles."] # [serde (skip_serializing_if = "Option::is_none")] pub no_import_cycles : Option < RuleConfiguration < biome_rule_options :: no_import_cycles :: NoImportCyclesOptions >> , # [doc = "Disallow string literals inside JSX elements."] # [serde (skip_serializing_if = "Option::is_none")] pub no_jsx_literals : Option < RuleConfiguration < biome_rule_options :: no_jsx_literals :: NoJsxLiteralsOptions >> , # [doc = "Disallow Promises to be used in places where they are almost certainly a mistake."] # [serde (skip_serializing_if = "Option::is_none")] pub no_misused_promises : Option < RuleFixConfiguration < biome_rule_options :: no_misused_promises :: NoMisusedPromisesOptions >> , # [doc = "Prevent client components from being async functions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_next_async_client_component : Option < RuleConfiguration < biome_rule_options :: no_next_async_client_component :: NoNextAsyncClientComponentOptions >> , # [doc = "Disallow non-null assertions after optional chaining expressions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_non_null_asserted_optional_chain : Option < RuleConfiguration < biome_rule_options :: no_non_null_asserted_optional_chain :: NoNonNullAssertedOptionalChainOptions >> , # [doc = "Disallow useVisibleTask$() functions in Qwik components."] # [serde (skip_serializing_if = "Option::is_none")] pub no_qwik_use_visible_task : Option < RuleConfiguration < biome_rule_options :: no_qwik_use_visible_task :: NoQwikUseVisibleTaskOptions >> , # [doc = "Replaces usages of forwardRef with passing ref as a prop."] # [serde (skip_serializing_if = "Option::is_none")] pub no_react_forward_ref : Option < RuleFixConfiguration < biome_rule_options :: no_react_forward_ref :: NoReactForwardRefOptions >> , # [doc = "Disallow usage of sensitive data such as API keys and tokens."] # [serde (skip_serializing_if = "Option::is_none")] pub no_secrets : Option < RuleConfiguration < biome_rule_options :: no_secrets :: NoSecretsOptions >> , # [doc = "Disallow variable declarations from shadowing variables declared in the outer scope."] # [serde (skip_serializing_if = "Option::is_none")] pub no_shadow : Option < RuleConfiguration < biome_rule_options :: no_shadow :: NoShadowOptions >> , # [doc = "Disallow unnecessary type-based conditions that can be statically determined as redundant."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unnecessary_conditions : Option < RuleConfiguration < biome_rule_options :: no_unnecessary_conditions :: NoUnnecessaryConditionsOptions >> , # [doc = "Warn when importing non-existing exports."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unresolved_imports : Option < RuleConfiguration < biome_rule_options :: no_unresolved_imports :: NoUnresolvedImportsOptions >> , # [doc = "Disallow expression statements that are neither a function call nor an assignment."] # [serde (skip_serializing_if = "Option::is_none")] pub no_unused_expressions : Option < RuleConfiguration < biome_rule_options :: no_unused_expressions :: NoUnusedExpressionsOptions >> , # [doc = "Disallow unused catch bindings."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_catch_binding : Option < RuleFixConfiguration < biome_rule_options :: no_useless_catch_binding :: NoUselessCatchBindingOptions >> , # [doc = "Disallow the use of useless undefined."] # [serde (skip_serializing_if = "Option::is_none")] pub no_useless_undefined : Option < RuleFixConfiguration < biome_rule_options :: no_useless_undefined :: NoUselessUndefinedOptions >> , # [doc = "Enforce that Vue component data options are declared as functions."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_data_object_declaration : Option < RuleFixConfiguration < biome_rule_options :: no_vue_data_object_declaration :: NoVueDataObjectDeclarationOptions >> , # [doc = "Disallow duplicate keys in Vue component data, methods, computed properties, and other options."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_duplicate_keys : Option < RuleConfiguration < biome_rule_options :: no_vue_duplicate_keys :: NoVueDuplicateKeysOptions >> , # [doc = "Disallow reserved keys in Vue component data and computed properties."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_keys : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_keys :: NoVueReservedKeysOptions >> , # [doc = "Disallow reserved names to be used as props."] # [serde (skip_serializing_if = "Option::is_none")] pub no_vue_reserved_props : Option < RuleConfiguration < biome_rule_options :: no_vue_reserved_props :: NoVueReservedPropsOptions >> , # [doc = "Enforces href attribute for \\<a> elements."] # [serde (skip_serializing_if = "Option::is_none")] pub use_anchor_href : Option < RuleConfiguration < biome_rule_options :: use_anchor_href :: UseAnchorHrefOptions >> , # [doc = "Enforce consistent arrow function bodies."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_arrow_return : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_arrow_return :: UseConsistentArrowReturnOptions >> , # [doc = "Enforce type definitions to consistently use either interface or type."] # [serde (skip_serializing_if = "Option::is_none")] pub use_consistent_type_definitions : Option < RuleFixConfiguration < biome_rule_options :: use_consistent_type_definitions :: UseConsistentTypeDefinitionsOptions >> , # [doc = "Require switch-case statements to be exhaustive."] # [serde (skip_serializing_if = "Option::is_none")] pub use_exhaustive_switch_cases : Option < RuleFixConfiguration < biome_rule_options :: use_exhaustive_switch_cases :: UseExhaustiveSwitchCasesOptions >> , # [doc = "Enforce types in functions, methods, variables, and parameters."] # [serde (skip_serializing_if = "Option::is_none")] pub use_explicit_type : Option < RuleConfiguration < biome_rule_options :: use_explicit_type :: UseExplicitTypeOptions >> , # [doc = "Enforces that \\<img> elements have both width and height attributes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_image_size : Option < RuleConfiguration < biome_rule_options :: use_image_size :: UseImageSizeOptions >> , # [doc = "Enforce a maximum number of parameters in function definitions."] # [serde (skip_serializing_if = "Option::is_none")] pub use_max_params : Option < RuleConfiguration < biome_rule_options :: use_max_params :: UseMaxParamsOptions >> , # [doc = "Prefer using the class prop as a classlist over the classnames helper."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_classlist : Option < RuleConfiguration < biome_rule_options :: use_qwik_classlist :: UseQwikClasslistOptions >> , # [doc = "Disallow use* hooks outside of component$ or other use* hooks in Qwik applications."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_method_usage : Option < RuleConfiguration < biome_rule_options :: use_qwik_method_usage :: UseQwikMethodUsageOptions >> , # [doc = "Disallow unserializable expressions in Qwik dollar ($) scopes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_qwik_valid_lexical_scope : Option < RuleConfiguration < biome_rule_options :: use_qwik_valid_lexical_scope :: UseQwikValidLexicalScopeOptions >> , # [doc = "Enforce that components are defined as functions and never as classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_react_function_components : Option < RuleConfiguration < biome_rule_options :: use_react_function_components :: UseReactFunctionComponentsOptions >> , # [doc = "Enforce the sorting of CSS utility classes."] # [serde (skip_serializing_if = "Option::is_none")] pub use_sorted_classes : Option < RuleFixConfiguration < biome_rule_options :: use_sorted_classes :: UseSortedClassesOptions >> , # [doc = "Enforce multi-word component names in Vue components."] # [serde (skip_serializing_if = "Option::is_none")] pub use_vue_multi_word_component_names : Option < RuleConfiguration < biome_rule_options :: use_vue_multi_word_component_names :: UseVueMultiWordComponentNamesOptions >> }
 impl Nursery {
     const GROUP_NAME: &'static str = "nursery";
     pub(crate) const GROUP_RULES: &'static [&'static str] = &[
         "noDeprecatedImports",
+        "noDeprecatedProperties",
         "noDuplicateDependencies",
         "noFloatingPromises",
         "noImportCycles",
@@ -4678,7 +4683,7 @@ impl Nursery {
         "useVueMultiWordComponentNames",
     ];
     const RECOMMENDED_RULES_AS_FILTERS: &'static [RuleFilter<'static>] =
-        &[RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7])];
+        &[RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8])];
     const ALL_RULES_AS_FILTERS: &'static [RuleFilter<'static>] = &[
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]),
@@ -4714,6 +4719,7 @@ impl Nursery {
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]),
         RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]),
+        RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]),
     ];
 }
 impl RuleGroupExt for Nursery {
@@ -4730,170 +4736,175 @@ impl RuleGroupExt for Nursery {
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.no_duplicate_dependencies.as_ref()
+        if let Some(rule) = self.no_deprecated_properties.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.no_floating_promises.as_ref()
+        if let Some(rule) = self.no_duplicate_dependencies.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.no_import_cycles.as_ref()
+        if let Some(rule) = self.no_floating_promises.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.no_jsx_literals.as_ref()
+        if let Some(rule) = self.no_import_cycles.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.no_misused_promises.as_ref()
+        if let Some(rule) = self.no_jsx_literals.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.no_next_async_client_component.as_ref()
+        if let Some(rule) = self.no_misused_promises.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.no_non_null_asserted_optional_chain.as_ref()
+        if let Some(rule) = self.no_next_async_client_component.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.no_qwik_use_visible_task.as_ref()
+        if let Some(rule) = self.no_non_null_asserted_optional_chain.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.no_react_forward_ref.as_ref()
+        if let Some(rule) = self.no_qwik_use_visible_task.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.no_secrets.as_ref()
+        if let Some(rule) = self.no_react_forward_ref.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.no_shadow.as_ref()
+        if let Some(rule) = self.no_secrets.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.no_unnecessary_conditions.as_ref()
+        if let Some(rule) = self.no_shadow.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.no_unresolved_imports.as_ref()
+        if let Some(rule) = self.no_unnecessary_conditions.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.no_unused_expressions.as_ref()
+        if let Some(rule) = self.no_unresolved_imports.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.no_useless_catch_binding.as_ref()
+        if let Some(rule) = self.no_unused_expressions.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref()
+        if let Some(rule) = self.no_useless_catch_binding.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
         }
-        if let Some(rule) = self.no_vue_data_object_declaration.as_ref()
+        if let Some(rule) = self.no_useless_undefined.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
         }
-        if let Some(rule) = self.no_vue_duplicate_keys.as_ref()
+        if let Some(rule) = self.no_vue_data_object_declaration.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
         }
-        if let Some(rule) = self.no_vue_reserved_keys.as_ref()
+        if let Some(rule) = self.no_vue_duplicate_keys.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
         }
-        if let Some(rule) = self.no_vue_reserved_props.as_ref()
+        if let Some(rule) = self.no_vue_reserved_keys.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
         }
-        if let Some(rule) = self.use_anchor_href.as_ref()
+        if let Some(rule) = self.no_vue_reserved_props.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
         }
-        if let Some(rule) = self.use_consistent_arrow_return.as_ref()
+        if let Some(rule) = self.use_anchor_href.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
         }
-        if let Some(rule) = self.use_consistent_type_definitions.as_ref()
+        if let Some(rule) = self.use_consistent_arrow_return.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
         }
-        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref()
+        if let Some(rule) = self.use_consistent_type_definitions.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
         }
-        if let Some(rule) = self.use_explicit_type.as_ref()
+        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
         }
-        if let Some(rule) = self.use_image_size.as_ref()
+        if let Some(rule) = self.use_explicit_type.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
         }
-        if let Some(rule) = self.use_max_params.as_ref()
+        if let Some(rule) = self.use_image_size.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
         }
-        if let Some(rule) = self.use_qwik_classlist.as_ref()
+        if let Some(rule) = self.use_max_params.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
         }
-        if let Some(rule) = self.use_qwik_method_usage.as_ref()
+        if let Some(rule) = self.use_qwik_classlist.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
         }
-        if let Some(rule) = self.use_qwik_valid_lexical_scope.as_ref()
+        if let Some(rule) = self.use_qwik_method_usage.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
         }
-        if let Some(rule) = self.use_react_function_components.as_ref()
+        if let Some(rule) = self.use_qwik_valid_lexical_scope.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref()
+        if let Some(rule) = self.use_react_function_components.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
         }
-        if let Some(rule) = self.use_vue_multi_word_component_names.as_ref()
+        if let Some(rule) = self.use_sorted_classes.as_ref()
             && rule.is_enabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
+        }
+        if let Some(rule) = self.use_vue_multi_word_component_names.as_ref()
+            && rule.is_enabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
         }
         index_set
     }
@@ -4904,170 +4915,175 @@ impl RuleGroupExt for Nursery {
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[0]));
         }
-        if let Some(rule) = self.no_duplicate_dependencies.as_ref()
+        if let Some(rule) = self.no_deprecated_properties.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[1]));
         }
-        if let Some(rule) = self.no_floating_promises.as_ref()
+        if let Some(rule) = self.no_duplicate_dependencies.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[2]));
         }
-        if let Some(rule) = self.no_import_cycles.as_ref()
+        if let Some(rule) = self.no_floating_promises.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[3]));
         }
-        if let Some(rule) = self.no_jsx_literals.as_ref()
+        if let Some(rule) = self.no_import_cycles.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[4]));
         }
-        if let Some(rule) = self.no_misused_promises.as_ref()
+        if let Some(rule) = self.no_jsx_literals.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[5]));
         }
-        if let Some(rule) = self.no_next_async_client_component.as_ref()
+        if let Some(rule) = self.no_misused_promises.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[6]));
         }
-        if let Some(rule) = self.no_non_null_asserted_optional_chain.as_ref()
+        if let Some(rule) = self.no_next_async_client_component.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[7]));
         }
-        if let Some(rule) = self.no_qwik_use_visible_task.as_ref()
+        if let Some(rule) = self.no_non_null_asserted_optional_chain.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[8]));
         }
-        if let Some(rule) = self.no_react_forward_ref.as_ref()
+        if let Some(rule) = self.no_qwik_use_visible_task.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[9]));
         }
-        if let Some(rule) = self.no_secrets.as_ref()
+        if let Some(rule) = self.no_react_forward_ref.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[10]));
         }
-        if let Some(rule) = self.no_shadow.as_ref()
+        if let Some(rule) = self.no_secrets.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[11]));
         }
-        if let Some(rule) = self.no_unnecessary_conditions.as_ref()
+        if let Some(rule) = self.no_shadow.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[12]));
         }
-        if let Some(rule) = self.no_unresolved_imports.as_ref()
+        if let Some(rule) = self.no_unnecessary_conditions.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[13]));
         }
-        if let Some(rule) = self.no_unused_expressions.as_ref()
+        if let Some(rule) = self.no_unresolved_imports.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[14]));
         }
-        if let Some(rule) = self.no_useless_catch_binding.as_ref()
+        if let Some(rule) = self.no_unused_expressions.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[15]));
         }
-        if let Some(rule) = self.no_useless_undefined.as_ref()
+        if let Some(rule) = self.no_useless_catch_binding.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[16]));
         }
-        if let Some(rule) = self.no_vue_data_object_declaration.as_ref()
+        if let Some(rule) = self.no_useless_undefined.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[17]));
         }
-        if let Some(rule) = self.no_vue_duplicate_keys.as_ref()
+        if let Some(rule) = self.no_vue_data_object_declaration.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[18]));
         }
-        if let Some(rule) = self.no_vue_reserved_keys.as_ref()
+        if let Some(rule) = self.no_vue_duplicate_keys.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[19]));
         }
-        if let Some(rule) = self.no_vue_reserved_props.as_ref()
+        if let Some(rule) = self.no_vue_reserved_keys.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[20]));
         }
-        if let Some(rule) = self.use_anchor_href.as_ref()
+        if let Some(rule) = self.no_vue_reserved_props.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[21]));
         }
-        if let Some(rule) = self.use_consistent_arrow_return.as_ref()
+        if let Some(rule) = self.use_anchor_href.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[22]));
         }
-        if let Some(rule) = self.use_consistent_type_definitions.as_ref()
+        if let Some(rule) = self.use_consistent_arrow_return.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[23]));
         }
-        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref()
+        if let Some(rule) = self.use_consistent_type_definitions.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[24]));
         }
-        if let Some(rule) = self.use_explicit_type.as_ref()
+        if let Some(rule) = self.use_exhaustive_switch_cases.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[25]));
         }
-        if let Some(rule) = self.use_image_size.as_ref()
+        if let Some(rule) = self.use_explicit_type.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[26]));
         }
-        if let Some(rule) = self.use_max_params.as_ref()
+        if let Some(rule) = self.use_image_size.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[27]));
         }
-        if let Some(rule) = self.use_qwik_classlist.as_ref()
+        if let Some(rule) = self.use_max_params.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[28]));
         }
-        if let Some(rule) = self.use_qwik_method_usage.as_ref()
+        if let Some(rule) = self.use_qwik_classlist.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[29]));
         }
-        if let Some(rule) = self.use_qwik_valid_lexical_scope.as_ref()
+        if let Some(rule) = self.use_qwik_method_usage.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[30]));
         }
-        if let Some(rule) = self.use_react_function_components.as_ref()
+        if let Some(rule) = self.use_qwik_valid_lexical_scope.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[31]));
         }
-        if let Some(rule) = self.use_sorted_classes.as_ref()
+        if let Some(rule) = self.use_react_function_components.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[32]));
         }
-        if let Some(rule) = self.use_vue_multi_word_component_names.as_ref()
+        if let Some(rule) = self.use_sorted_classes.as_ref()
             && rule.is_disabled()
         {
             index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[33]));
+        }
+        if let Some(rule) = self.use_vue_multi_word_component_names.as_ref()
+            && rule.is_disabled()
+        {
+            index_set.insert(RuleFilter::Rule(Self::GROUP_NAME, Self::GROUP_RULES[34]));
         }
         index_set
     }
@@ -5101,6 +5117,10 @@ impl RuleGroupExt for Nursery {
         match rule_name {
             "noDeprecatedImports" => self
                 .no_deprecated_imports
+                .as_ref()
+                .map(|conf| (conf.level(), conf.get_options())),
+            "noDeprecatedProperties" => self
+                .no_deprecated_properties
                 .as_ref()
                 .map(|conf| (conf.level(), conf.get_options())),
             "noDuplicateDependencies" => self
@@ -5244,6 +5264,7 @@ impl From<GroupPlainConfiguration> for Nursery {
         Self {
             recommended: None,
             no_deprecated_imports: Some(value.into()),
+            no_deprecated_properties: Some(value.into()),
             no_duplicate_dependencies: Some(value.into()),
             no_floating_promises: Some(value.into()),
             no_import_cycles: Some(value.into()),

--- a/crates/biome_css_analyze/src/lint.rs
+++ b/crates/biome_css_analyze/src/lint.rs
@@ -5,6 +5,7 @@
 pub mod a11y;
 pub mod complexity;
 pub mod correctness;
+pub mod nursery;
 pub mod style;
 pub mod suspicious;
-::biome_analyze::declare_category! { pub Lint { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: style :: Style , self :: suspicious :: Suspicious ,] } }
+::biome_analyze::declare_category! { pub Lint { kind : Lint , groups : [self :: a11y :: A11y , self :: complexity :: Complexity , self :: correctness :: Correctness , self :: nursery :: Nursery , self :: style :: Style , self :: suspicious :: Suspicious ,] } }

--- a/crates/biome_css_analyze/src/lint/nursery.rs
+++ b/crates/biome_css_analyze/src/lint/nursery.rs
@@ -1,0 +1,7 @@
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+//! Generated file, do not edit by hand, see `xtask/codegen`
+
+use biome_analyze::declare_lint_group;
+pub mod no_deprecated_properties;
+declare_lint_group! { pub Nursery { name : "nursery" , rules : [self :: no_deprecated_properties :: NoDeprecatedProperties ,] } }

--- a/crates/biome_css_analyze/src/lint/nursery/no_deprecated_properties.rs
+++ b/crates/biome_css_analyze/src/lint/nursery/no_deprecated_properties.rs
@@ -1,0 +1,230 @@
+use biome_analyze::{
+    Ast, FixKind, Rule, RuleDiagnostic, RuleSource, context::RuleContext, declare_lint_rule,
+};
+use biome_console::markup;
+use biome_css_factory::make;
+use biome_css_syntax::{AnyCssDeclarationName, CssGenericProperty, CssSyntaxKind, CssSyntaxToken};
+use biome_rowan::{AstNode, BatchMutationExt};
+use biome_rule_options::no_deprecated_properties::NoDeprecatedPropertiesOptions;
+
+use crate::CssRuleAction;
+
+declare_lint_rule! {
+    /// Disallow deprecated properties.
+    ///
+    /// This rule flags properties that were removed or deprecated after being in the CSS
+    /// specifications, including editor drafts, and were either:
+    ///
+    /// - shipped in a stable version of a browser
+    /// - shipped by a developer channel/edition browser
+    /// - shipped but behind experimental flags
+    /// - polyfilled with some adoption before any browser actually shipped
+    /// - had an MDN page at one point in time
+    ///
+    /// ## Examples
+    ///
+    /// ### Invalid
+    ///
+    /// ```css,expect_diagnostic
+    /// a { clip: rect(0, 0, 0, 0); }
+    /// ```
+    ///
+    /// ```css,expect_diagnostic
+    /// a { word-wrap: break-word; }
+    /// ```
+    ///
+    /// ### Valid
+    ///
+    /// ```css
+    /// a { clip-path: rect(0 0 0 0); }
+    /// ```
+    ///
+    /// ```css
+    /// a { overflow-wrap: break-word; }
+    /// ```
+    ///
+    /// ## Options
+    ///
+    /// ### `ignoreProperties`
+    ///
+    /// Ignores the specified properties.
+    ///
+    /// ```json,options
+    /// {
+    ///   "options": {
+    ///     "ignoreProperties": ["clip", "grid-row-gap"]
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// #### Valid
+    ///
+    /// ```css,use_options
+    /// a { clip: rect(0, 0, 0, 0); }
+    /// ```
+    ///
+    /// ```css,use_options
+    /// a { grid-row-gap: 4px; }
+    /// ```
+    pub NoDeprecatedProperties {
+        version: "next",
+        name: "noDeprecatedProperties",
+        language: "css",
+        recommended: false,
+        fix_kind: FixKind::Unsafe,
+        sources: &[RuleSource::Stylelint("property-no-deprecated").same()],
+    }
+}
+
+impl Rule for NoDeprecatedProperties {
+    type Query = Ast<CssGenericProperty>;
+    type State = ();
+    type Signals = Option<Self::State>;
+    type Options = NoDeprecatedPropertiesOptions;
+
+    fn run(ctx: &RuleContext<Self>) -> Option<Self::State> {
+        is_deprecated_property(ctx.query(), ctx.options())?.then_some(())
+    }
+
+    fn diagnostic(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<RuleDiagnostic> {
+        let span = ctx.query().range();
+        let name = ctx.query().name().ok()?.to_trimmed_text();
+
+        Some(
+            RuleDiagnostic::new(
+                rule_category!(),
+                span,
+                markup! { "Deprecated property "<Emphasis>{name.text()}</Emphasis>" is not allowed." },
+            )
+            .note(markup! {
+                "The property has been removed or deprecated in the CSS specification that were previously existed."
+            }),
+        )
+    }
+
+    fn action(ctx: &RuleContext<Self>, _state: &Self::State) -> Option<CssRuleAction> {
+        let node = ctx.query();
+        let replacement = get_replacement(node)?;
+        let mut mutation = ctx.root().begin();
+
+        mutation.replace_node(
+            node.clone(),
+            node.clone()
+                .with_name(AnyCssDeclarationName::CssIdentifier(make::css_identifier(
+                    CssSyntaxToken::new_detached(CssSyntaxKind::IDENT, replacement, [], []),
+                ))),
+        );
+
+        Some(CssRuleAction::new(
+            ctx.metadata().action_category(ctx.category(), ctx.group()),
+            ctx.metadata().applicability(),
+            markup! { "Replace it with a valid CSS property." }.to_owned(),
+            mutation,
+        ))
+    }
+}
+
+/// Check if the property is deprecated.
+fn is_deprecated_property(
+    property: &CssGenericProperty,
+    options: &NoDeprecatedPropertiesOptions,
+) -> Option<bool> {
+    let name = property.name().ok()?.to_trimmed_text();
+    let name = name.text();
+
+    if options
+        .ignore_properties
+        .iter()
+        .any(|ignored_property| ignored_property.as_ref() == name)
+    {
+        return Some(false);
+    }
+
+    Some(match name {
+        // Allowed when the value is `vertical`
+        "-webkit-box-orient" if property.value().to_trimmed_text() == "vertical" => false,
+
+        "-khtml-box-align"
+        | "-khtml-box-direction"
+        | "-khtml-box-flex"
+        | "-khtml-box-lines"
+        | "-khtml-box-ordinal-group"
+        | "-khtml-box-orient"
+        | "-khtml-box-pack"
+        | "-khtml-user-modify"
+        | "-moz-box-align"
+        | "-moz-box-direction"
+        | "-moz-box-flex"
+        | "-moz-box-lines"
+        | "-moz-box-ordinal-group"
+        | "-moz-box-orient"
+        | "-moz-box-pack"
+        | "-moz-user-modify"
+        | "-ms-box-align"
+        | "-ms-box-direction"
+        | "-ms-box-flex"
+        | "-ms-box-lines"
+        | "-ms-box-ordinal-group"
+        | "-ms-box-orient"
+        | "-ms-box-pack"
+        | "-webkit-box-align"
+        | "-webkit-box-direction"
+        | "-webkit-box-flex"
+        | "-webkit-box-lines"
+        | "-webkit-box-ordinal-group"
+        | "-webkit-box-orient"
+        | "-webkit-box-pack"
+        | "-webkit-user-modify"
+        | "grid-column-gap"
+        | "grid-gap"
+        | "grid-row-gap"
+        | "ime-mode"
+        | "page-break-after"
+        | "page-break-before"
+        | "page-break-inside"
+        | "position-try-options"
+        | "scroll-snap-coordinate"
+        | "scroll-snap-destination"
+        | "scroll-snap-margin-bottom"
+        | "scroll-snap-margin-left"
+        | "scroll-snap-margin-right"
+        | "scroll-snap-margin-top"
+        | "scroll-snap-margin"
+        | "scroll-snap-points-x"
+        | "scroll-snap-points-y"
+        | "scroll-snap-type-x"
+        | "scroll-snap-type-y"
+        | "word-wrap"
+        | "clip" => true,
+
+        _ => false,
+    })
+}
+
+/// Return a replacement of the deprecated property if applicable.
+fn get_replacement(property: &CssGenericProperty) -> Option<&'static str> {
+    Some(match property.name().ok()?.to_trimmed_text().text() {
+        "-khtml-box-align" | "-moz-box-align" | "-ms-box-align" | "-webkit-box-align" => {
+            "align-items"
+        }
+        "-khtml-box-flex" | "-moz-box-flex" | "-ms-box-flex" | "-webkit-box-flex" => "flex-grow",
+        "-khtml-box-ordinal-group"
+        | "-moz-box-ordinal-group"
+        | "-ms-box-ordinal-group"
+        | "-webkit-box-ordinal-group" => "order",
+        "grid-column-gap" => "column-gap",
+        "grid-gap" => "gap",
+        "grid-row-gap" => "row-gap",
+        "page-break-after" => "break-after",
+        "page-break-before" => "break-before",
+        "page-break-inside" => "break-inside",
+        "position-try-options" => "position-try-fallbacks",
+        "scroll-snap-margin-bottom" => "scroll-margin-bottom",
+        "scroll-snap-margin-left" => "scroll-margin-left",
+        "scroll-snap-margin-right" => "scroll-margin-right",
+        "scroll-snap-margin-top" => "scroll-margin-top",
+        "scroll-snap-margin" => "scroll-margin",
+        "word-wrap" => "overflow-wrap",
+        _ => return None,
+    })
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.css
@@ -1,0 +1,21 @@
+/* Ignored */
+a {
+	grid-column-gap: 1px;
+}
+
+a {
+	grid-gap: 1px;
+}
+
+a {
+	grid-row-gap: 1px;
+}
+
+a {
+	word-wrap: break-word;
+}
+
+/* Not ignored */
+a {
+	-webkit-user-modify: read-only;
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.css.snap
@@ -1,0 +1,47 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: ignoredProperties.css
+---
+# Input
+```css
+/* Ignored */
+a {
+	grid-column-gap: 1px;
+}
+
+a {
+	grid-gap: 1px;
+}
+
+a {
+	grid-row-gap: 1px;
+}
+
+a {
+	word-wrap: break-word;
+}
+
+/* Not ignored */
+a {
+	-webkit-user-modify: read-only;
+}
+
+```
+
+# Diagnostics
+```
+ignoredProperties.css:20:2 lint/nursery/noDeprecatedProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property -webkit-user-modify is not allowed.
+  
+    18 │ /* Not ignored */
+    19 │ a {
+  > 20 │ 	-webkit-user-modify: read-only;
+       │ 	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    21 │ }
+    22 │ 
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.options.json
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/ignoredProperties.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noDeprecatedProperties": {
+          "level": "on",
+          "options": {
+            "ignoreProperties": ["grid-column-gap", "grid-gap", "grid-row-gap", "word-wrap"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/invalid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/invalid.css
@@ -1,0 +1,17 @@
+a {
+	clip: rect(0, 0, 0, 0);
+}
+
+a {
+	/* comment */
+	clip: rect(0, 0, 0, 0);
+}
+
+a {
+	ime-mode: active;
+}
+
+a {
+	-moz-box-flex: revert;
+	-moz-box-pack: start;
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/invalid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/invalid.css.snap
@@ -1,0 +1,117 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: invalid.css
+---
+# Input
+```css
+a {
+	clip: rect(0, 0, 0, 0);
+}
+
+a {
+	/* comment */
+	clip: rect(0, 0, 0, 0);
+}
+
+a {
+	ime-mode: active;
+}
+
+a {
+	-moz-box-flex: revert;
+	-moz-box-pack: start;
+}
+
+```
+
+# Diagnostics
+```
+invalid.css:2:2 lint/nursery/noDeprecatedProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property clip is not allowed.
+  
+    1 │ a {
+  > 2 │ 	clip: rect(0, 0, 0, 0);
+      │ 	^^^^^^^^^^^^^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+
+```
+
+```
+invalid.css:7:2 lint/nursery/noDeprecatedProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property clip is not allowed.
+  
+    5 │ a {
+    6 │ 	/* comment */
+  > 7 │ 	clip: rect(0, 0, 0, 0);
+      │ 	^^^^^^^^^^^^^^^^^^^^^^
+    8 │ }
+    9 │ 
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+
+```
+
+```
+invalid.css:11:2 lint/nursery/noDeprecatedProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property ime-mode is not allowed.
+  
+    10 │ a {
+  > 11 │ 	ime-mode: active;
+       │ 	^^^^^^^^^^^^^^^^
+    12 │ }
+    13 │ 
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+
+```
+
+```
+invalid.css:15:2 lint/nursery/noDeprecatedProperties  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property -moz-box-flex is not allowed.
+  
+    14 │ a {
+  > 15 │ 	-moz-box-flex: revert;
+       │ 	^^^^^^^^^^^^^^^^^^^^^
+    16 │ 	-moz-box-pack: start;
+    17 │ }
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+  i Unsafe fix: Replace it with a valid CSS property.
+  
+    13 13 │   
+    14 14 │   a {
+    15    │ - → -moz-box-flex:·revert;
+       15 │ + → flex-grow:·revert;
+    16 16 │   	-moz-box-pack: start;
+    17 17 │   }
+  
+
+```
+
+```
+invalid.css:16:2 lint/nursery/noDeprecatedProperties ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i Deprecated property -moz-box-pack is not allowed.
+  
+    14 │ a {
+    15 │ 	-moz-box-flex: revert;
+  > 16 │ 	-moz-box-pack: start;
+       │ 	^^^^^^^^^^^^^^^^^^^^
+    17 │ }
+    18 │ 
+  
+  i The property has been removed or deprecated in the CSS specification that were previously existed.
+  
+
+```

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/valid.css
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/valid.css
@@ -1,0 +1,12 @@
+/* should not generate diagnostics */
+
+a {
+	clip-path: rect(0 0 0 0);
+}
+
+/* 'Accept `-webkit-box-orient` if its value is `vertical` */
+a {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}

--- a/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/valid.css.snap
+++ b/crates/biome_css_analyze/tests/specs/nursery/noDeprecatedProperties/valid.css.snap
@@ -1,0 +1,20 @@
+---
+source: crates/biome_css_analyze/tests/spec_tests.rs
+expression: valid.css
+---
+# Input
+```css
+/* should not generate diagnostics */
+
+a {
+	clip-path: rect(0 0 0 0);
+}
+
+/* 'Accept `-webkit-box-orient` if its value is `vertical` */
+a {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+```

--- a/crates/biome_diagnostics_categories/src/categories.rs
+++ b/crates/biome_diagnostics_categories/src/categories.rs
@@ -163,6 +163,7 @@ define_categories! {
     "lint/correctness/useYield": "https://biomejs.dev/linter/rules/use-yield",
     "lint/nursery/noColorInvalidHex": "https://biomejs.dev/linter/rules/no-color-invalid-hex",
     "lint/nursery/noDeprecatedImports": "https://biomejs.dev/linter/rules/no-deprecated-imports",
+    "lint/nursery/noDeprecatedProperties": "https://biomejs.dev/linter/rules/no-deprecated-properties",
     "lint/nursery/noDuplicateDependencies": "https://biomejs.dev/linter/rules/no-duplicate-dependencies",
     "lint/nursery/noFloatingPromises": "https://biomejs.dev/linter/rules/no-floating-promises",
     "lint/nursery/noImplicitCoercion": "https://biomejs.dev/linter/rules/no-implicit-coercion",

--- a/crates/biome_rule_options/src/lib.rs
+++ b/crates/biome_rule_options/src/lib.rs
@@ -43,6 +43,7 @@ pub mod no_debugger;
 pub mod no_default_export;
 pub mod no_delete;
 pub mod no_deprecated_imports;
+pub mod no_deprecated_properties;
 pub mod no_descending_specificity;
 pub mod no_distracting_elements;
 pub mod no_document_cookie;

--- a/crates/biome_rule_options/src/no_deprecated_properties.rs
+++ b/crates/biome_rule_options/src/no_deprecated_properties.rs
@@ -1,0 +1,9 @@
+use biome_deserialize_macros::Deserializable;
+use serde::{Deserialize, Serialize};
+#[derive(Default, Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+pub struct NoDeprecatedPropertiesOptions {
+    #[serde(default)]
+    pub ignore_properties: Box<[Box<str>]>,
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -1630,6 +1630,10 @@ export interface Nursery {
 	 */
 	noDeprecatedImports?: RuleConfiguration_for_NoDeprecatedImportsOptions;
 	/**
+	 * Disallow deprecated properties.
+	 */
+	noDeprecatedProperties?: RuleFixConfiguration_for_NoDeprecatedPropertiesOptions;
+	/**
 	 * Prevent the listing of duplicate dependencies. The rule supports the following dependency groups: "bundledDependencies", "bundleDependencies", "dependencies", "devDependencies", "overrides", "optionalDependencies", and "peerDependencies".
 	 */
 	noDuplicateDependencies?: RuleConfiguration_for_NoDuplicateDependenciesOptions;
@@ -3005,6 +3009,9 @@ export type RuleConfiguration_for_UseYieldOptions =
 export type RuleConfiguration_for_NoDeprecatedImportsOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoDeprecatedImportsOptions;
+export type RuleFixConfiguration_for_NoDeprecatedPropertiesOptions =
+	| RulePlainConfiguration
+	| RuleWithFixOptions_for_NoDeprecatedPropertiesOptions;
 export type RuleConfiguration_for_NoDuplicateDependenciesOptions =
 	| RulePlainConfiguration
 	| RuleWithOptions_for_NoDuplicateDependenciesOptions;
@@ -5398,6 +5405,20 @@ export interface RuleWithOptions_for_NoDeprecatedImportsOptions {
 	 * Rule's options
 	 */
 	options: NoDeprecatedImportsOptions;
+}
+export interface RuleWithFixOptions_for_NoDeprecatedPropertiesOptions {
+	/**
+	 * The kind of the code actions emitted by the rule
+	 */
+	fix?: FixKind;
+	/**
+	 * The severity of the emitted diagnostics by the rule
+	 */
+	level: RulePlainConfiguration;
+	/**
+	 * Rule's options
+	 */
+	options: NoDeprecatedPropertiesOptions;
 }
 export interface RuleWithOptions_for_NoDuplicateDependenciesOptions {
 	/**
@@ -8165,6 +8186,9 @@ export interface UseValidForDirectionOptions {}
 export interface UseValidTypeofOptions {}
 export interface UseYieldOptions {}
 export interface NoDeprecatedImportsOptions {}
+export interface NoDeprecatedPropertiesOptions {
+	ignoreProperties?: string[];
+}
 export interface NoDuplicateDependenciesOptions {}
 export interface NoFloatingPromisesOptions {}
 export interface NoImportCyclesOptions {
@@ -8941,6 +8965,7 @@ export type Category =
 	| "lint/correctness/useYield"
 	| "lint/nursery/noColorInvalidHex"
 	| "lint/nursery/noDeprecatedImports"
+	| "lint/nursery/noDeprecatedProperties"
 	| "lint/nursery/noDuplicateDependencies"
 	| "lint/nursery/noFloatingPromises"
 	| "lint/nursery/noImplicitCoercion"

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -2861,6 +2861,23 @@
 			"type": "object",
 			"additionalProperties": false
 		},
+		"NoDeprecatedPropertiesConfiguration": {
+			"anyOf": [
+				{ "$ref": "#/definitions/RulePlainConfiguration" },
+				{ "$ref": "#/definitions/RuleWithNoDeprecatedPropertiesOptions" }
+			]
+		},
+		"NoDeprecatedPropertiesOptions": {
+			"type": "object",
+			"properties": {
+				"ignoreProperties": {
+					"default": [],
+					"type": "array",
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"NoDescendingSpecificityConfiguration": {
 			"anyOf": [
 				{ "$ref": "#/definitions/RulePlainConfiguration" },
@@ -4996,6 +5013,13 @@
 						{ "type": "null" }
 					]
 				},
+				"noDeprecatedProperties": {
+					"description": "Disallow deprecated properties.",
+					"anyOf": [
+						{ "$ref": "#/definitions/NoDeprecatedPropertiesConfiguration" },
+						{ "type": "null" }
+					]
+				},
 				"noDuplicateDependencies": {
 					"description": "Prevent the listing of duplicate dependencies. The rule supports the following dependency groups: \"bundledDependencies\", \"bundleDependencies\", \"dependencies\", \"devDependencies\", \"overrides\", \"optionalDependencies\", and \"peerDependencies\".",
 					"anyOf": [
@@ -6538,6 +6562,25 @@
 				"options": {
 					"description": "Rule's options",
 					"allOf": [{ "$ref": "#/definitions/NoDeprecatedImportsOptions" }]
+				}
+			},
+			"additionalProperties": false
+		},
+		"RuleWithNoDeprecatedPropertiesOptions": {
+			"type": "object",
+			"required": ["level"],
+			"properties": {
+				"fix": {
+					"description": "The kind of the code actions emitted by the rule",
+					"anyOf": [{ "$ref": "#/definitions/FixKind" }, { "type": "null" }]
+				},
+				"level": {
+					"description": "The severity of the emitted diagnostics by the rule",
+					"allOf": [{ "$ref": "#/definitions/RulePlainConfiguration" }]
+				},
+				"options": {
+					"description": "Rule's options",
+					"allOf": [{ "$ref": "#/definitions/NoDeprecatedPropertiesOptions" }]
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
## Summary

This pull request adds a new rule `noDeprecatedProperties`, ported from the [`property-no-deprecated`](https://stylelint.io/user-guide/rules/property-no-deprecated) rule in stylelint.

## Test Plan

Added snapshot tests.

## Docs

Added documentation comments (copy-pasted from stylelint's docs).