### PR TITLE
fix(parse/css): allow `@plugin` to accept options

### DIFF
--- a/.changeset/small-sides-teach.md
+++ b/.changeset/small-sides-teach.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#7860](https://github.com/biomejs/biome/issues/7860): The css parser, with `tailwindDirectives` enabled, will now accept `@plugin` options.

--- a/crates/biome_css_factory/src/generated/node_factory.rs
+++ b/crates/biome_css_factory/src/generated/node_factory.rs
@@ -2452,19 +2452,42 @@ pub fn tw_functional_utility_name(
         ],
     ))
 }
-pub fn tw_plugin_at_rule(
+pub fn tw_plugin_at_rule(plugin_token: SyntaxToken, name: CssString) -> TwPluginAtRuleBuilder {
+    TwPluginAtRuleBuilder {
+        plugin_token,
+        name,
+        block: None,
+        semicolon_token: None,
+    }
+}
+pub struct TwPluginAtRuleBuilder {
     plugin_token: SyntaxToken,
     name: CssString,
-    semicolon_token: SyntaxToken,
-) -> TwPluginAtRule {
-    TwPluginAtRule::unwrap_cast(SyntaxNode::new_detached(
-        CssSyntaxKind::TW_PLUGIN_AT_RULE,
-        [
-            Some(SyntaxElement::Token(plugin_token)),
-            Some(SyntaxElement::Node(name.into_syntax())),
-            Some(SyntaxElement::Token(semicolon_token)),
-        ],
-    ))
+    block: Option<AnyCssDeclarationBlock>,
+    semicolon_token: Option<SyntaxToken>,
+}
+impl TwPluginAtRuleBuilder {
+    pub fn with_block(mut self, block: AnyCssDeclarationBlock) -> Self {
+        self.block = Some(block);
+        self
+    }
+    pub fn with_semicolon_token(mut self, semicolon_token: SyntaxToken) -> Self {
+        self.semicolon_token = Some(semicolon_token);
+        self
+    }
+    pub fn build(self) -> TwPluginAtRule {
+        TwPluginAtRule::unwrap_cast(SyntaxNode::new_detached(
+            CssSyntaxKind::TW_PLUGIN_AT_RULE,
+            [
+                Some(SyntaxElement::Token(self.plugin_token)),
+                Some(SyntaxElement::Node(self.name.into_syntax())),
+                self.block
+                    .map(|token| SyntaxElement::Node(token.into_syntax())),
+                self.semicolon_token
+                    .map(|token| SyntaxElement::Token(token)),
+            ],
+        ))
+    }
 }
 pub fn tw_reference_at_rule(
     reference_token: SyntaxToken,

--- a/crates/biome_css_factory/src/generated/syntax_factory.rs
+++ b/crates/biome_css_factory/src/generated/syntax_factory.rs
@@ -5048,7 +5048,7 @@ impl SyntaxFactory for CssSyntaxFactory {
             }
             TW_PLUGIN_AT_RULE => {
                 let mut elements = (&children).into_iter();
-                let mut slots: RawNodeSlots<3usize> = RawNodeSlots::default();
+                let mut slots: RawNodeSlots<4usize> = RawNodeSlots::default();
                 let mut current_element = elements.next();
                 if let Some(element) = &current_element
                     && element.kind() == T![plugin]
@@ -5059,6 +5059,13 @@ impl SyntaxFactory for CssSyntaxFactory {
                 slots.next_slot();
                 if let Some(element) = &current_element
                     && CssString::can_cast(element.kind())
+                {
+                    slots.mark_present();
+                    current_element = elements.next();
+                }
+                slots.next_slot();
+                if let Some(element) = &current_element
+                    && AnyCssDeclarationBlock::can_cast(element.kind())
                 {
                     slots.mark_present();
                     current_element = elements.next();

--- a/crates/biome_css_formatter/src/tailwind/statements/plugin_at_rule.rs
+++ b/crates/biome_css_formatter/src/tailwind/statements/plugin_at_rule.rs
@@ -9,17 +9,20 @@ impl FormatNodeRule<TwPluginAtRule> for FormatTwPluginAtRule {
         let TwPluginAtRuleFields {
             plugin_token,
             name,
+            block,
             semicolon_token,
         } = node.as_fields();
 
-        write!(
-            f,
-            [
-                plugin_token.format(),
-                space(),
-                name.format(),
-                semicolon_token.format()
-            ]
-        )
+        write!(f, [plugin_token.format(), space(), name.format()])?;
+        if let Some(block) = block {
+            write!(f, [space(), block.format()])?;
+            if let Some(semicolon_token) = semicolon_token {
+                write!(f, [format_removed(&semicolon_token)])?;
+            }
+        } else {
+            write!(f, [semicolon_token.format()])?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-no-options.css
+++ b/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-no-options.css
@@ -1,0 +1,1 @@
+@plugin    "my-plugin"     ;

--- a/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-no-options.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-no-options.css.snap
@@ -1,0 +1,43 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/tailwind/plugin-no-options.css
+---
+# Input
+
+```css
+@plugin    "my-plugin"     ;
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+@plugin "my-plugin";
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+@plugin "my-plugin";
+```

--- a/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-with-options.css
+++ b/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-with-options.css
@@ -1,0 +1,4 @@
+@plugin    "my-plugin"     {
+	debug:   false;
+	threshold:0.5;
+}

--- a/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-with-options.css.snap
+++ b/crates/biome_css_formatter/tests/specs/css/tailwind/plugin-with-options.css.snap
@@ -1,0 +1,52 @@
+---
+source: crates/biome_formatter_test/src/snapshot_builder.rs
+info: css/tailwind/plugin-with-options.css
+---
+# Input
+
+```css
+@plugin    "my-plugin"     {
+	debug:   false;
+	threshold:0.5;
+}
+
+```
+
+
+=============================
+
+# Outputs
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+}
+```
+
+## Output 1
+
+-----
+Indent style: Tab
+Indent width: 2
+Line ending: LF
+Line width: 80
+Quote style: Double Quotes
+-----
+
+```css
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+}
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options-2.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options-2.css
@@ -1,0 +1,8 @@
+@plugin "my-plugin" {
+  .some-selector > * {
+    primary: "blue";
+    secondary: "green";
+  }
+}
+
+/* Error: `@plugin` can only contain declarations. */

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options-2.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options-2.css.snap
@@ -1,0 +1,158 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@plugin "my-plugin" {
+  .some-selector > * {
+    primary: "blue";
+    secondary: "green";
+  }
+}
+
+/* Error: `@plugin` can only contain declarations. */
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwPluginAtRule {
+                plugin_token: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")],
+                name: CssString {
+                    value_token: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")],
+                },
+                block: CssBogusBlock {
+                    items: [
+                        L_CURLY@20..21 "{" [] [],
+                        CssBogus {
+                            items: [
+                                CssBogus {
+                                    items: [
+                                        DOT@21..25 "." [Newline("\n"), Whitespace("  ")] [],
+                                        IDENT@25..39 "some-selector" [] [Whitespace(" ")],
+                                        R_ANGLE@39..41 ">" [] [Whitespace(" ")],
+                                        STAR@41..43 "*" [] [Whitespace(" ")],
+                                        L_CURLY@43..44 "{" [] [],
+                                        IDENT@44..56 "primary" [Newline("\n"), Whitespace("    ")] [],
+                                        COLON@56..58 ":" [] [Whitespace(" ")],
+                                        CSS_STRING_LITERAL@58..64 "\"blue\"" [] [],
+                                        SEMICOLON@64..65 ";" [] [],
+                                        IDENT@65..79 "secondary" [Newline("\n"), Whitespace("    ")] [],
+                                        COLON@79..81 ":" [] [Whitespace(" ")],
+                                        CSS_STRING_LITERAL@81..88 "\"green\"" [] [],
+                                        SEMICOLON@88..89 ";" [] [],
+                                    ],
+                                },
+                            ],
+                        },
+                        R_CURLY@89..93 "}" [Newline("\n"), Whitespace("  ")] [],
+                    ],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        CssBogusRule {
+            items: [
+                R_CURLY@93..95 "}" [Newline("\n")] [],
+            ],
+        },
+    ],
+    eof_token: EOF@95..150 "" [Newline("\n"), Newline("\n"), Comments("/* Error: `@plugin` c ...")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..150
+  0: (empty)
+  1: CSS_RULE_LIST@0..95
+    0: CSS_AT_RULE@0..93
+      0: AT@0..1 "@" [] []
+      1: TW_PLUGIN_AT_RULE@1..93
+        0: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")]
+        1: CSS_STRING@8..20
+          0: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")]
+        2: CSS_BOGUS_BLOCK@20..93
+          0: L_CURLY@20..21 "{" [] []
+          1: CSS_BOGUS@21..89
+            0: CSS_BOGUS@21..89
+              0: DOT@21..25 "." [Newline("\n"), Whitespace("  ")] []
+              1: IDENT@25..39 "some-selector" [] [Whitespace(" ")]
+              2: R_ANGLE@39..41 ">" [] [Whitespace(" ")]
+              3: STAR@41..43 "*" [] [Whitespace(" ")]
+              4: L_CURLY@43..44 "{" [] []
+              5: IDENT@44..56 "primary" [Newline("\n"), Whitespace("    ")] []
+              6: COLON@56..58 ":" [] [Whitespace(" ")]
+              7: CSS_STRING_LITERAL@58..64 "\"blue\"" [] []
+              8: SEMICOLON@64..65 ";" [] []
+              9: IDENT@65..79 "secondary" [Newline("\n"), Whitespace("    ")] []
+              10: COLON@79..81 ":" [] [Whitespace(" ")]
+              11: CSS_STRING_LITERAL@81..88 "\"green\"" [] []
+              12: SEMICOLON@88..89 ";" [] []
+          2: R_CURLY@89..93 "}" [Newline("\n"), Whitespace("  ")] []
+        3: (empty)
+    1: CSS_BOGUS_RULE@93..95
+      0: R_CURLY@93..95 "}" [Newline("\n")] []
+  2: EOF@95..150 "" [Newline("\n"), Newline("\n"), Comments("/* Error: `@plugin` c ...")] []
+
+```
+
+## Diagnostics
+
+```
+plugin-with-invalid-options-2.css:2:3 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a declaration item but instead found '.some-selector > * {
+        primary: "blue";
+        secondary: "green";'.
+  
+    1 │ @plugin "my-plugin" {
+  > 2 │   .some-selector > * {
+      │   ^^^^^^^^^^^^^^^^^^^^
+  > 3 │     primary: "blue";
+  > 4 │     secondary: "green";
+      │     ^^^^^^^^^^^^^^^^^^^
+    5 │   }
+    6 │ }
+  
+  i Expected a declaration item here.
+  
+    1 │ @plugin "my-plugin" {
+  > 2 │   .some-selector > * {
+      │   ^^^^^^^^^^^^^^^^^^^^
+  > 3 │     primary: "blue";
+  > 4 │     secondary: "green";
+      │     ^^^^^^^^^^^^^^^^^^^
+    5 │   }
+    6 │ }
+  
+plugin-with-invalid-options-2.css:6:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a qualified rule, or an at rule but instead found '}'.
+  
+    4 │     secondary: "green";
+    5 │   }
+  > 6 │ }
+      │ ^
+    7 │ 
+    8 │ /* Error: `@plugin` can only contain declarations. */
+  
+  i Expected a qualified rule, or an at rule here.
+  
+    4 │     secondary: "green";
+    5 │   }
+  > 6 │ }
+      │ ^
+    7 │ 
+    8 │ /* Error: `@plugin` can only contain declarations. */
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options.css
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options.css
@@ -1,0 +1,5 @@
+@plugin "my-plugin" {
+  color: { red: 100; green: 200; blue: 300 };
+}
+
+/* Error: Objects are not supported in `@plugin` options. */

--- a/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/error/tailwind/when-enabled/plugin-with-invalid-options.css.snap
@@ -1,0 +1,211 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@plugin "my-plugin" {
+  color: { red: 100; green: 200; blue: 300 };
+}
+
+/* Error: Objects are not supported in `@plugin` options. */
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwPluginAtRule {
+                plugin_token: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")],
+                name: CssString {
+                    value_token: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@20..21 "{" [] [],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssBogusProperty {
+                                    items: [
+                                        CssIdentifier {
+                                            value_token: IDENT@21..29 "color" [Newline("\n"), Whitespace("  ")] [],
+                                        },
+                                        COLON@29..31 ":" [] [Whitespace(" ")],
+                                        CssBogus {
+                                            items: [
+                                                CssBogusPropertyValue {
+                                                    items: [
+                                                        L_CURLY@31..33 "{" [] [Whitespace(" ")],
+                                                        IDENT@33..36 "red" [] [],
+                                                        COLON@36..38 ":" [] [Whitespace(" ")],
+                                                        CSS_NUMBER_LITERAL@38..41 "100" [] [],
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@41..43 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@43..48 "green" [] [],
+                                    },
+                                    colon_token: COLON@48..50 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@50..53 "200" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@53..55 ";" [] [Whitespace(" ")],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@55..59 "blue" [] [],
+                                    },
+                                    colon_token: COLON@59..61 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@61..65 "300" [] [Whitespace(" ")],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: missing (optional),
+                        },
+                    ],
+                    r_curly_token: R_CURLY@65..66 "}" [] [],
+                },
+                semicolon_token: SEMICOLON@66..67 ";" [] [],
+            },
+        },
+        CssBogusRule {
+            items: [
+                R_CURLY@67..69 "}" [Newline("\n")] [],
+            ],
+        },
+    ],
+    eof_token: EOF@69..132 "" [Newline("\n"), Newline("\n"), Comments("/* Error: Objects are ..."), Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..132
+  0: (empty)
+  1: CSS_RULE_LIST@0..69
+    0: CSS_AT_RULE@0..67
+      0: AT@0..1 "@" [] []
+      1: TW_PLUGIN_AT_RULE@1..67
+        0: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")]
+        1: CSS_STRING@8..20
+          0: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_BLOCK@20..66
+          0: L_CURLY@20..21 "{" [] []
+          1: CSS_DECLARATION_LIST@21..65
+            0: CSS_DECLARATION_WITH_SEMICOLON@21..43
+              0: CSS_DECLARATION@21..41
+                0: CSS_BOGUS_PROPERTY@21..41
+                  0: CSS_IDENTIFIER@21..29
+                    0: IDENT@21..29 "color" [Newline("\n"), Whitespace("  ")] []
+                  1: COLON@29..31 ":" [] [Whitespace(" ")]
+                  2: CSS_BOGUS@31..41
+                    0: CSS_BOGUS_PROPERTY_VALUE@31..41
+                      0: L_CURLY@31..33 "{" [] [Whitespace(" ")]
+                      1: IDENT@33..36 "red" [] []
+                      2: COLON@36..38 ":" [] [Whitespace(" ")]
+                      3: CSS_NUMBER_LITERAL@38..41 "100" [] []
+                1: (empty)
+              1: SEMICOLON@41..43 ";" [] [Whitespace(" ")]
+            1: CSS_DECLARATION_WITH_SEMICOLON@43..55
+              0: CSS_DECLARATION@43..53
+                0: CSS_GENERIC_PROPERTY@43..53
+                  0: CSS_IDENTIFIER@43..48
+                    0: IDENT@43..48 "green" [] []
+                  1: COLON@48..50 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@50..53
+                    0: CSS_NUMBER@50..53
+                      0: CSS_NUMBER_LITERAL@50..53 "200" [] []
+                1: (empty)
+              1: SEMICOLON@53..55 ";" [] [Whitespace(" ")]
+            2: CSS_DECLARATION_WITH_SEMICOLON@55..65
+              0: CSS_DECLARATION@55..65
+                0: CSS_GENERIC_PROPERTY@55..65
+                  0: CSS_IDENTIFIER@55..59
+                    0: IDENT@55..59 "blue" [] []
+                  1: COLON@59..61 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@61..65
+                    0: CSS_NUMBER@61..65
+                      0: CSS_NUMBER_LITERAL@61..65 "300" [] [Whitespace(" ")]
+                1: (empty)
+              1: (empty)
+          2: R_CURLY@65..66 "}" [] []
+        3: SEMICOLON@66..67 ";" [] []
+    1: CSS_BOGUS_RULE@67..69
+      0: R_CURLY@67..69 "}" [Newline("\n")] []
+  2: EOF@69..132 "" [Newline("\n"), Newline("\n"), Comments("/* Error: Objects are ..."), Newline("\n")] []
+
+```
+
+## Diagnostics
+
+```
+plugin-with-invalid-options.css:2:10 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Unexpected value or character.
+  
+    1 │ @plugin "my-plugin" {
+  > 2 │   color: { red: 100; green: 200; blue: 300 };
+      │          ^^^^^^^^^^
+    3 │ }
+    4 │ 
+  
+  i Expected one of:
+  
+  - identifier
+  - string
+  - number
+  - dimension
+  - ratio
+  - custom property
+  - function
+  
+plugin-with-invalid-options.css:3:1 parse ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  × Expected a qualified rule, or an at rule but instead found '}'.
+  
+    1 │ @plugin "my-plugin" {
+    2 │   color: { red: 100; green: 200; blue: 300 };
+  > 3 │ }
+      │ ^
+    4 │ 
+    5 │ /* Error: Objects are not supported in `@plugin` options. */
+  
+  i Expected a qualified rule, or an at rule here.
+  
+    1 │ @plugin "my-plugin" {
+    2 │   color: { red: 100; green: 200; blue: 300 };
+  > 3 │ }
+      │ ^
+    4 │ 
+    5 │ /* Error: Objects are not supported in `@plugin` options. */
+  
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options-2.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options-2.css
@@ -1,0 +1,16 @@
+@plugin '../custom-plugin' {
+	is-null: null;
+	is-true: true;
+	is-false: false;
+	is-int: 1234567;
+	is-float: 1.35;
+	is-sci: 0.0000135;
+	is-str-null: 'null';
+	is-str-true: 'true';
+	is-str-false: 'false';
+	is-str-int: '1234567';
+	is-str-float: '1.35';
+	is-str-sci: '1.35e-5';
+	is-arr: 'foo', 'bar';
+	is-arr-mixed: null, true, false, 1234567, 1.35, 'foo', 'bar', 'true';
+}

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options-2.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options-2.css.snap
@@ -1,0 +1,546 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@plugin '../custom-plugin' {
+	is-null: null;
+	is-true: true;
+	is-false: false;
+	is-int: 1234567;
+	is-float: 1.35;
+	is-sci: 0.0000135;
+	is-str-null: 'null';
+	is-str-true: 'true';
+	is-str-false: 'false';
+	is-str-int: '1234567';
+	is-str-float: '1.35';
+	is-str-sci: '1.35e-5';
+	is-arr: 'foo', 'bar';
+	is-arr-mixed: null, true, false, 1234567, 1.35, 'foo', 'bar', 'true';
+}
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwPluginAtRule {
+                plugin_token: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")],
+                name: CssString {
+                    value_token: CSS_STRING_LITERAL@8..27 "'../custom-plugin'" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@27..28 "{" [] [],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@28..37 "is-null" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@37..39 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@39..43 "null" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@43..44 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@44..53 "is-true" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@53..55 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@55..59 "true" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@59..60 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@60..70 "is-false" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@70..72 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@72..77 "false" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@77..78 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@78..86 "is-int" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@86..88 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@88..95 "1234567" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@95..96 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@96..106 "is-float" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@106..108 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@108..112 "1.35" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@112..113 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@113..121 "is-sci" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@121..123 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@123..132 "0.0000135" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@132..133 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@133..146 "is-str-null" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@146..148 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@148..154 "'null'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@154..155 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@155..168 "is-str-true" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@168..170 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@170..176 "'true'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@176..177 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@177..191 "is-str-false" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@191..193 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@193..200 "'false'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@200..201 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@201..213 "is-str-int" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@213..215 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@215..224 "'1234567'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@224..225 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@225..239 "is-str-float" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@239..241 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@241..247 "'1.35'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@247..248 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@248..260 "is-str-sci" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@260..262 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@262..271 "'1.35e-5'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@271..272 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@272..280 "is-arr" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@280..282 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@282..287 "'foo'" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@287..289 "," [] [Whitespace(" ")],
+                                        },
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@289..294 "'bar'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@294..295 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@295..309 "is-arr-mixed" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@309..311 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@311..315 "null" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@315..317 "," [] [Whitespace(" ")],
+                                        },
+                                        CssIdentifier {
+                                            value_token: IDENT@317..321 "true" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@321..323 "," [] [Whitespace(" ")],
+                                        },
+                                        CssIdentifier {
+                                            value_token: IDENT@323..328 "false" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@328..330 "," [] [Whitespace(" ")],
+                                        },
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@330..337 "1234567" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@337..339 "," [] [Whitespace(" ")],
+                                        },
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@339..343 "1.35" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@343..345 "," [] [Whitespace(" ")],
+                                        },
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@345..350 "'foo'" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@350..352 "," [] [Whitespace(" ")],
+                                        },
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@352..357 "'bar'" [] [],
+                                        },
+                                        CssGenericDelimiter {
+                                            value: COMMA@357..359 "," [] [Whitespace(" ")],
+                                        },
+                                        CssString {
+                                            value_token: CSS_STRING_LITERAL@359..365 "'true'" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@365..366 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@366..368 "}" [Newline("\n")] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+    ],
+    eof_token: EOF@368..369 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..369
+  0: (empty)
+  1: CSS_RULE_LIST@0..368
+    0: CSS_AT_RULE@0..368
+      0: AT@0..1 "@" [] []
+      1: TW_PLUGIN_AT_RULE@1..368
+        0: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")]
+        1: CSS_STRING@8..27
+          0: CSS_STRING_LITERAL@8..27 "'../custom-plugin'" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_BLOCK@27..368
+          0: L_CURLY@27..28 "{" [] []
+          1: CSS_DECLARATION_LIST@28..366
+            0: CSS_DECLARATION_WITH_SEMICOLON@28..44
+              0: CSS_DECLARATION@28..43
+                0: CSS_GENERIC_PROPERTY@28..43
+                  0: CSS_IDENTIFIER@28..37
+                    0: IDENT@28..37 "is-null" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@37..39 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@39..43
+                    0: CSS_IDENTIFIER@39..43
+                      0: IDENT@39..43 "null" [] []
+                1: (empty)
+              1: SEMICOLON@43..44 ";" [] []
+            1: CSS_DECLARATION_WITH_SEMICOLON@44..60
+              0: CSS_DECLARATION@44..59
+                0: CSS_GENERIC_PROPERTY@44..59
+                  0: CSS_IDENTIFIER@44..53
+                    0: IDENT@44..53 "is-true" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@53..55 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@55..59
+                    0: CSS_IDENTIFIER@55..59
+                      0: IDENT@55..59 "true" [] []
+                1: (empty)
+              1: SEMICOLON@59..60 ";" [] []
+            2: CSS_DECLARATION_WITH_SEMICOLON@60..78
+              0: CSS_DECLARATION@60..77
+                0: CSS_GENERIC_PROPERTY@60..77
+                  0: CSS_IDENTIFIER@60..70
+                    0: IDENT@60..70 "is-false" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@70..72 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@72..77
+                    0: CSS_IDENTIFIER@72..77
+                      0: IDENT@72..77 "false" [] []
+                1: (empty)
+              1: SEMICOLON@77..78 ";" [] []
+            3: CSS_DECLARATION_WITH_SEMICOLON@78..96
+              0: CSS_DECLARATION@78..95
+                0: CSS_GENERIC_PROPERTY@78..95
+                  0: CSS_IDENTIFIER@78..86
+                    0: IDENT@78..86 "is-int" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@86..88 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@88..95
+                    0: CSS_NUMBER@88..95
+                      0: CSS_NUMBER_LITERAL@88..95 "1234567" [] []
+                1: (empty)
+              1: SEMICOLON@95..96 ";" [] []
+            4: CSS_DECLARATION_WITH_SEMICOLON@96..113
+              0: CSS_DECLARATION@96..112
+                0: CSS_GENERIC_PROPERTY@96..112
+                  0: CSS_IDENTIFIER@96..106
+                    0: IDENT@96..106 "is-float" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@106..108 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@108..112
+                    0: CSS_NUMBER@108..112
+                      0: CSS_NUMBER_LITERAL@108..112 "1.35" [] []
+                1: (empty)
+              1: SEMICOLON@112..113 ";" [] []
+            5: CSS_DECLARATION_WITH_SEMICOLON@113..133
+              0: CSS_DECLARATION@113..132
+                0: CSS_GENERIC_PROPERTY@113..132
+                  0: CSS_IDENTIFIER@113..121
+                    0: IDENT@113..121 "is-sci" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@121..123 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@123..132
+                    0: CSS_NUMBER@123..132
+                      0: CSS_NUMBER_LITERAL@123..132 "0.0000135" [] []
+                1: (empty)
+              1: SEMICOLON@132..133 ";" [] []
+            6: CSS_DECLARATION_WITH_SEMICOLON@133..155
+              0: CSS_DECLARATION@133..154
+                0: CSS_GENERIC_PROPERTY@133..154
+                  0: CSS_IDENTIFIER@133..146
+                    0: IDENT@133..146 "is-str-null" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@146..148 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@148..154
+                    0: CSS_STRING@148..154
+                      0: CSS_STRING_LITERAL@148..154 "'null'" [] []
+                1: (empty)
+              1: SEMICOLON@154..155 ";" [] []
+            7: CSS_DECLARATION_WITH_SEMICOLON@155..177
+              0: CSS_DECLARATION@155..176
+                0: CSS_GENERIC_PROPERTY@155..176
+                  0: CSS_IDENTIFIER@155..168
+                    0: IDENT@155..168 "is-str-true" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@168..170 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@170..176
+                    0: CSS_STRING@170..176
+                      0: CSS_STRING_LITERAL@170..176 "'true'" [] []
+                1: (empty)
+              1: SEMICOLON@176..177 ";" [] []
+            8: CSS_DECLARATION_WITH_SEMICOLON@177..201
+              0: CSS_DECLARATION@177..200
+                0: CSS_GENERIC_PROPERTY@177..200
+                  0: CSS_IDENTIFIER@177..191
+                    0: IDENT@177..191 "is-str-false" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@191..193 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@193..200
+                    0: CSS_STRING@193..200
+                      0: CSS_STRING_LITERAL@193..200 "'false'" [] []
+                1: (empty)
+              1: SEMICOLON@200..201 ";" [] []
+            9: CSS_DECLARATION_WITH_SEMICOLON@201..225
+              0: CSS_DECLARATION@201..224
+                0: CSS_GENERIC_PROPERTY@201..224
+                  0: CSS_IDENTIFIER@201..213
+                    0: IDENT@201..213 "is-str-int" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@213..215 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@215..224
+                    0: CSS_STRING@215..224
+                      0: CSS_STRING_LITERAL@215..224 "'1234567'" [] []
+                1: (empty)
+              1: SEMICOLON@224..225 ";" [] []
+            10: CSS_DECLARATION_WITH_SEMICOLON@225..248
+              0: CSS_DECLARATION@225..247
+                0: CSS_GENERIC_PROPERTY@225..247
+                  0: CSS_IDENTIFIER@225..239
+                    0: IDENT@225..239 "is-str-float" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@239..241 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@241..247
+                    0: CSS_STRING@241..247
+                      0: CSS_STRING_LITERAL@241..247 "'1.35'" [] []
+                1: (empty)
+              1: SEMICOLON@247..248 ";" [] []
+            11: CSS_DECLARATION_WITH_SEMICOLON@248..272
+              0: CSS_DECLARATION@248..271
+                0: CSS_GENERIC_PROPERTY@248..271
+                  0: CSS_IDENTIFIER@248..260
+                    0: IDENT@248..260 "is-str-sci" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@260..262 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@262..271
+                    0: CSS_STRING@262..271
+                      0: CSS_STRING_LITERAL@262..271 "'1.35e-5'" [] []
+                1: (empty)
+              1: SEMICOLON@271..272 ";" [] []
+            12: CSS_DECLARATION_WITH_SEMICOLON@272..295
+              0: CSS_DECLARATION@272..294
+                0: CSS_GENERIC_PROPERTY@272..294
+                  0: CSS_IDENTIFIER@272..280
+                    0: IDENT@272..280 "is-arr" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@280..282 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@282..294
+                    0: CSS_STRING@282..287
+                      0: CSS_STRING_LITERAL@282..287 "'foo'" [] []
+                    1: CSS_GENERIC_DELIMITER@287..289
+                      0: COMMA@287..289 "," [] [Whitespace(" ")]
+                    2: CSS_STRING@289..294
+                      0: CSS_STRING_LITERAL@289..294 "'bar'" [] []
+                1: (empty)
+              1: SEMICOLON@294..295 ";" [] []
+            13: CSS_DECLARATION_WITH_SEMICOLON@295..366
+              0: CSS_DECLARATION@295..365
+                0: CSS_GENERIC_PROPERTY@295..365
+                  0: CSS_IDENTIFIER@295..309
+                    0: IDENT@295..309 "is-arr-mixed" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@309..311 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@311..365
+                    0: CSS_IDENTIFIER@311..315
+                      0: IDENT@311..315 "null" [] []
+                    1: CSS_GENERIC_DELIMITER@315..317
+                      0: COMMA@315..317 "," [] [Whitespace(" ")]
+                    2: CSS_IDENTIFIER@317..321
+                      0: IDENT@317..321 "true" [] []
+                    3: CSS_GENERIC_DELIMITER@321..323
+                      0: COMMA@321..323 "," [] [Whitespace(" ")]
+                    4: CSS_IDENTIFIER@323..328
+                      0: IDENT@323..328 "false" [] []
+                    5: CSS_GENERIC_DELIMITER@328..330
+                      0: COMMA@328..330 "," [] [Whitespace(" ")]
+                    6: CSS_NUMBER@330..337
+                      0: CSS_NUMBER_LITERAL@330..337 "1234567" [] []
+                    7: CSS_GENERIC_DELIMITER@337..339
+                      0: COMMA@337..339 "," [] [Whitespace(" ")]
+                    8: CSS_NUMBER@339..343
+                      0: CSS_NUMBER_LITERAL@339..343 "1.35" [] []
+                    9: CSS_GENERIC_DELIMITER@343..345
+                      0: COMMA@343..345 "," [] [Whitespace(" ")]
+                    10: CSS_STRING@345..350
+                      0: CSS_STRING_LITERAL@345..350 "'foo'" [] []
+                    11: CSS_GENERIC_DELIMITER@350..352
+                      0: COMMA@350..352 "," [] [Whitespace(" ")]
+                    12: CSS_STRING@352..357
+                      0: CSS_STRING_LITERAL@352..357 "'bar'" [] []
+                    13: CSS_GENERIC_DELIMITER@357..359
+                      0: COMMA@357..359 "," [] [Whitespace(" ")]
+                    14: CSS_STRING@359..365
+                      0: CSS_STRING_LITERAL@359..365 "'true'" [] []
+                1: (empty)
+              1: SEMICOLON@365..366 ";" [] []
+          2: R_CURLY@366..368 "}" [Newline("\n")] []
+        3: (empty)
+  2: EOF@368..369 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options.css
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options.css
@@ -1,0 +1,9 @@
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+}
+
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+};

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin-with-options.css.snap
@@ -1,0 +1,206 @@
+---
+source: crates/biome_css_parser/tests/spec_test.rs
+expression: snapshot
+---
+## Input
+
+```css
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+}
+
+@plugin "my-plugin" {
+	debug: false;
+	threshold: 0.5;
+};
+
+```
+
+
+## AST
+
+```
+CssRoot {
+    bom_token: missing (optional),
+    rules: CssRuleList [
+        CssAtRule {
+            at_token: AT@0..1 "@" [] [],
+            rule: TwPluginAtRule {
+                plugin_token: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")],
+                name: CssString {
+                    value_token: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@20..21 "{" [] [],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@21..28 "debug" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@28..30 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@30..35 "false" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@35..36 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@36..47 "threshold" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@47..49 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@49..52 "0.5" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@52..53 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@53..55 "}" [Newline("\n")] [],
+                },
+                semicolon_token: missing (optional),
+            },
+        },
+        CssAtRule {
+            at_token: AT@55..58 "@" [Newline("\n"), Newline("\n")] [],
+            rule: TwPluginAtRule {
+                plugin_token: PLUGIN_KW@58..65 "plugin" [] [Whitespace(" ")],
+                name: CssString {
+                    value_token: CSS_STRING_LITERAL@65..77 "\"my-plugin\"" [] [Whitespace(" ")],
+                },
+                block: CssDeclarationBlock {
+                    l_curly_token: L_CURLY@77..78 "{" [] [],
+                    declarations: CssDeclarationList [
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@78..85 "debug" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@85..87 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssIdentifier {
+                                            value_token: IDENT@87..92 "false" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@92..93 ";" [] [],
+                        },
+                        CssDeclarationWithSemicolon {
+                            declaration: CssDeclaration {
+                                property: CssGenericProperty {
+                                    name: CssIdentifier {
+                                        value_token: IDENT@93..104 "threshold" [Newline("\n"), Whitespace("\t")] [],
+                                    },
+                                    colon_token: COLON@104..106 ":" [] [Whitespace(" ")],
+                                    value: CssGenericComponentValueList [
+                                        CssNumber {
+                                            value_token: CSS_NUMBER_LITERAL@106..109 "0.5" [] [],
+                                        },
+                                    ],
+                                },
+                                important: missing (optional),
+                            },
+                            semicolon_token: SEMICOLON@109..110 ";" [] [],
+                        },
+                    ],
+                    r_curly_token: R_CURLY@110..112 "}" [Newline("\n")] [],
+                },
+                semicolon_token: SEMICOLON@112..113 ";" [] [],
+            },
+        },
+    ],
+    eof_token: EOF@113..114 "" [Newline("\n")] [],
+}
+```
+
+## CST
+
+```
+0: CSS_ROOT@0..114
+  0: (empty)
+  1: CSS_RULE_LIST@0..113
+    0: CSS_AT_RULE@0..55
+      0: AT@0..1 "@" [] []
+      1: TW_PLUGIN_AT_RULE@1..55
+        0: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")]
+        1: CSS_STRING@8..20
+          0: CSS_STRING_LITERAL@8..20 "\"my-plugin\"" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_BLOCK@20..55
+          0: L_CURLY@20..21 "{" [] []
+          1: CSS_DECLARATION_LIST@21..53
+            0: CSS_DECLARATION_WITH_SEMICOLON@21..36
+              0: CSS_DECLARATION@21..35
+                0: CSS_GENERIC_PROPERTY@21..35
+                  0: CSS_IDENTIFIER@21..28
+                    0: IDENT@21..28 "debug" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@28..30 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@30..35
+                    0: CSS_IDENTIFIER@30..35
+                      0: IDENT@30..35 "false" [] []
+                1: (empty)
+              1: SEMICOLON@35..36 ";" [] []
+            1: CSS_DECLARATION_WITH_SEMICOLON@36..53
+              0: CSS_DECLARATION@36..52
+                0: CSS_GENERIC_PROPERTY@36..52
+                  0: CSS_IDENTIFIER@36..47
+                    0: IDENT@36..47 "threshold" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@47..49 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@49..52
+                    0: CSS_NUMBER@49..52
+                      0: CSS_NUMBER_LITERAL@49..52 "0.5" [] []
+                1: (empty)
+              1: SEMICOLON@52..53 ";" [] []
+          2: R_CURLY@53..55 "}" [Newline("\n")] []
+        3: (empty)
+    1: CSS_AT_RULE@55..113
+      0: AT@55..58 "@" [Newline("\n"), Newline("\n")] []
+      1: TW_PLUGIN_AT_RULE@58..113
+        0: PLUGIN_KW@58..65 "plugin" [] [Whitespace(" ")]
+        1: CSS_STRING@65..77
+          0: CSS_STRING_LITERAL@65..77 "\"my-plugin\"" [] [Whitespace(" ")]
+        2: CSS_DECLARATION_BLOCK@77..112
+          0: L_CURLY@77..78 "{" [] []
+          1: CSS_DECLARATION_LIST@78..110
+            0: CSS_DECLARATION_WITH_SEMICOLON@78..93
+              0: CSS_DECLARATION@78..92
+                0: CSS_GENERIC_PROPERTY@78..92
+                  0: CSS_IDENTIFIER@78..85
+                    0: IDENT@78..85 "debug" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@85..87 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@87..92
+                    0: CSS_IDENTIFIER@87..92
+                      0: IDENT@87..92 "false" [] []
+                1: (empty)
+              1: SEMICOLON@92..93 ";" [] []
+            1: CSS_DECLARATION_WITH_SEMICOLON@93..110
+              0: CSS_DECLARATION@93..109
+                0: CSS_GENERIC_PROPERTY@93..109
+                  0: CSS_IDENTIFIER@93..104
+                    0: IDENT@93..104 "threshold" [Newline("\n"), Whitespace("\t")] []
+                  1: COLON@104..106 ":" [] [Whitespace(" ")]
+                  2: CSS_GENERIC_COMPONENT_VALUE_LIST@106..109
+                    0: CSS_NUMBER@106..109
+                      0: CSS_NUMBER_LITERAL@106..109 "0.5" [] []
+                1: (empty)
+              1: SEMICOLON@109..110 ";" [] []
+          2: R_CURLY@110..112 "}" [Newline("\n")] []
+        3: SEMICOLON@112..113 ";" [] []
+  2: EOF@113..114 "" [Newline("\n")] []
+
+```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/plugin.css.snap
@@ -23,6 +23,7 @@ CssRoot {
                 name: CssString {
                     value_token: CSS_STRING_LITERAL@8..33 "\"@tailwindcss/typography\"" [] [],
                 },
+                block: missing (optional),
                 semicolon_token: SEMICOLON@33..34 ";" [] [],
             },
         },
