### PR TITLE
docs: fix typo in `ignoreUnknown` option description

### DIFF
--- a/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_check/check_help.snap
@@ -26,7 +26,7 @@ The configuration that is contained inside the file `biome.json`
                               above this limit will be ignored for performance reasons. Defaults to
                               1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
-                              that doesn't know
+                              that it doesn't know
         --indent-style=<tab|space>  The indent style.
         --indent-width=NUMBER  The size of the indentation, 2 by default
         --line-ending=<lf|crlf|cr>  The type of line ending.

--- a/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_ci/ci_help.snap
@@ -27,7 +27,7 @@ The configuration that is contained inside the file `biome.json`
                               above this limit will be ignored for performance reasons. Defaults to
                               1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
-                              that doesn't know
+                              that it doesn't know
         --indent-style=<tab|space>  The indent style.
         --indent-width=NUMBER  The size of the indentation, 2 by default
         --line-ending=<lf|crlf|cr>  The type of line ending.

--- a/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_format/format_help.snap
@@ -94,7 +94,7 @@ The configuration of the filesystem
                               above this limit will be ignored for performance reasons. Defaults to
                               1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
-                              that doesn't know
+                              that it doesn't know
 
 Global options applied to all commands
         --colors=<off|force>  Set the formatting mode for markup: "off" prints everything as plain

--- a/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
+++ b/crates/biome_cli/tests/snapshots/main_commands_lint/lint_help.snap
@@ -28,7 +28,7 @@ The configuration of the filesystem
                               above this limit will be ignored for performance reasons. Defaults to
                               1 MiB
         --files-ignore-unknown=<true|false>  Tells Biome to not emit diagnostics when handling files
-                              that doesn't know
+                              that it doesn't know
 
 Linter options specific to the JavaScript linter
         --javascript-linter-enabled=<true|false>  Control the linter for JavaScript (and its super

--- a/crates/biome_configuration/src/lib.rs
+++ b/crates/biome_configuration/src/lib.rs
@@ -536,7 +536,7 @@ pub struct FilesConfiguration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_size: Option<MaxSize>,
 
-    /// Tells Biome to not emit diagnostics when handling files that doesn't know
+    /// Tells Biome to not emit diagnostics when handling files that it doesn't know
     #[bpaf(long("files-ignore-unknown"), argument("true|false"), optional)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_unknown: Option<FilesIgnoreUnknownEnabled>,

--- a/packages/@biomejs/backend-jsonrpc/src/workspace.ts
+++ b/packages/@biomejs/backend-jsonrpc/src/workspace.ts
@@ -159,7 +159,7 @@ Please be aware that rules relying on the module graph or type inference informa
 	 */
 	experimentalScannerIgnores?: string[];
 	/**
-	 * Tells Biome to not emit diagnostics when handling files that doesn't know
+	 * Tells Biome to not emit diagnostics when handling files that it doesn't know
 	 */
 	ignoreUnknown?: Bool;
 	/**

--- a/packages/@biomejs/biome/configuration_schema.json
+++ b/packages/@biomejs/biome/configuration_schema.json
@@ -1491,7 +1491,7 @@
 					"items": { "type": "string" }
 				},
 				"ignoreUnknown": {
-					"description": "Tells Biome to not emit diagnostics when handling files that doesn't know",
+					"description": "Tells Biome to not emit diagnostics when handling files that it doesn't know",
 					"anyOf": [{ "$ref": "#/definitions/Bool" }, { "type": "null" }]
 				},
 				"includes": {


### PR DESCRIPTION
## Summary

Fix a small typo in the description of `ignoreUnknown`:

```diff
- Tells Biome to not emit diagnostics when handling files that doesn't know
+ Tells Biome to not emit diagnostics when handling files that it doesn't know
```