### PR TITLE
fix(lint/useExhaustiveDependencies): correct fix for method calls

### DIFF
--- a/.changeset/plain-radios-argue.md
+++ b/.changeset/plain-radios-argue.md
@@ -1,0 +1,25 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7704](https://github.com/biomejs/biome/issues/7704): The [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies/) rule now correctly adds an object dependency when its method is called within the closure.
+
+For example:
+
+```js
+function Component(props) {
+  useEffect(() => {
+    props.foo();
+  }, []);
+}
+```
+
+will now be fixed to:
+
+```js
+function Component(props) {
+  useEffect(() => {
+    props.foo();
+  }, [props]);
+}
+```

--- a/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_exhaustive_dependencies.rs
@@ -400,6 +400,18 @@ fn get_whole_static_member_expression(reference: &JsSyntaxNode) -> Option<AnyJsM
         .last()?
         .parent()?;
 
+    // If the parent node is a call expression, drop the last part of the member expression to
+    // avoid breaking the prototype chain.
+    if let Some(parent) = root.parent()
+        && JsCallExpression::can_cast(parent.kind())
+    {
+        return AnyJsMemberExpression::cast(root)?
+            .object()
+            .ok()?
+            .into_syntax()
+            .cast();
+    }
+
     root.cast()
 }
 

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue7704.js
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue7704.js
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+function InvalidComponent(props) {
+	useEffect(() => {
+		props.foo();
+	}, []);
+}
+
+function InvalidComponent2(props) {
+	useEffect(() => {
+		props.foo();
+	}, [props.foo]);
+}
+
+function ValidComponent(props) {
+	useEffect(() => {
+		props.foo();
+	}, [props]);
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue7704.js.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useExhaustiveDependencies/issue7704.js.snap
@@ -1,0 +1,116 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: issue7704.js
+---
+# Input
+```js
+import { useEffect } from "react";
+
+function InvalidComponent(props) {
+	useEffect(() => {
+		props.foo();
+	}, []);
+}
+
+function InvalidComponent2(props) {
+	useEffect(() => {
+		props.foo();
+	}, [props.foo]);
+}
+
+function ValidComponent(props) {
+	useEffect(() => {
+		props.foo();
+	}, [props]);
+}
+
+```
+
+# Diagnostics
+```
+issue7704.js:4:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook does not specify its dependency on props.
+  
+    3 │ function InvalidComponent(props) {
+  > 4 │ 	useEffect(() => {
+      │ 	^^^^^^^^^
+    5 │ 		props.foo();
+    6 │ 	}, []);
+  
+  i This dependency is being used here, but is not specified in the hook dependency list.
+  
+    3 │ function InvalidComponent(props) {
+    4 │ 	useEffect(() => {
+  > 5 │ 		props.foo();
+      │ 		^^^^^
+    6 │ 	}, []);
+    7 │ }
+  
+  i Either include it or remove the dependency array.
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    6 │ → },·[props]);
+      │       +++++   
+
+```
+
+```
+issue7704.js:10:2 lint/correctness/useExhaustiveDependencies ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook specifies a dependency more specific that its captures: props.foo
+  
+     9 │ function InvalidComponent2(props) {
+  > 10 │ 	useEffect(() => {
+       │ 	^^^^^^^^^
+    11 │ 		props.foo();
+    12 │ 	}, [props.foo]);
+  
+  i This capture is more generic than...
+  
+     9 │ function InvalidComponent2(props) {
+    10 │ 	useEffect(() => {
+  > 11 │ 		props.foo();
+       │ 		^^^^^
+    12 │ 	}, [props.foo]);
+    13 │ }
+  
+  i ...this dependency.
+  
+    10 │ 	useEffect(() => {
+    11 │ 		props.foo();
+  > 12 │ 	}, [props.foo]);
+       │ 	    ^^^^^^^^^
+    13 │ }
+    14 │ 
+  
+
+```
+
+```
+issue7704.js:10:2 lint/correctness/useExhaustiveDependencies  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × This hook does not specify its dependency on props.
+  
+     9 │ function InvalidComponent2(props) {
+  > 10 │ 	useEffect(() => {
+       │ 	^^^^^^^^^
+    11 │ 		props.foo();
+    12 │ 	}, [props.foo]);
+  
+  i This dependency is being used here, but is not specified in the hook dependency list.
+  
+     9 │ function InvalidComponent2(props) {
+    10 │ 	useEffect(() => {
+  > 11 │ 		props.foo();
+       │ 		^^^^^
+    12 │ 	}, [props.foo]);
+    13 │ }
+  
+  i Unsafe fix: Add the missing dependency to the list.
+  
+    12 │ → },·[props.foo,·props]);
+       │                +++++++   
+
+```


### PR DESCRIPTION
## Summary

The useExhaustiveDependencies now correctly adds the object as a dependency when its method is called within a React hook. It should be avoided to add the method itself as a dependency because it will break the prototype chain.

## Test Plan

Added a snapshot test.

## Docs

N/A
