### PR TITLE
ci(rules-check): add noSecrets exception

### DIFF
--- a/xtask/rules_check/src/lib.rs
+++ b/xtask/rules_check/src/lib.rs
@@ -85,6 +85,7 @@ pub fn check_rules() -> anyhow::Result<()> {
                         | "noProcessGlobal"
                         | "noReactPropAssignments"
                         | "noRestrictedElements"
+                        | "noSecrets"
                         | "noSolidDestructuredProps"
                         | "useJsonImportAttributes"
                         | "useParseIntRadix"


### PR DESCRIPTION
## Summary

Add `noSecrets` as an exception in the rules-check xtask

## Test Plan

CI must pass.