@@ -43,7 +44,8 @@ CssRoot {
         0: PLUGIN_KW@1..8 "plugin" [] [Whitespace(" ")]
         1: CSS_STRING@8..33
           0: CSS_STRING_LITERAL@8..33 "\"@tailwindcss/typography\"" [] []
-        2: SEMICOLON@33..34 ";" [] []
+        2: (empty)
+        3: SEMICOLON@33..34 ";" [] []
   2: EOF@34..35 "" [Newline("\n")] []
 
 ```

--- a/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/shadcn-default.css.snap
+++ b/crates/biome_css_parser/tests/css_test_suite/ok/tailwind/shadcn-default.css.snap
@@ -182,6 +182,7 @@ CssRoot {
                 name: CssString {
                     value_token: CSS_STRING_LITERAL@32..53 "\"tailwindcss-animate\"" [] [],
                 },
+                block: missing (optional),
                 semicolon_token: SEMICOLON@53..54 ";" [] [],
             },
         },
@@ -4457,7 +4458,8 @@ CssRoot {
         0: PLUGIN_KW@25..32 "plugin" [] [Whitespace(" ")]
         1: CSS_STRING@32..53
           0: CSS_STRING_LITERAL@32..53 "\"tailwindcss-animate\"" [] []
-        2: SEMICOLON@53..54 ";" [] []
+        2: (empty)
+        3: SEMICOLON@53..54 ";" [] []
     2: CSS_AT_RULE@54..93
       0: AT@54..57 "@" [Newline("\n"), Newline("\n")] []
       1: TW_CUSTOM_VARIANT_AT_RULE@57..93

--- a/crates/biome_css_syntax/src/generated/nodes.rs
+++ b/crates/biome_css_syntax/src/generated/nodes.rs
@@ -7130,6 +7130,7 @@ impl TwPluginAtRule {
         TwPluginAtRuleFields {
             plugin_token: self.plugin_token(),
             name: self.name(),
+            block: self.block(),
             semicolon_token: self.semicolon_token(),
         }
     }
@@ -7139,8 +7140,11 @@ impl TwPluginAtRule {
     pub fn name(&self) -> SyntaxResult<CssString> {
         support::required_node(&self.syntax, 1usize)
     }
-    pub fn semicolon_token(&self) -> SyntaxResult<SyntaxToken> {
-        support::required_token(&self.syntax, 2usize)
+    pub fn block(&self) -> Option<AnyCssDeclarationBlock> {
+        support::node(&self.syntax, 2usize)
+    }
+    pub fn semicolon_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, 3usize)
     }
 }
 impl Serialize for TwPluginAtRule {
@@ -7155,7 +7159,8 @@ impl Serialize for TwPluginAtRule {
 pub struct TwPluginAtRuleFields {
     pub plugin_token: SyntaxResult<SyntaxToken>,
     pub name: SyntaxResult<CssString>,
-    pub semicolon_token: SyntaxResult<SyntaxToken>,
+    pub block: Option<AnyCssDeclarationBlock>,
+    pub semicolon_token: Option<SyntaxToken>,
 }
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct TwReferenceAtRule {
@@ -18357,9 +18362,10 @@ impl std::fmt::Debug for TwPluginAtRule {
                     &support::DebugSyntaxResult(self.plugin_token()),
                 )
                 .field("name", &support::DebugSyntaxResult(self.name()))
+                .field("block", &support::DebugOptionalElement(self.block()))
                 .field(
                     "semicolon_token",
-                    &support::DebugSyntaxResult(self.semicolon_token()),
+                    &support::DebugOptionalElement(self.semicolon_token()),
                 )
                 .finish()
         } else {

--- a/crates/biome_css_syntax/src/generated/nodes_mut.rs
+++ b/crates/biome_css_syntax/src/generated/nodes_mut.rs
@@ -2898,10 +2898,16 @@ impl TwPluginAtRule {
                 .splice_slots(1usize..=1usize, once(Some(element.into_syntax().into()))),
         )
     }
-    pub fn with_semicolon_token(self, element: SyntaxToken) -> Self {
+    pub fn with_block(self, element: Option<AnyCssDeclarationBlock>) -> Self {
+        Self::unwrap_cast(self.syntax.splice_slots(
+            2usize..=2usize,
+            once(element.map(|element| element.into_syntax().into())),
+        ))
+    }
+    pub fn with_semicolon_token(self, element: Option<SyntaxToken>) -> Self {
         Self::unwrap_cast(
             self.syntax
-                .splice_slots(2usize..=2usize, once(Some(element.into()))),
+                .splice_slots(3usize..=3usize, once(element.map(|element| element.into()))),
         )
     }
 }

--- a/crates/biome_grit_patterns/src/grit_target_language/css_target_language/constants.rs
+++ b/crates/biome_grit_patterns/src/grit_target_language/css_target_language/constants.rs
@@ -3,5 +3,7 @@
 use crate::grit_target_language::DisregardedSlotCondition::{self, *};
 use biome_css_syntax::CssSyntaxKind::{self, *};
 
-pub(crate) const DISREGARDED_SNIPPET_SLOTS: &[(CssSyntaxKind, u32, DisregardedSlotCondition)] =
-    &[(CSS_DECLARATION_WITH_SEMICOLON, 1, Always)];
+pub(crate) const DISREGARDED_SNIPPET_SLOTS: &[(CssSyntaxKind, u32, DisregardedSlotCondition)] = &[
+    (CSS_DECLARATION_WITH_SEMICOLON, 1, Always),
+    (TW_PLUGIN_AT_RULE, 3, Always),
+];

--- a/crates/biome_parser/src/lib.rs
+++ b/crates/biome_parser/src/lib.rs
@@ -388,6 +388,8 @@ pub trait Parser: Sized {
     }
 
     /// Consume the next token if `kind` matches.
+    ///
+    /// Returns `true` if the token was consumed, `false` otherwise.
     fn eat(&mut self, kind: Self::Kind) -> bool {
         if !self.at(kind) {
             return false;
@@ -399,6 +401,8 @@ pub trait Parser: Sized {
     }
 
     /// Consume the next token if token set matches.
+    ///
+    /// Returns `true` if the token was consumed, `false` otherwise.
     fn eat_ts(&mut self, kinds: TokenSet<Self::Kind>) -> bool {
         if !self.at_ts(kinds) {
             return false;
@@ -410,6 +414,8 @@ pub trait Parser: Sized {
     }
 
     /// Consume the next token if token set matches using the specified `context.
+    ///
+    /// Returns `true` if the token was consumed, `false` otherwise.
     fn eat_ts_with_context(
         &mut self,
         kinds: TokenSet<Self::Kind>,

--- a/xtask/codegen/css.ungram
+++ b/xtask/codegen/css.ungram
@@ -1966,7 +1966,12 @@ TwConfigAtRule =
 
 // Tailwind 4.0 @plugin directive (compatibility)
 // @plugin "@tailwindcss/typography";
+// @plugin "my-plugin" {
+//  debug: false;
+//  threshold: 0.5;
+// }
 TwPluginAtRule =
   'plugin'
   name: CssString
-  ';'
+  block: AnyCssDeclarationBlock?
+  ';'?


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Please provide enough information so that others can review your PR.
	Once created, your PR will be automatically labeled according to changed files.
	Learn more about contributing: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->
The css parser is now able to parse `@plugin` declarations that have options blocks.

<!-- Link any relevant issues if necessary or include a transcript of any Discord discussion. -->
fixes #7860

<!-- If you create a user-facing change, please write a changeset: https://github.com/biomejs/biome/blob/main/CONTRIBUTING.md#writing-a-changeset (your changeset is often a good starting point for this summary as well) -->

## Test Plan

<!-- What demonstrates that your implementation is correct? -->
added parser and formatter tests

## Docs

<!-- If you're submitting a new rule or action (or an option for them), the documentation is part of the code. Make sure rules and actions have example usages, and that all options are documented. -->

<!-- For other features, please submit a documentation PR to the `next` branch of our website: https://github.com/biomejs/website/. Link the PR here once it's ready. -->
