### PR TITLE
fix(cli): ignore missing paths from --changed

### DIFF
--- a/.changeset/fix-changed-missing-paths.md
+++ b/.changeset/fix-changed-missing-paths.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#4952](https://github.com/biomejs/biome/issues/4952): `--changed` now ignores files removed from the working tree instead of emitting an internal error.

--- a/crates/biome_cli/tests/commands/lint.rs
+++ b/crates/biome_cli/tests/commands/lint.rs
@@ -2322,6 +2322,30 @@ fn should_error_if_changed_flag_is_used_without_since_or_default_branch_config()
 }
 
 #[test]
+fn should_skip_missing_changed_files() {
+    let mut console = BufferConsole::default();
+    let mut fs = MemoryFileSystem::default();
+
+    fs.set_on_get_changed_files(Box::new(|| vec![String::from("missing.js")]));
+
+    let (fs, result) = run_cli(
+        fs,
+        &mut console,
+        Args::from(["lint", "--changed", "--since=main"].as_slice()),
+    );
+
+    assert!(result.is_err(), "run_cli returned {result:?}");
+
+    assert_cli_snapshot(SnapshotPayload::new(
+        module_path!(),
+        "should_skip_missing_changed_files",
+        fs,
+        console,
+        result,
+    ));
+}
+
+#[test]
 fn should_process_changed_files_if_changed_flag_is_set_and_default_branch_is_configured() {
     let mut console = BufferConsole::default();
     let mut fs = MemoryFileSystem::default();

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_missing_changed_files.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/should_skip_missing_changed_files.snap
@@ -1,0 +1,27 @@
+---
+source: crates/biome_cli/tests/snap_test.rs
+assertion_line: 432
+expression: redactor(content)
+---
+# Termination Message
+
+```block
+lint ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × No files were processed in the specified paths.
+  
+  i Check your biome.json or biome.jsonc to ensure the paths are not ignored by the configuration.
+  
+  i These paths were provided but ignored:
+  
+  ! The list is empty.
+  
+
+
+```
+
+# Emitted Messages
+
+```block
+Checked 0 files in <TIME>. No fixes applied.
+```


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

- Fixed [#4952](https://github.com/biomejs/biome/issues/4952) by filtering `--changed` results to skip files that were deleted or renamed locally, preventing the internal IO error.
- Added a regression test and snapshot for the missing-file scenario

## Test Plan

- `cargo build`
- `cargo test -p biome_cli`

## Docs

- Not applicable; no documentation updates required.

