### PR TITLE
feat(useSortedClasses): add support for custom classes

### DIFF
--- a/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_config.rs
+++ b/crates/biome_js_analyze/src/lint/nursery/use_sorted_classes/sort_config.rs
@@ -17,6 +17,12 @@ pub struct UtilityLayer {
     pub classes: &'static [&'static str],
 }
 
+/// An owned version of UtilityLayer for dynamic class lists.
+pub struct UtilityLayerOwned {
+    pub name: String,
+    pub classes: Vec<String>,
+}
+
 pub fn build_variant_weight(size: usize) -> BitVec<u8, Lsb0> {
     let mut bit_vec = BitVec::new();
     let iterable = vec![false; size];
@@ -36,6 +42,10 @@ pub struct SortConfig {
     pub utilities: &'static [UtilityLayer],
     pub variants: VariantsConfig,
     pub layer_index_map: HashMap<&'static str, usize>,
+    /// Optional owned utilities for dynamic custom classes
+    pub utilities_owned: Option<Vec<UtilityLayerOwned>>,
+    /// Optional owned layer index map for custom classes
+    pub layer_index_map_owned: Option<HashMap<String, usize>>,
 }
 
 impl SortConfig {
@@ -54,6 +64,79 @@ impl SortConfig {
             utilities: preset.utilities,
             variants: preset.variants,
             layer_index_map,
+            utilities_owned: None,
+            layer_index_map_owned: None,
+        }
+    }
+
+    /// Gets the layer index, regardless of owned/static backing.
+    #[allow(dead_code)]
+    pub fn layer_index(&self, name: &str) -> Option<usize> {
+        if let Some(map) = &self.layer_index_map_owned {
+            map.get(name).copied()
+        } else {
+            self.layer_index_map.get(name).copied()
+        }
+    }
+
+    /// Creates a new sort config with custom classes merged into the preset.
+    pub fn with_custom_classes(
+        preset: &ConfigPreset,
+        custom_components: Option<&[Box<str>]>,
+        custom_utilities: Option<&[Box<str>]>,
+    ) -> Self {
+        // Early return if no custom classes provided
+        if custom_components.is_none() && custom_utilities.is_none() {
+            return Self::new(preset);
+        }
+
+        // Build owned utility layers by merging preset with custom classes
+        let utilities_owned: Vec<UtilityLayerOwned> = preset
+            .utilities
+            .iter()
+            .map(|layer| {
+                let mut classes: Vec<String> =
+                    layer.classes.iter().copied().map(String::from).collect();
+
+                // Append custom classes to the end of their respective layer
+                match layer.name {
+                    "components" => {
+                        if let Some(custom) = custom_components {
+                            classes.extend(custom.iter().map(|s| s.to_string()));
+                        }
+                    }
+                    "utilities" => {
+                        if let Some(custom) = custom_utilities {
+                            classes.extend(custom.iter().map(|s| s.to_string()));
+                        }
+                    }
+                    _ => {} // No custom classes for other layers
+                }
+
+                UtilityLayerOwned {
+                    name: layer.name.to_string(),
+                    classes,
+                }
+            })
+            .collect();
+
+        // Compute owned layer index map
+        let layer_index_map_owned: HashMap<String, usize> = utilities_owned
+            .iter()
+            .enumerate()
+            .map(|(idx, layer)| (layer.name.clone(), idx))
+            .chain(std::iter::once((
+                "arbitrary".to_string(),
+                utilities_owned.len(),
+            )))
+            .collect();
+
+        Self {
+            utilities: preset.utilities,
+            variants: preset.variants,
+            layer_index_map: HashMap::new(), // Unused when utilities_owned is Some
+            utilities_owned: Some(utilities_owned),
+            layer_index_map_owned: Some(layer_index_map_owned),
         }
     }
 }

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.jsx
@@ -1,0 +1,14 @@
+// Valid (already sorted)
+<div class="container btn-primary px-2 text-red-500 custom-utility" />;
+
+// Invalid (needs sorting - custom classes should go after their layer's classes)
+<div class="custom-utility px-2 container text-red-500" />;
+
+// Invalid (utilities need sorting with custom class)
+<div class="text-red-500 custom-utility px-2" />;
+
+// Custom component class
+<div class="card container block" />;
+
+// Multiple custom classes
+<div class="text-lg custom-spacing px-4 custom-layout" />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.jsx.snap
@@ -1,0 +1,113 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: customClasses.jsx
+---
+# Input
+```jsx
+// Valid (already sorted)
+<div class="container btn-primary px-2 text-red-500 custom-utility" />;
+
+// Invalid (needs sorting - custom classes should go after their layer's classes)
+<div class="custom-utility px-2 container text-red-500" />;
+
+// Invalid (utilities need sorting with custom class)
+<div class="text-red-500 custom-utility px-2" />;
+
+// Custom component class
+<div class="card container block" />;
+
+// Multiple custom classes
+<div class="text-lg custom-spacing px-4 custom-layout" />;
+
+```
+
+# Diagnostics
+```
+customClasses.jsx:5:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    4 │ // Invalid (needs sorting - custom classes should go after their layer's classes)
+  > 5 │ <div class="custom-utility px-2 container text-red-500" />;
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Invalid (utilities need sorting with custom class)
+  
+  i Unsafe fix: Sort the classes.
+  
+     3  3 │   
+     4  4 │   // Invalid (needs sorting - custom classes should go after their layer's classes)
+     5    │ - <div·class="custom-utility·px-2·container·text-red-500"·/>;
+        5 │ + <div·class="container·px-2·text-red-500·custom-utility"·/>;
+     6  6 │   
+     7  7 │   // Invalid (utilities need sorting with custom class)
+  
+
+```
+
+```
+customClasses.jsx:8:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     7 │ // Invalid (utilities need sorting with custom class)
+   > 8 │ <div class="text-red-500 custom-utility px-2" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Custom component class
+  
+  i Unsafe fix: Sort the classes.
+  
+     6  6 │   
+     7  7 │   // Invalid (utilities need sorting with custom class)
+     8    │ - <div·class="text-red-500·custom-utility·px-2"·/>;
+        8 │ + <div·class="px-2·text-red-500·custom-utility"·/>;
+     9  9 │   
+    10 10 │   // Custom component class
+  
+
+```
+
+```
+customClasses.jsx:11:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    10 │ // Custom component class
+  > 11 │ <div class="card container block" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+    13 │ // Multiple custom classes
+  
+  i Unsafe fix: Sort the classes.
+  
+     9  9 │   
+    10 10 │   // Custom component class
+    11    │ - <div·class="card·container·block"·/>;
+       11 │ + <div·class="container·card·block"·/>;
+    12 12 │   
+    13 13 │   // Multiple custom classes
+  
+
+```
+
+```
+customClasses.jsx:14:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    13 │ // Multiple custom classes
+  > 14 │ <div class="text-lg custom-spacing px-4 custom-layout" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    15 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+    12 12 │   
+    13 13 │   // Multiple custom classes
+    14    │ - <div·class="text-lg·custom-spacing·px-4·custom-layout"·/>;
+       14 │ + <div·class="px-4·text-lg·custom-layout·custom-spacing"·/>;
+    15 15 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/customClasses.options.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useSortedClasses": {
+					"level": "error",
+					"options": {
+						"classes": {
+							"components": ["btn-", "card$"],
+							"utilities": ["custom-"]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.jsx
@@ -1,0 +1,11 @@
+// Invalid (needs sorting - custom classes should go after their layer's classes)
+<div class="custom-utility px-2 container text-red-500" />;
+
+// Invalid (utilities need sorting with custom class)
+<div class="text-red-500 custom-utility px-2" />;
+
+// Custom component class
+<div class="card container block" />;
+
+// Multiple custom classes
+<div class="text-lg custom-spacing px-4 custom-layout" />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.jsx.snap
@@ -1,0 +1,109 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: invalidCustomClasses.jsx
+---
+# Input
+```jsx
+// Invalid (needs sorting - custom classes should go after their layer's classes)
+<div class="custom-utility px-2 container text-red-500" />;
+
+// Invalid (utilities need sorting with custom class)
+<div class="text-red-500 custom-utility px-2" />;
+
+// Custom component class
+<div class="card container block" />;
+
+// Multiple custom classes
+<div class="text-lg custom-spacing px-4 custom-layout" />;
+
+```
+
+# Diagnostics
+```
+invalidCustomClasses.jsx:2:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    1 │ // Invalid (needs sorting - custom classes should go after their layer's classes)
+  > 2 │ <div class="custom-utility px-2 container text-red-500" />;
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    3 │ 
+    4 │ // Invalid (utilities need sorting with custom class)
+  
+  i Unsafe fix: Sort the classes.
+  
+     1  1 │   // Invalid (needs sorting - custom classes should go after their layer's classes)
+     2    │ - <div·class="custom-utility·px-2·container·text-red-500"·/>;
+        2 │ + <div·class="container·px-2·text-red-500·custom-utility"·/>;
+     3  3 │   
+     4  4 │   // Invalid (utilities need sorting with custom class)
+  
+
+```
+
+```
+invalidCustomClasses.jsx:5:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    4 │ // Invalid (utilities need sorting with custom class)
+  > 5 │ <div class="text-red-500 custom-utility px-2" />;
+      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │ 
+    7 │ // Custom component class
+  
+  i Unsafe fix: Sort the classes.
+  
+     3  3 │   
+     4  4 │   // Invalid (utilities need sorting with custom class)
+     5    │ - <div·class="text-red-500·custom-utility·px-2"·/>;
+        5 │ + <div·class="px-2·text-red-500·custom-utility"·/>;
+     6  6 │   
+     7  7 │   // Custom component class
+  
+
+```
+
+```
+invalidCustomClasses.jsx:8:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+     7 │ // Custom component class
+   > 8 │ <div class="card container block" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^
+     9 │ 
+    10 │ // Multiple custom classes
+  
+  i Unsafe fix: Sort the classes.
+  
+     6  6 │   
+     7  7 │   // Custom component class
+     8    │ - <div·class="card·container·block"·/>;
+        8 │ + <div·class="container·card·block"·/>;
+     9  9 │   
+    10 10 │   // Multiple custom classes
+  
+
+```
+
+```
+invalidCustomClasses.jsx:11:12 lint/nursery/useSortedClasses  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  i These CSS classes should be sorted.
+  
+    10 │ // Multiple custom classes
+  > 11 │ <div class="text-lg custom-spacing px-4 custom-layout" />;
+       │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    12 │ 
+  
+  i Unsafe fix: Sort the classes.
+  
+     9  9 │   
+    10 10 │   // Multiple custom classes
+    11    │ - <div·class="text-lg·custom-spacing·px-4·custom-layout"·/>;
+       11 │ + <div·class="px-4·text-lg·custom-layout·custom-spacing"·/>;
+    12 12 │   
+  
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/invalidCustomClasses.options.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useSortedClasses": {
+					"level": "error",
+					"options": {
+						"classes": {
+							"components": ["btn-", "card$"],
+							"utilities": ["custom-"]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.jsx
@@ -1,0 +1,4 @@
+/* should not generate diagnostics */
+
+// Valid (already sorted)
+<div class="container btn-primary px-2 text-red-500 custom-utility" />;

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.jsx.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: validCustomClasses.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+
+// Valid (already sorted)
+<div class="container btn-primary px-2 text-red-500 custom-utility" />;
+
+```

--- a/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.options.json
+++ b/crates/biome_js_analyze/tests/specs/nursery/useSortedClasses/validCustomClasses.options.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+	"linter": {
+		"rules": {
+			"nursery": {
+				"useSortedClasses": {
+					"level": "error",
+					"options": {
+						"classes": {
+							"components": ["btn-", "card$"],
+							"utilities": ["custom-"]
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8269,6 +8269,10 @@ export interface UseSortedClassesOptions {
 	 */
 	attributes?: string[];
 	/**
+	 * Custom utility and component classes to be sorted.
+	 */
+	classes?: CustomClasses;
+	/**
 	 * Names of the functions or tagged templates that will be sorted.
 	 */
 	functions?: string[];
@@ -8615,6 +8619,16 @@ For example, for React's `useRef()` hook the value would be `true`, while for `u
 }
 export type UseConsistentArrowReturnStyle = "asNeeded" | "always" | "never";
 export type ConsistentTypeDefinition = "interface" | "type";
+export interface CustomClasses {
+	/**
+	 * Custom component classes to be sorted.
+	 */
+	components?: string[];
+	/**
+	 * Custom utility classes to be sorted.
+	 */
+	utilities?: string[];
+}
 /**
  * Specifies whether property assignments on function parameters are allowed or denied.
  */

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1392,6 +1392,22 @@
 			},
 			"additionalProperties": false
 		},
