### PR TITLE
feat(js/useImportExtensions): add `extensionMappings` option

### DIFF
--- a/.changeset/six-plants-lie.md
+++ b/.changeset/six-plants-lie.md
@@ -1,0 +1,17 @@
+---
+"@biomejs/biome": minor
+---
+
+Added the `extensionMappings` option to `useImportExtensions`. This allows users to specify custom file extensions for different module types.
+
+For example, if you want to ban all `.ts` imports in favor of `.js` imports, you can now do so with this option:
+
+```json
+{
+    "options": {
+        "extensionMappings": {
+            "ts": "js",
+        }
+    }
+}
+```

--- a/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/use_import_extensions.rs
@@ -77,6 +77,32 @@ declare_lint_rule! {
     ///
     /// The rule provides the options described below.
     ///
+    /// ### extensionMappings
+    ///
+    /// A map of file extensions to their suggested replacements. This allows you
+    /// to specify custom mappings for import extensions. For example, you can
+    /// map TypeScript imports to JavaScript extensions.
+    ///
+    /// This is useful if you are bundling your code to JavaScript into a package
+    /// and want to make sure all imports of TypeScript files use the `.js` extension
+    /// instead.
+    ///
+    /// If no mapping is found for a given extension, and the import is missing an extension,
+    /// the rule will suggest using the actual extension of the resolved file.
+    ///
+    /// Default: `{}` (empty object)
+    ///
+    /// ```json,options
+    /// {
+    ///     "options": {
+    ///         "extensionMappings": {
+    ///             "ts": "js",
+    ///             "tsx": "js"
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
     /// ### forceJsExtensions
     ///
     /// Normally, this rule suggests to use the extension of the module that is
@@ -259,6 +285,11 @@ fn get_extensionless_import(
 
     let extension = if force_js_extensions {
         "js"
+    } else if let Some(extension_mappings) = ctx.options().extension_mappings.as_ref()
+        && let Some(mapped_extension) =
+            resolved_extension.and_then(|ext| extension_mappings.get(ext))
+    {
+        mapped_extension.as_ref()
     } else {
         resolved_extension?
     };

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/bar.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/bar.ts
@@ -1,0 +1,1 @@
+export const bar = "bar";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/bar.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/bar.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 137
+expression: bar.ts
+---
+# Input
+```ts
+export const bar = "bar";
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/foo.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/foo.ts
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/foo.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/foo.ts.snap
@@ -1,0 +1,9 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 137
+expression: foo.ts
+---
+# Input
+```ts
+export const foo = "foo";
+```

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.options.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "correctness": {
+        "useImportExtensions": {
+          "level": "error",
+          "options": {
+            "extensionMappings": {
+              "ts": "js"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.ts
@@ -1,0 +1,2 @@
+import "./foo";
+import "./bar.ts";

--- a/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/useImportExtensions/invalidWithExtensionMappings.ts.snap
@@ -1,0 +1,56 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+assertion_line: 137
+expression: invalidWithExtensionMappings.ts
+---
+# Input
+```ts
+import "./foo";
+import "./bar.ts";
+
+```
+
+# Diagnostics
+```
+invalidWithExtensionMappings.ts:1:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━━━
+
+  ! Add a file extension for relative imports.
+  
+  > 1 │ import "./foo";
+      │        ^^^^^^^
+    2 │ import "./bar.ts";
+    3 │ 
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .js.
+  
+    1   │ - import·"./foo";
+      1 │ + import·"./foo.js";
+    2 2 │   import "./bar.ts";
+    3 3 │   
+  
+
+```
+
+```
+invalidWithExtensionMappings.ts:2:8 lint/correctness/useImportExtensions  FIXABLE  ━━━━━━━━━━━━━━━━━
+
+  ! Add a file extension for relative imports.
+  
+    1 │ import "./foo";
+  > 2 │ import "./bar.ts";
+      │        ^^^^^^^^^^
+    3 │ 
+  
+  i Explicit import improves compatibility with browsers and makes file resolution in tooling faster.
+  
+  i Safe fix: Add import extension .js.
+  
+    1 1 │   import "./foo";
+    2   │ - import·"./bar.ts";
+      2 │ + import·"./bar.js";
+    3 3 │   
+  
+
+```

--- a/crates/biome_rule_options/src/use_import_extensions.rs
+++ b/crates/biome_rule_options/src/use_import_extensions.rs
@@ -1,4 +1,5 @@
 use biome_deserialize_macros::{Deserializable, Merge};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 #[derive(Default, Clone, Debug, Deserialize, Deserializable, Merge, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -6,8 +7,13 @@ use serde::{Deserialize, Serialize};
 pub struct UseImportExtensionsOptions {
     /// If `true`, the suggested extension is always `.js` regardless of what
     /// extension the source file has in your project.
-    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub force_js_extensions: Option<bool>,
+
+    /// A map of file extensions to their suggested replacements.
+    /// For example, `{"ts": "js"}` would suggest `.js` extensions for TypeScript imports.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extension_mappings: Option<FxHashMap<Box<str>, Box<str>>>,
 }
 
 impl UseImportExtensionsOptions {

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -8276,6 +8276,10 @@ export interface UseHookAtTopLevelOptions {}
 export type UseImageSizeOptions = null;
 export interface UseImportExtensionsOptions {
 	/**
+	 * A map of file extensions to their suggested replacements. For example, `{"ts": "js"}` would suggest `.js` extensions for TypeScript imports.
+	 */
+	extensionMappings?: Record<string, string>;
+	/**
 	 * If `true`, the suggested extension is always `.js` regardless of what extension the source file has in your project.
 	 */
 	forceJsExtensions?: boolean;

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -14458,6 +14458,11 @@
 		"UseImportExtensionsOptions": {
 			"type": "object",
 			"properties": {
+				"extensionMappings": {
+					"description": "A map of file extensions to their suggested replacements. For example, `{\"ts\": \"js\"}` would suggest `.js` extensions for TypeScript imports.",
+					"type": ["object", "null"],
+					"additionalProperties": { "type": "string" }
+				},
 				"forceJsExtensions": {
 					"description": "If `true`, the suggested extension is always `.js` regardless of what extension the source file has in your project.",
 					"type": ["boolean", "null"]


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
Adds a new option to `useImportExtensions` to be a more precisely configurable version of `forcejsextensions`.

Open to suggestions for a better name for the option, I don't really like it but couldn't come up with anything else.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #7734

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->
updated the rule docs
<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
