### PR TITLE
Expand max_lines Range in NoExcessiveLinesPerFunctionOptions

### DIFF
--- a/crates/biome_rule_options/src/no_excessive_lines_per_function.rs
+++ b/crates/biome_rule_options/src/no_excessive_lines_per_function.rs
@@ -1,12 +1,12 @@
 use biome_deserialize_macros::Deserializable;
 use serde::{Deserialize, Serialize};
-use std::num::NonZeroU8;
+use std::num::NonZeroU16;
 #[derive(Clone, Debug, Deserialize, Deserializable, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct NoExcessiveLinesPerFunctionOptions {
     /// The maximum number of lines allowed in a function body.
-    pub max_lines: NonZeroU8,
+    pub max_lines: NonZeroU16,
     /// When this options is set to `true`, blank lines in the function body are not counted towards the maximum line limit.
     pub skip_blank_lines: bool,
     /// When this option is set to `true`, Immediately Invoked Function Expressions (IIFEs) are not checked for the maximum line limit.
@@ -16,9 +16,10 @@ pub struct NoExcessiveLinesPerFunctionOptions {
 impl Default for NoExcessiveLinesPerFunctionOptions {
     fn default() -> Self {
         Self {
-            max_lines: NonZeroU8::new(50).unwrap(),
+            max_lines: NonZeroU16::new(50).unwrap(),
             skip_blank_lines: false,
             skip_iifes: false,
         }
     }
 }
+


### PR DESCRIPTION
Updated the `max_lines` field in `NoExcessiveLinesPerFunctionOptions` to use `NonZeroU16` instead of `NonZeroU8`.
This change increases the maximum configurable number of lines per function, providing greater flexibility for large codebases.

This update improves maintainability for frontend projects (e.g., Next.js) and supports more consistent code style enforcement across teams working with complex components.