+		"CustomClasses": {
+			"type": "object",
+			"properties": {
+				"components": {
+					"description": "Custom component classes to be sorted.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				},
+				"utilities": {
+					"description": "Custom utility classes to be sorted.",
+					"type": ["array", "null"],
+					"items": { "type": "string" }
+				}
+			},
+			"additionalProperties": false
+		},
 		"CustomRestrictedElements": {
 			"type": "object",
 			"minProperties": 1,
@@ -14687,6 +14703,13 @@
 					"description": "Additional attributes that will be sorted.",
 					"type": ["array", "null"],
 					"items": { "type": "string" }
+				},
+				"classes": {
+					"description": "Custom utility and component classes to be sorted.",
+					"anyOf": [
+						{ "$ref": "#/definitions/CustomClasses" },
+						{ "type": "null" }
+					]
 				},
 				"functions": {
 					"description": "Names of the functions or tagged templates that will be sorted.",


### PR DESCRIPTION
## Summary

This PR adds support for custom component and utility classes to the [`useSortedClasses`](https://biomejs.dev/linter/rules/use-sorted-classes/) rule.

### Motivation

Currently, the `useSortedClasses` rule only recognizes and sorts Tailwind CSS's default classes. However, users often:
- Use Tailwind CSS plugins that add custom utilities
- Define their own utility classes in their projects
- Have custom component classes (like button variants, card styles, etc.)

Without this feature, these custom classes remain unsorted and may appear in inconsistent positions, defeating the purpose of the rule.

### Design Decisions

#### Long-term Vision vs. Pragmatic Solution

Ideally, Biome would parse and read the Tailwind configuration file (or CSS files) to automatically detect custom utilities. However, there are significant concerns with this approach:

1. **Tight coupling**: This would make Biome heavily coupled to Tailwind CSS specifics, which goes against Biome's goal of being a general-purpose utility class sorter that works with any framework (UnoCSS, custom utilities, etc.)

2. **Implementation timeline**: Implementing a robust configuration parser would take considerable time and effort before users can benefit from custom class support.

Given these constraints, this PR proposes a **pragmatic interim solution** that can be used immediately while we design and implement a better long-term approach.

#### Alternative Designs Considered

I've considered a more extensible approach that could support framework-specific presets:

```json
{
  "classes": [
    "tailwind.utilities",  // reserved for future preset
    "custom-",
    "foo-",
    "other-framework.options"  // reserved for other frameworks
  ]
}
```

However, this design introduces new concepts like tailwind.utilities as reserved identifiers, which felt premature at this stage. The current simpler approach of explicit components and utilities arrays is:
- Easier to understand and use
- Doesn't preclude future enhancements
- Provides immediate value without introducing complex abstractions
