### PR TITLE
fix: detect inifinite loops caused by conflicting rule fixes

### DIFF
--- a/crates/biome_service/src/file_handlers/css.rs
+++ b/crates/biome_service/src/file_handlers/css.rs
@@ -13,6 +13,7 @@ use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
     Settings, check_feature_activity, check_override_feature_activity,
 };
+use crate::utils::growth_guard::GrowthGuard;
 use crate::workspace::{
     CodeAction, DocumentFileSource, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult,
     PullActionsResult,
@@ -42,6 +43,7 @@ use biome_rowan::{AstNode, NodeCache};
 use biome_rowan::{TextRange, TextSize, TokenAtOffset};
 use camino::Utf8Path;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use tracing::{debug_span, error, info, trace_span};
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -634,6 +636,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let mut actions = Vec::new();
     let mut skipped_suggested_fixes = 0;
     let mut errors: u16 = 0;
+    let mut growth_guard = GrowthGuard::new(tree.syntax().text_range_with_trivia().len().into());
 
     loop {
         let (action, _) = analyze(
@@ -708,6 +711,27 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                             .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
                         range,
                     });
+
+                    // Check for runaway edit growth
+                    let curr_len: u32 = tree.syntax().text_range_with_trivia().len().into();
+                    if !growth_guard.check(curr_len) {
+                        // In order to provide a useful diagnostic, we want to flag the rules that caused the conflict.
+                        // We can do this by inspecting the last few fixes that were applied.
+                        // We limit it to the last 10 fixes. If there is a chain of conflicting fixes longer than that, something is **really** fucked up.
+
+                        let mut seen_rules = HashSet::new();
+                        for action in actions.iter().rev().take(10) {
+                            if let Some((group, rule)) = action.rule_name.as_ref() {
+                                seen_rules.insert((group.clone(), rule.clone()));
+                            }
+                        }
+
+                        return Err(WorkspaceError::RuleError(
+                            RuleError::ConflictingRuleFixesError {
+                                rules: seen_rules.into_iter().collect(),
+                            },
+                        ));
+                    }
                 }
             }
             None => {

--- a/crates/biome_service/src/file_handlers/graphql.rs
+++ b/crates/biome_service/src/file_handlers/graphql.rs
@@ -12,6 +12,7 @@ use crate::settings::{
     FormatSettings, LanguageListSettings, LanguageSettings, OverrideSettings, ServiceLanguage,
     Settings, check_feature_activity, check_override_feature_activity,
 };
+use crate::utils::growth_guard::GrowthGuard;
 use crate::workspace::{
     CodeAction, FixAction, FixFileMode, FixFileResult, GetSyntaxTreeResult, PullActionsResult,
 };
@@ -35,6 +36,7 @@ use biome_parser::AnyParse;
 use biome_rowan::{AstNode, NodeCache, TokenAtOffset};
 use camino::Utf8Path;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use tracing::{debug_span, error, info, trace_span};
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -544,6 +546,7 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let mut actions = Vec::new();
     let mut skipped_suggested_fixes = 0;
     let mut errors: u16 = 0;
+    let mut growth_guard = GrowthGuard::new(tree.syntax().text_range_with_trivia().len().into());
 
     loop {
         let (action, _) = analyze(&tree, filter, &analyzer_options, |signal| {
@@ -612,6 +615,27 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                             .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
                         range,
                     });
+
+                    // Check for runaway edit growth
+                    let curr_len: u32 = tree.syntax().text_range_with_trivia().len().into();
+                    if !growth_guard.check(curr_len) {
+                        // In order to provide a useful diagnostic, we want to flag the rules that caused the conflict.
+                        // We can do this by inspecting the last few fixes that were applied.
+                        // We limit it to the last 10 fixes. If there is a chain of conflicting fixes longer than that, something is **really** fucked up.
+
+                        let mut seen_rules = HashSet::new();
+                        for action in actions.iter().rev().take(10) {
+                            if let Some((group, rule)) = action.rule_name.as_ref() {
+                                seen_rules.insert((group.clone(), rule.clone()));
+                            }
+                        }
+
+                        return Err(WorkspaceError::RuleError(
+                            RuleError::ConflictingRuleFixesError {
+                                rules: seen_rules.into_iter().collect(),
+                            },
+                        ));
+                    }
                 }
             }
             None => {

--- a/crates/biome_service/src/file_handlers/javascript.rs
+++ b/crates/biome_service/src/file_handlers/javascript.rs
@@ -9,6 +9,7 @@ use crate::file_handlers::{FixAllParams, is_diagnostic_error};
 use crate::settings::{
     OverrideSettings, Settings, check_feature_activity, check_override_feature_activity,
 };
+use crate::utils::growth_guard::GrowthGuard;
 use crate::workspace::DocumentFileSource;
 use crate::{
     WorkspaceError,
@@ -56,6 +57,7 @@ use biome_rowan::{AstNode, BatchMutationExt, Direction, NodeCache, WalkEvent};
 use camino::Utf8Path;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
 use tracing::{debug, debug_span, error, trace_span};
@@ -870,6 +872,8 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
     let mut actions = Vec::new();
     let mut skipped_suggested_fixes = 0;
     let mut errors: u16 = 0;
+    // For detecting runaway edit growth
+    let mut growth_guard = GrowthGuard::new(tree.syntax().text_range_with_trivia().len().into());
 
     loop {
         let services = JsAnalyzerServices::from((
@@ -954,6 +958,27 @@ pub(crate) fn fix_all(params: FixAllParams) -> Result<FixFileResult, WorkspaceEr
                             .map(|(group, rule)| (Cow::Borrowed(group), Cow::Borrowed(rule))),
                         range,
                     });
+
+                    // Check for runaway edit growth
+                    let curr_len: u32 = tree.syntax().text_range_with_trivia().len().into();
+                    if !growth_guard.check(curr_len) {
+                        // In order to provide a useful diagnostic, we want to flag the rules that caused the conflict.
+                        // We can do this by inspecting the last few fixes that were applied.
+                        // We limit it to the last 10 fixes. If there is a chain of conflicting fixes longer than that, something is **really** fucked up.
+
+                        let mut seen_rules = HashSet::new();
+                        for action in actions.iter().rev().take(10) {
+                            if let Some((group, rule)) = action.rule_name.as_ref() {
+                                seen_rules.insert((group.clone(), rule.clone()));
+                            }
+                        }
+
+                        return Err(WorkspaceError::RuleError(
+                            RuleError::ConflictingRuleFixesError {
+                                rules: seen_rules.into_iter().collect(),
+                            },
+                        ));
+                    }
                 }
             }
             None => {

--- a/crates/biome_service/src/lib.rs
+++ b/crates/biome_service/src/lib.rs
@@ -12,6 +12,7 @@ pub mod workspace;
 pub mod workspace_types;
 
 mod scanner;
+mod utils;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/biome_service/src/utils/growth_guard.rs
+++ b/crates/biome_service/src/utils/growth_guard.rs
@@ -1,0 +1,70 @@
+const RATIO_Q: u32 = 100; // fixed-point 2 decimals
+const RATIO_GROWTH: u32 = 150; // 1.5x growth increase
+const RATIO_ACCEL: u32 = 180; // 1.8x delta increase
+const STREAK_LIMIT: u8 = 10;
+
+/// A guard that ensures a value does not grow too quickly.
+///
+/// Used to prevent runaway growth of files when applying fixes.
+pub(crate) struct GrowthGuard {
+    previous: u32,
+    previous_diff: u32,
+    /// multiplicative growth streak
+    growth_streak: u8,
+    /// delta acceleration streak
+    accel_streak: u8,
+}
+
+impl GrowthGuard {
+    pub fn new(initial: u32) -> Self {
+        Self {
+            previous: initial,
+            previous_diff: 0,
+            growth_streak: 0,
+            accel_streak: 0,
+        }
+    }
+
+    /// Check if the new value is allowed based on growth constraints.
+    ///
+    /// Returns `true` if the new value is allowed, `false` otherwise.
+    pub fn check(&mut self, new: u32) -> bool {
+        if new < self.previous {
+            // Allow decreases
+            self.previous = new;
+            self.previous_diff = 0;
+            self.growth_streak = 0;
+            self.accel_streak = 0;
+            return true;
+        }
+
+        let diff = new.saturating_sub(self.previous);
+
+        // Check for multiplicative growth
+        if new.saturating_mul(RATIO_Q) >= self.previous.saturating_mul(RATIO_GROWTH) {
+            self.growth_streak = self.growth_streak.saturating_add(1);
+        } else {
+            self.growth_streak = 0;
+        }
+
+        // Check for delta acceleration
+        if diff.saturating_mul(RATIO_Q) >= self.previous_diff.saturating_mul(RATIO_ACCEL)
+            && self.previous_diff > 0
+        {
+            self.accel_streak = self.accel_streak.saturating_add(1);
+        } else {
+            self.accel_streak = 0;
+        }
+
+        // Update state
+        self.previous = new;
+        self.previous_diff = diff;
+
+        // Enforce limits
+        if self.growth_streak >= STREAK_LIMIT || self.accel_streak >= STREAK_LIMIT {
+            return false;
+        }
+
+        true
+    }
+}

--- a/crates/biome_service/src/utils/mod.rs
+++ b/crates/biome_service/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod growth_guard;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
I recently encountered an infinite loop when applying fixes, and I have a hunch it's related to recent reports of biome using too many resources. Regardless, we want to detect this anyway to make it easier for users to give us good bug reports when this happens.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
related to (but does not solve) #7711

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
Reproduce #7711, and see that the diagnostic gets emitted.

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
