### PR TITLE
fix(parse/css): fix parsing `--*: initial;` with tailwindDirectives enabled

### DIFF
--- a/.changeset/itchy-aliens-ask.md
+++ b/.changeset/itchy-aliens-ask.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed #7843: The CSS parser, when `tailwindDirectives` is enabled, correctly parses `--*: initial;`.

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -2542,17 +2542,34 @@ pub fn tw_utility_at_rule(
 }
 pub fn tw_value_theme_reference(
     reference: CssDashedIdentifier,
-    minus_token: SyntaxToken,
     star_token: SyntaxToken,
-) -> TwValueThemeReference {
-    TwValueThemeReference::unwrap_cast(SyntaxNode::new_detached(
-        CssSyntaxKind::TW_VALUE_THEME_REFERENCE,
-        [
-            Some(SyntaxElement::Node(reference.into_syntax())),
-            Some(SyntaxElement::Token(minus_token)),
-            Some(SyntaxElement::Token(star_token)),
-        ],
-    ))
+) -> TwValueThemeReferenceBuilder {
+    TwValueThemeReferenceBuilder {
+        reference,
+        star_token,
+        minus_token: None,
+    }
+}
+pub struct TwValueThemeReferenceBuilder {
+    reference: CssDashedIdentifier,
+    star_token: SyntaxToken,
+    minus_token: Option<SyntaxToken>,
+}
+impl TwValueThemeReferenceBuilder {
+    pub fn with_minus_token(mut self, minus_token: SyntaxToken) -> Self {
+        self.minus_token = Some(minus_token);
+        self
+    }
+    pub fn build(self) -> TwValueThemeReference {
+        TwValueThemeReference::unwrap_cast(SyntaxNode::new_detached(
+            CssSyntaxKind::TW_VALUE_THEME_REFERENCE,
+            [
+                Some(SyntaxElement::Node(self.reference.into_syntax())),
+                self.minus_token.map(|token| SyntaxElement::Token(token)),
+                Some(SyntaxElement::Token(self.star_token)),
+            ],
+        ))
+    }
 }
 pub fn tw_variant_at_rule(
     variant_token: SyntaxToken,

--- a/crates/biome_css_parser/src/lexer/mod.rs
+++ b/crates/biome_css_parser/src/lexer/mod.rs
@@ -1011,6 +1011,12 @@ impl<'src> CssLexer<'src> {
             && current == b'-'
             && self.peek_byte() == Some(b'*')
         {
+            // HACK: handle `--*`
+            if self.prev_byte() == Some(b'-') {
+                self.advance(1);
+                return Some(current as char);
+            }
+            // otherwise, handle cases like `--color-*`
             return None;
         }
 
@@ -1305,6 +1311,7 @@ impl<'src> CssLexer<'src> {
                             // or the third and fourth code points are a valid escape
                             // return true.
                             BSL => self.is_valid_escape_at(3),
+                            MUL => true,
                             _ => false,
                         }
                     }

--- a/crates/biome_css_parser/src/syntax/property/mod.rs
+++ b/crates/biome_css_parser/src/syntax/property/mod.rs
@@ -6,11 +6,13 @@ use crate::parser::CssParser;
 use crate::syntax::css_modules::{
     composes_not_allowed, expected_classes_list, expected_composes_import_source,
 };
-use crate::syntax::parse_error::{expected_component_value, expected_identifier};
+use crate::syntax::parse_error::{
+    expected_component_value, expected_identifier, tailwind_disabled,
+};
 use crate::syntax::{
-    is_at_any_value, is_at_dashed_identifier, is_at_identifier, is_at_string, parse_any_value,
-    parse_custom_identifier_with_keywords, parse_dashed_identifier, parse_regular_identifier,
-    parse_string,
+    CssSyntaxFeatures, is_at_any_value, is_at_dashed_identifier, is_at_identifier, is_at_string,
+    parse_any_value, parse_custom_identifier_with_keywords, parse_dashed_identifier,
+    parse_regular_identifier, parse_string,
 };
 use biome_css_syntax::CssSyntaxKind::*;
 use biome_css_syntax::{CssSyntaxKind, T};
@@ -18,7 +20,7 @@ use biome_parser::parse_lists::ParseNodeList;
 use biome_parser::parse_recovery::{ParseRecovery, ParseRecoveryTokenSet, RecoveryResult};
 use biome_parser::prelude::ParsedSyntax;
 use biome_parser::prelude::ParsedSyntax::{Absent, Present};
-use biome_parser::{Parser, TokenSet, token_set};
+use biome_parser::{Parser, SyntaxFeature, TokenSet, token_set};
 
 #[inline]
 pub(crate) fn is_at_any_property(p: &mut CssParser) -> bool {
@@ -160,7 +162,11 @@ const END_OF_COMPOSES_CLASS_TOKEN_SET: TokenSet<CssSyntaxKind> =
 #[inline]
 fn is_at_generic_property(p: &mut CssParser) -> bool {
     is_at_identifier(p)
-        && (p.nth_at(1, T![:]) || (p.nth_at(1, T![-]) && p.nth_at(2, T![*]) && p.nth_at(3, T![:])))
+        && (p.nth_at(1, T![:])
+        // handle --*:
+        || (p.nth_at(1, T![*]) && p.nth_at(2, T![:]))
+        // handle --color-*:
+        || (p.nth_at(1, T![-]) && p.nth_at(2, T![*]) && p.nth_at(3, T![:])))
 }
 
 #[inline]
@@ -174,13 +180,22 @@ fn parse_generic_property(p: &mut CssParser) -> ParsedSyntax {
     if is_at_dashed_identifier(p) {
         let ident = parse_dashed_identifier(p).ok();
         if let Some(ident) = ident
-            && p.options().is_tailwind_directives_enabled()
-            && p.at(T![-])
+            && p.at_ts(token_set![T![-], T![*]])
         {
-            let m = ident.precede(p);
-            p.expect(T![-]);
-            p.expect(T![*]);
-            m.complete(p, TW_VALUE_THEME_REFERENCE);
+            CssSyntaxFeatures::Tailwind
+                .parse_exclusive_syntax(
+                    p,
+                    |p| {
+                        let m = ident.precede(p);
+                        if p.at(T![-]) {
+                            p.expect(T![-]);
+                        }
+                        p.expect(T![*]);
+                        Present(m.complete(p, TW_VALUE_THEME_REFERENCE))
+                    },
+                    |p, m| tailwind_disabled(p, m.range(p)),
+                )
+                .ok();
         }
     } else {
         parse_regular_identifier(p).ok();

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/custom-theme.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/custom-theme.css
@@ -1,0 +1,5 @@
+/* Negative test for crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css */
+
+.reset {
+	--*: initial;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/custom-theme.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-disabled/custom-theme.css.snap
@@ -1,0 +1,126 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+/* Negative test for crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css */
+
+.reset {
+	--*: initial;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssQualifiedRule {
+            prelude: CssSelectorList [
+                CssCompoundSelector {
+                    nesting_selectors: CssNestedSelectorList [],
+                    simple_selector: missing (optional),
+                    sub_selectors: CssSubSelectorList [
+                        CssClassSelector {
+                            dot_token: DOT@0..106 "." [Comments("/* Negative test for  ..."), Newline("\n"), Newline("\n")] [],
+                            name: CssCustomIdentifier {
+                                value_token: IDENT@106..112 "reset" [] [Whitespace(" ")],
+                            },
+                        },
+                    ],
+                },
+            ],
+            block: CssDeclarationOrRuleBlock {
+                l_curly_token: L_CURLY@112..113 "{" [] [],
+                items: CssDeclarationOrRuleList [
+                    CssDeclarationWithSemicolon {
+                        declaration: CssDeclaration {
+                            property: CssBogusProperty {
+                                items: [
+                                    CssBogusSupportsCondition {
+                                        items: [
+                                            CssDashedIdentifier {
+                                                value_token: IDENT@113..117 "--" [Newline("\n"), Whitespace("\t")] [],
+                                            },
+                                            STAR@117..118 "*" [] [],
+                                        ],
+                                    },
+                                    COLON@118..120 ":" [] [Whitespace(" ")],
+                                    CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@120..127 "initial" [] [],
+                                        },
+                                    ],
+                                ],
+                            },
+                            important: missing (optional),
+                        },
+                        semicolon_token: SEMICOLON@127..128 ";" [] [],
+                    },
+                ],
+                r_curly_token: R_CURLY@128..130 "}" [Newline("\n")] [],
+            },
+        },
+    ],
+    eof_token: EOF@130..131 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..131
+  0: (empty)
+  1: CSS_RULE_LIST@0..130
+    0: CSS_QUALIFIED_RULE@0..130
+      0: CSS_SELECTOR_LIST@0..112
+        0: CSS_COMPOUND_SELECTOR@0..112
+          0: CSS_NESTED_SELECTOR_LIST@0..0
+          1: (empty)
+          2: CSS_SUB_SELECTOR_LIST@0..112
+            0: CSS_CLASS_SELECTOR@0..112
+              0: DOT@0..106 "." [Comments("/* Negative test for  ..."), Newline("\n"), Newline("\n")] []
+              1: CSS_CUSTOM_IDENTIFIER@106..112
+                0: IDENT@106..112 "reset" [] [Whitespace(" ")]
+      1: CSS_DECLARATION_OR_RULE_BLOCK@112..130
+        0: L_CURLY@112..113 "{" [] []
+        1: CSS_DECLARATION_OR_RULE_LIST@113..128
+          0: CSS_DECLARATION_WITH_SEMICOLON@113..128
+            0: CSS_DECLARATION@113..127
+              0: CSS_BOGUS_PROPERTY@113..127
+                0: CSS_BOGUS_SUPPORTS_CONDITION@113..118
+                  0: CSS_DASHED_IDENTIFIER@113..117
+                    0: IDENT@113..117 "--" [Newline("\n"), Whitespace("\t")] []
+                  1: STAR@117..118 "*" [] []
+                1: COLON@118..120 ":" [] [Whitespace(" ")]
+                2: CSS_GENERIC_COMPONENT_VALUE_LIST@120..127
+                  0: CSS_IDENTIFIER@120..127
+                    0: IDENT@120..127 "initial" [] []
+              1: (empty)
+            1: SEMICOLON@127..128 ";" [] []
+        2: R_CURLY@128..130 "}" [Newline("\n")] []
+  2: EOF@130..131 "" [Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+custom-theme.css:4:2 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Tailwind-specific syntax is disabled.
+  
+    3 │ .reset {
+  > 4 │ 	--*: initial;
+      │ 	^^^
+    5 │ }
+    6 │ 
+  
+  i Enable `tailwindDirectives` in the css parser options, or remove this if you are not using Tailwind CSS.
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css
@@ -1,0 +1,5 @@
+/* From tailwind docs: https://tailwindcss.com/docs/theme#using-a-custom-theme */
+
+@theme {
+	--*: initial;
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/theme/custom-theme.css.snap
@@ -1,0 +1,93 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+/* From tailwind docs: https://tailwindcss.com/docs/theme#using-a-custom-theme */
+
+@theme {
+	--*: initial;
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..84 "@" [Comments("/* From tailwind docs ..."), Newline("\n"), Newline("\n")] [],
+            rule: TwThemeAtRule {
+                theme_token: THEME_KW@84..90 "theme" [] [Whitespace(" ")],
+                name: missing (optional),
+                block: CssDeclarationOrRuleBlock {
+                    l_curly_token: L_CURLY@90..91 "{" [] [],
+                    items: CssDeclarationOrRuleList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: TwValueThemeReference {
+                                        reference: CssDashedIdentifier {
+                                            value_token: IDENT@91..95 "--" [Newline("\n"), Whitespace("\t")] [],
+                                        },
+                                        minus_token: missing (optional),
+                                        star_token: STAR@95..96 "*" [] [],
+                                    },
+                                    colon_token: COLON@96..98 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@98..105 "initial" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@105..106 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@106..108 "}" [Newline("\n")] [],
+                },
+            },
+        },
+    ],
+    eof_token: EOF@108..109 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..109
+  0: (empty)
+  1: CSS_RULE_LIST@0..108
+    0: CSS_AT_RULE@0..108
+      0: AT@0..84 "@" [Comments("/* From tailwind docs ..."), Newline("\n"), Newline("\n")] []
+      1: TW_THEME_AT_RULE@84..108
+        0: THEME_KW@84..90 "theme" [] [Whitespace(" ")]
+        1: (empty)
+        2: CSS_DECLARATION_OR_RULE_BLOCK@90..108
+          0: L_CURLY@90..91 "{" [] []
+          1: CSS_DECLARATION_OR_RULE_LIST@91..106
+            0: CSS_DECLARATION_WITH_SEMICOLON@91..106
+              0: CSS_DECLARATION@91..105
+                0: CSS_GENERIC_PROPERTY@91..105
+                  0: TW_VALUE_THEME_REFERENCE@91..96
+                    0: CSS_DASHED_IDENTIFIER@91..95
+                      0: IDENT@91..95 "--" [Newline("\n"), Whitespace("\t")] []
+                    1: (empty)
+                    2: STAR@95..96 "*" [] []
+                  1: COLON@96..98 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@98..105
+                    0: CSS_IDENTIFIER@98..105
+                      0: IDENT@98..105 "initial" [] []
+                1: (empty)
+              1: SEMICOLON@105..106 ";" [] []
+          2: R_CURLY@106..108 "}" [Newline("\n")] []
+  2: EOF@108..109 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -7361,8 +7361,8 @@ impl TwValueThemeReference {
     pub fn reference(&self) -> SyntaxResult<CssDashedIdentifier> {
         support::required_node(&self.syntax, 0usize)
     }
-    pub fn minus_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 1usize)
+    pub fn minus_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 1usize)
     }
     pub fn star_token(&self) -> SyntaxResult<SyntaxToken> {
         support::required_token(&self.syntax, 2usize)
@@ -7379,7 +7379,7 @@ impl Serialize for TwValueThemeReference {
 #[derive(Serialize)]
 pub struct TwValueThemeReferenceFields {
     pub reference: SyntaxResult<CssDashedIdentifier>,
-    pub minus_token: SyntaxResult<SyntaxToken>,
+    pub minus_token: Option<SyntaxToken>,
     pub star_token: SyntaxResult<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -18619,7 +18619,7 @@ impl std::fmt::Debug for TwValueThemeReference {
                 .field("reference", &support::DebugSyntaxResult(self.reference()))
                 .field(
                     "minus_token",
-                    &support::DebugSyntaxResult(self.minus_token()),
+                    &support::DebugOptionalElement(self.minus_token()),
                 )
                 .field("star_token", &support::DebugSyntaxResult(self.star_token()))
                 .finish()

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -2992,10 +2992,10 @@ impl TwValueThemeReference {
                 .splice_slots(0usize..=0usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_minus_token(self, element: SyntaxToken) -> Self {
+    pub fn with_minus_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(1usize..=1usize, once(Some(element.into()))),
+                .splice_slots(1usize..=1usize, once(element.map(|element| element.into()))),
         )
     }
     pub fn with_star_token(self, element: SyntaxToken) -> Self {

--- a/crates/biome_parser/src/lexer.rs
+++ b/crates/biome_parser/src/lexer.rs
@@ -210,6 +210,15 @@ pub trait Lexer<'src> {
     }
 
     #[inline]
+    fn prev_byte(&self) -> Option<u8> {
+        if self.position() == 0 {
+            None
+        } else {
+            self.source().as_bytes().get(self.position() - 1).copied()
+        }
+    }
+
+    #[inline]
     fn text_position(&self) -> TextSize {
         TextSize::try_from(self.position()).expect("Input to be smaller than 4 GB")
     }

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1873,9 +1873,14 @@ CssMetavariable = value: 'grit_metavariable'
 // Tailwind
 
 // --value(--tab-size-*)
+//         ^^^^^^^^^^^^
+// --color-*: initial;
+// ^^^^^^^^^
+// --*: initial;
+// ^^^
 TwValueThemeReference =
 	reference: CssDashedIdentifier
-	'-'
+	'-'?
 	'*'
 
 // Enhanced @utility directive to support functional utilities


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->

fixes #7843

I wanted to keep the parsing of things like `--color-*` to remain the same where `--color` is the identifier, but if I just blindly did that for the `--*` case, then the identifier would be `-`, which would be confusing for lint rule authors.

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added a snapshot test

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
