### PR TITLE
ci: fix clippy failure

### DIFF
--- a/crates/biome_cli/src/service/windows.rs
+++ b/crates/biome_cli/src/service/windows.rs
@@ -129,7 +129,7 @@ impl AsyncRead for ClientReadHalf {
                         return Poll::Ready(Ok(()));
                     }
 
-                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
                     Err(err) => return Poll::Ready(Err(err)),
                 },
 
@@ -154,7 +154,7 @@ impl AsyncWrite for ClientWriteHalf {
             match self.inner.poll_write_ready(cx) {
                 Poll::Ready(Ok(())) => match self.inner.try_write(buf) {
                     Ok(count) => return Poll::Ready(Ok(count)),
-                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
                     Err(err) => return Poll::Ready(Err(err)),
                 },
 
@@ -257,7 +257,7 @@ impl AsyncRead for ServerReadHalf {
                         return Poll::Ready(Ok(()));
                     }
 
-                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
                     Err(err) => return Poll::Ready(Err(err)),
                 },
 
@@ -282,7 +282,7 @@ impl AsyncWrite for ServerWriteHalf {
             match self.inner.poll_write_ready(cx) {
                 Poll::Ready(Ok(())) => match self.inner.try_write(buf) {
                     Ok(count) => return Poll::Ready(Ok(count)),
-                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
                     Err(err) => return Poll::Ready(Err(err)),
                 },
 


### PR DESCRIPTION
## Summary

Fix Clippy failure on CI.
I don't know why this doesn't fail locally. `just lint`/`cargo lint` pass the `--all-features` and `--all-targets` to Clippy. This should thus emit a diagnostic...

## Test Plan

CI must pass