### PR TITLE
test: use Manifest::read_manifest to insert tsconfig

### DIFF
--- a/crates/biome_test_utils/src/lib.rs
+++ b/crates/biome_test_utils/src/lib.rs
@@ -16,7 +16,7 @@ use biome_js_parser::{AnyJsRoot, JsFileSource, JsParserOptions};
 use biome_js_type_info::{TypeData, TypeResolver};
 use biome_json_parser::{JsonParserOptions, ParseDiagnostic};
 use biome_module_graph::ModuleGraph;
-use biome_package::{PackageJson, TsConfigJson};
+use biome_package::{Manifest, PackageJson, TsConfigJson};
 use biome_project_layout::ProjectLayout;
 use biome_rowan::{Direction, Language, SyntaxKind, SyntaxNode, SyntaxSlot};
 use biome_service::file_handlers::DocumentFileSource;
@@ -212,14 +212,11 @@ pub fn project_layout_for_test_file(
     diagnostics: &mut Vec<String>,
 ) -> Arc<ProjectLayout> {
     let project_layout = ProjectLayout::default();
+    let fs = OsFileSystem::new(input_file.parent().unwrap().to_path_buf());
 
     let package_json_file = input_file.with_extension("package.json");
     if let Ok(json) = std::fs::read_to_string(&package_json_file) {
-        let deserialized = biome_deserialize::json::deserialize_from_json_str::<PackageJson>(
-            json.as_str(),
-            JsonParserOptions::default(),
-            "",
-        );
+        let deserialized = PackageJson::read_manifest(&fs, &package_json_file);
         if deserialized.has_errors() {
             diagnostics.extend(
                 deserialized
@@ -246,13 +243,7 @@ pub fn project_layout_for_test_file(
 
     let tsconfig_file = input_file.with_extension("tsconfig.json");
     if let Ok(json) = std::fs::read_to_string(&tsconfig_file) {
-        let deserialized = biome_deserialize::json::deserialize_from_json_str::<TsConfigJson>(
-            json.as_str(),
-            JsonParserOptions::default()
-                .with_allow_comments()
-                .with_allow_trailing_commas(),
-            "",
-        );
+        let deserialized = TsConfigJson::read_manifest(&fs, &tsconfig_file);
         if deserialized.has_errors() {
             diagnostics.extend(
                 deserialized


### PR DESCRIPTION
## Summary

Fixed the failing tests on CI. `tsconfig.json` has some paths based on where the project exists to resolve path aliases (#7597). `TSConfigJson::initialize_paths` needs to be called before inserting into the project layer. In this pull request, I changed the `project_layout_for_test_file` function to use `TSConfigJson::read_manifest` (impl of `Manifest::read_manifest`) to parse, deserialise and insert the tsconfig.json into the layout.

## Test Plan

CI should back green.

## Docs

N/A